### PR TITLE
fix: add 30s HTTP timeout to Groq plugin

### DIFF
--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -12,7 +12,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
     private const string BaseUrl = "https://api.groq.com/openai";
     private const string TranslationModel = "llama-3.3-70b-versatile";
 
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
     private IPluginHostServices? _host;
     private string? _apiKey;
     private string? _selectedModelId;


### PR DESCRIPTION
Adds a 30-second HTTP timeout to the Groq plugin's HttpClient, which previously had no timeout configured (infinite by default). This prevents the app from hanging when the Groq API is slow or unreachable. The existing error handling in `OpenAiApiHelper` already catches timeout exceptions and displays "API request timed out." to the user.

Fixes #6