### PR TITLE
fix: filter silence hallucinations from cloud transcription models

### DIFF
--- a/src/TypeWhisper.Core/Models/TranscriptionResult.cs
+++ b/src/TypeWhisper.Core/Models/TranscriptionResult.cs
@@ -6,5 +6,6 @@ public sealed record TranscriptionResult
     public string? DetectedLanguage { get; init; }
     public double Duration { get; init; }
     public double ProcessingTime { get; init; }
+    public float? NoSpeechProbability { get; init; }
     public IReadOnlyList<TranscriptionSegment> Segments { get; init; } = [];
 }

--- a/src/TypeWhisper.PluginSDK/Helpers/OpenAiTranscriptionHelper.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/OpenAiTranscriptionHelper.cs
@@ -64,6 +64,24 @@ public static class OpenAiTranscriptionHelper
         var language = root.TryGetProperty("language", out var langEl) ? langEl.GetString() : null;
         var duration = root.TryGetProperty("duration", out var durEl) ? durEl.GetDouble() : 0;
 
-        return new PluginTranscriptionResult(text.Trim(), language, duration);
+        // Extract min no_speech_prob from segments (verbose_json format).
+        // Using min so that the filter only triggers when ALL segments are silence.
+        float? minNoSpeechProb = null;
+        if (root.TryGetProperty("segments", out var segmentsEl)
+            && segmentsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var seg in segmentsEl.EnumerateArray())
+            {
+                if (seg.TryGetProperty("no_speech_prob", out var nspEl))
+                {
+                    var prob = (float)nspEl.GetDouble();
+                    minNoSpeechProb = minNoSpeechProb is null
+                        ? prob
+                        : Math.Min(minNoSpeechProb.Value, prob);
+                }
+            }
+        }
+
+        return new PluginTranscriptionResult(text.Trim(), language, duration, minNoSpeechProb);
     }
 }

--- a/src/TypeWhisper.PluginSDK/Models/PluginTranscriptionResult.cs
+++ b/src/TypeWhisper.PluginSDK/Models/PluginTranscriptionResult.cs
@@ -6,4 +6,6 @@ namespace TypeWhisper.PluginSDK.Models;
 /// <param name="Text">The transcribed text.</param>
 /// <param name="DetectedLanguage">ISO language code detected in the audio, or null.</param>
 /// <param name="DurationSeconds">Duration of the audio in seconds.</param>
-public sealed record PluginTranscriptionResult(string Text, string? DetectedLanguage, double DurationSeconds);
+public sealed record PluginTranscriptionResult(
+    string Text, string? DetectedLanguage, double DurationSeconds,
+    float? NoSpeechProbability = null);

--- a/src/TypeWhisper.PluginSDK/TypeWhisper.PluginSDK.csproj
+++ b/src/TypeWhisper.PluginSDK/TypeWhisper.PluginSDK.csproj
@@ -10,4 +10,8 @@
     <AssemblyName>TypeWhisper.PluginSDK</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -13,6 +13,12 @@ public sealed class AudioRecordingService : IDisposable
     private const float AgcMinGain = 1f;
     private const float NormalizationTarget = 0.707f;
 
+    /// <summary>
+    /// Minimum per-chunk RMS level to consider as containing speech.
+    /// Below this threshold, audio is treated as silence.
+    /// </summary>
+    public const float SpeechEnergyThreshold = 0.01f;
+
     private WaveInEvent? _waveIn;
     private WaveInEvent? _previewWaveIn;
     private List<float>? _sampleBuffer;
@@ -25,6 +31,7 @@ public sealed class AudioRecordingService : IDisposable
     private int? _configuredDeviceNumber;
     private int _activeDeviceNumber;
     private float _peakRmsLevel;
+    private float _preGainPeakRms;
     private float _currentRmsLevel;
     private System.Timers.Timer? _devicePollTimer;
     private int _lastKnownDeviceCount;
@@ -40,6 +47,7 @@ public sealed class AudioRecordingService : IDisposable
     public bool IsRecording => _isRecording;
     public float PeakRmsLevel => _peakRmsLevel;
     public float CurrentRmsLevel => _currentRmsLevel;
+    public bool HasSpeechEnergy => _preGainPeakRms >= SpeechEnergyThreshold;
     public TimeSpan RecordingDuration => _isRecording ? DateTime.UtcNow - _recordingStartTime : TimeSpan.Zero;
 
     public void SetMicrophoneDevice(int? deviceNumber)
@@ -97,6 +105,7 @@ public sealed class AudioRecordingService : IDisposable
 
         _sampleBuffer = new List<float>(SampleRate * 60); // Pre-alloc ~1 min
         _peakRmsLevel = 0;
+        _preGainPeakRms = 0;
         _recordingStartTime = DateTime.UtcNow;
         _isRecording = true;
     }
@@ -137,15 +146,18 @@ public sealed class AudioRecordingService : IDisposable
         var sampleCount = e.BytesRecorded / 2;
         float agcGain = 1f;
 
+        // Compute pre-gain RMS for speech energy detection (unaffected by AGC)
+        float preGainSum = 0;
+        for (var i = 0; i < sampleCount; i++)
+        {
+            var s = BitConverter.ToInt16(e.Buffer, i * 2) / 32768f;
+            preGainSum += s * s;
+        }
+        var preGainRms = MathF.Sqrt(preGainSum / sampleCount);
+        if (preGainRms > _preGainPeakRms) _preGainPeakRms = preGainRms;
+
         if (WhisperModeEnabled)
         {
-            float preGainSum = 0;
-            for (var i = 0; i < sampleCount; i++)
-            {
-                var s = BitConverter.ToInt16(e.Buffer, i * 2) / 32768f;
-                preGainSum += s * s;
-            }
-            var preGainRms = MathF.Sqrt(preGainSum / sampleCount);
             if (preGainRms > 0.0001f)
                 agcGain = Math.Clamp(AgcTargetRms / preGainRms, AgcMinGain, AgcMaxGain);
         }

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -346,7 +346,8 @@ internal sealed class PluginTranscriptionEngineAdapter : ITranscriptionEngine
         {
             Text = result.Text,
             DetectedLanguage = result.DetectedLanguage,
-            Duration = result.DurationSeconds
+            Duration = result.DurationSeconds,
+            NoSpeechProbability = result.NoSpeechProbability
         };
     }
 }

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -166,12 +166,17 @@ public sealed class StreamingHandler : IDisposable
                 var buffer = _audio.GetCurrentBuffer();
                 var bufferDuration = buffer is not null ? buffer.Length / 16000.0 : 0;
 
-                if (buffer is not null && bufferDuration > 0.5)
+                if (buffer is not null && bufferDuration > 0.5
+                    && _audio.PeakRmsLevel >= AudioRecordingService.SpeechEnergyThreshold)
                 {
                     try
                     {
                         var lang = language == "auto" ? null : language;
                         var result = await engine.TranscribeAsync(buffer, lang, task, ct);
+
+                        if (result.NoSpeechProbability is > 0.8f)
+                            continue;
+
                         var text = result.Text?.Trim() ?? "";
 
                         if (!string.IsNullOrEmpty(text))

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -348,6 +348,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             return;
         }
 
+        // Skip transcription if audio is essentially silence (prevents cloud model hallucinations)
+        if (!_audio.HasSpeechEnergy && partialSnapshot.Count == 0)
+        {
+            UpdateVisualState();
+            StatusText = Loc.Instance["Status.NoSpeech"];
+            PartialText = "";
+            _hotkey.ForceStop();
+            return;
+        }
+
         // Snapshot all context and enqueue — returns immediately
         var job = new TranscriptionJob(
             samples,
@@ -398,6 +408,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 var language = job.EffectiveLanguage == "auto" ? null : job.EffectiveLanguage;
                 var result = await _modelManager.Engine.TranscribeAsync(
                     job.Samples, language, job.EffectiveTask, ct);
+
+                if (result.NoSpeechProbability is > 0.8f)
+                {
+                    await Application.Current.Dispatcher.InvokeAsync(() =>
+                    {
+                        StatusText = Loc.Instance["Status.NoSpeech"];
+                        UpdateVisualState();
+                    });
+                    return;
+                }
 
                 if (string.IsNullOrWhiteSpace(result.Text))
                 {

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiTranscriptionHelperTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiTranscriptionHelperTests.cs
@@ -1,0 +1,125 @@
+using TypeWhisper.PluginSDK.Helpers;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class OpenAiTranscriptionHelperTests
+{
+    [Fact]
+    public void ParseTranscriptionResponse_VerboseJson_ExtractsNoSpeechProb()
+    {
+        var json = """
+        {
+            "text": "So.",
+            "language": "en",
+            "duration": 2.5,
+            "segments": [
+                { "text": "So.", "no_speech_prob": 0.95 }
+            ]
+        }
+        """;
+
+        var result = OpenAiTranscriptionHelper.ParseTranscriptionResponse(json);
+
+        Assert.Equal("So.", result.Text);
+        Assert.Equal("en", result.DetectedLanguage);
+        Assert.NotNull(result.NoSpeechProbability);
+        Assert.True(result.NoSpeechProbability > 0.9f);
+    }
+
+    [Fact]
+    public void ParseTranscriptionResponse_VerboseJson_ReturnsMinNoSpeechProb()
+    {
+        // Uses min so that mixed speech/silence audio is NOT filtered out
+        var json = """
+        {
+            "text": "Hello world. So.",
+            "language": "en",
+            "duration": 5.0,
+            "segments": [
+                { "text": "Hello world.", "no_speech_prob": 0.1 },
+                { "text": "So.", "no_speech_prob": 0.92 }
+            ]
+        }
+        """;
+
+        var result = OpenAiTranscriptionHelper.ParseTranscriptionResponse(json);
+
+        Assert.NotNull(result.NoSpeechProbability);
+        Assert.Equal(0.1f, result.NoSpeechProbability.Value, 0.01f);
+    }
+
+    [Fact]
+    public void ParseTranscriptionResponse_AllSegmentsSilence_ReturnsHighProb()
+    {
+        var json = """
+        {
+            "text": "So. Vorsicht!",
+            "language": "en",
+            "duration": 3.0,
+            "segments": [
+                { "text": "So.", "no_speech_prob": 0.95 },
+                { "text": "Vorsicht!", "no_speech_prob": 0.88 }
+            ]
+        }
+        """;
+
+        var result = OpenAiTranscriptionHelper.ParseTranscriptionResponse(json);
+
+        Assert.NotNull(result.NoSpeechProbability);
+        Assert.True(result.NoSpeechProbability > 0.8f);
+    }
+
+    [Fact]
+    public void ParseTranscriptionResponse_JsonFormat_NoSegments_ReturnsNull()
+    {
+        var json = """
+        {
+            "text": "Hello world",
+            "language": "en",
+            "duration": 2.0
+        }
+        """;
+
+        var result = OpenAiTranscriptionHelper.ParseTranscriptionResponse(json);
+
+        Assert.Equal("Hello world", result.Text);
+        Assert.Null(result.NoSpeechProbability);
+    }
+
+    [Fact]
+    public void ParseTranscriptionResponse_EmptySegments_ReturnsNull()
+    {
+        var json = """
+        {
+            "text": "",
+            "language": "en",
+            "duration": 1.0,
+            "segments": []
+        }
+        """;
+
+        var result = OpenAiTranscriptionHelper.ParseTranscriptionResponse(json);
+
+        Assert.Null(result.NoSpeechProbability);
+    }
+
+    [Fact]
+    public void ParseTranscriptionResponse_LowNoSpeechProb_IndicatesSpeech()
+    {
+        var json = """
+        {
+            "text": "This is a normal sentence.",
+            "language": "en",
+            "duration": 3.0,
+            "segments": [
+                { "text": "This is a normal sentence.", "no_speech_prob": 0.02 }
+            ]
+        }
+        """;
+
+        var result = OpenAiTranscriptionHelper.ParseTranscriptionResponse(json);
+
+        Assert.NotNull(result.NoSpeechProbability);
+        Assert.True(result.NoSpeechProbability < 0.1f);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -44,6 +44,20 @@ public class StreamingTranscriptionTests
     }
 
     [Fact]
+    public void PluginTranscriptionResult_NoSpeechProbability_DefaultIsNull()
+    {
+        var result = new PluginTranscriptionResult("Hello", "en", 2.0);
+        Assert.Null(result.NoSpeechProbability);
+    }
+
+    [Fact]
+    public void PluginTranscriptionResult_NoSpeechProbability_CanBeSet()
+    {
+        var result = new PluginTranscriptionResult("So.", "en", 1.0, 0.95f);
+        Assert.Equal(0.95f, result.NoSpeechProbability);
+    }
+
+    [Fact]
     public void SupportsStreaming_CanBeOverridden()
     {
         var mock = new Mock<ITranscriptionEnginePlugin>();


### PR DESCRIPTION
## Summary

Fixes #19. Certain Whisper models (Large V3 Turbo, GPT-4o Transcribe) hallucinate random multi-language text when given silent audio. This adds two layers of silence detection:

- **Energy gate (pre-filter):** Tracks pre-gain peak RMS per audio chunk. If no chunk during the recording exceeds the speech energy threshold (0.01 RMS), transcription is skipped entirely and "No speech detected" is shown. This works correctly even when AGC/WhisperMode amplifies the audio, since it checks the raw microphone level.
- **`no_speech_prob` filter (post-filter):** Parses the `no_speech_prob` field from `verbose_json` Whisper API responses (OpenAI whisper-1, Groq, OpenAI Compatible). If all segments report > 0.8 non-speech probability, the result is discarded as a hallucination.

Both filters apply to the final transcription path (`ProcessSingleJobAsync`) and the live polling fallback (`RunPollingFallbackAsync`). WebSocket streaming providers (Deepgram, AssemblyAI) handle silence server-side and are unaffected.

## Test plan
- [ ] Record 2-3 seconds of silence with Groq Whisper V3 Turbo - should show "No speech detected"
- [ ] Record silence with GPT-4o Transcribe - should show "No speech detected"
- [ ] Record normal speech - should transcribe correctly (no false positives)
- [ ] Verify whispered speech is still captured (low energy but above threshold)
- [ ] Verify local models (Parakeet, Canary) still work correctly via VAD path