### PR TITLE
[codex] Fix silent-stop overlay reset and streaming session leaks

### DIFF
--- a/src/TypeWhisper.Windows/AssemblyInfo.cs
+++ b/src/TypeWhisper.Windows/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Runtime.CompilerServices;
 
 [assembly:ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
@@ -8,3 +9,4 @@ using System.Windows;
                                                 //(used if a resource is not found in the page,
                                                 // app, or any theme specific resource dictionaries)
 )]
+[assembly: InternalsVisibleTo("TypeWhisper.PluginSystem.Tests")]

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -13,12 +13,12 @@ public sealed class StreamingHandler : IDisposable
     private readonly ModelManagerService _modelManager;
     private readonly AudioRecordingService _audio;
     private readonly IDictionaryService _dictionary;
+    private readonly StreamingTranscriptState _transcriptState = new();
 
     private CancellationTokenSource? _cts;
     private Task? _streamingTask;
     private IStreamingSession? _session;
-    private string _confirmedText = "";
-    private string _lastDisplayedText = "";
+    private Action<StreamingTranscriptEvent>? _transcriptHandler;
 
     public Action<string>? OnPartialTextUpdate { get; set; }
 
@@ -39,17 +39,16 @@ public sealed class StreamingHandler : IDisposable
     {
         Stop();
 
-        _confirmedText = "";
-        _lastDisplayedText = "";
+        var sessionVersion = _transcriptState.StartSession();
         _cts = new CancellationTokenSource();
         var ct = _cts.Token;
 
         var plugin = _modelManager.ActiveTranscriptionPlugin;
 
         if (plugin is not null && plugin.SupportsStreaming)
-            _streamingTask = RunWebSocketStreamingAsync(plugin, language, ct);
+            _streamingTask = RunWebSocketStreamingAsync(plugin, language, sessionVersion, ct);
         else
-            _streamingTask = RunPollingFallbackAsync(language, task, isStillRecording, ct);
+            _streamingTask = RunPollingFallbackAsync(language, task, isStillRecording, sessionVersion, ct);
     }
 
     public string Stop()
@@ -57,10 +56,16 @@ public sealed class StreamingHandler : IDisposable
         _audio.SamplesAvailable -= OnStreamingSamplesAvailable;
         _cts?.Cancel();
 
-        var finalText = _lastDisplayedText;
+        var finalText = _transcriptState.StopSession();
 
         var session = _session;
+        var transcriptHandler = _transcriptHandler;
         _session = null;
+        _transcriptHandler = null;
+
+        if (session is not null && transcriptHandler is not null)
+            session.TranscriptReceived -= transcriptHandler;
+
         if (session is not null)
         {
             // Fire-and-forget with timeout to avoid deadlock
@@ -70,8 +75,6 @@ public sealed class StreamingHandler : IDisposable
         _cts?.Dispose();
         _cts = null;
         _streamingTask = null;
-        _confirmedText = "";
-        _lastDisplayedText = "";
 
         return finalText;
     }
@@ -88,14 +91,21 @@ public sealed class StreamingHandler : IDisposable
     // ── WebSocket streaming path ──
 
     private async Task RunWebSocketStreamingAsync(
-        ITranscriptionEnginePlugin plugin, string? language, CancellationToken ct)
+        ITranscriptionEnginePlugin plugin, string? language, int sessionVersion, CancellationToken ct)
     {
         try
         {
             var lang = language == "auto" ? null : language;
-            _session = await plugin.StartStreamingAsync(lang, ct);
+            var session = await plugin.StartStreamingAsync(lang, ct);
+            if (!_transcriptState.IsCurrentSession(sessionVersion) || ct.IsCancellationRequested)
+            {
+                await CleanupSessionAsync(session);
+                return;
+            }
 
-            _session.TranscriptReceived += OnTranscriptReceived;
+            _session = session;
+            _transcriptHandler = evt => OnTranscriptReceived(evt, sessionVersion);
+            session.TranscriptReceived += _transcriptHandler;
             _audio.SamplesAvailable += OnStreamingSamplesAvailable;
 
             // Keep alive until cancelled
@@ -123,36 +133,20 @@ public sealed class StreamingHandler : IDisposable
         });
     }
 
-    private void OnTranscriptReceived(StreamingTranscriptEvent evt)
+    private void OnTranscriptReceived(StreamingTranscriptEvent evt, int sessionVersion)
     {
-        var text = evt.Text?.Trim() ?? "";
-        if (string.IsNullOrEmpty(text)) return;
+        if (_cts is null || _cts.IsCancellationRequested)
+            return;
 
-        text = _dictionary.ApplyCorrections(text);
-
-        if (evt.IsFinal)
-        {
-            _confirmedText = string.IsNullOrEmpty(_confirmedText)
-                ? text
-                : _confirmedText + " " + text;
-            _lastDisplayedText = _confirmedText;
-            OnPartialTextUpdate?.Invoke(_confirmedText);
-        }
-        else
-        {
-            var display = string.IsNullOrEmpty(_confirmedText)
-                ? text
-                : _confirmedText + " " + text;
-            _lastDisplayedText = display;
+        if (_transcriptState.TryApplyRealtime(sessionVersion, evt, _dictionary.ApplyCorrections, out var display))
             OnPartialTextUpdate?.Invoke(display);
-        }
     }
 
     // ── Polling fallback path ──
 
     private async Task RunPollingFallbackAsync(
         string? language, TranscriptionTask task,
-        Func<bool> isStillRecording, CancellationToken ct)
+        Func<bool> isStillRecording, int sessionVersion, CancellationToken ct)
     {
         var engine = _modelManager.Engine;
         var pollInterval = TimeSpan.FromSeconds(3.0);
@@ -181,10 +175,14 @@ public sealed class StreamingHandler : IDisposable
 
                         if (!string.IsNullOrEmpty(text))
                         {
-                            text = _dictionary.ApplyCorrections(text);
-                            var stable = StabilizeText(_confirmedText, text);
-                            _confirmedText = stable;
-                            OnPartialTextUpdate?.Invoke(stable);
+                            if (_transcriptState.TryApplyPolling(
+                                sessionVersion,
+                                text,
+                                _dictionary.ApplyCorrections,
+                                out var stable))
+                            {
+                                OnPartialTextUpdate?.Invoke(stable);
+                            }
                         }
                     }
                     catch (OperationCanceledException) { throw; }

--- a/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
@@ -1,0 +1,92 @@
+using System.Threading;
+using TypeWhisper.PluginSDK;
+
+namespace TypeWhisper.Windows.Services;
+
+internal sealed class StreamingTranscriptState
+{
+    private int _sessionVersion;
+    private string _confirmedText = "";
+    private string _lastDisplayedText = "";
+
+    public int StartSession()
+    {
+        _confirmedText = "";
+        _lastDisplayedText = "";
+        return Interlocked.Increment(ref _sessionVersion);
+    }
+
+    public string StopSession()
+    {
+        var finalText = _lastDisplayedText;
+        InvalidateSession();
+        _confirmedText = "";
+        _lastDisplayedText = "";
+        return finalText;
+    }
+
+    public bool IsCurrentSession(int sessionVersion) =>
+        sessionVersion == Volatile.Read(ref _sessionVersion);
+
+    public void InvalidateSession() => Interlocked.Increment(ref _sessionVersion);
+
+    public bool TryApplyRealtime(
+        int sessionVersion,
+        StreamingTranscriptEvent evt,
+        Func<string, string> corrector,
+        out string displayText)
+    {
+        displayText = "";
+        if (!IsCurrentSession(sessionVersion))
+            return false;
+
+        var text = evt.Text?.Trim() ?? "";
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        text = corrector(text);
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        if (evt.IsFinal)
+        {
+            _confirmedText = string.IsNullOrEmpty(_confirmedText)
+                ? text
+                : _confirmedText + " " + text;
+            _lastDisplayedText = _confirmedText;
+            displayText = _confirmedText;
+            return true;
+        }
+
+        displayText = string.IsNullOrEmpty(_confirmedText)
+            ? text
+            : _confirmedText + " " + text;
+        _lastDisplayedText = displayText;
+        return true;
+    }
+
+    public bool TryApplyPolling(
+        int sessionVersion,
+        string rawText,
+        Func<string, string> corrector,
+        out string displayText)
+    {
+        displayText = "";
+        if (!IsCurrentSession(sessionVersion))
+            return false;
+
+        var text = rawText.Trim();
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        text = corrector(text);
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        var stable = StreamingHandler.StabilizeText(_confirmedText, text);
+        _confirmedText = stable;
+        _lastDisplayedText = stable;
+        displayText = stable;
+        return true;
+    }
+}

--- a/src/TypeWhisper.Windows/ViewModels/DictationOverlayPresentation.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationOverlayPresentation.cs
@@ -1,0 +1,28 @@
+namespace TypeWhisper.Windows.ViewModels;
+
+internal sealed record DictationResetOutcome(
+    DictationState State,
+    bool IsOverlayVisible,
+    bool ShowFeedback,
+    bool FeedbackIsError,
+    bool ForceHotkeyStop);
+
+internal static class DictationOverlayPresentation
+{
+    public static bool ShowInlineFeedback(bool isOverlayVisible, bool showFeedback) =>
+        isOverlayVisible && showFeedback;
+
+    public static bool ShowDetachedFeedback(bool isOverlayVisible, bool showFeedback) =>
+        !isOverlayVisible && showFeedback;
+
+    public static bool HasVisibleContent(bool isOverlayVisible, bool showFeedback) =>
+        isOverlayVisible || ShowDetachedFeedback(isOverlayVisible, showFeedback);
+
+    public static DictationResetOutcome CreateTransientIdleFeedback(bool feedbackIsError = false) =>
+        new(
+            DictationState.Idle,
+            IsOverlayVisible: false,
+            ShowFeedback: true,
+            FeedbackIsError: feedbackIsError,
+            ForceHotkeyStop: true);
+}

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -142,22 +142,15 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             if (_isRecording)
             {
                 _isRecording = false;
-                _durationTimer?.Stop();
                 _audio.StopRecording();
-                _audioDucking.RestoreAudio();
-                _mediaPause.ResumeMedia();
-                State = DictationState.Idle;
-                IsOverlayVisible = false;
+                StopActiveRecordingInfrastructure();
             }
-            FeedbackText = Loc.Instance["Status.NoMicrophone"];
-            FeedbackIsError = true;
-            ShowFeedback = true;
+
+            ApplyTransientIdleFeedback(Loc.Instance["Status.NoMicrophone"], feedbackIsError: true);
         });
         _audio.DeviceAvailable += (_, _) => Application.Current?.Dispatcher.InvokeAsync(() =>
         {
-            FeedbackText = Loc.Instance["Status.MicrophoneRestored"];
-            FeedbackIsError = false;
-            ShowFeedback = true;
+            ShowTransientFeedback(Loc.Instance["Status.MicrophoneRestored"], isError: false);
         });
         _settings.SettingsChanged += _ =>
         {
@@ -175,10 +168,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             {
                 System.Diagnostics.Debug.WriteLine($"StopRecording error: {ex}");
                 _isRecording = false;
-                _audioDucking.RestoreAudio();
-                _mediaPause.ResumeMedia();
-                StatusText = Loc.Instance.GetString("Status.ErrorFormat", ex.Message);
-                UpdateVisualState();
+                StopActiveRecordingInfrastructure();
+                ApplyTransientIdleFeedback(
+                    Loc.Instance.GetString("Status.ErrorFormat", ex.Message),
+                    feedbackIsError: true);
             }
         });
 
@@ -195,6 +188,12 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
     public OverlayWidget LeftWidget => _settings.Current.OverlayLeftWidget;
     public OverlayWidget RightWidget => _settings.Current.OverlayRightWidget;
+    public bool ShowInlineFeedback =>
+        DictationOverlayPresentation.ShowInlineFeedback(IsOverlayVisible, ShowFeedback);
+    public bool ShowDetachedFeedback =>
+        DictationOverlayPresentation.ShowDetachedFeedback(IsOverlayVisible, ShowFeedback);
+    public bool HasOverlayContentVisible =>
+        DictationOverlayPresentation.HasVisibleContent(IsOverlayVisible, ShowFeedback);
 
     partial void OnPartialTextChanged(string value)
     {
@@ -221,6 +220,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
     partial void OnShowFeedbackChanged(bool value)
     {
+        RaiseOverlayPresentationChanged();
         _feedbackTimer?.Stop();
         _feedbackTimer?.Dispose();
         if (value)
@@ -234,6 +234,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _feedbackTimer.Start();
         }
     }
+
+    partial void OnIsOverlayVisibleChanged(bool value) => RaiseOverlayPresentationChanged();
 
     // Effective settings: profile override → global setting
     private string? EffectiveLanguage =>
@@ -260,10 +262,119 @@ public partial class DictationViewModel : ObservableObject, IDisposable
     /// <summary>Whether the service is currently recording.</summary>
     public bool IsRecording => _isRecording;
 
+    private void RaiseOverlayPresentationChanged()
+    {
+        OnPropertyChanged(nameof(ShowInlineFeedback));
+        OnPropertyChanged(nameof(ShowDetachedFeedback));
+        OnPropertyChanged(nameof(HasOverlayContentVisible));
+    }
+
+    private void ClearCapturedContext()
+    {
+        ActiveProcessName = null;
+        ActiveProfileName = null;
+        _activeProfile = null;
+        _capturedProcessName = null;
+        _capturedWindowTitle = null;
+    }
+
+    private void ClearPartialPreview()
+    {
+        _partialSegments.Clear();
+        PartialText = "";
+        IsExpanded = false;
+    }
+
+    private int DecrementPendingJobCount()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _pendingJobCount);
+            if (current == 0)
+                return 0;
+
+            var next = current - 1;
+            if (Interlocked.CompareExchange(ref _pendingJobCount, next, current) == current)
+                return next;
+        }
+    }
+
+    private void ShowTransientFeedback(string text, bool isError)
+    {
+        FeedbackText = text;
+        FeedbackIsError = isError;
+
+        if (ShowFeedback)
+            ShowFeedback = false;
+
+        ShowFeedback = true;
+    }
+
+    private void ResetSessionToIdle(bool clearFeedback = false, bool forceHotkeyStop = false)
+    {
+        State = DictationState.Idle;
+        StatusText = Loc.Instance["Status.Ready"];
+        IsOverlayVisible = false;
+        RecordingSeconds = 0;
+        CurrentHotkeyMode = null;
+        ClearCapturedContext();
+        ClearPartialPreview();
+
+        if (clearFeedback)
+        {
+            FeedbackText = null;
+            FeedbackIsError = false;
+            ShowFeedback = false;
+        }
+
+        if (forceHotkeyStop)
+            _hotkey.ForceStop();
+
+        _hotkey.IsCancelShortcutEnabled = _isRecording || _pendingJobCount > 0;
+    }
+
+    private void ApplyTransientIdleFeedback(string feedbackText, bool feedbackIsError = false)
+    {
+        var resetOutcome = DictationOverlayPresentation.CreateTransientIdleFeedback(feedbackIsError);
+
+        State = resetOutcome.State;
+        IsOverlayVisible = resetOutcome.IsOverlayVisible;
+        RecordingSeconds = 0;
+        CurrentHotkeyMode = null;
+        ClearCapturedContext();
+        ClearPartialPreview();
+        StatusText = Loc.Instance["Status.Ready"];
+        ShowTransientFeedback(feedbackText, resetOutcome.FeedbackIsError);
+
+        if (resetOutcome.ForceHotkeyStop)
+            _hotkey.ForceStop();
+
+        _hotkey.IsCancelShortcutEnabled = _isRecording || _pendingJobCount > 0;
+    }
+
+    private void StopActiveRecordingInfrastructure()
+    {
+        _durationTimer?.Stop();
+        _durationTimer?.Dispose();
+        _durationTimer = null;
+
+        _streamingHandler.Stop();
+        _audio.SamplesAvailable -= OnSamplesAvailable;
+        _audioDucking.RestoreAudio();
+        _mediaPause.ResumeMedia();
+        _vad?.Dispose();
+        _vad = null;
+        RecordingSeconds = 0;
+        CurrentHotkeyMode = null;
+    }
+
     private async Task StartRecording()
     {
         if (_isRecording) return;
         _isRecording = true;
+        FeedbackText = null;
+        FeedbackIsError = false;
+        ShowFeedback = false;
 
         // Capture active window context at recording start
         _capturedProcessName = _activeWindow.GetActiveWindowProcessName();
@@ -289,26 +400,25 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             }
             catch (Exception ex)
             {
-                StatusText = Loc.Instance.GetString("Status.ModelErrorFormat", ex.Message);
                 _isRecording = false;
+                ApplyTransientIdleFeedback(
+                    Loc.Instance.GetString("Status.ModelErrorFormat", ex.Message),
+                    feedbackIsError: true);
                 return;
             }
         }
 
         if (!_modelManager.Engine.IsModelLoaded)
         {
-            StatusText = Loc.Instance["Status.NoModelLoaded"];
             _isRecording = false;
+            ApplyTransientIdleFeedback(Loc.Instance["Status.NoModelLoaded"], feedbackIsError: true);
             return;
         }
 
         if (!_audio.HasDevice)
         {
-            StatusText = Loc.Instance["Status.NoMicrophone"];
-            FeedbackText = StatusText;
-            FeedbackIsError = true;
-            ShowFeedback = true;
             _isRecording = false;
+            ApplyTransientIdleFeedback(Loc.Instance["Status.NoMicrophone"], feedbackIsError: true);
             return;
         }
 
@@ -338,6 +448,15 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _audio.SamplesAvailable += OnSamplesAvailable;
         }
 
+        _audio.StartRecording();
+        if (!_audio.IsRecording)
+        {
+            _isRecording = false;
+            StopActiveRecordingInfrastructure();
+            ApplyTransientIdleFeedback(Loc.Instance["Status.NoMicrophone"], feedbackIsError: true);
+            return;
+        }
+
         _sound.PlayStartSound();
 
         if (_settings.Current.AudioDuckingEnabled)
@@ -345,7 +464,6 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         if (_settings.Current.PauseMediaDuringRecording)
             _mediaPause.PauseMedia();
 
-        _audio.StartRecording();
         _eventBus.Publish(new RecordingStartedEvent
         {
             AppName = _activeWindow.GetActiveWindowTitle(),
@@ -376,18 +494,18 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         if (!_isRecording) return;
         _isRecording = false;
 
-        _durationTimer?.Stop();
-        _durationTimer?.Dispose();
-        _durationTimer = null;
-
         var streamingText = _streamingHandler.Stop();
         _audio.SamplesAvailable -= OnSamplesAvailable;
 
         var samples = _audio.StopRecording();
         _eventBus.Publish(new RecordingStoppedEvent { DurationSeconds = _audio.RecordingDuration.TotalSeconds });
+        _durationTimer?.Stop();
+        _durationTimer?.Dispose();
+        _durationTimer = null;
         _audioDucking.RestoreAudio();
         _mediaPause.ResumeMedia();
         RecordingSeconds = 0;
+        CurrentHotkeyMode = null;
 
         // Flush remaining VAD segments
         List<string> partialSnapshot;
@@ -406,20 +524,14 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
         if (samples is null || samples.Length < 1600) // < 100ms
         {
-            UpdateVisualState();
-            StatusText = Loc.Instance["Status.TooShort"];
-            PartialText = "";
-            _hotkey.ForceStop();
+            ApplyTransientIdleFeedback(Loc.Instance["Status.TooShort"]);
             return;
         }
 
         // Skip transcription if audio is essentially silence (prevents cloud model hallucinations)
         if (!_audio.HasSpeechEnergy && partialSnapshot.Count == 0)
         {
-            UpdateVisualState();
-            StatusText = Loc.Instance["Status.NoSpeech"];
-            PartialText = "";
-            _hotkey.ForceStop();
+            ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]);
             return;
         }
 
@@ -444,32 +556,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         if (_isRecording)
         {
             _isRecording = false;
-
-            _durationTimer?.Stop();
-            _durationTimer?.Dispose();
-            _durationTimer = null;
-
-            _streamingHandler.Stop();
-            _audio.SamplesAvailable -= OnSamplesAvailable;
             _audio.StopRecording();
-            _audioDucking.RestoreAudio();
-            _mediaPause.ResumeMedia();
-            _vad?.Dispose();
-            _vad = null;
-            _partialSegments.Clear();
-            PartialText = "";
-            RecordingSeconds = 0;
-            CurrentHotkeyMode = null;
-            _hotkey.ForceStop();
-            StatusText = Loc.Instance["Status.Cancelled"];
-            UpdateVisualState();
+            StopActiveRecordingInfrastructure();
+            ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]);
             return Task.CompletedTask;
         }
 
         if (_pendingJobCount > 0)
         {
             CancelProcessing();
-            StatusText = Loc.Instance["Status.Cancelled"];
+            ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]);
         }
 
         return Task.CompletedTask;
@@ -480,9 +576,15 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         await foreach (var job in _jobChannel.Reader.ReadAllAsync(ct))
         {
             await Application.Current.Dispatcher.InvokeAsync(() => UpdateVisualState());
-            await ProcessSingleJobAsync(job, ct);
-            Interlocked.Decrement(ref _pendingJobCount);
-            await Application.Current.Dispatcher.InvokeAsync(() => UpdateVisualState());
+            try
+            {
+                await ProcessSingleJobAsync(job, ct);
+            }
+            finally
+            {
+                DecrementPendingJobCount();
+                await Application.Current.Dispatcher.InvokeAsync(() => UpdateVisualState());
+            }
         }
     }
 
@@ -513,20 +615,14 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 if (result.NoSpeechProbability is > 0.8f)
                 {
                     await Application.Current.Dispatcher.InvokeAsync(() =>
-                    {
-                        StatusText = Loc.Instance["Status.NoSpeech"];
-                        UpdateVisualState();
-                    });
+                        ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                     return;
                 }
 
                 if (string.IsNullOrWhiteSpace(result.Text))
                 {
                     await Application.Current.Dispatcher.InvokeAsync(() =>
-                    {
-                        StatusText = Loc.Instance["Status.NoSpeech"];
-                        UpdateVisualState();
-                    });
+                        ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                     return;
                 }
 
@@ -537,10 +633,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             if (string.IsNullOrWhiteSpace(rawText))
             {
                 await Application.Current.Dispatcher.InvokeAsync(() =>
-                {
-                    StatusText = Loc.Instance["Status.NoSpeech"];
-                    UpdateVisualState();
-                });
+                    ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                 return;
             }
 
@@ -763,10 +856,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         catch (OperationCanceledException)
         {
             await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                StatusText = Loc.Instance["Status.Cancelled"];
-                UpdateVisualState();
-            });
+                ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]));
         }
         catch (Exception ex)
         {
@@ -805,14 +895,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         }
         else
         {
-            State = DictationState.Idle;
-            StatusText = Loc.Instance["Status.Ready"];
-            IsOverlayVisible = false;
-            ActiveProcessName = null;
-            ActiveProfileName = null;
-            PartialText = "";
-            IsExpanded = false;
-            ShowFeedback = false;
+            ResetSessionToIdle(clearFeedback: false, forceHotkeyStop: false);
+            return;
         }
 
         _hotkey.IsCancelShortcutEnabled = _isRecording || _pendingJobCount > 0;
@@ -888,7 +972,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         _consumerCts.Cancel();
 
         while (_jobChannel.Reader.TryRead(out _))
-            Interlocked.Decrement(ref _pendingJobCount);
+            DecrementPendingJobCount();
 
         // Restart consumer with fresh CTS
         _consumerCts = new CancellationTokenSource();

--- a/src/TypeWhisper.Windows/Views/MainWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/MainWindow.xaml
@@ -25,7 +25,7 @@
     </Window.Resources>
 
     <Grid Margin="8"
-          Visibility="{Binding IsOverlayVisible, Converter={StaticResource BoolToVis}}">
+          Visibility="{Binding HasOverlayContentVisible, Converter={StaticResource BoolToVis}}">
 
         <Border x:Name="IslandBorder"
                 CornerRadius="22"
@@ -34,7 +34,8 @@
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 MinWidth="280"
-                Padding="14,10">
+                Padding="14,10"
+                Visibility="{Binding IsOverlayVisible, Converter={StaticResource BoolToVis}}">
             <Border.Effect>
                 <DropShadowEffect Color="Black" BlurRadius="12" Opacity="0.5" ShadowDepth="0"/>
             </Border.Effect>
@@ -84,18 +85,64 @@
                     </ScrollViewer>
                 </Border>
 
-                <!-- Feedback banner (errors only) -->
+                <!-- Inline feedback while overlay is already visible -->
                 <Border CornerRadius="0,0,22,22"
                         Padding="16,4,16,6"
-                        Background="#1AFF4444"
-                        Visibility="{Binding ShowFeedback, Converter={StaticResource BoolToVis}}">
+                        Visibility="{Binding ShowInlineFeedback, Converter={StaticResource BoolToVis}}">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="Background" Value="#1AFF4444"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding FeedbackIsError}" Value="False">
+                                    <Setter Property="Background" Value="#1A33D17A"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <TextBlock Text="{Binding FeedbackText}"
-                               Foreground="#FF6666"
                                FontSize="11"
                                HorizontalAlignment="Center"
-                               TextTrimming="CharacterEllipsis"/>
+                               TextTrimming="CharacterEllipsis">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="#FF6666"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FeedbackIsError}" Value="False">
+                                        <Setter Property="Foreground" Value="#66E3A2"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
                 </Border>
             </StackPanel>
+        </Border>
+
+        <Border CornerRadius="18"
+                Padding="14,7"
+                HorizontalAlignment="Center"
+                Background="#F0181818"
+                BorderBrush="#25FFFFFF"
+                BorderThickness="1"
+                Visibility="{Binding ShowDetachedFeedback, Converter={StaticResource BoolToVis}}">
+            <Border.Effect>
+                <DropShadowEffect Color="Black" BlurRadius="12" Opacity="0.5" ShadowDepth="0"/>
+            </Border.Effect>
+            <TextBlock Text="{Binding FeedbackText}"
+                       FontSize="11"
+                       HorizontalAlignment="Center"
+                       TextTrimming="CharacterEllipsis">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="#FF6666"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding FeedbackIsError}" Value="False">
+                                <Setter Property="Foreground" Value="#66E3A2"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
         </Border>
     </Grid>
 </Window>

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
@@ -1,0 +1,46 @@
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class DictationOverlayPresentationTests
+{
+    [Fact]
+    public void CreateTransientIdleFeedback_HidesOverlayAndForcesHotkeyReset()
+    {
+        var outcome = DictationOverlayPresentation.CreateTransientIdleFeedback();
+
+        Assert.Equal(DictationState.Idle, outcome.State);
+        Assert.False(outcome.IsOverlayVisible);
+        Assert.True(outcome.ShowFeedback);
+        Assert.False(outcome.FeedbackIsError);
+        Assert.True(outcome.ForceHotkeyStop);
+    }
+
+    [Fact]
+    public void DetachedFeedback_IsShownOnlyWhenOverlayIsHidden()
+    {
+        Assert.True(DictationOverlayPresentation.ShowDetachedFeedback(
+            isOverlayVisible: false,
+            showFeedback: true));
+        Assert.False(DictationOverlayPresentation.ShowDetachedFeedback(
+            isOverlayVisible: true,
+            showFeedback: true));
+        Assert.False(DictationOverlayPresentation.ShowDetachedFeedback(
+            isOverlayVisible: false,
+            showFeedback: false));
+    }
+
+    [Fact]
+    public void VisibleContent_RemainsVisibleForDetachedFeedback()
+    {
+        Assert.True(DictationOverlayPresentation.HasVisibleContent(
+            isOverlayVisible: false,
+            showFeedback: true));
+        Assert.True(DictationOverlayPresentation.HasVisibleContent(
+            isOverlayVisible: true,
+            showFeedback: false));
+        Assert.False(DictationOverlayPresentation.HasVisibleContent(
+            isOverlayVisible: false,
+            showFeedback: false));
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -172,3 +172,98 @@ public class StabilizeTextTests
         Assert.Equal("Hello", result);
     }
 }
+
+public class StreamingTranscriptStateTests
+{
+    [Fact]
+    public void StopSession_InvalidatesLateRealtimeEvents()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        var appliedBeforeStop = sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("Hello world", false),
+            text => text,
+            out var displayBeforeStop);
+
+        Assert.True(appliedBeforeStop);
+        Assert.Equal("Hello world", displayBeforeStop);
+
+        var finalText = sut.StopSession();
+
+        Assert.Equal("Hello world", finalText);
+
+        var appliedAfterStop = sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("Should be ignored", false),
+            text => text,
+            out var displayAfterStop);
+
+        Assert.False(appliedAfterStop);
+        Assert.Equal("", displayAfterStop);
+    }
+
+    [Fact]
+    public void RealtimeFinalTranscript_AppendsToConfirmedText()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        var interimApplied = sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("Hello", false),
+            text => text,
+            out var interimDisplay);
+        var finalApplied = sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("world", true),
+            text => text,
+            out var finalDisplay);
+
+        Assert.True(interimApplied);
+        Assert.Equal("Hello", interimDisplay);
+        Assert.True(finalApplied);
+        Assert.Equal("world", finalDisplay);
+        Assert.Equal("world", sut.StopSession());
+    }
+
+    [Fact]
+    public void PollingTranscript_UsesStabilizedCurrentSessionOnly()
+    {
+        var sut = new StreamingTranscriptState();
+        var firstSession = sut.StartSession();
+
+        var firstApplied = sut.TryApplyPolling(
+            firstSession,
+            "Hello world",
+            text => text,
+            out var firstDisplay);
+        var secondApplied = sut.TryApplyPolling(
+            firstSession,
+            "Hello world, how are you?",
+            text => text,
+            out var secondDisplay);
+
+        Assert.True(firstApplied);
+        Assert.Equal("Hello world", firstDisplay);
+        Assert.True(secondApplied);
+        Assert.Equal("Hello world, how are you?", secondDisplay);
+
+        var secondSession = sut.StartSession();
+        var staleApplied = sut.TryApplyPolling(
+            firstSession,
+            "Old session text",
+            text => text,
+            out _);
+        var currentApplied = sut.TryApplyPolling(
+            secondSession,
+            "Fresh session text",
+            text => text,
+            out var currentDisplay);
+
+        Assert.False(staleApplied);
+        Assert.True(currentApplied);
+        Assert.Equal("Fresh session text", currentDisplay);
+    }
+}


### PR DESCRIPTION
Fixes #27.

## Summary
Fix the silent-stop/reset path for dictation sessions so the overlay and hotkey state return to idle cleanly when no usable speech is captured.

## What Changed
- centralized idle reset handling in dictation state transitions for no-speech, too-short, cancel, device-loss, and early start failures
- prevented pending transcription jobs from leaving the UI stuck in `Processing`
- hardened streaming session teardown so late transcript events from an old session are ignored after stop
- updated the overlay UI to show brief detached feedback instead of leaving the full listening/processing bubble visible
- added focused tests for detached feedback presentation and streaming session invalidation

## Root Cause
The silent-stop path was spread across multiple branches in `DictationViewModel`, so some exits cleared only part of the session state. In parallel, streaming callbacks from an old session could still update preview text after stop, which made the overlay look stuck or caused the next hotkey press to feel like it was clearing stale state.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj`

## Impact
Users should now see the overlay dismiss immediately after silent or too-short recordings, with only brief feedback like `No speech detected` or `Too short`, and the next hotkey press should start a fresh recording normally.