### PR TITLE
fix: use Win32 API for reliable system language detection

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -4,7 +4,6 @@ using TypeWhisper.Core;
 using TypeWhisper.Core.Data;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Services;
-using System.Globalization;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
@@ -73,9 +72,8 @@ public partial class App : Application
 
         // Initialize localization
         Loc.Instance.Initialize();
-        var uiLang = settings.Current.UiLanguage
-            ?? CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-        Loc.Instance.CurrentLanguage = Loc.Instance.HasLanguage(uiLang) ? uiLang : "en";
+        Loc.Instance.CurrentLanguage = settings.Current.UiLanguage
+            ?? Loc.Instance.DetectSystemLanguage();
 
         // Initialize plugins (must happen after settings.Load so enabled state is available)
         var pluginManager = _serviceProvider.GetRequiredService<PluginManager>();

--- a/src/TypeWhisper.Windows/Native/NativeMethods.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.cs
@@ -62,6 +62,10 @@ internal static partial class NativeMethods
     [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
     public static partial IntPtr GetModuleHandleW(string? lpModuleName);
 
+    // Language detection — reads the Windows registry directly, unaffected by parent-process culture
+    [LibraryImport("kernel32.dll")]
+    public static partial ushort GetUserDefaultUILanguage();
+
     [LibraryImport("user32.dll")]
     public static partial short GetAsyncKeyState(int vKey);
 

--- a/src/TypeWhisper.Windows/Services/Localization/Loc.cs
+++ b/src/TypeWhisper.Windows/Services/Localization/Loc.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
+using TypeWhisper.Windows.Native;
 
 namespace TypeWhisper.Windows.Services.Localization;
 
@@ -116,12 +117,30 @@ public sealed class Loc : INotifyPropertyChanged
     public bool HasLanguage(string langCode) => _strings.ContainsKey(langCode);
 
     /// <summary>
-    /// Auto-detect language from system culture, falling back to English.
+    /// Auto-detect language from the Windows user default UI language, falling back to
+    /// CultureInfo.CurrentUICulture, then to English if the detected language is unavailable.
+    /// Uses GetUserDefaultUILanguage() which reads the registry directly and is not affected
+    /// by parent-process culture inheritance (e.g. Velopack installer).
     /// </summary>
     public string DetectSystemLanguage()
     {
-        var code = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-        return HasLanguage(code) ? code : FallbackLanguage;
+        string code;
+        try
+        {
+            var langId = NativeMethods.GetUserDefaultUILanguage();
+            var culture = CultureInfo.GetCultureInfo(langId);
+            code = culture.TwoLetterISOLanguageName;
+            Debug.WriteLine($"[Loc] GetUserDefaultUILanguage() LANGID=0x{langId:X4} -> \"{culture.Name}\" -> \"{code}\"");
+        }
+        catch (Exception ex)
+        {
+            code = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+            Debug.WriteLine($"[Loc] GetUserDefaultUILanguage() failed ({ex.Message}), fallback CurrentUICulture=\"{code}\"");
+        }
+
+        var result = HasLanguage(code) ? code : FallbackLanguage;
+        Debug.WriteLine($"[Loc] DetectSystemLanguage() -> \"{result}\"");
+        return result;
     }
 
     public string GetString(string key)

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginLocalization.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginLocalization.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using TypeWhisper.PluginSDK;
+using TypeWhisper.Windows.Services.Localization;
 
 namespace TypeWhisper.Windows.Services.Plugins;
 
@@ -31,7 +31,7 @@ public sealed class PluginLocalization : IPluginLocalization
     {
         _localizationDir = Path.Combine(pluginDirectory, LocalizationFolder);
         CurrentLanguage = languageOverride
-            ?? CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+            ?? Loc.Instance.CurrentLanguage;
 
         var available = new List<string>();
 


### PR DESCRIPTION
## Summary
- Replace `CultureInfo.CurrentUICulture` with Win32 `GetUserDefaultUILanguage()` API for system language detection, which reads the Windows registry directly and is unaffected by parent-process culture inheritance from the Velopack installer
- Centralize detection logic in `Loc.DetectSystemLanguage()` and update `App.xaml.cs` startup and `PluginLocalization` to use it
- Add debug logging for language detection to aid future diagnostics

Fixes #15