### PR TITLE
Add Groq LLM model selection and refresh

### DIFF
--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Windows.Controls;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
@@ -10,19 +11,38 @@ namespace TypeWhisper.Plugin.Groq;
 public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
 {
     private const string BaseUrl = "https://api.groq.com/openai";
-    private const string TranslationModel = "llama-3.3-70b-versatile";
-
-    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private readonly HttpClient _httpClient;
     private IPluginHostServices? _host;
     private string? _apiKey;
     private string? _selectedModelId;
     private string? _selectedApiModelName;
+    private string? _selectedLlmModelId;
+    private List<FetchedLlmModel> _fetchedLlmModels = [];
 
     private static readonly IReadOnlyList<TranscriptionModelEntry> TranscriptionModelEntries =
     [
         new("whisper-large-v3", "Whisper Large V3", "whisper-large-v3", SupportsTranslation: true),
         new("whisper-large-v3-turbo", "Whisper Large V3 Turbo", "whisper-large-v3-turbo", SupportsTranslation: false),
     ];
+
+    private static readonly IReadOnlyList<PluginModelInfo> FallbackLlmModels =
+    [
+        new("llama-3.3-70b-versatile", "Llama 3.3 70B"),
+        new("llama-3.1-8b-instant", "Llama 3.1 8B"),
+        new("openai/gpt-oss-120b", "GPT-OSS 120B"),
+        new("openai/gpt-oss-20b", "GPT-OSS 20B"),
+        new("moonshotai/kimi-k2-instruct-0905", "Kimi K2"),
+    ];
+
+    public GroqPlugin()
+        : this(CreateHttpClient())
+    {
+    }
+
+    internal GroqPlugin(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
 
     // ITypeWhisperPlugin
 
@@ -34,6 +54,16 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
     {
         _host = host;
         _apiKey = await host.LoadSecretAsync("api-key");
+        _selectedModelId = host.GetSetting<string>("selectedModel") ?? TranscriptionModelEntries[0].Id;
+        _selectedLlmModelId = host.GetSetting<string>("selectedLlmModel");
+        _fetchedLlmModels = NormalizeFetchedLlmModels(host.GetSetting<List<FetchedLlmModel>>("fetchedLlmModels") ?? []);
+
+        var selectedTranscription = TranscriptionModelEntries.FirstOrDefault(m => m.Id == _selectedModelId)
+            ?? TranscriptionModelEntries[0];
+        _selectedModelId = selectedTranscription.Id;
+        _selectedApiModelName = selectedTranscription.ApiModelName;
+
+        NormalizeSelectedLlmModel();
         host.Log(PluginLogLevel.Info, $"Activated (configured={IsConfigured})");
     }
 
@@ -73,6 +103,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
             ?? throw new ArgumentException($"Unknown model: {modelId}");
         _selectedModelId = modelId;
         _selectedApiModelName = entry.ApiModelName;
+        _host?.SetSetting("selectedModel", modelId);
     }
 
     public async Task<PluginTranscriptionResult> TranscribeAsync(
@@ -91,32 +122,92 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
     public string ProviderName => "Groq";
     public bool IsAvailable => IsConfigured;
 
-    public IReadOnlyList<PluginModelInfo> SupportedModels { get; } =
-        [new PluginModelInfo(TranslationModel, "Llama 3.3 70B Versatile")];
+    public IReadOnlyList<PluginModelInfo> SupportedModels =>
+        _fetchedLlmModels.Count > 0
+            ? _fetchedLlmModels.Select(m => new PluginModelInfo(m.Id, m.Id)).ToList()
+            : FallbackLlmModels;
 
     public async Task<string> ProcessAsync(string systemPrompt, string userText, string model, CancellationToken ct)
     {
         if (!IsConfigured)
             throw new InvalidOperationException("API key not configured");
 
+        var modelId = ResolveLlmModelId(string.IsNullOrWhiteSpace(model) ? null : model);
         return await OpenAiChatHelper.SendChatCompletionAsync(
-            _httpClient, BaseUrl, _apiKey!, model, systemPrompt, userText, ct);
+            _httpClient, BaseUrl, _apiKey!, modelId, systemPrompt, userText, ct);
     }
 
     // API key management (for settings view)
 
     internal string? ApiKey => _apiKey;
     internal IPluginLocalization? Loc => _host?.Localization;
+    internal string? SelectedLlmModelId => _selectedLlmModelId;
+    internal IReadOnlyList<FetchedLlmModel> FetchedLlmModels => _fetchedLlmModels;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {
-        _apiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
+        var normalizedApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
+        var wasConfigured = IsConfigured;
+        var changed = !string.Equals(_apiKey, normalizedApiKey, StringComparison.Ordinal);
+
+        _apiKey = normalizedApiKey;
         if (_host is not null)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
                 await _host.DeleteSecretAsync("api-key");
             else
                 await _host.StoreSecretAsync("api-key", apiKey);
+
+            if (changed && wasConfigured != IsConfigured)
+                _host.NotifyCapabilitiesChanged();
+        }
+    }
+
+    internal void SelectLlmModel(string modelId)
+    {
+        _selectedLlmModelId = modelId;
+        _host?.SetSetting("selectedLlmModel", modelId);
+    }
+
+    internal void SetFetchedLlmModels(List<FetchedLlmModel> models)
+    {
+        _fetchedLlmModels = NormalizeFetchedLlmModels(models);
+
+        _host?.SetSetting("fetchedLlmModels", _fetchedLlmModels);
+        NormalizeSelectedLlmModel();
+        _host?.NotifyCapabilitiesChanged();
+    }
+
+    internal async Task<List<FetchedLlmModel>?> FetchLlmModelsAsync(CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/models");
+        if (!string.IsNullOrEmpty(_apiKey))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("data", out var data))
+                return [];
+
+            return data.EnumerateArray()
+                .Select(e => new FetchedLlmModel(
+                    e.GetProperty("id").GetString() ?? "",
+                    e.TryGetProperty("owned_by", out var ob) ? ob.GetString() : null))
+                .Where(m => IsLlmModel(m.Id))
+                .OrderBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            return null;
         }
     }
 
@@ -135,6 +226,48 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
         }
     }
 
+    internal static bool IsLlmModel(string id)
+    {
+        var lowered = id.ToLowerInvariant();
+        var excluded = new[]
+        {
+            "whisper",
+            "distil-whisper",
+            "tool-use",
+            "orpheus",
+            "tts",
+            "prompt-guard",
+            "safeguard",
+        };
+
+        return !excluded.Any(lowered.Contains);
+    }
+
+    internal string ResolveLlmModelId(string? requestedModel) =>
+        !string.IsNullOrWhiteSpace(requestedModel)
+            ? requestedModel
+            : _selectedLlmModelId ?? SupportedModels.First().Id;
+
+    private void NormalizeSelectedLlmModel()
+    {
+        var availableIds = new HashSet<string>(SupportedModels.Select(m => m.Id), StringComparer.OrdinalIgnoreCase);
+        if (_selectedLlmModelId is not null && availableIds.Contains(_selectedLlmModelId))
+            return;
+
+        _selectedLlmModelId = SupportedModels.FirstOrDefault()?.Id;
+        if (_selectedLlmModelId is not null)
+            _host?.SetSetting("selectedLlmModel", _selectedLlmModelId);
+    }
+
+    private static List<FetchedLlmModel> NormalizeFetchedLlmModels(IEnumerable<FetchedLlmModel> models) =>
+        models
+            .Where(m => !string.IsNullOrWhiteSpace(m.Id) && IsLlmModel(m.Id))
+            .DistinctBy(m => m.Id)
+            .OrderBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromSeconds(30) };
+
     public void Dispose()
     {
         _httpClient.Dispose();
@@ -143,3 +276,5 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
     private sealed record TranscriptionModelEntry(
         string Id, string DisplayName, string ApiModelName, bool SupportsTranslation);
 }
+
+internal sealed record FetchedLlmModel(string Id, string? OwnedBy);

--- a/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="TypeWhisper.Plugin.Groq.GroqSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Margin="0,4">
+    <StackPanel Margin="0,4" MaxWidth="500">
         <TextBlock Text="API Key" FontWeight="SemiBold" Margin="0,0,0,4" />
         <Grid>
             <Grid.ColumnDefinitions>
@@ -12,6 +12,29 @@
             <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
-        <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />
+        <TextBlock x:Name="ApiKeyHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        <TextBlock x:Name="StatusText" Margin="0,6,0,0" FontSize="12" />
+
+        <StackPanel x:Name="ModelsSection" Margin="0,16,0,0" Visibility="Collapsed">
+            <TextBlock x:Name="TranscriptionModelLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
+            <ComboBox x:Name="TranscriptionModelPicker"
+                      DisplayMemberPath="DisplayName"
+                      SelectionChanged="OnTranscriptionModelChanged"
+                      Margin="0,0,0,16" />
+
+            <Grid Margin="0,0,0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="LlmModelLabel" FontWeight="SemiBold" VerticalAlignment="Center" />
+                <Button Grid.Column="1" x:Name="RefreshButton" Padding="12,4"
+                        Click="OnRefreshClick" />
+            </Grid>
+            <ComboBox x:Name="LlmModelPicker"
+                      DisplayMemberPath="DisplayName"
+                      SelectionChanged="OnLlmModelChanged" />
+            <TextBlock x:Name="LlmModelHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqSettingsView.xaml.cs
@@ -1,32 +1,53 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using TypeWhisper.PluginSDK.Models;
 
 namespace TypeWhisper.Plugin.Groq;
 
 public partial class GroqSettingsView : UserControl
 {
     private readonly GroqPlugin _plugin;
+    private bool _suppressPasswordChanged;
 
     public GroqSettingsView(GroqPlugin plugin)
     {
         _plugin = plugin;
         InitializeComponent();
         TestButton.Content = L("Settings.Test");
+        RefreshButton.Content = L("Settings.Refresh");
+        TranscriptionModelLabel.Text = L("Settings.TranscriptionModel");
+        LlmModelLabel.Text = L("Settings.LlmModel");
+        ApiKeyHintText.Text = L("Settings.ApiKeyHint");
+        LlmModelHintText.Text = L("Settings.LlmModelHint");
 
         // Pre-fill password box if API key is already set
         if (!string.IsNullOrEmpty(plugin.ApiKey))
         {
+            _suppressPasswordChanged = true;
             ApiKeyBox.Password = plugin.ApiKey;
+            _suppressPasswordChanged = false;
         }
+
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        PopulateModelPickers();
+        UpdateModelSectionVisibility();
     }
 
     private async void OnPasswordChanged(object sender, RoutedEventArgs e)
     {
+        if (_suppressPasswordChanged)
+            return;
+
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
         StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
+        UpdateModelSectionVisibility();
     }
 
     private async void OnTestClick(object sender, RoutedEventArgs e)
@@ -48,6 +69,11 @@ public partial class GroqSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
+                var models = await _plugin.FetchLlmModelsAsync();
+                if (models is not null)
+                    _plugin.SetFetchedLlmModels(models);
+
+                PopulateModelPickers();
                 StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
@@ -65,7 +91,88 @@ public partial class GroqSettingsView : UserControl
         finally
         {
             TestButton.IsEnabled = true;
+            UpdateModelSectionVisibility();
         }
+    }
+
+    private void OnTranscriptionModelChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (TranscriptionModelPicker.SelectedItem is PluginModelInfo model)
+            _plugin.SelectModel(model.Id);
+    }
+
+    private void OnLlmModelChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (LlmModelPicker.SelectedItem is PluginModelInfo model)
+            _plugin.SelectLlmModel(model.Id);
+    }
+
+    private async void OnRefreshClick(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(ApiKeyBox.Password))
+        {
+            StatusText.Text = L("Settings.EnterApiKey");
+            StatusText.Foreground = Brushes.Orange;
+            return;
+        }
+
+        RefreshButton.IsEnabled = false;
+        StatusText.Text = L("Settings.Testing");
+        StatusText.Foreground = Brushes.Gray;
+
+        try
+        {
+            var models = await _plugin.FetchLlmModelsAsync();
+            if (models is null)
+            {
+                StatusText.Text = L("Settings.RefreshFailed");
+                StatusText.Foreground = Brushes.Orange;
+                return;
+            }
+
+            _plugin.SetFetchedLlmModels(models);
+            PopulateModelPickers();
+            StatusText.Text = L("Settings.ModelsFetched", models.Count);
+            StatusText.Foreground = Brushes.Green;
+        }
+        catch (OperationCanceledException)
+        {
+            StatusText.Text = L("Settings.RefreshFailed");
+            StatusText.Foreground = Brushes.Orange;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = L("Settings.Error", ex.Message);
+            StatusText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            RefreshButton.IsEnabled = true;
+        }
+    }
+
+    private void PopulateModelPickers()
+    {
+        var transcriptionModels = _plugin.TranscriptionModels.ToList();
+        TranscriptionModelPicker.ItemsSource = transcriptionModels;
+        TranscriptionModelPicker.SelectedItem = transcriptionModels
+            .FirstOrDefault(m => m.Id == _plugin.SelectedModelId)
+            ?? transcriptionModels.FirstOrDefault();
+
+        var llmModels = _plugin.SupportedModels.ToList();
+        LlmModelPicker.ItemsSource = llmModels;
+        LlmModelPicker.SelectedItem = llmModels
+            .FirstOrDefault(m => m.Id == _plugin.SelectedLlmModelId)
+            ?? llmModels.FirstOrDefault();
+
+        LlmModelHintText.Text = _plugin.FetchedLlmModels.Count > 0
+            ? L("Settings.ModelsFetchedHint", _plugin.FetchedLlmModels.Count)
+            : L("Settings.LlmModelHint");
+    }
+
+    private void UpdateModelSectionVisibility()
+    {
+        ModelsSection.Visibility = _plugin.IsConfigured ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;

--- a/plugins/TypeWhisper.Plugin.Groq/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Groq/Localization/de.json
@@ -1,9 +1,17 @@
 {
   "Settings.Test": "Testen",
+  "Settings.Refresh": "Aktualisieren",
   "Settings.Saved": "Gespeichert",
   "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.ApiKeyHint": "Wird sicher gespeichert und für Groq-Transkription sowie LLM-Anfragen verwendet.",
   "Settings.Testing": "Teste...",
   "Settings.ApiKeyValid": "API-Key gültig!",
   "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.TranscriptionModel": "Transkriptions-Modell",
+  "Settings.LlmModel": "LLM-Modell",
+  "Settings.LlmModelHint": "Die Standardliste für Groq-LLMs wird verwendet. Mit \"Aktualisieren\" werden die aktuellen Modelle geladen.",
+  "Settings.ModelsFetched": "{0} Groq-LLM-Modell(e) geladen.",
+  "Settings.ModelsFetchedHint": "{0} Groq-LLM-Modell(e) aus der API geladen.",
+  "Settings.RefreshFailed": "Groq-LLM-Modelle konnten nicht geladen werden. Die gespeicherte oder Standardliste bleibt aktiv.",
   "Settings.Error": "Fehler: {0}"
 }

--- a/plugins/TypeWhisper.Plugin.Groq/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Groq/Localization/en.json
@@ -1,9 +1,17 @@
 {
   "Settings.Test": "Test",
+  "Settings.Refresh": "Refresh",
   "Settings.Saved": "Saved",
   "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.ApiKeyHint": "Stored securely and used for both Groq transcription and LLM requests.",
   "Settings.Testing": "Testing...",
   "Settings.ApiKeyValid": "API key valid!",
   "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.TranscriptionModel": "Transcription Model",
+  "Settings.LlmModel": "LLM Model",
+  "Settings.LlmModelHint": "Using the default Groq LLM list. Press Refresh to fetch the current models.",
+  "Settings.ModelsFetched": "Fetched {0} Groq LLM model(s).",
+  "Settings.ModelsFetchedHint": "Showing {0} Groq LLM model(s) fetched from the API.",
+  "Settings.RefreshFailed": "Could not fetch Groq LLM models. Keeping the saved/default list.",
   "Settings.Error": "Error: {0}"
 }

--- a/plugins/TypeWhisper.Plugin.Groq/TypeWhisper.Plugin.Groq.csproj
+++ b/plugins/TypeWhisper.Plugin.Groq/TypeWhisper.Plugin.Groq.csproj
@@ -8,6 +8,9 @@
     <RootNamespace>TypeWhisper.Plugin.Groq</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -1,0 +1,287 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.Plugin.Groq;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class GroqPluginTests
+{
+    [Fact]
+    public void TranscriptionModels_RemainCuratedWhisperModels()
+    {
+        var sut = new GroqPlugin();
+
+        var ids = sut.TranscriptionModels.Select(m => m.Id).ToArray();
+
+        Assert.Equal(["whisper-large-v3", "whisper-large-v3-turbo"], ids);
+    }
+
+    [Theory]
+    [InlineData("whisper-large-v3", false)]
+    [InlineData("distil-whisper-large-v3-en", false)]
+    [InlineData("meta-llama/llama-3.3-70b-versatile-tool-use-preview", false)]
+    [InlineData("playai-tts", false)]
+    [InlineData("orpheus-tts-1", false)]
+    [InlineData("llama-guard-prompt-guard", false)]
+    [InlineData("openai/gpt-oss-safeguard-20b", false)]
+    [InlineData("llama-3.1-8b-instant", true)]
+    [InlineData("openai/gpt-oss-120b", true)]
+    public void IsLlmModel_FiltersGroqModelIds(string modelId, bool expected)
+    {
+        Assert.Equal(expected, GroqPlugin.IsLlmModel(modelId));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_RestoresFetchedModelsAndNormalizesStaleSelectedLlmModel()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+        host.SetSetting("fetchedLlmModels", new List<FetchedLlmModel>
+        {
+            new("openai/gpt-oss-120b", "OpenAI"),
+            new("llama-3.1-8b-instant", "Meta"),
+        });
+        host.SetSetting("selectedLlmModel", "whisper-large-v3");
+
+        var sut = new GroqPlugin();
+        await sut.ActivateAsync(host);
+
+        Assert.Equal("llama-3.1-8b-instant", sut.SelectedLlmModelId);
+        Assert.Equal(
+            ["llama-3.1-8b-instant", "openai/gpt-oss-120b"],
+            sut.SupportedModels.Select(m => m.Id).ToArray());
+        Assert.Equal("llama-3.1-8b-instant", host.GetSetting<string>("selectedLlmModel"));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_UsesFallbackSelectedLlmModelWhenUnset()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+
+        var sut = new GroqPlugin();
+        await sut.ActivateAsync(host);
+
+        Assert.Equal(sut.SupportedModels.First().Id, sut.SelectedLlmModelId);
+        Assert.Equal(sut.SupportedModels.First().Id, host.GetSetting<string>("selectedLlmModel"));
+    }
+
+    [Fact]
+    public async Task FetchLlmModelsAsync_FiltersAndSortsGroqResults()
+    {
+        var handler = new CapturingHandler((request, _) =>
+        {
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal("Bearer groq-key", request.Headers.Authorization?.ToString());
+
+            return JsonResponse("""
+                {
+                  "data": [
+                    { "id": "whisper-large-v3", "owned_by": "OpenAI" },
+                    { "id": "openai/gpt-oss-120b", "owned_by": "OpenAI" },
+                    { "id": "llama-3.1-8b-instant", "owned_by": "Meta" },
+                    { "id": "orpheus-tts-1", "owned_by": "Groq" }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new GroqPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var models = await sut.FetchLlmModelsAsync();
+
+        Assert.NotNull(models);
+        Assert.Equal(
+            ["llama-3.1-8b-instant", "openai/gpt-oss-120b"],
+            models!.Select(m => m.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesSelectedLlmModelWhenCallerDoesNotOverride()
+    {
+        var handler = new CapturingHandler((_, body) =>
+        {
+            using var doc = JsonDocument.Parse(body ?? throw new InvalidOperationException("Missing request body."));
+            Assert.Equal("openai/gpt-oss-120b", doc.RootElement.GetProperty("model").GetString());
+
+            return JsonResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "done"
+                      }
+                    }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+        host.SetSetting("selectedLlmModel", "openai/gpt-oss-120b");
+
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new GroqPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.ProcessAsync("system", "user", "", CancellationToken.None);
+
+        Assert.Equal("done", result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesFallbackLlmModelWhenSelectionMissing()
+    {
+        var handler = new CapturingHandler((_, body) =>
+        {
+            using var doc = JsonDocument.Parse(body ?? throw new InvalidOperationException("Missing request body."));
+            Assert.Equal("llama-3.3-70b-versatile", doc.RootElement.GetProperty("model").GetString());
+
+            return JsonResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "fallback"
+                      }
+                    }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new GroqPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.ProcessAsync("system", "user", "", CancellationToken.None);
+
+        Assert.Equal("fallback", result);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_DoesNotNotifyWhenPrefilledValueIsWrittenBack()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+
+        var sut = new GroqPlugin();
+        await sut.ActivateAsync(host);
+
+        await sut.SetApiKeyAsync("groq-key");
+
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_NotifiesWhenConfigurationStateChanges()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new GroqPlugin();
+        await sut.ActivateAsync(host);
+
+        await sut.SetApiKeyAsync("groq-key");
+        await sut.SetApiKeyAsync("");
+
+        Assert.Equal(2, host.NotifyCapabilitiesChangedCount);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class CapturingHandler(
+        Func<HttpRequestMessage, string?, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responder(request, body);
+        }
+    }
+
+    private sealed class TestPluginHostServices : IPluginHostServices
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private readonly Dictionary<string, JsonElement> _settings = [];
+        public Dictionary<string, string?> Secrets { get; } = [];
+        public int NotifyCapabilitiesChangedCount { get; private set; }
+
+        public Task StoreSecretAsync(string key, string value)
+        {
+            Secrets[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadSecretAsync(string key) =>
+            Task.FromResult(Secrets.TryGetValue(key, out var value) ? value : null);
+
+        public Task DeleteSecretAsync(string key)
+        {
+            Secrets.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value)
+                ? value.Deserialize<T>(JsonOptions)
+                : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new TestPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() => NotifyCapabilitiesChangedCount++;
+        public IPluginLocalization Localization { get; } = new TestPluginLocalization();
+    }
+
+    private sealed class TestPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TestPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Windows\TypeWhisper.Windows.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Add Groq settings controls for transcription and LLM model selection
- Fetch and persist Groq LLM models from the API with fallback defaults
- Refresh plugin localization and expose test-friendly internals for model handling

## Testing
- Not run (not requested)