### PR TITLE
fix prompt provider selection

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
@@ -16,6 +16,7 @@ public partial class PromptsViewModel : ObservableObject
     private readonly IPromptActionService _promptActions;
     private readonly PluginManager _pluginManager;
     private readonly ISettingsService _settings;
+    private bool _isRefreshingProviders;
 
     [ObservableProperty] private PromptAction? _selectedAction;
 
@@ -45,6 +46,9 @@ public partial class PromptsViewModel : ObservableObject
         get => _settings.Current.DefaultLlmProvider;
         set
         {
+            if (string.Equals(_settings.Current.DefaultLlmProvider, value, StringComparison.Ordinal))
+                return;
+
             _settings.Save(_settings.Current with { DefaultLlmProvider = value });
             OnPropertyChanged();
             OnPropertyChanged(nameof(SelectedDefaultProvider));
@@ -60,7 +64,27 @@ public partial class PromptsViewModel : ObservableObject
             ?? AvailableProviders.FirstOrDefault();
         set
         {
+            if (_isRefreshingProviders)
+                return;
+
+            if (string.Equals(DefaultLlmProvider, value?.Value, StringComparison.Ordinal))
+                return;
+
             DefaultLlmProvider = value?.Value;
+            OnPropertyChanged();
+        }
+    }
+
+    public ProviderOption? SelectedEditProvider
+    {
+        get => AvailableProviders.FirstOrDefault(option => option.Value == EditProviderOverride)
+            ?? AvailableProviders.FirstOrDefault();
+        set
+        {
+            if (string.Equals(EditProviderOverride, value?.Value, StringComparison.Ordinal))
+                return;
+
+            EditProviderOverride = value?.Value;
             OnPropertyChanged();
         }
     }
@@ -85,9 +109,8 @@ public partial class PromptsViewModel : ObservableObject
         _pluginManager.PluginStateChanged += (_, _) => InvokeOnUiThread(RefreshProviders);
         _settings.SettingsChanged += _ => InvokeOnUiThread(() =>
         {
+            RefreshProviders();
             OnPropertyChanged(nameof(DefaultLlmProvider));
-            OnPropertyChanged(nameof(SelectedDefaultProvider));
-            OnPropertyChanged(nameof(DefaultProviderSummary));
         });
         RefreshActions();
         RefreshProviders();
@@ -112,13 +135,7 @@ public partial class PromptsViewModel : ObservableObject
     {
         if (action is null) return;
         SelectedAction = action;
-        _editingActionId = action.Id;
-        IsCreatingNew = false;
-        EditName = action.Name;
-        EditSystemPrompt = action.SystemPrompt;
-        EditIcon = action.Icon;
-        EditProviderOverride = action.ProviderOverride;
-        EditModelOverride = action.ModelOverride;
+        PopulateEditorFromAction(action);
         IsEditorOpen = true;
         ShowEditorDialog();
     }
@@ -220,23 +237,16 @@ public partial class PromptsViewModel : ObservableObject
 
     public void RefreshProviders()
     {
+        _isRefreshingProviders = true;
         AvailableProviders.Clear();
         AvailableProviders.Add(new ProviderOption(null, GetDefaultProviderLabel()));
-        foreach (var provider in _pluginManager.LlmProviders)
-        {
-            if (!provider.IsAvailable) continue;
-            var plugin = _pluginManager.AllPlugins
-                .FirstOrDefault(p => p.Instance == provider);
-            if (plugin is null) continue;
+        foreach (var option in GetExplicitProviderOptions())
+            AvailableProviders.Add(option);
+        _isRefreshingProviders = false;
 
-            foreach (var model in provider.SupportedModels)
-            {
-                var modelId = $"plugin:{plugin.Manifest.Id}:{model.Id}";
-                AvailableProviders.Add(new ProviderOption(modelId, $"{provider.ProviderName} / {model.DisplayName}"));
-            }
-        }
         OnPropertyChanged(nameof(HasLlmProviders));
         OnPropertyChanged(nameof(SelectedDefaultProvider));
+        OnPropertyChanged(nameof(SelectedEditProvider));
         OnPropertyChanged(nameof(DefaultProviderSummary));
     }
 
@@ -253,19 +263,56 @@ public partial class PromptsViewModel : ObservableObject
 
     private string GetDefaultProviderLabel()
     {
-        var firstAvailable = _pluginManager.LlmProviders.FirstOrDefault(p => p.IsAvailable);
-        if (firstAvailable is null)
+        var configuredDefault = _settings.Current.DefaultLlmProvider;
+        if (string.IsNullOrWhiteSpace(configuredDefault))
             return Loc.Instance["Prompts.DefaultProviderLabelNone"];
 
-        var firstModel = firstAvailable.SupportedModels.FirstOrDefault();
-        if (firstModel is not null)
-            return Loc.Instance.GetString("Prompts.DefaultProviderLabelFormat",
-                $"{firstAvailable.ProviderName} / {firstModel.DisplayName}");
+        var configuredOption = TryResolveProviderOption(configuredDefault);
+        if (configuredOption is not null)
+            return Loc.Instance.GetString("Prompts.DefaultProviderLabelFormat", configuredOption.DisplayName);
 
         return Loc.Instance["Prompts.DefaultProviderLabelNone"];
     }
 
+    private IReadOnlyList<ProviderOption> GetExplicitProviderOptions()
+    {
+        var options = new List<ProviderOption>();
+        foreach (var provider in _pluginManager.LlmProviders)
+        {
+            if (!provider.IsAvailable) continue;
+            var plugin = _pluginManager.AllPlugins
+                .FirstOrDefault(p => p.Instance == provider);
+            if (plugin is null) continue;
+
+            foreach (var model in provider.SupportedModels)
+            {
+                var modelId = $"plugin:{plugin.Manifest.Id}:{model.Id}";
+                options.Add(new ProviderOption(modelId, $"{provider.ProviderName} / {model.DisplayName}"));
+            }
+        }
+
+        return options;
+    }
+
+    private ProviderOption? TryResolveProviderOption(string pluginModelId)
+    {
+        return GetExplicitProviderOptions()
+            .FirstOrDefault(option => string.Equals(option.Value, pluginModelId, StringComparison.Ordinal));
+    }
+
+    private void PopulateEditorFromAction(PromptAction action)
+    {
+        _editingActionId = action.Id;
+        IsCreatingNew = false;
+        EditName = action.Name;
+        EditSystemPrompt = action.SystemPrompt;
+        EditIcon = action.Icon;
+        EditProviderOverride = action.ProviderOverride;
+        EditModelOverride = action.ModelOverride;
+    }
+
     partial void OnIsCreatingNewChanged(bool value) => OnPropertyChanged(nameof(EditorTitle));
+    partial void OnEditProviderOverrideChanged(string? value) => OnPropertyChanged(nameof(SelectedEditProvider));
 
     private void ShowEditorDialog()
     {

--- a/src/TypeWhisper.Windows/Views/PromptEditorWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/PromptEditorWindow.xaml
@@ -95,8 +95,7 @@
                                     </StackPanel>
                                     <ComboBox Grid.Column="1"
                                               ItemsSource="{Binding AvailableProviders}"
-                                              SelectedValue="{Binding EditProviderOverride}"
-                                              SelectedValuePath="Value"
+                                              SelectedItem="{Binding SelectedEditProvider}"
                                               DisplayMemberPath="DisplayName"
                                               Style="{StaticResource SettingsAlignedComboBoxStyle}"/>
                                 </Grid>

--- a/tests/TypeWhisper.PluginSystem.Tests/PromptsViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PromptsViewModelTests.cs
@@ -5,6 +5,7 @@ using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
+using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
 using TypeWhisper.Windows.ViewModels;
 
@@ -20,6 +21,8 @@ public class PromptsViewModelTests
     public PromptsViewModelTests()
     {
         _profiles.Setup(p => p.Profiles).Returns([]);
+        Loc.Instance.Initialize();
+        Loc.Instance.CurrentLanguage = "en";
     }
 
     [Fact]
@@ -56,6 +59,136 @@ public class PromptsViewModelTests
         Assert.Equal(explicitOption, sut.SelectedDefaultProvider);
     }
 
+    [Fact]
+    public void DefaultProviderLabel_UsesConfiguredDefaultLlmProvider()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.openai:gpt-4.1-mini"
+        });
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var openAi = CreateLlmProvider("com.typewhisper.openai", "OpenAI", "gpt-4.1-mini", "GPT-4.1 Mini");
+        var pluginManager = CreatePluginManager(settings, groq, openAi);
+
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+
+        Assert.Equal("(Default - OpenAI / GPT-4.1 Mini)", sut.AvailableProviders.First().DisplayName);
+        Assert.Equal("(Default - OpenAI / GPT-4.1 Mini)", sut.DefaultProviderSummary);
+    }
+
+    [Fact]
+    public void SettingsChanged_RebuildsAvailableProvidersAndUpdatesDefaultLabel()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.groq:llama-3.3-70b-versatile"
+        });
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var openAi = CreateLlmProvider("com.typewhisper.openai", "OpenAI", "gpt-4.1-mini", "GPT-4.1 Mini");
+        var pluginManager = CreatePluginManager(settings, groq, openAi);
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+
+        settings.Save(settings.Current with
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.openai:gpt-4.1-mini"
+        });
+
+        Assert.Equal("(Default - OpenAI / GPT-4.1 Mini)", sut.AvailableProviders.First().DisplayName);
+        Assert.Equal("(Default - OpenAI / GPT-4.1 Mini)", sut.DefaultProviderSummary);
+    }
+
+    [Fact]
+    public void SelectedDefaultProvider_ReflectsConfiguredDefaultAfterSettingsChange()
+    {
+        var settings = new FakeSettingsService(new AppSettings());
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var openAi = CreateLlmProvider("com.typewhisper.openai", "OpenAI", "gpt-4.1-mini", "GPT-4.1 Mini");
+        var pluginManager = CreatePluginManager(settings, groq, openAi);
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+
+        settings.Save(settings.Current with
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.openai:gpt-4.1-mini"
+        });
+
+        Assert.Equal("plugin:com.typewhisper.openai:gpt-4.1-mini", sut.SelectedDefaultProvider?.Value);
+        Assert.Equal("OpenAI / GPT-4.1 Mini", sut.SelectedDefaultProvider?.DisplayName);
+    }
+
+    [Fact]
+    public void PromptEditorStandardSelection_RemainsNullOverride()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.groq:llama-3.3-70b-versatile"
+        });
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var pluginManager = CreatePluginManager(settings, groq);
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+        var action = new PromptAction
+        {
+            Id = "prompt-1",
+            Name = "Translate",
+            SystemPrompt = "Translate this.",
+            ProviderOverride = null
+        };
+
+        InvokePrivateMethod(sut, "PopulateEditorFromAction", action);
+
+        Assert.Null(sut.EditProviderOverride);
+        Assert.Null(sut.AvailableProviders.First().Value);
+        Assert.Equal("(Default - Groq / Llama 3.3 70B Versatile)", sut.AvailableProviders.First().DisplayName);
+        Assert.Equal(sut.AvailableProviders.First(), sut.SelectedEditProvider);
+    }
+
+    [Fact]
+    public void SelectedEditProvider_UsesExplicitOverride_WhenPresent()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.groq:llama-3.3-70b-versatile"
+        });
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var openAi = CreateLlmProvider("com.typewhisper.openai", "OpenAI", "gpt-4.1-mini", "GPT-4.1 Mini");
+        var pluginManager = CreatePluginManager(settings, groq, openAi);
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+        var action = new PromptAction
+        {
+            Id = "prompt-2",
+            Name = "Reply",
+            SystemPrompt = "Write a reply.",
+            ProviderOverride = "plugin:com.typewhisper.openai:gpt-4.1-mini"
+        };
+
+        InvokePrivateMethod(sut, "PopulateEditorFromAction", action);
+
+        Assert.Equal("plugin:com.typewhisper.openai:gpt-4.1-mini", sut.EditProviderOverride);
+        Assert.Equal("OpenAI / GPT-4.1 Mini", sut.SelectedEditProvider?.DisplayName);
+    }
+
+    [Fact]
+    public void DefaultProviderLabel_ShowsUnavailableState_WhenConfiguredDefaultCannotBeResolved()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.openai:gpt-4.1-mini"
+        });
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var pluginManager = CreatePluginManager(settings, groq);
+
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings);
+
+        Assert.Equal("(Default - none configured)", sut.AvailableProviders.First().DisplayName);
+        Assert.Equal("(Default - none configured)", sut.DefaultProviderSummary);
+        Assert.DoesNotContain("Groq", sut.AvailableProviders.First().DisplayName);
+    }
+
     private Mock<IPromptActionService> CreatePromptActionService()
     {
         var promptActions = new Mock<IPromptActionService>();
@@ -64,7 +197,7 @@ public class PromptsViewModelTests
         return promptActions;
     }
 
-    private PluginManager CreatePluginManager(ISettingsService settings, Mock<ILlmProviderPlugin> provider)
+    private PluginManager CreatePluginManager(ISettingsService settings, params Mock<ILlmProviderPlugin>[] providers)
     {
         var pluginManager = new PluginManager(
             _loader,
@@ -74,23 +207,23 @@ public class PromptsViewModelTests
             settings,
             []);
 
-        var manifest = new PluginManifest
-        {
-            Id = "com.typewhisper.groq",
-            Name = "Groq",
-            Version = "1.0.0",
-            AssemblyName = Path.GetFileName(Assembly.GetExecutingAssembly().Location),
-            PluginClass = typeof(object).FullName ?? "System.Object"
-        };
+        var loadedPlugins = providers
+            .Select(provider => new LoadedPlugin(
+                new PluginManifest
+                {
+                    Id = provider.Object.PluginId,
+                    Name = provider.Object.ProviderName,
+                    Version = "1.0.0",
+                    AssemblyName = Path.GetFileName(Assembly.GetExecutingAssembly().Location),
+                    PluginClass = typeof(object).FullName ?? "System.Object"
+                },
+                provider.Object,
+                new PluginAssemblyLoadContext(Assembly.GetExecutingAssembly().Location),
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? AppContext.BaseDirectory))
+            .ToList();
 
-        var loadedPlugin = new LoadedPlugin(
-            manifest,
-            provider.Object,
-            new PluginAssemblyLoadContext(Assembly.GetExecutingAssembly().Location),
-            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? AppContext.BaseDirectory);
-
-        SetPrivateField(pluginManager, "_allPlugins", new List<LoadedPlugin> { loadedPlugin });
-        SetPrivateField(pluginManager, "_llmProviders", new List<ILlmProviderPlugin> { provider.Object });
+        SetPrivateField(pluginManager, "_allPlugins", loadedPlugins);
+        SetPrivateField(pluginManager, "_llmProviders", providers.Select(provider => provider.Object).ToList());
         return pluginManager;
     }
 
@@ -115,6 +248,13 @@ public class PromptsViewModelTests
         var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
         field.SetValue(target, value);
+    }
+
+    private static void InvokePrivateMethod(object target, string methodName, params object[] arguments)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMethodException(target.GetType().FullName, methodName);
+        method.Invoke(target, arguments);
     }
 
     private sealed class FakeSettingsService(AppSettings initialSettings) : ISettingsService


### PR DESCRIPTION
## What changed
- fixed prompt provider labeling so the editor's `Standard` option reflects the actual global default LLM provider
- rebuilt prompt provider options when settings change and guarded the prompts view model against recursive selection/save updates
- switched the prompt editor provider combo box to item-based selection so prompts using the default route render the selected provider entry correctly on reopen
- added regression tests for default-provider labels, settings refresh, standard editor selection, explicit overrides, and unavailable defaults

## Why
The prompt editor treated `ProviderOverride = null` as the correct runtime default, but the UI did not reliably display the corresponding `Standard` entry when reopening a prompt. The settings refresh path also caused recursive updates that could crash the prompts view.

## Impact
- editing a prompt now shows the expected provider selection in the combo box
- changing the global default provider updates prompt routing labels consistently
- opening the Prompts section no longer crashes due to recursive provider selection updates

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter PromptsViewModelTests`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- manual app verification of the prompt edit flow