### PR TITLE
Fix history and prompt provider races

### DIFF
--- a/src/TypeWhisper.Core/Services/HistoryService.cs
+++ b/src/TypeWhisper.Core/Services/HistoryService.cs
@@ -78,7 +78,6 @@ public sealed class HistoryService : IHistoryService
     public void AddRecord(TranscriptionRecord record)
     {
         EnsureCacheLoaded();
-        List<TranscriptionRecord> snapshot;
         lock (_gate)
         {
             _cache.Insert(0, record);
@@ -93,17 +92,15 @@ public sealed class HistoryService : IHistoryService
                 _distinctApps.Sort(StringComparer.OrdinalIgnoreCase);
             }
 
-            snapshot = _cache.ToList();
+            SaveToDisk(_cache.ToList());
         }
 
-        SaveToDisk(snapshot);
         RecordsChanged?.Invoke();
     }
 
     public void UpdateRecord(string id, string finalText)
     {
         EnsureCacheLoaded();
-        List<TranscriptionRecord> snapshot;
         lock (_gate)
         {
             var idx = _cache.FindIndex(r => r.Id == id);
@@ -115,17 +112,15 @@ public sealed class HistoryService : IHistoryService
                 _totalWords += updated.WordCount - old.WordCount;
             }
 
-            snapshot = _cache.ToList();
+            SaveToDisk(_cache.ToList());
         }
 
-        SaveToDisk(snapshot);
         RecordsChanged?.Invoke();
     }
 
     public void DeleteRecord(string id)
     {
         EnsureCacheLoaded();
-        List<TranscriptionRecord> snapshot;
         string? removedAudioFileName = null;
         lock (_gate)
         {
@@ -141,11 +136,10 @@ public sealed class HistoryService : IHistoryService
             }
 
             RebuildDistinctApps();
-            snapshot = _cache.ToList();
+            SaveToDisk(_cache.ToList());
         }
 
         DeleteAudioFile(removedAudioFileName);
-        SaveToDisk(snapshot);
         RecordsChanged?.Invoke();
     }
 
@@ -161,10 +155,10 @@ public sealed class HistoryService : IHistoryService
             _totalWords = 0;
             _totalDuration = 0;
             _distinctApps.Clear();
+            SaveToDisk([]);
         }
 
         DeleteAudioFiles(audioFiles);
-        SaveToDisk([]);
         RecordsChanged?.Invoke();
     }
 
@@ -190,7 +184,6 @@ public sealed class HistoryService : IHistoryService
         EnsureCacheLoaded();
         var cutoff = DateTime.UtcNow - retention.Value;
         List<string?> removedAudioFiles;
-        List<TranscriptionRecord>? snapshot = null;
 
         lock (_gate)
         {
@@ -204,11 +197,10 @@ public sealed class HistoryService : IHistoryService
 
             _cache = _cache.Where(r => r.CreatedAt >= cutoff).ToList();
             RebuildStats();
-            snapshot = _cache.ToList();
+            SaveToDisk(_cache.ToList());
         }
 
         DeleteAudioFiles(removedAudioFiles);
-        SaveToDisk(snapshot!);
         RecordsChanged?.Invoke();
     }
 

--- a/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PromptsViewModel.cs
@@ -81,6 +81,9 @@ public partial class PromptsViewModel : ObservableObject
             ?? AvailableProviders.FirstOrDefault();
         set
         {
+            if (_isRefreshingProviders)
+                return;
+
             if (string.Equals(EditProviderOverride, value?.Value, StringComparison.Ordinal))
                 return;
 

--- a/tests/TypeWhisper.PluginSystem.Tests/PromptsViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PromptsViewModelTests.cs
@@ -172,6 +172,28 @@ public class PromptsViewModelTests
     }
 
     [Fact]
+    public void SelectedEditProvider_IgnoresTransientNullDuringProviderRefresh()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            DefaultLlmProvider = "plugin:com.typewhisper.groq:llama-3.3-70b-versatile"
+        });
+        var promptActions = CreatePromptActionService();
+        var groq = CreateLlmProvider("com.typewhisper.groq", "Groq", "llama-3.3-70b-versatile", "Llama 3.3 70B Versatile");
+        var openAi = CreateLlmProvider("com.typewhisper.openai", "OpenAI", "gpt-4.1-mini", "GPT-4.1 Mini");
+        var pluginManager = CreatePluginManager(settings, groq, openAi);
+        var sut = new PromptsViewModel(promptActions.Object, pluginManager, settings)
+        {
+            EditProviderOverride = "plugin:com.typewhisper.openai:gpt-4.1-mini"
+        };
+
+        SetPrivateField(sut, "_isRefreshingProviders", true);
+        sut.SelectedEditProvider = null;
+
+        Assert.Equal("plugin:com.typewhisper.openai:gpt-4.1-mini", sut.EditProviderOverride);
+    }
+
+    [Fact]
     public void DefaultProviderLabel_ShowsUnavailableState_WhenConfiguredDefaultCannotBeResolved()
     {
         var settings = new FakeSettingsService(new AppSettings


### PR DESCRIPTION
## Summary
- Serialize history file writes with in-memory history mutations so persisted snapshots cannot be reordered under concurrent calls.
- Ignore transient prompt editor provider selection updates while provider options are being refreshed.
- Add a regression test covering editor provider override preservation during refresh.

## Validation
- `dotnet test TypeWhisper.slnx`

## Notes
- Existing nullable and MVVM Toolkit warnings remain unchanged.