### PR TITLE
feat: add visual indicators for hybrid hotkey toggle mode

### DIFF
--- a/src/TypeWhisper.Windows/Controls/Overlay/HotkeyModeWidget.xaml
+++ b/src/TypeWhisper.Windows/Controls/Overlay/HotkeyModeWidget.xaml
@@ -1,13 +1,34 @@
 <UserControl x:Class="TypeWhisper.Windows.Controls.Overlay.HotkeyModeWidget"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:TypeWhisper.Windows.Converters">
+             xmlns:conv="clr-namespace:TypeWhisper.Windows.Converters"
+             xmlns:svc="clr-namespace:TypeWhisper.Windows.Services">
     <UserControl.Resources>
         <conv:HotkeyModeLabelConverter x:Key="HotkeyModeLabel"/>
     </UserControl.Resources>
-    <Border Background="#333" CornerRadius="6" Padding="5,2">
+    <Border CornerRadius="6" Padding="5,2">
+        <Border.Style>
+            <Style TargetType="Border">
+                <Setter Property="Background" Value="#333"/>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding CurrentHotkeyMode}" Value="{x:Static svc:HotkeyMode.Toggle}">
+                        <Setter Property="Background" Value="#4DFFA500"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Border.Style>
         <TextBlock Text="{Binding CurrentHotkeyMode, Converter={StaticResource HotkeyModeLabel}}"
-                   Foreground="#AAA" FontSize="9" FontWeight="SemiBold"
-                   VerticalAlignment="Center"/>
+                   FontSize="9" FontWeight="SemiBold" VerticalAlignment="Center">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="#AAA"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding CurrentHotkeyMode}" Value="{x:Static svc:HotkeyMode.Toggle}">
+                            <Setter Property="Foreground" Value="#FFA500"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
     </Border>
 </UserControl>

--- a/src/TypeWhisper.Windows/Converters/ValueConverters.cs
+++ b/src/TypeWhisper.Windows/Converters/ValueConverters.cs
@@ -96,6 +96,29 @@ public sealed class SecondsToTimerConverter : IValueConverter
 }
 
 /// <summary>
+/// Converts HotkeyMode? to an overlay border brush.
+/// Toggle mode = amber border (attention needed), otherwise transparent.
+/// </summary>
+public sealed class HotkeyModeToOverlayBorderConverter : IValueConverter
+{
+    private static readonly SolidColorBrush ToggleBrush = CreateFrozen(Color.FromArgb(0xCC, 0xFF, 0xA5, 0x00));
+    private static readonly SolidColorBrush TransparentBrush = CreateFrozen(Colors.Transparent);
+
+    private static SolidColorBrush CreateFrozen(Color color)
+    {
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is HotkeyMode.Toggle ? ToggleBrush : TransparentBrush;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
 /// Converts HotkeyMode? to a short label: TOG or PTT.
 /// </summary>
 public sealed class HotkeyModeLabelConverter : IValueConverter

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -240,6 +240,8 @@
 
   "Status.Ready": "Bereit",
   "Status.Recording": "Aufnahme...",
+  "Status.RecordingToggle": "Aufnahme (Toggle) - Hotkey dr\u00fccken zum Stoppen",
+  "Status.RecordingHold": "Aufnahme (Halten)...",
   "Status.Processing": "Verarbeite...",
   "Status.NoSpeech": "Keine Sprache erkannt",
   "Status.TooShort": "Zu kurz",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -240,6 +240,8 @@
 
   "Status.Ready": "Ready",
   "Status.Recording": "Recording...",
+  "Status.RecordingToggle": "Recording (Toggle) - press hotkey to stop",
+  "Status.RecordingHold": "Recording (Hold)...",
   "Status.Processing": "Processing...",
   "Status.NoSpeech": "No speech detected",
   "Status.TooShort": "Too short",

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -166,6 +166,22 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         IsExpanded = !string.IsNullOrEmpty(value);
     }
 
+    partial void OnCurrentHotkeyModeChanged(HotkeyMode? value)
+    {
+        if (_isRecording)
+            StatusText = GetRecordingStatusText();
+    }
+
+    private string GetRecordingStatusText()
+    {
+        return CurrentHotkeyMode switch
+        {
+            HotkeyMode.Toggle => Loc.Instance["Status.RecordingToggle"],
+            HotkeyMode.PushToTalk => Loc.Instance["Status.RecordingHold"],
+            _ => Loc.Instance["Status.Recording"]
+        };
+    }
+
     private System.Timers.Timer? _feedbackTimer;
 
     partial void OnShowFeedbackChanged(bool value)
@@ -288,9 +304,9 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         _eventBus.Publish(new RecordingStartedEvent());
 
         State = DictationState.Recording;
-        StatusText = Loc.Instance["Status.Recording"];
-        TranscribedText = "";
         CurrentHotkeyMode = _hotkey.CurrentMode;
+        StatusText = GetRecordingStatusText();
+        TranscribedText = "";
         IsOverlayVisible = true;
         RecordingSeconds = 0;
 

--- a/src/TypeWhisper.Windows/Views/MainWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/MainWindow.xaml
@@ -21,6 +21,7 @@
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
         <conv:NonEmptyToVisibilityConverter x:Key="NonEmptyToVis"/>
+        <conv:HotkeyModeToOverlayBorderConverter x:Key="HotkeyModeBorder"/>
     </Window.Resources>
 
     <Grid Margin="8"
@@ -29,6 +30,8 @@
         <Border x:Name="IslandBorder"
                 CornerRadius="22"
                 Background="#F0181818"
+                BorderBrush="{Binding CurrentHotkeyMode, Converter={StaticResource HotkeyModeBorder}}"
+                BorderThickness="1.5"
                 HorizontalAlignment="Center"
                 Padding="0">
             <Border.Effect>


### PR DESCRIPTION
## Summary

Fixes #7 - The hybrid hotkey toggle mode was confusing because users didn't realize recording stayed active after a short press.

- **Mode-aware status text**: Shows "Recording (Toggle) - press hotkey to stop" for toggle mode and "Recording (Hold)..." for PTT mode instead of the generic "Recording..."
- **Amber overlay border**: The overlay pill gets a subtle amber border when in toggle mode, providing an ambient visual cue that action is needed to stop recording
- **Enhanced HotkeyModeWidget**: For users who enabled the widget, "TOG" now renders with amber tint consistent with the border

No new settings required - this is an unconditional UX improvement. The hybrid hotkey behavior (600ms threshold) is unchanged.

## Test Plan
- [ ] Press Ctrl+Shift quickly (<600ms) - overlay should show "Recording (Toggle) - press hotkey to stop" with amber border
- [ ] Hold Ctrl+Shift >600ms - overlay shows "Recording (Hold)..." with no amber border
- [ ] Release after long hold stops recording normally
- [ ] Press hotkey again in toggle mode stops recording
- [ ] If HotkeyModeWidget is enabled, "TOG" label appears amber-tinted
- [ ] Verify German localization shows correct text