### PR TITLE
fix: skip translation when configured language matches target (fixes #9)

### DIFF
--- a/src/TypeWhisper.Core/Services/PostProcessingPipeline.cs
+++ b/src/TypeWhisper.Core/Services/PostProcessingPipeline.cs
@@ -100,7 +100,7 @@ public sealed class PostProcessingPipeline : IPostProcessingPipeline
                 async (text, ct) =>
                 {
                     var sourceLang = detectedLang ?? effectiveLang ?? "de";
-                    if (sourceLang == targetLang)
+                    if (sourceLang == targetLang || effectiveLang == targetLang)
                         return text;
 
                     if (options.StatusCallback is not null)

--- a/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
@@ -65,6 +65,21 @@ public class PostProcessingPipelineTests
     }
 
     [Fact]
+    public async Task ProcessAsync_Translation_SkippedWhenEffectiveLanguageMatchesTarget()
+    {
+        var options = new PipelineOptions
+        {
+            TranslationHandler = (text, src, tgt, _) => Task.FromResult($"[{tgt}] {text}"),
+            TranslationTarget = "it",
+            EffectiveSourceLanguage = "it",
+            DetectedLanguage = "en" // Whisper hallucinated English
+        };
+
+        var result = await _sut.ProcessAsync("ciao mondo", options);
+        Assert.Equal("ciao mondo", result.Text);
+    }
+
+    [Fact]
     public async Task ProcessAsync_Translation_SkippedWhenSameLanguage()
     {
         var options = new PipelineOptions


### PR DESCRIPTION
## Summary
When Whisper hallucinates a different language (e.g. detecting English while the user speaks Italian), the translation step would incorrectly translate already-correct text. This adds a check so that when the user's explicitly configured source language matches the translation target, translation is skipped regardless of Whisper's detected language. Auto-detect behavior is preserved since the configured language is null in that case.

## Test Plan
- [x] New test: `ProcessAsync_Translation_SkippedWhenEffectiveLanguageMatchesTarget` verifies the hallucination scenario
- [x] All 14 existing pipeline tests still pass