### PR TITLE
fix: show warnings when no LLM provider configured for prompt actions

### DIFF
--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -357,6 +357,9 @@
   "Welcome.Done": "Fertig!",
 
   "Prompts.DefaultProviderLabel": "(Standard)",
+  "Prompts.DefaultProviderLabelNone": "(Standard - keiner konfiguriert)",
+  "Prompts.DefaultProviderLabelFormat": "(Standard - {0})",
+  "Prompts.ProviderOverride": "Provider",
   "Prompts.NewPromptTitle": "Neuer Prompt",
   "Prompts.EditPromptTitle": "Prompt bearbeiten",
 
@@ -369,6 +372,7 @@
   "Translation.None": "Keine \u00dcbersetzung",
 
   "Error.NoLlmProvider": "Kein LLM-Provider verf\u00fcgbar. Bitte konfigurieren Sie einen API-Key in den Erweiterungen.",
+  "Error.PromptProcessingFailed": "Prompt-Verarbeitung fehlgeschlagen: {0}",
   "Error.NoApiKeyFormat": "Kein API-Key f\u00fcr {0}",
   "Error.FileNotFound": "Datei nicht gefunden.",
   "Error.TranslationNotAvailableFormat": "Keine \u00dcbersetzung verf\u00fcgbar f\u00fcr {0}->{1}",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -357,6 +357,9 @@
   "Welcome.Done": "Done!",
 
   "Prompts.DefaultProviderLabel": "(Default)",
+  "Prompts.DefaultProviderLabelNone": "(Default - none configured)",
+  "Prompts.DefaultProviderLabelFormat": "(Default - {0})",
+  "Prompts.ProviderOverride": "Provider",
   "Prompts.NewPromptTitle": "New Prompt",
   "Prompts.EditPromptTitle": "Edit Prompt",
 
@@ -369,6 +372,7 @@
   "Translation.None": "No Translation",
 
   "Error.NoLlmProvider": "No LLM provider available. Please configure an API key in Extensions.",
+  "Error.PromptProcessingFailed": "Prompt processing failed: {0}",
   "Error.NoApiKeyFormat": "No API key for {0}",
   "Error.FileNotFound": "File not found.",
   "Error.TranslationNotAvailableFormat": "No translation available for {0}->{1}",

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -447,8 +447,19 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             if (job.ActiveProfile?.PromptActionId is { } promptActionId)
             {
                 var promptAction = _promptActions.Actions.FirstOrDefault(a => a.Id == promptActionId);
-                if (promptAction is not null && _promptProcessing.IsAnyProviderAvailable)
-                    llmHandler = (text, token) => _promptProcessing.ProcessAsync(promptAction, text, token);
+                if (promptAction is not null)
+                {
+                    if (_promptProcessing.IsAnyProviderAvailable)
+                    {
+                        llmHandler = (text, token) => _promptProcessing.ProcessAsync(promptAction, text, token);
+                    }
+                    else
+                    {
+                        FeedbackText = Loc.Instance["Error.NoLlmProvider"];
+                        FeedbackIsError = true;
+                        ShowFeedback = true;
+                    }
+                }
             }
 
             // Build plugin post-processors (capture context in closure)

--- a/src/TypeWhisper.Windows/ViewModels/PromptPaletteViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PromptPaletteViewModel.cs
@@ -7,6 +7,7 @@ using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
 using TypeWhisper.Windows.Views;
 
@@ -80,7 +81,14 @@ public partial class PromptPaletteViewModel : ObservableObject
             return;
 
         if (!_processing.IsAnyProviderAvailable)
+        {
+            MessageBox.Show(
+                Loc.Instance["Error.NoLlmProvider"],
+                "TypeWhisper",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
             return;
+        }
 
         try
         {
@@ -104,9 +112,18 @@ public partial class PromptPaletteViewModel : ObservableObject
 
             await _textInsertion.InsertTextAsync(result, autoPaste: true);
         }
+        catch (OperationCanceledException)
+        {
+            // Timeout or user cancellation - no error to show
+        }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Prompt processing error: {ex.Message}");
+            MessageBox.Show(
+                Loc.Instance.GetString("Error.PromptProcessingFailed", ex.Message),
+                "TypeWhisper",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
         }
     }
 

--- a/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
@@ -189,7 +189,7 @@ public partial class PromptsViewModel : ObservableObject
     public void RefreshProviders()
     {
         AvailableProviders.Clear();
-        AvailableProviders.Add(new ProviderOption(null, Loc.Instance["Prompts.DefaultProviderLabel"]));
+        AvailableProviders.Add(new ProviderOption(null, GetDefaultProviderLabel()));
         foreach (var provider in _pluginManager.LlmProviders)
         {
             if (!provider.IsAvailable) continue;
@@ -204,6 +204,20 @@ public partial class PromptsViewModel : ObservableObject
             }
         }
         OnPropertyChanged(nameof(HasLlmProviders));
+    }
+
+    private string GetDefaultProviderLabel()
+    {
+        var firstAvailable = _pluginManager.LlmProviders.FirstOrDefault(p => p.IsAvailable);
+        if (firstAvailable is null)
+            return Loc.Instance["Prompts.DefaultProviderLabelNone"];
+
+        var firstModel = firstAvailable.SupportedModels.FirstOrDefault();
+        if (firstModel is not null)
+            return Loc.Instance.GetString("Prompts.DefaultProviderLabelFormat",
+                $"{firstAvailable.ProviderName} / {firstModel.DisplayName}");
+
+        return Loc.Instance["Prompts.DefaultProviderLabelNone"];
     }
 }
 

--- a/src/TypeWhisper.Windows/Views/Sections/PromptsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/PromptsSection.xaml
@@ -97,7 +97,16 @@
                          AcceptsReturn="True" TextWrapping="Wrap"
                          MinHeight="80" MaxHeight="160"
                          VerticalScrollBarVisibility="Auto"
-                         Margin="0,0,0,12"/>
+                         Margin="0,0,0,10"/>
+
+                <!-- Provider override -->
+                <TextBlock Text="{loc:Str Prompts.ProviderOverride}" Style="{StaticResource LabelStyle}"/>
+                <ComboBox ItemsSource="{Binding Prompts.AvailableProviders}"
+                          SelectedValue="{Binding Prompts.EditProviderOverride}"
+                          SelectedValuePath="Value"
+                          DisplayMemberPath="DisplayName"
+                          Width="320" HorizontalAlignment="Left"
+                          Margin="0,0,0,12"/>
 
                 <!-- Buttons -->
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
## Summary

- Show a MessageBox warning when executing a prompt action with no LLM provider available, instead of silently doing nothing (fixes #8)
- Add per-action provider override dropdown to the prompt editor UI (the data model already supported it but the UI was missing)
- Make the "(Default)" provider label context-aware, showing which provider it resolves to or "(Default - none configured)"
- Show overlay feedback in dictation mode when a profile's prompt action is skipped due to missing provider

## Test plan
- [ ] Create a prompt action with no provider override and no global default - executing should show a warning MessageBox
- [ ] Verify the default provider dropdown shows the resolved provider name (e.g. "(Default - OpenAI / gpt-4o-mini)")
- [ ] Verify the prompt editor now has a "Provider" dropdown to set per-action overrides
- [ ] Verify per-action provider override persists after save and reload