### PR TITLE
fix: load selected model for file transcription

### DIFF
--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -141,7 +141,7 @@ public sealed class HttpApiService : IDisposable
         var activePlugin = _modelManager.ActiveTranscriptionPlugin;
         var result = new
         {
-            status = _modelManager.Engine.IsModelLoaded ? "ready" : "no_model",
+            status = _modelManager.ActiveModelId is not null ? "ready" : "no_model",
             activeModel = _modelManager.ActiveModelId,
             apiVersion = "1.0",
             supports_streaming = activePlugin?.SupportsStreaming ?? false,
@@ -171,7 +171,7 @@ public sealed class HttpApiService : IDisposable
 
     private async Task<(int, string)> HandleTranscribe(HttpListenerRequest request, CancellationToken ct)
     {
-        if (!_modelManager.Engine.IsModelLoaded)
+        if (!await _modelManager.EnsureModelLoadedAsync(cancellationToken: ct))
             return (503, JsonSerializer.Serialize(new { error = "No model loaded" }));
 
         var tempPath = Path.Combine(Path.GetTempPath(), $"tw_api_{Guid.NewGuid()}.tmp");

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -71,11 +71,6 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
                     return new PluginTranscriptionEngineAdapter(plugin);
             }
 
-            // Fallback: first available transcription engine
-            var fallback = _pluginManager.TranscriptionEngines.FirstOrDefault();
-            if (fallback is not null)
-                return new PluginTranscriptionEngineAdapter(fallback);
-
             return NoOpTranscriptionEngine.Instance;
         }
     }
@@ -243,6 +238,25 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
             UnloadModel();
 
         SetStatus(modelId, ModelStatus.NotDownloaded);
+    }
+
+    public async Task<bool> EnsureModelLoadedAsync(string? modelId = null, CancellationToken cancellationToken = default)
+    {
+        var targetModelId = modelId ?? _settings.Current.SelectedModelId;
+        if (string.IsNullOrWhiteSpace(targetModelId))
+            return false;
+
+        if (ActiveModelId == targetModelId)
+        {
+            CancelAutoUnload();
+            return true;
+        }
+
+        if (!IsDownloaded(targetModelId))
+            return false;
+
+        await LoadModelAsync(targetModelId, cancellationToken);
+        return true;
     }
 
     /// <summary>

--- a/src/TypeWhisper.Windows/ViewModels/FileTranscriptionViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/FileTranscriptionViewModel.cs
@@ -58,12 +58,6 @@ public partial class FileTranscriptionViewModel : ObservableObject
             return;
         }
 
-        if (!_modelManager.Engine.IsModelLoaded)
-        {
-            StatusText = Loc.Instance["Status.NoModelLoaded"];
-            return;
-        }
-
         FilePath = filePath;
         IsProcessing = true;
         HasResult = false;
@@ -75,6 +69,12 @@ public partial class FileTranscriptionViewModel : ObservableObject
 
         try
         {
+            if (!await _modelManager.EnsureModelLoadedAsync(cancellationToken: _cts.Token))
+            {
+                StatusText = Loc.Instance["Status.NoModelLoaded"];
+                return;
+            }
+
             var samples = await _audioFile.LoadAudioAsync(filePath, _cts.Token);
 
             StatusText = Loc.Instance["FileTranscription.Transcribing"];

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using Moq;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Plugins;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class ModelManagerServiceTests
+{
+    private readonly Mock<IActiveWindowService> _activeWindow = new();
+    private readonly Mock<IProfileService> _profiles = new();
+    private readonly Mock<ISettingsService> _settings = new();
+    private readonly PluginEventBus _eventBus = new();
+    private readonly PluginLoader _loader = new();
+
+    public ModelManagerServiceTests()
+    {
+        _profiles.Setup(p => p.Profiles).Returns([]);
+    }
+
+    [Fact]
+    public void Engine_WithoutActiveModel_DoesNotFallbackToArbitraryConfiguredPlugin()
+    {
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            SelectedModelId = ModelManagerService.GetPluginModelId("com.typewhisper.sherpa-onnx", "parakeet")
+        });
+
+        var pluginManager = CreatePluginManager(
+            new FakeTranscriptionPlugin("com.typewhisper.openai-compatible", configured: true, selectedModelId: "whisper"),
+            new FakeTranscriptionPlugin("com.typewhisper.sherpa-onnx", configured: true, selectedModelId: null));
+
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        Assert.IsType<NoOpTranscriptionEngine>(sut.Engine);
+        Assert.False(sut.Engine.IsModelLoaded);
+    }
+
+    [Fact]
+    public async Task EnsureModelLoadedAsync_LoadsSelectedModel_WhenNoActiveModelExists()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            SelectedModelId = fullModelId
+        });
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true);
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        var loaded = await sut.EnsureModelLoadedAsync();
+
+        Assert.True(loaded);
+        Assert.Equal(fullModelId, sut.ActiveModelId);
+        Assert.Equal(modelId, plugin.SelectedModelId);
+        Assert.Equal(modelId, plugin.LastLoadedModelId);
+        Assert.True(sut.Engine.IsModelLoaded);
+    }
+
+    private PluginManager CreatePluginManager(params ITranscriptionEnginePlugin[] transcriptionEngines)
+    {
+        var pluginManager = new PluginManager(
+            _loader,
+            _eventBus,
+            _activeWindow.Object,
+            _profiles.Object,
+            _settings.Object,
+            []);
+
+        SetPrivateField(pluginManager, "_transcriptionEngines", transcriptionEngines.ToList());
+        return pluginManager;
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        field.SetValue(target, value);
+    }
+
+    private sealed class FakeTranscriptionPlugin : ITranscriptionEnginePlugin
+    {
+        public FakeTranscriptionPlugin(
+            string pluginId,
+            bool configured,
+            string? selectedModelId,
+            bool supportsModelDownload = false)
+        {
+            PluginId = pluginId;
+            IsConfigured = configured;
+            SelectedModelId = selectedModelId;
+            SupportsModelDownload = supportsModelDownload;
+            TranscriptionModels = [new PluginModelInfo("parakeet", "Parakeet"), new PluginModelInfo("whisper", "Whisper")];
+        }
+
+        public string PluginId { get; }
+        public string PluginName => PluginId;
+        public string PluginVersion => "1.0.0";
+        public string ProviderId => PluginId;
+        public string ProviderDisplayName => PluginId;
+        public bool IsConfigured { get; }
+        public bool SupportsModelDownload { get; }
+        public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; }
+        public string? SelectedModelId { get; private set; }
+        public bool SupportsTranslation => false;
+        public string? LastLoadedModelId { get; private set; }
+
+        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
+        public Task DeactivateAsync() => Task.CompletedTask;
+        public System.Windows.Controls.UserControl? CreateSettingsView() => null;
+        public void SelectModel(string modelId) => SelectedModelId = modelId;
+        public Task LoadModelAsync(string modelId, CancellationToken ct)
+        {
+            LastLoadedModelId = modelId;
+            SelectedModelId = modelId;
+            return Task.CompletedTask;
+        }
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(byte[] wavAudio, string? language, bool translate, string? prompt, CancellationToken ct) =>
+            Task.FromResult(new PluginTranscriptionResult("ok", language ?? "en", 1));
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary
- remove the arbitrary transcription-engine fallback when no plugin model is active
- make file transcription explicitly load the selected model before transcribing
- add regression coverage for the selected-model load path and the previous fallback bug

## Testing
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --filter ModelManagerServiceTests`

Fixes #30