### PR TITLE
[codex] Fix disappearing provider and model selection state

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -279,13 +279,24 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _activeProfile = _profiles.MatchProfile(_capturedProcessName, url);
         }
 
-        // Switch to profile model override if needed (cloud switch is instant)
-        var profileModel = EffectiveModelId;
-        if (profileModel is not null && profileModel != _modelManager.ActiveModelId)
+        var desiredModelId = EffectiveModelId ?? _settings.Current.SelectedModelId;
+        if (string.IsNullOrWhiteSpace(desiredModelId))
+        {
+            StatusText = Loc.Instance["Status.NoModelLoaded"];
+            _isRecording = false;
+            return;
+        }
+
+        if (desiredModelId != _modelManager.ActiveModelId || !_modelManager.Engine.IsModelLoaded)
         {
             try
             {
-                await _modelManager.LoadModelAsync(profileModel);
+                if (!await _modelManager.EnsureModelLoadedAsync(desiredModelId))
+                {
+                    StatusText = Loc.Instance["Status.NoModelLoaded"];
+                    _isRecording = false;
+                    return;
+                }
             }
             catch (Exception ex)
             {

--- a/src/TypeWhisper.Windows/ViewModels/ModelManagerViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/ModelManagerViewModel.cs
@@ -51,6 +51,12 @@ public partial class ModelManagerViewModel : ObservableObject
 
         _modelManager.PluginManager.PluginStateChanged += (_, _) =>
             Application.Current.Dispatcher.Invoke(RebuildProviders);
+
+        _settings.SettingsChanged += _ => InvokeOnUiThread(() =>
+        {
+            SyncSelectedModelOption();
+            RefreshActiveModelDetails();
+        });
     }
 
     private void RebuildProviders()
@@ -172,8 +178,19 @@ public partial class ModelManagerViewModel : ObservableObject
             return;
 
         _isSyncingSelection = true;
-        SelectedModelOptionId = ActiveModelId;
+        SelectedModelOptionId = _settings.Current.SelectedModelId;
         _isSyncingSelection = false;
+    }
+
+    private static void InvokeOnUiThread(Action action)
+    {
+        if (Application.Current?.Dispatcher is { } dispatcher && !dispatcher.CheckAccess())
+        {
+            dispatcher.Invoke(action);
+            return;
+        }
+
+        action();
     }
 
     private void RefreshActiveModelDetails()

--- a/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
@@ -47,12 +47,23 @@ public partial class PromptsViewModel : ObservableObject
         {
             _settings.Save(_settings.Current with { DefaultLlmProvider = value });
             OnPropertyChanged();
+            OnPropertyChanged(nameof(SelectedDefaultProvider));
             OnPropertyChanged(nameof(DefaultProviderSummary));
         }
     }
 
     public ObservableCollection<ProviderOption> AvailableProviders { get; } = [];
     public string DefaultProviderSummary => GetDefaultProviderLabel();
+    public ProviderOption? SelectedDefaultProvider
+    {
+        get => AvailableProviders.FirstOrDefault(option => option.Value == DefaultLlmProvider)
+            ?? AvailableProviders.FirstOrDefault();
+        set
+        {
+            DefaultLlmProvider = value?.Value;
+            OnPropertyChanged();
+        }
+    }
 
     public static IReadOnlyList<string> IconOptions { get; } =
     [
@@ -71,6 +82,13 @@ public partial class PromptsViewModel : ObservableObject
         _settings = settings;
 
         _promptActions.ActionsChanged += RefreshActions;
+        _pluginManager.PluginStateChanged += (_, _) => InvokeOnUiThread(RefreshProviders);
+        _settings.SettingsChanged += _ => InvokeOnUiThread(() =>
+        {
+            OnPropertyChanged(nameof(DefaultLlmProvider));
+            OnPropertyChanged(nameof(SelectedDefaultProvider));
+            OnPropertyChanged(nameof(DefaultProviderSummary));
+        });
         RefreshActions();
         RefreshProviders();
     }
@@ -218,7 +236,19 @@ public partial class PromptsViewModel : ObservableObject
             }
         }
         OnPropertyChanged(nameof(HasLlmProviders));
+        OnPropertyChanged(nameof(SelectedDefaultProvider));
         OnPropertyChanged(nameof(DefaultProviderSummary));
+    }
+
+    private static void InvokeOnUiThread(Action action)
+    {
+        if (Application.Current?.Dispatcher is { } dispatcher && !dispatcher.CheckAccess())
+        {
+            dispatcher.Invoke(action);
+            return;
+        }
+
+        action();
     }
 
     private string GetDefaultProviderLabel()

--- a/src/TypeWhisper.Windows/Views/Sections/PromptsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/PromptsSection.xaml
@@ -41,8 +41,7 @@
                             Visibility="{Binding Prompts.HasLlmProviders, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="{loc:Str Prompts.DefaultProvider}" Style="{StaticResource HintStyle}" Margin="0,0,0,6"/>
                     <ComboBox ItemsSource="{Binding Prompts.AvailableProviders}"
-                              SelectedValue="{Binding Prompts.DefaultLlmProvider}"
-                              SelectedValuePath="Value"
+                              SelectedItem="{Binding Prompts.SelectedDefaultProvider}"
                               DisplayMemberPath="DisplayName"
                               Style="{StaticResource SettingsAlignedComboBoxStyle}"
                               Width="280"/>

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -1,0 +1,146 @@
+using System.Reflection;
+using Moq;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class ModelManagerViewModelTests
+{
+    private readonly Mock<IActiveWindowService> _activeWindow = new();
+    private readonly Mock<IProfileService> _profiles = new();
+    private readonly PluginEventBus _eventBus = new();
+    private readonly PluginLoader _loader = new();
+
+    public ModelManagerViewModelTests()
+    {
+        _profiles.Setup(p => p.Profiles).Returns([]);
+    }
+
+    [Fact]
+    public void Constructor_UsesSavedSelection_WhenNoModelIsActive()
+    {
+        const string pluginId = "com.typewhisper.groq";
+        const string modelId = "whisper-large-v3";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            SelectedModelId = fullModelId
+        });
+
+        var pluginManager = CreatePluginManager(settings,
+            new FakeTranscriptionPlugin(pluginId, "Groq", modelId, "Whisper Large V3", configured: true));
+        var modelManager = new ModelManagerService(pluginManager, settings);
+
+        var sut = new ModelManagerViewModel(modelManager, settings);
+
+        Assert.Equal(fullModelId, sut.SelectedModelOptionId);
+        Assert.Equal("Groq", sut.ActiveProviderDisplayName);
+        Assert.Equal("Whisper Large V3", sut.ActiveModelDisplayName);
+    }
+
+    [Fact]
+    public async Task UnloadModel_KeepsSavedSelectionVisible()
+    {
+        const string pluginId = "com.typewhisper.groq";
+        const string modelId = "whisper-large-v3";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            SelectedModelId = fullModelId
+        });
+
+        var pluginManager = CreatePluginManager(settings,
+            new FakeTranscriptionPlugin(pluginId, "Groq", modelId, "Whisper Large V3", configured: true));
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var sut = new ModelManagerViewModel(modelManager, settings);
+
+        await modelManager.LoadModelAsync(fullModelId);
+        modelManager.UnloadModel();
+
+        Assert.Equal(fullModelId, sut.SelectedModelOptionId);
+        Assert.Equal("Groq", sut.ActiveProviderDisplayName);
+        Assert.Equal("Whisper Large V3", sut.ActiveModelDisplayName);
+    }
+
+    private PluginManager CreatePluginManager(ISettingsService settings, params ITranscriptionEnginePlugin[] transcriptionEngines)
+    {
+        var pluginManager = new PluginManager(
+            _loader,
+            _eventBus,
+            _activeWindow.Object,
+            _profiles.Object,
+            settings,
+            []);
+
+        SetPrivateField(pluginManager, "_transcriptionEngines", transcriptionEngines.ToList());
+        return pluginManager;
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        field.SetValue(target, value);
+    }
+
+    private sealed class FakeSettingsService(AppSettings initialSettings) : ISettingsService
+    {
+        public AppSettings Current { get; private set; } = initialSettings;
+        public event Action<AppSettings>? SettingsChanged;
+
+        public AppSettings Load() => Current;
+
+        public void Save(AppSettings settings)
+        {
+            Current = settings;
+            SettingsChanged?.Invoke(settings);
+        }
+    }
+
+    private sealed class FakeTranscriptionPlugin : ITranscriptionEnginePlugin
+    {
+        public FakeTranscriptionPlugin(
+            string pluginId,
+            string providerDisplayName,
+            string modelId,
+            string modelDisplayName,
+            bool configured)
+        {
+            PluginId = pluginId;
+            ProviderDisplayName = providerDisplayName;
+            IsConfigured = configured;
+            TranscriptionModels = [new PluginModelInfo(modelId, modelDisplayName)];
+        }
+
+        public string PluginId { get; }
+        public string PluginName => PluginId;
+        public string PluginVersion => "1.0.0";
+        public string ProviderId => PluginId;
+        public string ProviderDisplayName { get; }
+        public bool IsConfigured { get; }
+        public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; }
+        public string? SelectedModelId { get; private set; }
+        public bool SupportsTranslation => false;
+
+        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
+        public Task DeactivateAsync() => Task.CompletedTask;
+        public System.Windows.Controls.UserControl? CreateSettingsView() => null;
+        public void SelectModel(string selectedModelId) => SelectedModelId = selectedModelId;
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(
+            byte[] wavAudio,
+            string? language,
+            bool translate,
+            string? prompt,
+            CancellationToken ct) =>
+            Task.FromResult(new PluginTranscriptionResult("ok", language ?? "en", 1));
+
+        public void Dispose() { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/PromptsViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PromptsViewModelTests.cs
@@ -1,0 +1,133 @@
+using System.IO;
+using System.Reflection;
+using Moq;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class PromptsViewModelTests
+{
+    private readonly Mock<IActiveWindowService> _activeWindow = new();
+    private readonly Mock<IProfileService> _profiles = new();
+    private readonly PluginEventBus _eventBus = new();
+    private readonly PluginLoader _loader = new();
+
+    public PromptsViewModelTests()
+    {
+        _profiles.Setup(p => p.Profiles).Returns([]);
+    }
+
+    [Fact]
+    public void SelectedDefaultProvider_FallsBackToVisibleDefaultOption()
+    {
+        var settings = new FakeSettingsService(new AppSettings());
+        var promptActions = CreatePromptActionService();
+        var provider = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var pluginManager = CreatePluginManager(settings, provider);
+
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+
+        Assert.Null(settings.Current.DefaultLlmProvider);
+        Assert.NotNull(sut.SelectedDefaultProvider);
+        Assert.Equal(sut.AvailableProviders.First(), sut.SelectedDefaultProvider);
+        Assert.Null(sut.SelectedDefaultProvider!.Value);
+    }
+
+    [Fact]
+    public void SelectedDefaultProvider_PersistsExplicitProviderChoice()
+    {
+        var settings = new FakeSettingsService(new AppSettings());
+        var promptActions = CreatePromptActionService();
+        var provider = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var pluginManager = CreatePluginManager(settings, provider);
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+
+        var explicitOption = sut.AvailableProviders.Single(option =>
+            option.Value == "plugin:com.typewhisper.groq:llama-3.3-70b-versatile");
+
+        sut.SelectedDefaultProvider = explicitOption;
+
+        Assert.Equal(explicitOption.Value, settings.Current.DefaultLlmProvider);
+        Assert.Equal(explicitOption, sut.SelectedDefaultProvider);
+    }
+
+    private Mock<IPromptActionService> CreatePromptActionService()
+    {
+        var promptActions = new Mock<IPromptActionService>();
+        promptActions.Setup(service => service.Actions).Returns([]);
+        promptActions.Setup(service => service.EnabledActions).Returns([]);
+        return promptActions;
+    }
+
+    private PluginManager CreatePluginManager(ISettingsService settings, Mock<ILlmProviderPlugin> provider)
+    {
+        var pluginManager = new PluginManager(
+            _loader,
+            _eventBus,
+            _activeWindow.Object,
+            _profiles.Object,
+            settings,
+            []);
+
+        var manifest = new PluginManifest
+        {
+            Id = "com.typewhisper.groq",
+            Name = "Groq",
+            Version = "1.0.0",
+            AssemblyName = Path.GetFileName(Assembly.GetExecutingAssembly().Location),
+            PluginClass = typeof(object).FullName ?? "System.Object"
+        };
+
+        var loadedPlugin = new LoadedPlugin(
+            manifest,
+            provider.Object,
+            new PluginAssemblyLoadContext(Assembly.GetExecutingAssembly().Location),
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? AppContext.BaseDirectory);
+
+        SetPrivateField(pluginManager, "_allPlugins", new List<LoadedPlugin> { loadedPlugin });
+        SetPrivateField(pluginManager, "_llmProviders", new List<ILlmProviderPlugin> { provider.Object });
+        return pluginManager;
+    }
+
+    private static Mock<ILlmProviderPlugin> CreateLlmProvider(
+        string pluginId,
+        string providerName,
+        string modelId,
+        string modelDisplayName)
+    {
+        var provider = new Mock<ILlmProviderPlugin>();
+        provider.SetupGet(plugin => plugin.PluginId).Returns(pluginId);
+        provider.SetupGet(plugin => plugin.PluginName).Returns(providerName);
+        provider.SetupGet(plugin => plugin.PluginVersion).Returns("1.0.0");
+        provider.SetupGet(plugin => plugin.ProviderName).Returns(providerName);
+        provider.SetupGet(plugin => plugin.IsAvailable).Returns(true);
+        provider.SetupGet(plugin => plugin.SupportedModels).Returns([new PluginModelInfo(modelId, modelDisplayName)]);
+        return provider;
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        field.SetValue(target, value);
+    }
+
+    private sealed class FakeSettingsService(AppSettings initialSettings) : ISettingsService
+    {
+        public AppSettings Current { get; private set; } = initialSettings;
+        public event Action<AppSettings>? SettingsChanged;
+
+        public AppSettings Load() => Current;
+
+        public void Save(AppSettings settings)
+        {
+            Current = settings;
+            SettingsChanged?.Invoke(settings);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep the prompt settings default LLM provider dropdown populated by binding it to a visible default option instead of a null selected value
- preserve the saved transcription model selection in settings even when no model is currently active
- reload the saved default transcription model when dictation starts so Groq/default model state does not appear to disappear
- add regression coverage for prompt provider selection and model-selection persistence

## Why
Issue #34 reports that model/provider configuration frequently appears to vanish, especially with Groq. The root cause was a mix of transient UI state and persisted settings drifting apart:
- the prompt provider combo could render empty when no explicit provider had been saved yet
- the model settings UI mirrored the active loaded model instead of the persisted selected model
- dictation did not always restore the saved default model before starting

## User Impact
- the default LLM provider field no longer appears blank when providers are available
- the selected transcription model remains visible in settings after unloads or state refreshes
- dictation can recover the saved default model automatically instead of forcing users to reselect it repeatedly

## Validation
- `dotnet test TypeWhisper.slnx`

Closes #34