### PR TITLE
fix: handle missing microphone gracefully (fixes #5)

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -124,7 +124,8 @@ public partial class App : Application
         var audio = _serviceProvider.GetRequiredService<AudioRecordingService>();
         var mic = settings.Current.SelectedMicrophoneDevice;
         if (mic.HasValue) audio.SetMicrophoneDevice(mic);
-        audio.WarmUp();
+        if (!audio.WarmUp())
+            System.Diagnostics.Debug.WriteLine("No audio input device available at startup. Polling for device...");
 
         // Start API server if enabled
         if (settings.Current.ApiServerEnabled)

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -251,6 +251,8 @@
   "Status.Done": "Fertig",
   "Status.ActionFormat": "{0} wird ausgeführt...",
   "Status.Cancelled": "Abgebrochen",
+  "Status.NoMicrophone": "Kein Mikrofon angeschlossen",
+  "Status.MicrophoneRestored": "Mikrofon verbunden",
   "Status.ErrorFormat": "Fehler: {0}",
   "Status.ModelErrorFormat": "Modell-Fehler: {0}",
   "Status.NoModelLoaded": "Kein Modell geladen",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -251,6 +251,8 @@
   "Status.Done": "Done",
   "Status.ActionFormat": "Running {0}...",
   "Status.Cancelled": "Cancelled",
+  "Status.NoMicrophone": "No microphone connected",
+  "Status.MicrophoneRestored": "Microphone connected",
   "Status.ErrorFormat": "Error: {0}",
   "Status.ModelErrorFormat": "Model error: {0}",
   "Status.NoModelLoaded": "No model loaded",

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -34,7 +34,9 @@ public sealed class AudioRecordingService : IDisposable
     public event EventHandler<SamplesAvailableEventArgs>? SamplesAvailable;
     public event EventHandler? DevicesChanged;
     public event EventHandler? DeviceLost;
+    public event EventHandler? DeviceAvailable;
 
+    public bool HasDevice => WaveInEvent.DeviceCount > 0;
     public bool WhisperModeEnabled { get; set; }
     public bool NormalizationEnabled { get; set; } = true;
     public bool IsRecording => _isRecording;
@@ -54,25 +56,47 @@ public sealed class AudioRecordingService : IDisposable
         _activeDeviceNumber = newDevice;
     }
 
-    public void WarmUp()
+    public bool WarmUp()
     {
-        if (_isWarmedUp || _disposed) return;
+        if (_isWarmedUp || _disposed) return _isWarmedUp;
+
+        if (WaveInEvent.DeviceCount == 0)
+        {
+            System.Diagnostics.Debug.WriteLine("WarmUp: No audio input devices available.");
+            StartDevicePolling();
+            return false;
+        }
 
         _activeDeviceNumber = _configuredDeviceNumber ?? FindBestMicrophoneDevice();
-
-        _waveIn = new WaveInEvent
+        if (_activeDeviceNumber < 0)
         {
-            DeviceNumber = _activeDeviceNumber,
-            WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
-            BufferMilliseconds = 30
-        };
+            StartDevicePolling();
+            return false;
+        }
 
-        _waveIn.DataAvailable += OnDataAvailable;
-        _waveIn.RecordingStopped += OnRecordingStopped;
-        _waveIn.StartRecording();
+        try
+        {
+            _waveIn = new WaveInEvent
+            {
+                DeviceNumber = _activeDeviceNumber,
+                WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
+                BufferMilliseconds = 30
+            };
 
-        _isWarmedUp = true;
+            _waveIn.DataAvailable += OnDataAvailable;
+            _waveIn.RecordingStopped += OnRecordingStopped;
+            _waveIn.StartRecording();
+
+            _isWarmedUp = true;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"WarmUp failed: {ex.Message}");
+            DisposeWaveIn();
+        }
+
         StartDevicePolling();
+        return _isWarmedUp;
     }
 
     public static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices()
@@ -90,8 +114,8 @@ public sealed class AudioRecordingService : IDisposable
     {
         if (_isRecording) return;
 
-        if (!_isWarmedUp)
-            WarmUp();
+        if (!_isWarmedUp && !WarmUp())
+            return;
 
         if (_waveIn is null) return;
 
@@ -225,7 +249,7 @@ public sealed class AudioRecordingService : IDisposable
                 return i;
         }
 
-        return 0;
+        return deviceCount > 0 ? 0 : -1;
     }
 
     private void StartDevicePolling()
@@ -243,18 +267,29 @@ public sealed class AudioRecordingService : IDisposable
         try
         {
             var currentCount = WaveInEvent.DeviceCount;
-            if (currentCount != _lastKnownDeviceCount)
-            {
-                _lastKnownDeviceCount = currentCount;
-                DevicesChanged?.Invoke(this, EventArgs.Empty);
+            if (currentCount == _lastKnownDeviceCount) return;
 
-                if (_isWarmedUp && _activeDeviceNumber >= currentCount)
-                {
-                    DeviceLost?.Invoke(this, EventArgs.Empty);
-                    DisposeWaveIn();
-                    _configuredDeviceNumber = null;
-                    WarmUp();
-                }
+            var previousCount = _lastKnownDeviceCount;
+            _lastKnownDeviceCount = currentCount;
+            DevicesChanged?.Invoke(this, EventArgs.Empty);
+
+            if (currentCount == 0 && _isWarmedUp)
+            {
+                DeviceLost?.Invoke(this, EventArgs.Empty);
+                DisposeWaveIn();
+                _configuredDeviceNumber = null;
+            }
+            else if (currentCount > 0 && previousCount == 0)
+            {
+                DeviceAvailable?.Invoke(this, EventArgs.Empty);
+                WarmUp();
+            }
+            else if (_isWarmedUp && _activeDeviceNumber >= currentCount)
+            {
+                DeviceLost?.Invoke(this, EventArgs.Empty);
+                DisposeWaveIn();
+                _configuredDeviceNumber = null;
+                WarmUp();
             }
         }
         catch { }
@@ -263,18 +298,28 @@ public sealed class AudioRecordingService : IDisposable
     public void StartPreview(int? deviceNumber)
     {
         StopPreview();
-        if (_disposed) return;
+        if (_disposed || WaveInEvent.DeviceCount == 0) return;
 
         var deviceIndex = deviceNumber ?? FindBestMicrophoneDevice();
-        _previewWaveIn = new WaveInEvent
+        if (deviceIndex < 0) return;
+
+        try
         {
-            DeviceNumber = deviceIndex,
-            WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
-            BufferMilliseconds = 50
-        };
-        _previewWaveIn.DataAvailable += OnPreviewDataAvailable;
-        _previewWaveIn.StartRecording();
-        _isPreviewing = true;
+            _previewWaveIn = new WaveInEvent
+            {
+                DeviceNumber = deviceIndex,
+                WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
+                BufferMilliseconds = 50
+            };
+            _previewWaveIn.DataAvailable += OnPreviewDataAvailable;
+            _previewWaveIn.StartRecording();
+            _isPreviewing = true;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"StartPreview failed: {ex.Message}");
+            StopPreview();
+        }
     }
 
     public void StopPreview()

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -126,6 +126,28 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         _consumerTask = Task.Run(() => ProcessJobsAsync(_consumerCts.Token));
 
         _audio.AudioLevelChanged += OnAudioLevelChanged;
+        _audio.DeviceLost += (_, _) => Application.Current?.Dispatcher.InvokeAsync(async () =>
+        {
+            if (_isRecording)
+            {
+                _isRecording = false;
+                _durationTimer?.Stop();
+                _audio.StopRecording();
+                _audioDucking.RestoreAudio();
+                _mediaPause.ResumeMedia();
+                State = DictationState.Idle;
+                IsOverlayVisible = false;
+            }
+            FeedbackText = Loc.Instance["Status.NoMicrophone"];
+            FeedbackIsError = true;
+            ShowFeedback = true;
+        });
+        _audio.DeviceAvailable += (_, _) => Application.Current?.Dispatcher.InvokeAsync(() =>
+        {
+            FeedbackText = Loc.Instance["Status.MicrophoneRestored"];
+            FeedbackIsError = false;
+            ShowFeedback = true;
+        });
         _settings.SettingsChanged += _ =>
         {
             OnPropertyChanged(nameof(LeftWidget));
@@ -247,6 +269,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         if (!_modelManager.Engine.IsModelLoaded)
         {
             StatusText = Loc.Instance["Status.NoModelLoaded"];
+            _isRecording = false;
+            return;
+        }
+
+        if (!_audio.HasDevice)
+        {
+            StatusText = Loc.Instance["Status.NoMicrophone"];
+            FeedbackText = StatusText;
+            FeedbackIsError = true;
+            ShowFeedback = true;
             _isRecording = false;
             return;
         }

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -109,6 +109,7 @@ public partial class SettingsViewModel : ObservableObject
     public void StartMicrophonePreview()
     {
         _audio.PreviewLevelChanged -= OnPreviewLevelChanged;
+        if (!_audio.HasDevice) return;
         _audio.StartPreview(SelectedMicrophoneDevice);
         _audio.PreviewLevelChanged += OnPreviewLevelChanged;
     }

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -181,6 +181,7 @@ public partial class WelcomeViewModel : ObservableObject
     private void StartMicTest()
     {
         _audio.AudioLevelChanged += OnMicLevel;
+        if (!_audio.HasDevice) return;
         _audio.WarmUp();
         _audio.StartRecording();
     }


### PR DESCRIPTION
## Summary

- Guard `AudioRecordingService.WarmUp()` and `StartPreview()` against zero audio input devices with early-return checks and try-catch, preventing the app from freezing when no microphone is connected.
- Add `HasDevice` property and `DeviceAvailable` event for automatic recovery when a microphone is plugged in (detected via existing 2-second polling timer).
- Show localized user feedback ("No microphone connected" / "Microphone connected") through the existing overlay notification system.
- Guard all caller sites (App startup, DictationViewModel, WelcomeViewModel, SettingsViewModel) to skip recording/preview gracefully when no device is available.

## Test plan
- [ ] Start app with no microphone connected - should not freeze, shows "No microphone connected" feedback
- [ ] Plug in a microphone while app is running - should auto-recover within ~2s and show "Microphone connected"
- [ ] Unplug microphone during active recording - should stop gracefully and notify
- [ ] Normal operation with microphone connected - all existing behavior unchanged