### PR TITLE
[codex] Fix hotkey parser parity for recorder-supported keys

### DIFF
--- a/src/TypeWhisper.Windows/Controls/HotkeyRecorderControl.cs
+++ b/src/TypeWhisper.Windows/Controls/HotkeyRecorderControl.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.Extensions.DependencyInjection;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Windows.Services;
 
 namespace TypeWhisper.Windows.Controls;
@@ -198,42 +199,8 @@ public sealed class HotkeyRecorderControl : Control
         return string.Join("+", parts);
     }
 
-    internal static string FormatKeyName(Key key) => key switch
-    {
-        Key.Space => "Space",
-        >= Key.F1 and <= Key.F12 => key.ToString(),
-        >= Key.A and <= Key.Z => key.ToString(),
-        >= Key.D0 and <= Key.D9 => ((char)('0' + (key - Key.D0))).ToString(),
-        >= Key.NumPad0 and <= Key.NumPad9 => "Num" + (key - Key.NumPad0),
-        Key.OemMinus => "-",
-        Key.OemPlus => "=",
-        Key.OemOpenBrackets => "[",
-        Key.OemCloseBrackets => "]",
-        Key.OemSemicolon => ";",
-        Key.OemQuotes => "'",
-        Key.OemComma => ",",
-        Key.OemPeriod => ".",
-        Key.OemQuestion => "/",
-        Key.OemBackslash or Key.Oem5 => "\\",
-        Key.OemTilde => "`",
-        Key.Return => "Enter",
-        Key.Back => "Backspace",
-        Key.Tab => "Tab",
-        Key.Delete => "Delete",
-        Key.Insert => "Insert",
-        Key.Home => "Home",
-        Key.End => "End",
-        Key.PageUp => "PageUp",
-        Key.PageDown => "PageDown",
-        Key.Up => "Up",
-        Key.Down => "Down",
-        Key.Left => "Left",
-        Key.Right => "Right",
-        Key.PrintScreen or Key.Snapshot => "PrintScreen",
-        Key.Pause => "Pause",
-        Key.Scroll => "ScrollLock",
-        _ => ""
-    };
+    internal static string FormatKeyName(Key key) =>
+        HotkeyKeyMap.TryGetToken(key, out var token) ? token : "";
 
     internal static bool IsModifierKey(Key key) => key
         is Key.LeftCtrl or Key.RightCtrl

--- a/src/TypeWhisper.Windows/Native/HotkeyKeyMap.cs
+++ b/src/TypeWhisper.Windows/Native/HotkeyKeyMap.cs
@@ -1,0 +1,146 @@
+using System.Windows.Input;
+
+namespace TypeWhisper.Windows.Native;
+
+internal static class HotkeyKeyMap
+{
+    private static readonly HotkeyKeyDefinition[] Definitions =
+    [
+        new("Space", NativeMethods.VK_SPACE, Key.Space),
+        new("Enter", NativeMethods.VK_RETURN, Key.Return),
+        new("Backspace", NativeMethods.VK_BACK, Key.Back),
+        new("Tab", NativeMethods.VK_TAB, Key.Tab),
+        new("Delete", NativeMethods.VK_DELETE, Key.Delete),
+        new("Insert", NativeMethods.VK_INSERT, Key.Insert),
+        new("Home", NativeMethods.VK_HOME, Key.Home),
+        new("End", NativeMethods.VK_END, Key.End),
+        new("PageUp", NativeMethods.VK_PRIOR, Key.PageUp),
+        new("PageDown", NativeMethods.VK_NEXT, Key.PageDown),
+        new("Up", NativeMethods.VK_UP, Key.Up),
+        new("Down", NativeMethods.VK_DOWN, Key.Down),
+        new("Left", NativeMethods.VK_LEFT, Key.Left),
+        new("Right", NativeMethods.VK_RIGHT, Key.Right),
+        new("PrintScreen", NativeMethods.VK_SNAPSHOT, Key.PrintScreen, Key.Snapshot),
+        new("Pause", NativeMethods.VK_PAUSE, Key.Pause),
+        new("ScrollLock", NativeMethods.VK_SCROLL, Key.Scroll),
+        new("`", NativeMethods.VK_OEM_3, Key.OemTilde),
+        new("-", NativeMethods.VK_OEM_MINUS, Key.OemMinus),
+        new("=", NativeMethods.VK_OEM_PLUS, Key.OemPlus),
+        new("[", NativeMethods.VK_OEM_4, Key.OemOpenBrackets),
+        new("]", NativeMethods.VK_OEM_6, Key.OemCloseBrackets),
+        new(";", NativeMethods.VK_OEM_1, Key.OemSemicolon),
+        new("'", NativeMethods.VK_OEM_7, Key.OemQuotes),
+        new(",", NativeMethods.VK_OEM_COMMA, Key.OemComma),
+        new(".", NativeMethods.VK_OEM_PERIOD, Key.OemPeriod),
+        new("/", NativeMethods.VK_OEM_2, Key.OemQuestion),
+        new("\\", NativeMethods.VK_OEM_5, Key.OemBackslash, Key.Oem5)
+    ];
+
+    private static readonly Dictionary<Key, string> TokensByKey = BuildTokensByKey();
+    private static readonly Dictionary<string, uint> VirtualKeysByToken = Definitions
+        .ToDictionary(definition => definition.Token, definition => definition.VirtualKey, StringComparer.OrdinalIgnoreCase);
+
+    public static bool TryGetToken(Key key, out string token)
+    {
+        if (TokensByKey.TryGetValue(key, out token!))
+            return true;
+
+        if (key is >= Key.F1 and <= Key.F12)
+        {
+            token = key.ToString();
+            return true;
+        }
+
+        if (key is >= Key.A and <= Key.Z)
+        {
+            token = key.ToString();
+            return true;
+        }
+
+        if (key is >= Key.D0 and <= Key.D9)
+        {
+            token = ((char)('0' + (key - Key.D0))).ToString();
+            return true;
+        }
+
+        if (key is >= Key.NumPad0 and <= Key.NumPad9)
+        {
+            token = "Num" + (key - Key.NumPad0);
+            return true;
+        }
+
+        token = "";
+        return false;
+    }
+
+    public static bool TryGetVirtualKey(string token, out uint virtualKey)
+    {
+        virtualKey = 0;
+        if (string.IsNullOrWhiteSpace(token))
+            return false;
+
+        if (VirtualKeysByToken.TryGetValue(token, out virtualKey))
+            return true;
+
+        if (token.StartsWith('F') && token.Length is 2 or 3
+            && int.TryParse(token.AsSpan(1), out var functionNumber)
+            && functionNumber is >= 1 and <= 12)
+        {
+            virtualKey = (uint)(NativeMethods.VK_F1 + functionNumber - 1);
+            return true;
+        }
+
+        if (token.Length == 1)
+        {
+            if (token[0] is >= 'A' and <= 'Z')
+            {
+                virtualKey = token[0];
+                return true;
+            }
+
+            if (token[0] is >= 'a' and <= 'z')
+            {
+                virtualKey = char.ToUpperInvariant(token[0]);
+                return true;
+            }
+
+            if (token[0] is >= '0' and <= '9')
+            {
+                virtualKey = token[0];
+                return true;
+            }
+        }
+
+        if (token.Length == 4
+            && token.StartsWith("Num", StringComparison.OrdinalIgnoreCase)
+            && token[3] is >= '0' and <= '9')
+        {
+            virtualKey = (uint)(NativeMethods.VK_NUMPAD0 + (token[3] - '0'));
+            return true;
+        }
+
+        if (token.Equals("Esc", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("Escape", StringComparison.OrdinalIgnoreCase))
+        {
+            virtualKey = NativeMethods.VK_ESCAPE;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static Dictionary<Key, string> BuildTokensByKey()
+    {
+        var tokensByKey = new Dictionary<Key, string>();
+
+        foreach (var definition in Definitions)
+        {
+            foreach (var key in definition.Keys)
+                tokensByKey.TryAdd(key, definition.Token);
+        }
+
+        return tokensByKey;
+    }
+}
+
+internal sealed record HotkeyKeyDefinition(string Token, uint VirtualKey, params Key[] Keys);

--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -442,7 +442,7 @@ internal static class HotkeyParser
                 case "WIN" or "SUPER" or "META":
                     modifiers |= NativeMethods.MOD_WIN; break;
                 default:
-                    vk = ParseKey(upper);
+                    vk = ParseKey(part.Trim());
                     if (vk == 0) return false;
                     break;
             }
@@ -450,19 +450,6 @@ internal static class HotkeyParser
         return vk != 0 || modifiers != 0;
     }
 
-    private static uint ParseKey(string key)
-    {
-        if (key.StartsWith('F') && key.Length is 2 or 3 &&
-            int.TryParse(key.AsSpan(1), out var fNum) && fNum is >= 1 and <= 12)
-            return (uint)(NativeMethods.VK_F1 + fNum - 1);
-
-        return key switch
-        {
-            "ESC" or "ESCAPE" => NativeMethods.VK_ESCAPE,
-            "SPACE" => NativeMethods.VK_SPACE,
-            _ when key.Length == 1 && key[0] is >= 'A' and <= 'Z' => (uint)key[0],
-            _ when key.Length == 1 && key[0] is >= '0' and <= '9' => (uint)key[0],
-            _ => 0
-        };
-    }
+    private static uint ParseKey(string key) =>
+        HotkeyKeyMap.TryGetVirtualKey(key, out var virtualKey) ? virtualKey : 0;
 }

--- a/src/TypeWhisper.Windows/Native/NativeMethods.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.cs
@@ -36,6 +36,11 @@ internal static partial class NativeMethods
     public const int VK_LMENU = 0xA4;
     public const int VK_RMENU = 0xA5;
     public const int VK_SPACE = 0x20;
+    public const int VK_PRIOR = 0x21;
+    public const int VK_NEXT = 0x22;
+    public const int VK_END = 0x23;
+    public const int VK_HOME = 0x24;
+    public const int VK_LEFT = 0x25;
     public const int VK_F1 = 0x70;
     public const int VK_F9 = 0x78;
     public const int VK_F12 = 0x7B;
@@ -97,12 +102,33 @@ internal static partial class NativeMethods
     public const int VK_RETURN = 0x0D;
     public const int VK_ESCAPE = 0x1B;
     public const int VK_BACK = 0x08;
+    public const int VK_TAB = 0x09;
+    public const int VK_PAUSE = 0x13;
     public const int VK_UP = 0x26;
+    public const int VK_RIGHT = 0x27;
     public const int VK_DOWN = 0x28;
+    public const int VK_INSERT = 0x2D;
+    public const int VK_DELETE = 0x2E;
+    public const int VK_SNAPSHOT = 0x2C;
+    public const int VK_SCROLL = 0x91;
     public const int VK_C = 0x43;
+    public const int VK_NUMPAD0 = 0x60;
 
     // Clipboard
     public const int VK_V = 0x56;
+
+    // OEM keys
+    public const int VK_OEM_1 = 0xBA;
+    public const int VK_OEM_PLUS = 0xBB;
+    public const int VK_OEM_COMMA = 0xBC;
+    public const int VK_OEM_MINUS = 0xBD;
+    public const int VK_OEM_PERIOD = 0xBE;
+    public const int VK_OEM_2 = 0xBF;
+    public const int VK_OEM_3 = 0xC0;
+    public const int VK_OEM_4 = 0xDB;
+    public const int VK_OEM_5 = 0xDC;
+    public const int VK_OEM_6 = 0xDD;
+    public const int VK_OEM_7 = 0xDE;
 
     // Keyboard input simulation
     [LibraryImport("user32.dll", SetLastError = true)]

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -6,6 +6,64 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public class HotkeyInputTests
 {
+    public static IEnumerable<object[]> RecorderSupportedNonModifierKeys()
+    {
+        yield return [Key.Space, "Space", (uint)NativeMethods.VK_SPACE];
+        yield return [Key.Return, "Enter", (uint)NativeMethods.VK_RETURN];
+        yield return [Key.Back, "Backspace", (uint)NativeMethods.VK_BACK];
+        yield return [Key.Tab, "Tab", (uint)NativeMethods.VK_TAB];
+        yield return [Key.Delete, "Delete", (uint)NativeMethods.VK_DELETE];
+        yield return [Key.Insert, "Insert", (uint)NativeMethods.VK_INSERT];
+        yield return [Key.Home, "Home", (uint)NativeMethods.VK_HOME];
+        yield return [Key.End, "End", (uint)NativeMethods.VK_END];
+        yield return [Key.PageUp, "PageUp", (uint)NativeMethods.VK_PRIOR];
+        yield return [Key.PageDown, "PageDown", (uint)NativeMethods.VK_NEXT];
+        yield return [Key.Up, "Up", (uint)NativeMethods.VK_UP];
+        yield return [Key.Down, "Down", (uint)NativeMethods.VK_DOWN];
+        yield return [Key.Left, "Left", (uint)NativeMethods.VK_LEFT];
+        yield return [Key.Right, "Right", (uint)NativeMethods.VK_RIGHT];
+        yield return [Key.PrintScreen, "PrintScreen", (uint)NativeMethods.VK_SNAPSHOT];
+        yield return [Key.Pause, "Pause", (uint)NativeMethods.VK_PAUSE];
+        yield return [Key.Scroll, "ScrollLock", (uint)NativeMethods.VK_SCROLL];
+        yield return [Key.OemTilde, "`", (uint)NativeMethods.VK_OEM_3];
+        yield return [Key.OemMinus, "-", (uint)NativeMethods.VK_OEM_MINUS];
+        yield return [Key.OemPlus, "=", (uint)NativeMethods.VK_OEM_PLUS];
+        yield return [Key.OemOpenBrackets, "[", (uint)NativeMethods.VK_OEM_4];
+        yield return [Key.OemCloseBrackets, "]", (uint)NativeMethods.VK_OEM_6];
+        yield return [Key.OemSemicolon, ";", (uint)NativeMethods.VK_OEM_1];
+        yield return [Key.OemQuotes, "'", (uint)NativeMethods.VK_OEM_7];
+        yield return [Key.OemComma, ",", (uint)NativeMethods.VK_OEM_COMMA];
+        yield return [Key.OemPeriod, ".", (uint)NativeMethods.VK_OEM_PERIOD];
+        yield return [Key.OemQuestion, "/", (uint)NativeMethods.VK_OEM_2];
+        yield return [Key.OemBackslash, "\\", (uint)NativeMethods.VK_OEM_5];
+
+        for (var keyValue = (int)Key.A; keyValue <= (int)Key.Z; keyValue++)
+        {
+            var key = (Key)keyValue;
+            var token = key.ToString();
+            yield return [key, token, (uint)token[0]];
+        }
+
+        for (var keyValue = (int)Key.D0; keyValue <= (int)Key.D9; keyValue++)
+        {
+            var key = (Key)keyValue;
+            var digit = (char)('0' + (key - Key.D0));
+            yield return [key, digit.ToString(), (uint)digit];
+        }
+
+        for (var keyValue = (int)Key.F1; keyValue <= (int)Key.F12; keyValue++)
+        {
+            var key = (Key)keyValue;
+            yield return [key, key.ToString(), (uint)(NativeMethods.VK_F1 + (key - Key.F1))];
+        }
+
+        for (var keyValue = (int)Key.NumPad0; keyValue <= (int)Key.NumPad9; keyValue++)
+        {
+            var key = (Key)keyValue;
+            yield return [key, $"Num{key - Key.NumPad0}", (uint)(NativeMethods.VK_NUMPAD0 + (key - Key.NumPad0))];
+        }
+    }
+
     [Fact]
     public void ModifierOnly_WinAlt_PressWinThenAlt_DoesNotSwallowAltKeyUp()
     {
@@ -156,6 +214,56 @@ public class HotkeyInputTests
 
         Assert.Equal("", hotkey);
         Assert.Equal(ModifierKeys.None, sut.GetCurrentModifiers());
+    }
+
+    [Theory]
+    [MemberData(nameof(RecorderSupportedNonModifierKeys))]
+    public void RecorderAndParser_RoundTripAllSupportedNonModifierKeys(Key key, string expectedToken, uint expectedVk)
+    {
+        var hotkey = HotkeyRecorderControl.FormatHotkey(ModifierKeys.Control | ModifierKeys.Alt, key);
+
+        Assert.Equal($"Ctrl+Alt+{expectedToken}", hotkey);
+        Assert.True(HotkeyParser.Parse(hotkey, out var modifiers, out var vk));
+        Assert.Equal(NativeMethods.MOD_CONTROL | NativeMethods.MOD_ALT, modifiers);
+        Assert.Equal(expectedVk, vk);
+    }
+
+    [Theory]
+    [InlineData("Ctrl+,", NativeMethods.MOD_CONTROL, NativeMethods.VK_OEM_COMMA)]
+    [InlineData("Ctrl+.", NativeMethods.MOD_CONTROL, NativeMethods.VK_OEM_PERIOD)]
+    [InlineData("Win+/", NativeMethods.MOD_WIN, NativeMethods.VK_OEM_2)]
+    [InlineData("Ctrl+;", NativeMethods.MOD_CONTROL, NativeMethods.VK_OEM_1)]
+    [InlineData("Alt+'", NativeMethods.MOD_ALT, NativeMethods.VK_OEM_7)]
+    [InlineData("Alt+[", NativeMethods.MOD_ALT, NativeMethods.VK_OEM_4)]
+    [InlineData("Alt+]", NativeMethods.MOD_ALT, NativeMethods.VK_OEM_6)]
+    [InlineData("Ctrl+\\", NativeMethods.MOD_CONTROL, NativeMethods.VK_OEM_5)]
+    [InlineData("Ctrl+-", NativeMethods.MOD_CONTROL, NativeMethods.VK_OEM_MINUS)]
+    [InlineData("Ctrl+=", NativeMethods.MOD_CONTROL, NativeMethods.VK_OEM_PLUS)]
+    [InlineData("Ctrl+PageUp", NativeMethods.MOD_CONTROL, NativeMethods.VK_PRIOR)]
+    [InlineData("Alt+Left", NativeMethods.MOD_ALT, NativeMethods.VK_LEFT)]
+    [InlineData("Win+PrintScreen", NativeMethods.MOD_WIN, NativeMethods.VK_SNAPSHOT)]
+    [InlineData("Ctrl+Num3", NativeMethods.MOD_CONTROL, NativeMethods.VK_NUMPAD0 + 3)]
+    public void Parser_SupportsRegressionAndNamedKeyCombinations(string hotkey, uint expectedModifiers, uint expectedVk)
+    {
+        Assert.True(HotkeyParser.Parse(hotkey, out var modifiers, out var vk));
+        Assert.Equal(expectedModifiers, modifiers);
+        Assert.Equal(expectedVk, vk);
+    }
+
+    [Theory]
+    [InlineData("Esc")]
+    [InlineData("Escape")]
+    public void Parser_KeepsEscapeAliases(string hotkey)
+    {
+        Assert.True(HotkeyParser.Parse(hotkey, out var modifiers, out var vk));
+        Assert.Equal(0u, modifiers);
+        Assert.Equal((uint)NativeMethods.VK_ESCAPE, vk);
+    }
+
+    [Fact]
+    public void Parser_RejectsUnknownKeyTokens()
+    {
+        Assert.False(HotkeyParser.Parse("Ctrl+UnknownKey", out _, out _));
     }
 
     private static HotkeyMatchStateMachine CreateStateMachine(uint modifiers, uint vk = 0)


### PR DESCRIPTION
## Summary
- add a shared hotkey key map so the recorder and parser use the same canonical tokens
- extend hotkey parsing to support recorder-emitted punctuation, named keys, and numpad digits
- add roundtrip and regression tests covering issue #28 and the broader recorder-supported key set

## Root cause
The hotkey recorder could persist combinations like `Ctrl+,` and `Alt+[`, but the parser only understood letters, digits, function keys, `Space`, and `Esc`. Those recorded shortcuts looked valid in the UI but never activated at runtime.

## Validation
- `dotnet test tests\\TypeWhisper.PluginSystem.Tests\\TypeWhisper.PluginSystem.Tests.csproj --filter HotkeyInputTests`

Refs #28