### PR TITLE
Fix Win hotkey suppression

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -156,7 +156,6 @@ internal sealed class HotkeyMatchStateMachine
     private readonly HashSet<uint> _pressedKeys = [];
     private readonly HashSet<uint> _pendingSuppressedKeyUps = [];
     private readonly HashSet<uint> _suppressedKeyDowns = [];
-    private uint _pendingSuppressedWinKey;
 
     private uint _targetModifiers;
     private uint _targetVk;
@@ -193,15 +192,6 @@ internal sealed class HotkeyMatchStateMachine
         if (isKeyDown)
         {
             var firstPress = _pressedKeys.Add(vkCode);
-            var preSuppressedWinDown = false;
-
-            if (!_isPressed && firstPress && ShouldPreSuppressWinKeyDown(vkCode))
-            {
-                swallow = true;
-                preSuppressedWinDown = true;
-                _pendingSuppressedWinKey = vkCode;
-                _suppressedKeyDowns.Add(vkCode);
-            }
 
             if (!_isPressed)
             {
@@ -220,9 +210,6 @@ internal sealed class HotkeyMatchStateMachine
                         _pendingSuppressedKeyUps.Add(unsuppressedWinKey);
                         _suppressedKeyDowns.Add(unsuppressedWinKey);
                     }
-
-                    if (preSuppressedWinDown)
-                        _pendingSuppressedWinKey = 0;
                 }
             }
             else if (!firstPress && ShouldSuppressWhilePressed(vkCode))
@@ -235,14 +222,6 @@ internal sealed class HotkeyMatchStateMachine
         }
         else if (isKeyUp)
         {
-            if (!_isPressed && _pendingSuppressedWinKey == vkCode)
-            {
-                _pendingSuppressedWinKey = 0;
-                _pressedKeys.Remove(vkCode);
-                _suppressedKeyDowns.Remove(vkCode);
-                return new HotkeyProcessResult(raiseKeyDown, raiseKeyUp, true, vkCode);
-            }
-
             if (_isPressed && ShouldRelease(vkCode))
             {
                 _isPressed = false;
@@ -254,8 +233,6 @@ internal sealed class HotkeyMatchStateMachine
 
             _pressedKeys.Remove(vkCode);
             _suppressedKeyDowns.Remove(vkCode);
-            if (_pendingSuppressedWinKey == vkCode)
-                _pendingSuppressedWinKey = 0;
         }
 
         return new HotkeyProcessResult(raiseKeyDown, raiseKeyUp, swallow);
@@ -266,7 +243,6 @@ internal sealed class HotkeyMatchStateMachine
         _pressedKeys.Clear();
         _pendingSuppressedKeyUps.Clear();
         _suppressedKeyDowns.Clear();
-        _pendingSuppressedWinKey = 0;
         _isPressed = false;
     }
 
@@ -340,17 +316,6 @@ internal sealed class HotkeyMatchStateMachine
         vkCode == _targetVk
         || ((_targetModifiers & NativeMethods.MOD_WIN) != 0 && HotkeyKeyClassifier.IsWinKey(vkCode));
 
-    private bool ShouldPreSuppressWinKeyDown(uint vkCode)
-    {
-        if (!HotkeyKeyClassifier.IsWinKey(vkCode))
-            return false;
-
-        if ((_targetModifiers & NativeMethods.MOD_WIN) == 0)
-            return false;
-
-        return _targetVk != 0 || (_targetModifiers & ~NativeMethods.MOD_WIN) != 0;
-    }
-
     private void CaptureWinKeyUpsForSuppression()
     {
         if ((_targetModifiers & NativeMethods.MOD_WIN) == 0)
@@ -422,6 +387,12 @@ internal static class HotkeyKeyClassifier
 
 internal static class HotkeyParser
 {
+    public static string Normalize(string? hotkeyString)
+    {
+        var normalized = hotkeyString?.Trim() ?? "";
+        return Parse(normalized, out _, out _) ? normalized : "";
+    }
+
     public static bool Parse(string hotkeyString, out uint modifiers, out uint vk)
     {
         modifiers = 0;
@@ -447,9 +418,23 @@ internal static class HotkeyParser
                     break;
             }
         }
-        return vk != 0 || modifiers != 0;
+
+        if (vk == 0)
+            return CountModifiers(modifiers) >= 2;
+
+        return true;
     }
 
     private static uint ParseKey(string key) =>
         HotkeyKeyMap.TryGetVirtualKey(key, out var virtualKey) ? virtualKey : 0;
+
+    private static int CountModifiers(uint modifiers)
+    {
+        var count = 0;
+        if ((modifiers & NativeMethods.MOD_CONTROL) != 0) count++;
+        if ((modifiers & NativeMethods.MOD_SHIFT) != 0) count++;
+        if ((modifiers & NativeMethods.MOD_ALT) != 0) count++;
+        if ((modifiers & NativeMethods.MOD_WIN) != 0) count++;
+        return count;
+    }
 }

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -587,6 +587,7 @@
 
   "Hotkey.Placeholder": "Tastenkombination dr\u00fccken...",
   "Hotkey.ClickToAssign": "Klicken zum Belegen",
+  "Hotkey.ModifierOnlyHint": "Einzelne Modifikatortasten wie Win sind nicht erlaubt. Nutze eine Kombination wie Ctrl+Shift oder Alt+Win, damit Windows-Shortcuts weiter funktionieren.",
 
   "PromptPalette.NoActions": "Keine Aktionen gefunden",
 

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -587,6 +587,7 @@
 
   "Hotkey.Placeholder": "Press key combination...",
   "Hotkey.ClickToAssign": "Click to assign",
+  "Hotkey.ModifierOnlyHint": "Single modifier keys like Win are not allowed. Use a combination like Ctrl+Shift or Alt+Win so Windows shortcuts keep working.",
 
   "PromptPalette.NoActions": "No actions found",
 

--- a/src/TypeWhisper.Windows/ViewModels/ProfilesViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/ProfilesViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.Core.Translation;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Views;
@@ -267,7 +268,7 @@ public partial class ProfilesViewModel : ObservableObject
         EditTranscriptionModelOverride = value.TranscriptionModelOverride;
         EditPriority = value.Priority;
         EditIsEnabled = value.IsEnabled;
-        EditHotkey = value.HotkeyData;
+        EditHotkey = HotkeyParser.Normalize(value.HotkeyData);
 
         foreach (var p in value.ProcessNames) ProcessNameChips.Add(p);
         foreach (var u in value.UrlPatterns) UrlPatternChips.Add(u);
@@ -360,7 +361,7 @@ public partial class ProfilesViewModel : ObservableObject
             TranscriptionModelOverride = string.IsNullOrWhiteSpace(EditTranscriptionModelOverride) ? null : EditTranscriptionModelOverride,
             Priority = EditPriority,
             IsEnabled = EditIsEnabled,
-            HotkeyData = string.IsNullOrWhiteSpace(EditHotkey) ? null : EditHotkey,
+            HotkeyData = string.IsNullOrWhiteSpace(HotkeyParser.Normalize(EditHotkey)) ? null : HotkeyParser.Normalize(EditHotkey),
             UpdatedAt = DateTime.UtcNow
         };
 

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
 
@@ -144,7 +145,7 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private void Save()
     {
-        var mainDictationHotkey = PushToTalkHotkey?.Trim() ?? "";
+        var mainDictationHotkey = HotkeyParser.Normalize(PushToTalkHotkey);
 
         var updated = _settings.Current with
         {
@@ -164,14 +165,14 @@ public partial class SettingsViewModel : ObservableObject
             TranslationTargetLanguage = TranslationTargetLanguage,
             ApiServerEnabled = ApiServerEnabled,
             ApiServerPort = ApiServerPort,
-            ToggleOnlyHotkey = ToggleOnlyHotkey,
-            HoldOnlyHotkey = HoldOnlyHotkey,
+            ToggleOnlyHotkey = HotkeyParser.Normalize(ToggleOnlyHotkey),
+            HoldOnlyHotkey = HotkeyParser.Normalize(HoldOnlyHotkey),
             AudioDuckingEnabled = AudioDuckingEnabled,
             AudioDuckingLevel = AudioDuckingLevel,
             PauseMediaDuringRecording = PauseMediaDuringRecording,
             OverlayLeftWidget = OverlayLeftWidget,
             OverlayRightWidget = OverlayRightWidget,
-            PromptPaletteHotkey = PromptPaletteHotkey,
+            PromptPaletteHotkey = HotkeyParser.Normalize(PromptPaletteHotkey),
             SaveToHistoryEnabled = SaveToHistoryEnabled,
             SpokenFeedbackEnabled = SpokenFeedbackEnabled,
             MemoryEnabled = MemoryEnabled,
@@ -184,13 +185,15 @@ public partial class SettingsViewModel : ObservableObject
 
     private void LoadFromSettings(AppSettings s)
     {
-        var mainDictationHotkey = !string.IsNullOrWhiteSpace(s.PushToTalkHotkey)
-            ? s.PushToTalkHotkey
-            : s.ToggleHotkey;
+        var pushToTalkHotkey = HotkeyParser.Normalize(s.PushToTalkHotkey);
+        var toggleHotkey = HotkeyParser.Normalize(s.ToggleHotkey);
+        var mainDictationHotkey = !string.IsNullOrWhiteSpace(pushToTalkHotkey)
+            ? pushToTalkHotkey
+            : toggleHotkey;
 
-        ToggleHotkey = string.IsNullOrWhiteSpace(s.ToggleHotkey)
+        ToggleHotkey = string.IsNullOrWhiteSpace(toggleHotkey)
             ? mainDictationHotkey
-            : s.ToggleHotkey;
+            : toggleHotkey;
         PushToTalkHotkey = mainDictationHotkey;
         Language = s.Language;
         AutoPaste = s.AutoPaste;
@@ -206,14 +209,14 @@ public partial class SettingsViewModel : ObservableObject
         TranslationTargetLanguage = s.TranslationTargetLanguage;
         ApiServerEnabled = s.ApiServerEnabled;
         ApiServerPort = s.ApiServerPort;
-        ToggleOnlyHotkey = s.ToggleOnlyHotkey;
-        HoldOnlyHotkey = s.HoldOnlyHotkey;
+        ToggleOnlyHotkey = HotkeyParser.Normalize(s.ToggleOnlyHotkey);
+        HoldOnlyHotkey = HotkeyParser.Normalize(s.HoldOnlyHotkey);
         AudioDuckingEnabled = s.AudioDuckingEnabled;
         AudioDuckingLevel = s.AudioDuckingLevel;
         PauseMediaDuringRecording = s.PauseMediaDuringRecording;
         OverlayLeftWidget = s.OverlayLeftWidget;
         OverlayRightWidget = s.OverlayRightWidget;
-        PromptPaletteHotkey = s.PromptPaletteHotkey;
+        PromptPaletteHotkey = HotkeyParser.Normalize(s.PromptPaletteHotkey);
         SaveToHistoryEnabled = s.SaveToHistoryEnabled;
         SpokenFeedbackEnabled = s.SpokenFeedbackEnabled;
         MemoryEnabled = s.MemoryEnabled;

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
@@ -419,13 +420,13 @@ public partial class WelcomeViewModel : ObservableObject
     }
 
     private static string ResolveMainDictationHotkey(AppSettings settings) =>
-        !string.IsNullOrWhiteSpace(settings.PushToTalkHotkey)
-            ? settings.PushToTalkHotkey
-            : settings.ToggleHotkey;
+        !string.IsNullOrWhiteSpace(HotkeyParser.Normalize(settings.PushToTalkHotkey))
+            ? HotkeyParser.Normalize(settings.PushToTalkHotkey)
+            : HotkeyParser.Normalize(settings.ToggleHotkey);
 
     private void PersistMainDictationHotkey(string? hotkey)
     {
-        var normalizedHotkey = hotkey?.Trim() ?? "";
+        var normalizedHotkey = HotkeyParser.Normalize(hotkey);
         var current = _settings.Current;
 
         if (current.PushToTalkHotkey == normalizedHotkey && current.ToggleHotkey == normalizedHotkey)

--- a/src/TypeWhisper.Windows/Views/Sections/ProfilesSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/ProfilesSection.xaml
@@ -380,6 +380,7 @@
                                     <StackPanel Margin="0,0,14,0">
                                         <TextBlock Text="{loc:Str Profiles.HotkeyLabel}" Style="{StaticResource ProfileRowLabelStyle}" Margin="0,0,0,6"/>
                                         <TextBlock Text="{loc:Str Profiles.HotkeyHint}" Style="{StaticResource HintStyle}" Margin="0"/>
+                                        <TextBlock Text="{loc:Str Hotkey.ModifierOnlyHint}" Style="{StaticResource HintStyle}" Margin="0,6,0,0"/>
                                     </StackPanel>
                                     <controls:HotkeyRecorderControl Grid.Column="1" Hotkey="{Binding Profiles.EditHotkey, Mode=TwoWay}" HorizontalAlignment="Right" Width="250"/>
                                 </Grid>

--- a/src/TypeWhisper.Windows/Views/Sections/ShortcutsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/ShortcutsSection.xaml
@@ -20,6 +20,9 @@
                 <TextBlock Text="{loc:Str Shortcuts.Subtitle}"
                            Style="{StaticResource PageSubtitleStyle}"
                            Margin="0"/>
+                <TextBlock Text="{loc:Str Hotkey.ModifierOnlyHint}"
+                           Style="{StaticResource HintStyle}"
+                           Margin="0,8,0,0"/>
             </StackPanel>
 
             <TextBlock Text="{loc:Str Shortcuts.MainSection}"

--- a/src/TypeWhisper.Windows/Views/WelcomeWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/WelcomeWindow.xaml
@@ -557,11 +557,16 @@
                                                                 HorizontalAlignment="Stretch"
                                                                 MinWidth="280"/>
 
-                                <TextBlock Grid.Row="1"
-                                           Grid.ColumnSpan="2"
-                                           Text="{loc:Str Welcome.MainHotkeyHint}"
-                                           Style="{StaticResource PageSubtitleStyle}"
-                                           Margin="0,12,0,0"/>
+                                <StackPanel Grid.Row="1"
+                                            Grid.ColumnSpan="2"
+                                            Margin="0,12,0,0">
+                                    <TextBlock Text="{loc:Str Welcome.MainHotkeyHint}"
+                                               Style="{StaticResource PageSubtitleStyle}"
+                                               Margin="0"/>
+                                    <TextBlock Text="{loc:Str Hotkey.ModifierOnlyHint}"
+                                               Style="{StaticResource HintStyle}"
+                                               Margin="0,8,0,0"/>
+                                </StackPanel>
                             </Grid>
                         </Border>
 

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -70,7 +70,7 @@ public class HotkeyInputTests
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_ALT);
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.True(winDown.Swallow);
+        Assert.Equal(default, winDown);
 
         var altDown = sut.ProcessKeyEvent(NativeMethods.VK_LMENU, isKeyDown: true, isKeyUp: false);
         Assert.True(altDown.RaiseKeyDown);
@@ -131,7 +131,7 @@ public class HotkeyInputTests
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.True(winDown.Swallow);
+        Assert.Equal(default, winDown);
 
         var ctrlDown = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
         Assert.True(ctrlDown.RaiseKeyDown);
@@ -144,17 +144,15 @@ public class HotkeyInputTests
     }
 
     [Fact]
-    public void ModifierOnly_CtrlWin_WhenWinIsPressedAlone_ReplaysStandaloneWinTap()
+    public void ModifierOnly_CtrlWin_WhenWinIsPressedAlone_AllowsStandaloneWinTap()
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.True(winDown.Swallow);
+        Assert.Equal(default, winDown);
 
         var winUp = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true);
-        Assert.True(winUp.Swallow);
-        Assert.Equal((uint)NativeMethods.VK_LWIN, winUp.SyntheticKeyTapVk);
-        Assert.False(winUp.RaiseKeyUp);
+        Assert.Equal(default, winUp);
     }
 
     [Fact]
@@ -162,7 +160,8 @@ public class HotkeyInputTests
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL, (uint)'X');
 
-        _ = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
+        var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
+        Assert.Equal(default, winDown);
         _ = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
 
         var xDown = sut.ProcessKeyEvent((uint)'X', isKeyDown: true, isKeyUp: false);
@@ -178,6 +177,32 @@ public class HotkeyInputTests
 
         var winUp = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true);
         Assert.True(winUp.Swallow);
+    }
+
+    [Fact]
+    public void ModifierOnly_CtrlWin_AllowsOtherWinShortcutsToPassThrough()
+    {
+        var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
+
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: false, isKeyUp: true));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true));
+    }
+
+    [Fact]
+    public void KeyedHotkey_WinX_AllowsOtherWinShortcutsToPassThrough()
+    {
+        var sut = CreateStateMachine(NativeMethods.MOD_WIN, (uint)'X');
+
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: false, isKeyUp: true));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true));
     }
 
     [Fact]
@@ -258,6 +283,28 @@ public class HotkeyInputTests
         Assert.True(HotkeyParser.Parse(hotkey, out var modifiers, out var vk));
         Assert.Equal(0u, modifiers);
         Assert.Equal((uint)NativeMethods.VK_ESCAPE, vk);
+    }
+
+    [Theory]
+    [InlineData("Ctrl")]
+    [InlineData("Shift")]
+    [InlineData("Alt")]
+    [InlineData("Win")]
+    public void Parser_RejectsSingleModifierOnlyHotkeys(string hotkey)
+    {
+        Assert.False(HotkeyParser.Parse(hotkey, out _, out _));
+        Assert.Equal("", HotkeyParser.Normalize(hotkey));
+    }
+
+    [Theory]
+    [InlineData("Ctrl+Shift", NativeMethods.MOD_CONTROL | NativeMethods.MOD_SHIFT)]
+    [InlineData("Alt+Win", NativeMethods.MOD_ALT | NativeMethods.MOD_WIN)]
+    public void Parser_AllowsModifierOnlyChordsWithTwoOrMoreModifiers(string hotkey, uint expectedModifiers)
+    {
+        Assert.True(HotkeyParser.Parse(hotkey, out var modifiers, out var vk));
+        Assert.Equal(expectedModifiers, modifiers);
+        Assert.Equal(0u, vk);
+        Assert.Equal(hotkey, HotkeyParser.Normalize(hotkey));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Prevent `Win` from being swallowed as a standalone hotkey so Windows shortcuts like `Win+Shift+S` keep working
- Normalize legacy hotkey values in settings, onboarding, and profiles so invalid `Win`-only entries are cleared on load/save
- Add UI copy in settings, onboarding, and profile editing to explain that single modifier keys are not allowed

## Testing
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --filter HotkeyInputTests`
- `dotnet build src/TypeWhisper.Windows/TypeWhisper.Windows.csproj`