### PR TITLE
Fix Windows autostart toggle handling

### DIFF
--- a/src/TypeWhisper.Windows/Services/StartupService.cs
+++ b/src/TypeWhisper.Windows/Services/StartupService.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using System.IO;
 using Microsoft.Win32;
 using TypeWhisper.Core;
+using Velopack.Locators;
+using Velopack.Windows;
 
 namespace TypeWhisper.Windows.Services;
 
@@ -9,18 +11,18 @@ public static class StartupService
 {
     private const string RegistryKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
     private const string AppName = "TypeWhisper";
+    private const string MinimizedArgument = "--minimized";
 
-    public static bool IsEnabled
-    {
-        get
-        {
-            using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, false);
-            return key?.GetValue(AppName) is not null;
-        }
-    }
+    public static bool IsEnabled => HasStartupShortcut() || HasRegistryEntry();
 
     public static void Enable()
     {
+        if (TryEnableStartupShortcut())
+        {
+            DeleteRegistryEntry();
+            return;
+        }
+
         var exePath = Environment.ProcessPath;
         if (string.IsNullOrEmpty(exePath))
         {
@@ -28,23 +30,144 @@ public static class StartupService
             return;
         }
 
-        var value = $"\"{exePath}\" --minimized";
-        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, true);
+        var value = $"\"{exePath}\" {MinimizedArgument}";
+        using var key = Registry.CurrentUser.CreateSubKey(RegistryKey, writable: true);
         key?.SetValue(AppName, value);
-        Log($"Enabled auto-start: {value}");
+        Log($"Enabled auto-start via registry: {value}");
     }
 
     public static void Disable()
     {
-        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, true);
-        key?.DeleteValue(AppName, throwOnMissingValue: false);
-        Log("Disabled auto-start");
+        var removedShortcut = TryDisableStartupShortcut();
+        var removedRegistry = DeleteRegistryEntry();
+        Log($"Disabled auto-start (startup shortcut removed: {removedShortcut}, registry removed: {removedRegistry})");
     }
 
     public static void SetEnabled(bool enabled)
     {
         if (enabled) Enable();
         else Disable();
+    }
+
+#pragma warning disable CS0618 // Velopack's shortcut helper remains the supported API for Startup links.
+    private static bool HasStartupShortcut()
+    {
+        var locator = GetVelopackLocator();
+        if (locator is null || string.IsNullOrWhiteSpace(locator.ThisExeRelativePath))
+            return false;
+
+        try
+        {
+            var shortcuts = new Shortcuts(locator);
+            return shortcuts.FindShortcuts(locator.ThisExeRelativePath, ShortcutLocation.Startup).Count > 0;
+        }
+        catch (Exception ex)
+        {
+            Log($"Startup shortcut detection failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static bool HasRegistryEntry()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, false);
+            return key?.GetValue(AppName) is not null;
+        }
+        catch (Exception ex)
+        {
+            Log($"Registry detection failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static bool TryEnableStartupShortcut()
+    {
+        var locator = GetVelopackLocator();
+        if (locator is null || string.IsNullOrWhiteSpace(locator.ThisExeRelativePath))
+            return false;
+
+        try
+        {
+            var shortcuts = new Shortcuts(locator);
+            var existingShortcuts = shortcuts.FindShortcuts(locator.ThisExeRelativePath, ShortcutLocation.Startup);
+            var iconPath = Environment.ProcessPath ?? locator.ProcessExePath ?? string.Empty;
+
+            shortcuts.CreateShortcut(
+                locator.ThisExeRelativePath,
+                ShortcutLocation.Startup,
+                updateOnly: existingShortcuts.Count > 0,
+                programArguments: MinimizedArgument,
+                icon: iconPath);
+
+            Log($"Enabled auto-start via startup shortcut for '{locator.ThisExeRelativePath}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log($"Startup shortcut enable failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static bool TryDisableStartupShortcut()
+    {
+        var locator = GetVelopackLocator();
+        if (locator is null || string.IsNullOrWhiteSpace(locator.ThisExeRelativePath))
+            return false;
+
+        try
+        {
+            var shortcuts = new Shortcuts(locator);
+            var existingShortcuts = shortcuts.FindShortcuts(locator.ThisExeRelativePath, ShortcutLocation.Startup);
+            if (existingShortcuts.Count == 0)
+                return false;
+
+            shortcuts.DeleteShortcuts(locator.ThisExeRelativePath, ShortcutLocation.Startup);
+            Log($"Removed startup shortcut for '{locator.ThisExeRelativePath}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log($"Startup shortcut removal failed: {ex.Message}");
+            return false;
+        }
+    }
+#pragma warning restore CS0618
+
+    private static bool DeleteRegistryEntry()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, writable: true);
+            var existed = key?.GetValue(AppName) is not null;
+            key?.DeleteValue(AppName, throwOnMissingValue: false);
+            if (existed)
+                Log("Removed legacy registry auto-start entry");
+            return existed;
+        }
+        catch (Exception ex)
+        {
+            Log($"Registry cleanup failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static IVelopackLocator? GetVelopackLocator()
+    {
+        try
+        {
+            if (!VelopackLocator.IsCurrentSet)
+                return null;
+
+            return VelopackLocator.Current;
+        }
+        catch (Exception ex)
+        {
+            Log($"Velopack locator unavailable: {ex.Message}");
+            return null;
+        }
     }
 
     private static void Log(string message)

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -103,9 +103,17 @@ public partial class SettingsViewModel : ObservableObject
 
         _settings.SettingsChanged += OnSettingsChanged;
 
-        PropertyChanged += (_, _) =>
+        PropertyChanged += (_, args) =>
         {
-            if (!_isLoading) Save();
+            if (_isLoading) return;
+
+            if (args.PropertyName == nameof(AutostartEnabled))
+            {
+                ApplyAutostartSetting();
+                return;
+            }
+
+            Save();
         };
     }
 
@@ -180,7 +188,23 @@ public partial class SettingsViewModel : ObservableObject
             UiLanguage = UiLanguage
         };
         _settings.Save(updated);
-        StartupService.SetEnabled(AutostartEnabled);
+    }
+
+    private void ApplyAutostartSetting()
+    {
+        var requestedAutostartEnabled = AutostartEnabled;
+        var currentAutostartEnabled = StartupService.IsEnabled;
+
+        if (currentAutostartEnabled != requestedAutostartEnabled)
+            StartupService.SetEnabled(requestedAutostartEnabled);
+
+        var actualAutostartEnabled = StartupService.IsEnabled;
+        if (actualAutostartEnabled == requestedAutostartEnabled)
+            return;
+
+        _isLoading = true;
+        AutostartEnabled = actualAutostartEnabled;
+        _isLoading = false;
     }
 
     private void LoadFromSettings(AppSettings s)


### PR DESCRIPTION
## Summary
- Separate the autostart toggle from the generic settings save flow so it updates `StartupService` directly
- Keep the toggle state in sync with the actual system autostart status instead of bouncing back via `SettingsChanged`
- Preserve the Velopack startup shortcut path with registry fallback for non-packaged runs

## Testing
- `dotnet build src/TypeWhisper.Windows/TypeWhisper.Windows.csproj /p:UseAppHost=false`
- Not run (not requested)