### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Open TypeWhisper
+        2. Go to ...
+        3. Click on ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: windows-version
+    attributes:
+      label: Windows Version
+      placeholder: "e.g. Windows 11 24H2"
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: TypeWhisper Version
+      placeholder: "e.g. 0.6.1"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste any relevant log output or error details.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you've thought about?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR change? -->
+
+## Related Issue
+
+<!-- Link the issue this PR addresses, if applicable. Example: Closes #123 -->
+
+## Test Plan
+
+- [ ] `dotnet test`
+- [ ] Built and ran locally
+- [ ] Tested the changed functionality manually
+- [ ] No regressions in existing features
+
+## Notes
+
+<!-- Anything reviewers should know before looking at the change. -->


### PR DESCRIPTION
## Summary

Add repository templates for issue intake and pull requests.

## Related Issue

None.

## Changes

- Add bug report and feature request issue forms.
- Allow blank issues through issue template configuration.
- Add a pull request template with summary, related issue, test plan, and notes sections.

## Test Plan

- [x] `git diff --check`
- [x] `dotnet test` (not run; template-only change)
- [x] Reviewed the rendered Markdown/YAML content locally