### PR TITLE
fix: localize hardcoded German strings in plugin settings views (#14)

### DIFF
--- a/plugins/TypeWhisper.Plugin.AssemblyAi/AssemblyAiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.AssemblyAi/AssemblyAiPlugin.cs
@@ -174,6 +174,7 @@ public sealed class AssemblyAiPlugin : ITranscriptionEnginePlugin
     // API key management (for settings view)
 
     internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {

--- a/plugins/TypeWhisper.Plugin.AssemblyAi/AssemblyAiSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.AssemblyAi/AssemblyAiSettingsView.xaml
@@ -9,7 +9,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
-            <Button Grid.Column="1" Content="Testen" Margin="8,0,0,0" Padding="12,4"
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />

--- a/plugins/TypeWhisper.Plugin.AssemblyAi/AssemblyAiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.AssemblyAi/AssemblyAiSettingsView.xaml.cs
@@ -12,6 +12,7 @@ public partial class AssemblyAiSettingsView : UserControl
     {
         _plugin = plugin;
         InitializeComponent();
+        TestButton.Content = L("Settings.Test");
 
         if (!string.IsNullOrEmpty(plugin.ApiKey))
         {
@@ -23,7 +24,7 @@ public partial class AssemblyAiSettingsView : UserControl
     {
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
-        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : "Gespeichert";
+        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
     }
 
@@ -32,13 +33,13 @@ public partial class AssemblyAiSettingsView : UserControl
         var key = ApiKeyBox.Password;
         if (string.IsNullOrWhiteSpace(key))
         {
-            StatusText.Text = "Bitte zuerst einen API-Key eingeben";
+            StatusText.Text = L("Settings.EnterApiKey");
             StatusText.Foreground = Brushes.Orange;
             return;
         }
 
         TestButton.IsEnabled = false;
-        StatusText.Text = "Teste...";
+        StatusText.Text = L("Settings.Testing");
         StatusText.Foreground = Brushes.Gray;
 
         try
@@ -46,18 +47,18 @@ public partial class AssemblyAiSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
-                StatusText.Text = "API-Key gültig!";
+                StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
             else
             {
-                StatusText.Text = "Ungültiger API-Key";
+                StatusText.Text = L("Settings.ApiKeyInvalid");
                 StatusText.Foreground = Brushes.Red;
             }
         }
         catch (Exception ex)
         {
-            StatusText.Text = $"Fehler: {ex.Message}";
+            StatusText.Text = L("Settings.Error", ex.Message);
             StatusText.Foreground = Brushes.Red;
         }
         finally
@@ -65,4 +66,7 @@ public partial class AssemblyAiSettingsView : UserControl
             TestButton.IsEnabled = true;
         }
     }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.AssemblyAi/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.AssemblyAi/Localization/de.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Testen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Key gültig!",
+  "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.AssemblyAi/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.AssemblyAi/Localization/en.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Test",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.AssemblyAi/TypeWhisper.Plugin.AssemblyAi.csproj
+++ b/plugins/TypeWhisper.Plugin.AssemblyAi/TypeWhisper.Plugin.AssemblyAi.csproj
@@ -14,6 +14,9 @@
     <Content Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Target Name="CopyToAppPlugins" AfterTargets="Build">
     <PropertyGroup>
@@ -24,5 +27,10 @@
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.Deepgram/DeepgramPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Deepgram/DeepgramPlugin.cs
@@ -114,6 +114,7 @@ public sealed class DeepgramPlugin : ITranscriptionEnginePlugin
     // API key management (for settings view)
 
     internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {

--- a/plugins/TypeWhisper.Plugin.Deepgram/DeepgramSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Deepgram/DeepgramSettingsView.xaml
@@ -9,7 +9,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
-            <Button Grid.Column="1" Content="Testen" Margin="8,0,0,0" Padding="12,4"
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />

--- a/plugins/TypeWhisper.Plugin.Deepgram/DeepgramSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Deepgram/DeepgramSettingsView.xaml.cs
@@ -12,6 +12,7 @@ public partial class DeepgramSettingsView : UserControl
     {
         _plugin = plugin;
         InitializeComponent();
+        TestButton.Content = L("Settings.Test");
 
         if (!string.IsNullOrEmpty(plugin.ApiKey))
         {
@@ -23,7 +24,7 @@ public partial class DeepgramSettingsView : UserControl
     {
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
-        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : "Gespeichert";
+        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
     }
 
@@ -32,13 +33,13 @@ public partial class DeepgramSettingsView : UserControl
         var key = ApiKeyBox.Password;
         if (string.IsNullOrWhiteSpace(key))
         {
-            StatusText.Text = "Bitte zuerst einen API-Key eingeben";
+            StatusText.Text = L("Settings.EnterApiKey");
             StatusText.Foreground = Brushes.Orange;
             return;
         }
 
         TestButton.IsEnabled = false;
-        StatusText.Text = "Teste...";
+        StatusText.Text = L("Settings.Testing");
         StatusText.Foreground = Brushes.Gray;
 
         try
@@ -46,18 +47,18 @@ public partial class DeepgramSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
-                StatusText.Text = "API-Key gültig!";
+                StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
             else
             {
-                StatusText.Text = "Ungültiger API-Key";
+                StatusText.Text = L("Settings.ApiKeyInvalid");
                 StatusText.Foreground = Brushes.Red;
             }
         }
         catch (Exception ex)
         {
-            StatusText.Text = $"Fehler: {ex.Message}";
+            StatusText.Text = L("Settings.Error", ex.Message);
             StatusText.Foreground = Brushes.Red;
         }
         finally
@@ -65,4 +66,7 @@ public partial class DeepgramSettingsView : UserControl
             TestButton.IsEnabled = true;
         }
     }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.Deepgram/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Deepgram/Localization/de.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Testen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Key gültig!",
+  "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Deepgram/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Deepgram/Localization/en.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Test",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Deepgram/TypeWhisper.Plugin.Deepgram.csproj
+++ b/plugins/TypeWhisper.Plugin.Deepgram/TypeWhisper.Plugin.Deepgram.csproj
@@ -14,6 +14,9 @@
     <Content Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Target Name="CopyToAppPlugins" AfterTargets="Build">
     <PropertyGroup>
@@ -24,5 +27,10 @@
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -61,6 +61,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin
     // API key management (for settings view)
 
     internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml
@@ -9,7 +9,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
-            <Button Grid.Column="1" Content="Testen" Margin="8,0,0,0" Padding="12,4"
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
@@ -12,6 +12,7 @@ public partial class GeminiSettingsView : UserControl
     {
         _plugin = plugin;
         InitializeComponent();
+        TestButton.Content = L("Settings.Test");
 
         // Pre-fill password box if API key is already set
         if (!string.IsNullOrEmpty(plugin.ApiKey))
@@ -24,7 +25,7 @@ public partial class GeminiSettingsView : UserControl
     {
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
-        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : "Gespeichert";
+        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
     }
 
@@ -33,13 +34,13 @@ public partial class GeminiSettingsView : UserControl
         var key = ApiKeyBox.Password;
         if (string.IsNullOrWhiteSpace(key))
         {
-            StatusText.Text = "Bitte zuerst einen API-Key eingeben";
+            StatusText.Text = L("Settings.EnterApiKey");
             StatusText.Foreground = Brushes.Orange;
             return;
         }
 
         TestButton.IsEnabled = false;
-        StatusText.Text = "Teste...";
+        StatusText.Text = L("Settings.Testing");
         StatusText.Foreground = Brushes.Gray;
 
         try
@@ -47,18 +48,18 @@ public partial class GeminiSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
-                StatusText.Text = "API-Key gültig!";
+                StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
             else
             {
-                StatusText.Text = "Ungültiger API-Key";
+                StatusText.Text = L("Settings.ApiKeyInvalid");
                 StatusText.Foreground = Brushes.Red;
             }
         }
         catch (Exception ex)
         {
-            StatusText.Text = $"Fehler: {ex.Message}";
+            StatusText.Text = L("Settings.Error", ex.Message);
             StatusText.Foreground = Brushes.Red;
         }
         finally
@@ -66,4 +67,7 @@ public partial class GeminiSettingsView : UserControl
             TestButton.IsEnabled = true;
         }
     }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/Localization/de.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Testen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Key gültig!",
+  "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Gemini/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/Localization/en.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Test",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Gemini/TypeWhisper.Plugin.Gemini.csproj
+++ b/plugins/TypeWhisper.Plugin.Gemini/TypeWhisper.Plugin.Gemini.csproj
@@ -14,6 +14,9 @@
     <Content Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Target Name="CopyToAppPlugins" AfterTargets="Build">
     <PropertyGroup>
@@ -24,5 +27,10 @@
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -106,6 +106,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
     // API key management (for settings view)
 
     internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {

--- a/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml
@@ -9,7 +9,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
-            <Button Grid.Column="1" Content="Testen" Margin="8,0,0,0" Padding="12,4"
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />

--- a/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml.cs
@@ -12,6 +12,7 @@ public partial class GroqSettingsView : UserControl
     {
         _plugin = plugin;
         InitializeComponent();
+        TestButton.Content = L("Settings.Test");
 
         // Pre-fill password box if API key is already set
         if (!string.IsNullOrEmpty(plugin.ApiKey))
@@ -24,7 +25,7 @@ public partial class GroqSettingsView : UserControl
     {
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
-        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : "Gespeichert";
+        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
     }
 
@@ -33,13 +34,13 @@ public partial class GroqSettingsView : UserControl
         var key = ApiKeyBox.Password;
         if (string.IsNullOrWhiteSpace(key))
         {
-            StatusText.Text = "Bitte zuerst einen API-Key eingeben";
+            StatusText.Text = L("Settings.EnterApiKey");
             StatusText.Foreground = Brushes.Orange;
             return;
         }
 
         TestButton.IsEnabled = false;
-        StatusText.Text = "Teste...";
+        StatusText.Text = L("Settings.Testing");
         StatusText.Foreground = Brushes.Gray;
 
         try
@@ -47,18 +48,18 @@ public partial class GroqSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
-                StatusText.Text = "API-Key gültig!";
+                StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
             else
             {
-                StatusText.Text = "Ungültiger API-Key";
+                StatusText.Text = L("Settings.ApiKeyInvalid");
                 StatusText.Foreground = Brushes.Red;
             }
         }
         catch (Exception ex)
         {
-            StatusText.Text = $"Fehler: {ex.Message}";
+            StatusText.Text = L("Settings.Error", ex.Message);
             StatusText.Foreground = Brushes.Red;
         }
         finally
@@ -66,4 +67,7 @@ public partial class GroqSettingsView : UserControl
             TestButton.IsEnabled = true;
         }
     }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.Groq/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Groq/Localization/de.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Testen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Key gültig!",
+  "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Groq/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Groq/Localization/en.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Test",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Groq/TypeWhisper.Plugin.Groq.csproj
+++ b/plugins/TypeWhisper.Plugin.Groq/TypeWhisper.Plugin.Groq.csproj
@@ -14,6 +14,9 @@
     <Content Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Target Name="CopyToAppPlugins" AfterTargets="Build">
     <PropertyGroup>
@@ -24,5 +27,10 @@
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.OpenAi/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Localization/de.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Testen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Key gültig!",
+  "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.OpenAi/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Localization/en.json
@@ -1,0 +1,9 @@
+{
+  "Settings.Test": "Test",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
@@ -109,6 +109,7 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
     // API key management (for settings view)
 
     internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiSettingsView.xaml
@@ -9,7 +9,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
-            <Button Grid.Column="1" Content="Testen" Margin="8,0,0,0" Padding="12,4"
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiSettingsView.xaml.cs
@@ -12,6 +12,7 @@ public partial class OpenAiSettingsView : UserControl
     {
         _plugin = plugin;
         InitializeComponent();
+        TestButton.Content = L("Settings.Test");
 
         // Pre-fill password box if API key is already set
         if (!string.IsNullOrEmpty(plugin.ApiKey))
@@ -24,7 +25,7 @@ public partial class OpenAiSettingsView : UserControl
     {
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
-        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : "Gespeichert";
+        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
     }
 
@@ -33,13 +34,13 @@ public partial class OpenAiSettingsView : UserControl
         var key = ApiKeyBox.Password;
         if (string.IsNullOrWhiteSpace(key))
         {
-            StatusText.Text = "Bitte zuerst einen API-Key eingeben";
+            StatusText.Text = L("Settings.EnterApiKey");
             StatusText.Foreground = Brushes.Orange;
             return;
         }
 
         TestButton.IsEnabled = false;
-        StatusText.Text = "Teste...";
+        StatusText.Text = L("Settings.Testing");
         StatusText.Foreground = Brushes.Gray;
 
         try
@@ -47,18 +48,18 @@ public partial class OpenAiSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
-                StatusText.Text = "API-Key gültig!";
+                StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
             else
             {
-                StatusText.Text = "Ungültiger API-Key";
+                StatusText.Text = L("Settings.ApiKeyInvalid");
                 StatusText.Foreground = Brushes.Red;
             }
         }
         catch (Exception ex)
         {
-            StatusText.Text = $"Fehler: {ex.Message}";
+            StatusText.Text = L("Settings.Error", ex.Message);
             StatusText.Foreground = Brushes.Red;
         }
         finally
@@ -66,4 +67,7 @@ public partial class OpenAiSettingsView : UserControl
             TestButton.IsEnabled = true;
         }
     }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.OpenAi/TypeWhisper.Plugin.OpenAi.csproj
+++ b/plugins/TypeWhisper.Plugin.OpenAi/TypeWhisper.Plugin.OpenAi.csproj
@@ -14,6 +14,9 @@
     <Content Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Target Name="CopyToAppPlugins" AfterTargets="Build">
     <PropertyGroup>
@@ -24,5 +27,10 @@
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/de.json
@@ -1,0 +1,19 @@
+{
+  "Settings.Connect": "Verbinden",
+  "Settings.Save": "Speichern",
+  "Settings.ApiKeyHint": "Nicht nötig für lokale Server wie Ollama oder LM Studio",
+  "Settings.ModelSelection": "\uD83D\uDCCB Modellauswahl",
+  "Settings.Refresh": "\uD83D\uDD04 Aktualisieren",
+  "Settings.TranscriptionModel": "Transkriptions-Modell",
+  "Settings.LlmModel": "LLM-Modell",
+  "Settings.NoModelsFound": "\u26A0 Keine Modelle über die API gefunden. Du kannst die Modellnamen manuell eingeben.",
+  "Settings.Connecting": "Verbinde...",
+  "Settings.TryingConnection": "Versuche Verbindung zu {0}...",
+  "Settings.ConnectionFailed": "Verbindung fehlgeschlagen",
+  "Settings.ServerNotResponding": "Server {0} antwortet nicht oder der /v1/models Endpunkt ist nicht verfügbar.",
+  "Settings.Timeout": "Zeitüberschreitung",
+  "Settings.TimeoutDetail": "Server {0} hat nicht innerhalb von 10 Sekunden geantwortet.",
+  "Settings.ConnectionError": "Verbindungsfehler",
+  "Settings.ConnectionSuccess": "Server: {0}\n{1} Modell(e) verfügbar",
+  "Settings.Connected": "Verbunden - {0} Modelle"
+}

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/en.json
@@ -1,0 +1,19 @@
+{
+  "Settings.Connect": "Connect",
+  "Settings.Save": "Save",
+  "Settings.ApiKeyHint": "Not needed for local servers like Ollama or LM Studio",
+  "Settings.ModelSelection": "\uD83D\uDCCB Model Selection",
+  "Settings.Refresh": "\uD83D\uDD04 Refresh",
+  "Settings.TranscriptionModel": "Transcription Model",
+  "Settings.LlmModel": "LLM Model",
+  "Settings.NoModelsFound": "\u26A0 No models found via the API. You can enter model names manually.",
+  "Settings.Connecting": "Connecting...",
+  "Settings.TryingConnection": "Trying to connect to {0}...",
+  "Settings.ConnectionFailed": "Connection failed",
+  "Settings.ServerNotResponding": "Server {0} is not responding or the /v1/models endpoint is not available.",
+  "Settings.Timeout": "Timeout",
+  "Settings.TimeoutDetail": "Server {0} did not respond within 10 seconds.",
+  "Settings.ConnectionError": "Connection error",
+  "Settings.ConnectionSuccess": "Server: {0}\n{1} model(s) available",
+  "Settings.Connected": "Connected - {0} models"
+}

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -132,6 +132,7 @@ public sealed class OpenAiCompatiblePlugin : ITranscriptionEnginePlugin, ILlmPro
     // Internal methods for settings view
     internal string? BaseUrl => _baseUrl;
     internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
     internal string? SelectedTranscriptionModelId => _selectedModelId;
     internal string? SelectedLlmModelId => _selectedLlmModelId;
     internal IReadOnlyList<FetchedModel> FetchedModels => _fetchedModels;

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml
@@ -19,7 +19,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <TextBox x:Name="UrlBox" FontFamily="Consolas" Text="http://localhost:11434"/>
-            <Button Grid.Column="1" Content="Verbinden" Margin="8,0,0,0"
+            <Button Grid.Column="1" Margin="8,0,0,0"
                     Click="OnConnectClick" x:Name="ConnectButton"/>
         </Grid>
 
@@ -43,7 +43,7 @@
         <TextBlock Text="&#x1F511; API Key (optional)" Foreground="{StaticResource PluginLabelBrush}"
                    FontWeight="SemiBold" Margin="0,14,0,6"/>
         <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnApiKeyChanged"/>
-        <TextBlock Text="Nicht nötig für lokale Server wie Ollama oder LM Studio"
+        <TextBlock x:Name="ApiKeyHintText"
                    FontSize="11" Foreground="{StaticResource PluginHintBrush}" Margin="0,3,0,0"/>
 
         <!-- Models Section (hidden until connected) -->
@@ -54,21 +54,21 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="&#x1F4CB; Modellauswahl" Foreground="{StaticResource PluginLabelBrush}"
+                <TextBlock x:Name="ModelSelectionHeader" Foreground="{StaticResource PluginLabelBrush}"
                            FontWeight="SemiBold" VerticalAlignment="Center"/>
-                <Button Grid.Column="1" Content="&#x1F504; Aktualisieren"
+                <Button Grid.Column="1"
                         Click="OnRefreshClick" x:Name="RefreshButton"/>
             </Grid>
 
             <!-- Fetched models pickers -->
             <StackPanel x:Name="PickerSection" Visibility="Collapsed">
-                <TextBlock Text="Transkriptions-Modell" FontSize="12"
+                <TextBlock x:Name="TranscriptionModelLabel1" FontSize="12"
                            Foreground="{StaticResource PluginHintBrush}" Margin="0,0,0,4"/>
                 <ComboBox x:Name="TranscriptionModelPicker"
                           SelectionChanged="OnTranscriptionModelChanged"
                           DisplayMemberPath="Id" Margin="0,0,0,12"/>
 
-                <TextBlock Text="LLM-Modell" FontSize="12"
+                <TextBlock x:Name="LlmModelLabel1" FontSize="12"
                            Foreground="{StaticResource PluginHintBrush}" Margin="0,0,0,4"/>
                 <ComboBox x:Name="LlmModelPicker"
                           SelectionChanged="OnLlmModelChanged"
@@ -78,11 +78,11 @@
             <!-- Manual entry fallback -->
             <StackPanel x:Name="ManualSection" Visibility="Collapsed">
                 <Border Background="#252525" CornerRadius="6" Padding="12,8" Margin="0,0,0,8">
-                    <TextBlock Text="&#x26A0; Keine Modelle über die API gefunden. Du kannst die Modellnamen manuell eingeben."
+                    <TextBlock x:Name="NoModelsWarning"
                                FontSize="12" Foreground="{StaticResource PluginHintBrush}" TextWrapping="Wrap"/>
                 </Border>
 
-                <TextBlock Text="Transkriptions-Modell" FontSize="12"
+                <TextBlock x:Name="TranscriptionModelLabel2" FontSize="12"
                            Foreground="{StaticResource PluginHintBrush}" Margin="0,0,0,4"/>
                 <Grid Margin="0,0,0,12">
                     <Grid.ColumnDefinitions>
@@ -90,11 +90,11 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <TextBox x:Name="ManualTranscriptionBox" FontFamily="Consolas"/>
-                    <Button Grid.Column="1" Content="Speichern" Margin="8,0,0,0"
+                    <Button Grid.Column="1" x:Name="SaveTranscriptionButton" Margin="8,0,0,0"
                             Click="OnSaveManualTranscription"/>
                 </Grid>
 
-                <TextBlock Text="LLM-Modell" FontSize="12"
+                <TextBlock x:Name="LlmModelLabel2" FontSize="12"
                            Foreground="{StaticResource PluginHintBrush}" Margin="0,0,0,4"/>
                 <Grid>
                     <Grid.ColumnDefinitions>
@@ -102,7 +102,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <TextBox x:Name="ManualLlmBox" FontFamily="Consolas"/>
-                    <Button Grid.Column="1" Content="Speichern" Margin="8,0,0,0"
+                    <Button Grid.Column="1" x:Name="SaveLlmButton" Margin="8,0,0,0"
                             Click="OnSaveManualLlm"/>
                 </Grid>
             </StackPanel>

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml.cs
@@ -12,6 +12,19 @@ public partial class OpenAiCompatibleSettingsView : UserControl
     {
         _plugin = plugin;
         InitializeComponent();
+
+        ConnectButton.Content = L("Settings.Connect");
+        ApiKeyHintText.Text = L("Settings.ApiKeyHint");
+        ModelSelectionHeader.Text = L("Settings.ModelSelection");
+        RefreshButton.Content = L("Settings.Refresh");
+        TranscriptionModelLabel1.Text = L("Settings.TranscriptionModel");
+        LlmModelLabel1.Text = L("Settings.LlmModel");
+        NoModelsWarning.Text = L("Settings.NoModelsFound");
+        TranscriptionModelLabel2.Text = L("Settings.TranscriptionModel");
+        SaveTranscriptionButton.Content = L("Settings.Save");
+        LlmModelLabel2.Text = L("Settings.LlmModel");
+        SaveLlmButton.Content = L("Settings.Save");
+
         Loaded += OnLoaded;
     }
 
@@ -51,8 +64,8 @@ public partial class OpenAiCompatibleSettingsView : UserControl
             await _plugin.SetApiKeyAsync(key);
 
         ConnectButton.IsEnabled = false;
-        ConnectButton.Content = "Verbinde...";
-        ShowConnectionStatus("\u23F3", "Verbinde...", $"Versuche Verbindung zu {url}...", Brushes.Gray);
+        ConnectButton.Content = L("Settings.Connecting");
+        ShowConnectionStatus("\u23F3", L("Settings.Connecting"), L("Settings.TryingConnection", url), Brushes.Gray);
 
         try
         {
@@ -75,15 +88,15 @@ public partial class OpenAiCompatibleSettingsView : UserControl
             }
             else
             {
-                ShowConnectionStatus("\u274C", "Verbindung fehlgeschlagen",
-                    $"Server {url} antwortet nicht oder der /v1/models Endpunkt ist nicht verfügbar.",
+                ShowConnectionStatus("\u274C", L("Settings.ConnectionFailed"),
+                    L("Settings.ServerNotResponding", url),
                     Brushes.Red);
             }
         }
         catch (OperationCanceledException)
         {
-            ShowConnectionStatus("\u274C", "Zeitüberschreitung",
-                $"Server {url} hat nicht innerhalb von 10 Sekunden geantwortet.",
+            ShowConnectionStatus("\u274C", L("Settings.Timeout"),
+                L("Settings.TimeoutDetail", url),
                 Brushes.Red);
         }
         catch (Exception ex)
@@ -92,12 +105,12 @@ public partial class OpenAiCompatibleSettingsView : UserControl
             if (ex.InnerException is not null)
                 detail += $" ({ex.InnerException.Message})";
 
-            ShowConnectionStatus("\u274C", "Verbindungsfehler", detail, Brushes.Red);
+            ShowConnectionStatus("\u274C", L("Settings.ConnectionError"), detail, Brushes.Red);
         }
         finally
         {
             ConnectButton.IsEnabled = true;
-            ConnectButton.Content = "Verbinden";
+            ConnectButton.Content = L("Settings.Connect");
         }
     }
 
@@ -110,8 +123,8 @@ public partial class OpenAiCompatibleSettingsView : UserControl
         transcriptionCount = modelCount;
         llmCount = modelCount;
 
-        var detail = $"Server: {url}\n{modelCount} Modell(e) verfügbar";
-        ShowConnectionStatus("\u2705", $"Verbunden — {modelCount} Modelle", detail,
+        var detail = L("Settings.ConnectionSuccess", url, modelCount);
+        ShowConnectionStatus("\u2705", L("Settings.Connected", modelCount), detail,
             new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)));
     }
 
@@ -201,4 +214,7 @@ public partial class OpenAiCompatibleSettingsView : UserControl
         if (!string.IsNullOrEmpty(id))
             _plugin.SelectLlmModel(id);
     }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/TypeWhisper.Plugin.OpenAiCompatible.csproj
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/TypeWhisper.Plugin.OpenAiCompatible.csproj
@@ -14,5 +14,23 @@
     <Content Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
+  <Target Name="CopyToAppPlugins" AfterTargets="Build">
+    <PropertyGroup>
+      <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
+      <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.openai-compatible\</PluginOutputDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
+  </Target>
 </Project>

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginHostServices.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginHostServices.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
+using AppLocalization = TypeWhisper.Windows.Services.Localization;
 
 namespace TypeWhisper.Windows.Services.Plugins;
 
@@ -46,7 +47,7 @@ public sealed class PluginHostServices : IPluginHostServices
         _eventBus = eventBus;
         _profiles = profiles;
         _onCapabilitiesChanged = onCapabilitiesChanged;
-        _localization = new PluginLocalization(pluginDirectory);
+        _localization = new PluginLocalization(pluginDirectory, AppLocalization.Loc.Instance.CurrentLanguage);
         _pluginDataDirectory = Path.Combine(Core.TypeWhisperEnvironment.PluginDataPath, pluginId);
         _settingsFilePath = Path.Combine(_pluginDataDirectory, "settings.json");
     }


### PR DESCRIPTION
## Summary

Fixes #14 - Plugin settings views (API key test, connection status) always showed German text regardless of the app's language setting.

- Replaced all hardcoded German strings in 6 plugin settings views with `IPluginLocalization` calls
- Created `Localization/en.json` and `de.json` for all 6 plugins (OpenAI, Groq, Gemini, Deepgram, AssemblyAI, OpenAI Compatible)
- Fixed `PluginHostServices` to pass the app's configured language instead of the system culture
- Added missing `CopyToAppPlugins` build target to the OpenAI Compatible plugin

## Test Plan

- [ ] Set app language to English, verify plugin settings show English strings
- [ ] Set app language to German, verify plugin settings show German strings
- [ ] Test API key validation flow (enter key, click Test, verify status messages)
- [ ] Test OpenAI Compatible connection flow (connect, timeout, error states)