### PR TITLE
[codex] Prep 0.6.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Create GitHub Release
         run: |
           TAG="${{ github.ref_name }}"
+          NOTES_FILE="docs/releases/${TAG}.md"
 
           # Check if a draft release already exists (manual feature release notes)
           EXISTING_DRAFT=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null || echo "")
@@ -131,11 +132,23 @@ jobs:
           elif [ "$EXISTING_DRAFT" = "false" ]; then
             echo "Published release found for $TAG. Uploading assets..."
             gh release upload "$TAG" artifacts/* --clobber
+          elif [ -f "$NOTES_FILE" ]; then
+            echo "Using curated release notes from $NOTES_FILE"
+
+            PRERELEASE_FLAG=""
+            if [[ "$TAG" == *-* ]]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+
+            gh release create "$TAG" artifacts/* \
+              --title "$TAG" \
+              --notes-file "$NOTES_FILE" \
+              $PRERELEASE_FLAG
           else
             echo "No existing release. Generating notes from commits..."
 
             # Find previous tag
-            PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p')
+            PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | sed -n '2p')
 
             if [ -n "$PREV_TAG" ]; then
               RANGE="${PREV_TAG}..${TAG}"

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ TestResults/
 *~
 .DS_Store
 releases/
+!docs/releases/
+!docs/releases/*.md
 publish/
 .agents/
 .claude/

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,0 +1,20 @@
+# TypeWhisper v0.6.1
+
+TypeWhisper 0.6.1 is a focused stability release that tightens dictation behavior, file transcription model selection, provider state handling, and release packaging.
+
+## Improvements
+
+- Improved provider and model state handling so the app is less likely to lose the selected configuration while switching between engines and prompts.
+- Refined the bundled Groq integration with better LLM model selection and refresh behavior.
+
+## Fixes
+
+- Fixed recorder-compatible hotkey parsing so captured shortcuts round-trip correctly through the UI and runtime hotkey pipeline.
+- Fixed file transcription to load the model the user actually selected instead of falling back unexpectedly.
+- Fixed the silent-stop overlay reset path and closed a streaming session leak that could leave overlay state behind after recording ended.
+
+## Release Prep
+
+- Hardened the release workflow so app tags prefer curated notes from `docs/releases/` and fall back to commit-generated notes only when no curated file exists.
+- Scoped previous-tag lookup to app tags only, preventing plugin tags from polluting app release note ranges.
+- Prepared the Windows release metadata for `0.6.1`, including CLI version reporting and Groq plugin metadata alignment for `plugin-groq-v1.0.2`.

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -48,7 +48,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
 
     public string PluginId => "com.typewhisper.groq";
     public string PluginName => "Groq";
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.2";
 
     public async Task ActivateAsync(IPluginHostServices host)
     {

--- a/plugins/TypeWhisper.Plugin.Groq/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Groq/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.groq",
   "name": "Groq",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Groq Whisper transcription and Llama translation",
   "assemblyName": "TypeWhisper.Plugin.Groq.dll",

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text.Json;
 
 namespace TypeWhisper.Cli;
@@ -24,7 +25,7 @@ static class Program
 
         if (args[0] == "--version")
         {
-            Console.WriteLine("typewhisper-cli 1.0.0");
+            Console.WriteLine($"typewhisper-cli {GetVersion()}");
             return 0;
         }
 
@@ -159,6 +160,24 @@ static class Program
     }
 
     static bool HasFlag(string[] args, string flag) => Array.IndexOf(args, flag) >= 0;
+
+    static string GetVersion()
+    {
+        var info = Assembly.GetEntryAssembly()
+            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (!string.IsNullOrWhiteSpace(info))
+        {
+            var plus = info.IndexOf('+');
+            return plus > 0 ? info[..plus] : info;
+        }
+
+        return Assembly.GetEntryAssembly()
+            ?.GetName()
+            .Version?
+            .ToString() ?? "dev";
+    }
 
     static string Prop(JsonElement el, string name) =>
         el.TryGetProperty(name, out var v) ? v.GetString() ?? "" : "";

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -12,6 +12,23 @@ namespace TypeWhisper.PluginSystem.Tests;
 public class GroqPluginTests
 {
     [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifestPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.Groq", "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var sut = new GroqPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
     public void TranscriptionModels_RemainCuratedWhisperModels()
     {
         var sut = new GroqPlugin();


### PR DESCRIPTION
## Summary
- prepare the app release workflow for `v0.6.1` with curated release notes support
- align CLI version reporting with assembly metadata instead of a hardcoded string
- bump the bundled Groq plugin metadata to `1.0.2` and add a guard test for manifest/runtime version drift

## Why
The `0.6.1` patch release should ship from the existing workflow without manual note editing in GitHub, and the published version metadata should match what users actually install. The Groq plugin also had a manifest/runtime version mismatch that would make the marketplace package look inconsistent.

## Impact
- app tags like `v0.6.1` now prefer curated notes from `docs/releases/` and only fall back to generated notes when no curated file exists
- `typewhisper --version` now reports the build version from assembly metadata
- the Groq plugin package, manifest, and runtime version now agree on `1.0.2`

## Validation
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release`
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release`
- `dotnet build TypeWhisper.slnx -c Release -p:Version=0.6.1`
- `dotnet build src/TypeWhisper.Cli/TypeWhisper.Cli.csproj -c Release -p:Version=0.6.1`
- local packaging validation for `win-x64` and `win-arm64` with Velopack (`0.6.1`)