### PR TITLE
ci: configure Dependabot for NuGet dependency graph

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directories:
+      - "/src/**/*"
+      - "/tests/**/*"
+      - "/plugins/**/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- add a minimal `.github/dependabot.yml` for `nuget`
- point Dependabot at the nested `src`, `tests`, and `plugins` trees
- disable normal version update PRs with `open-pull-requests-limit: 0`

## Why
The repository root currently contains `TypeWhisper.slnx`, but GitHub's .NET autosubmission only auto-triggers from a supported root manifest (for example `.sln`/`.csproj`) or from a `dependabot.yml` that declares `nuget`.

At the moment the repository's dependency graph is empty, so the `dependency-review` action fails even though the repository is public.

This keeps the change narrowly focused on populating the dependency graph without turning on routine version-bump PR noise.
