### PR TITLE
Add Windows release channels

### DIFF
--- a/.github/workflows/package-dry-run.yml
+++ b/.github/workflows/package-dry-run.yml
@@ -6,12 +6,22 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Velopack release track to validate.'
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+          - daily
 
 permissions:
   contents: read
 
 concurrency:
-  group: package-dry-run-${{ github.event.pull_request.number || github.ref }}
+  group: package-dry-run-${{ github.event.pull_request.number || github.ref }}-${{ inputs.channel || 'stable' }}
   cancel-in-progress: true
 
 jobs:
@@ -23,11 +33,36 @@ jobs:
         rid:
           - win-x64
           - win-arm64
-    env:
-      VERSION: 0.0.1-dryrun.${{ github.run_number }}
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Resolve dry-run channel
+        id: meta
+        shell: pwsh
+        run: |
+          $channel = "${{ inputs.channel || 'stable' }}"
+          $date = (Get-Date).ToUniversalTime().ToString("yyyyMMdd")
+          $rid = "${{ matrix.rid }}"
+
+          switch ($channel) {
+            "rc" {
+              $version = "0.0.1-rc.dryrun.${{ github.run_number }}"
+              $suffix = "-rc"
+            }
+            "daily" {
+              $version = "0.0.1-daily.$date.${{ github.run_number }}"
+              $suffix = "-daily"
+            }
+            default {
+              $version = "0.0.1-dryrun.${{ github.run_number }}"
+              $suffix = ""
+            }
+          }
+
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "channel_suffix=$suffix" >> $env:GITHUB_OUTPUT
+          "velopack_channel=$rid$suffix" >> $env:GITHUB_OUTPUT
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -41,13 +76,13 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/logs | Out-Null
-          New-Item -ItemType Directory -Force -Path "releases/${{ matrix.rid }}" | Out-Null
+          New-Item -ItemType Directory -Force -Path "releases/${{ steps.meta.outputs.velopack_channel }}" | Out-Null
 
       - name: Restore solution
         run: dotnet restore TypeWhisper.slnx
 
       - name: Build solution
-        run: dotnet build TypeWhisper.slnx -c Release --no-restore -p:Version=${{ env.VERSION }} -bl:artifacts/logs/typewhisper-package.binlog
+        run: dotnet build TypeWhisper.slnx -c Release --no-restore -p:Version=${{ steps.meta.outputs.version }} -bl:artifacts/logs/typewhisper-package.binlog
 
       - name: Build bundled plugins
         shell: pwsh
@@ -58,14 +93,14 @@ jobs:
               throw "Restore failed: $($project.FullName)"
             }
 
-            dotnet build $project.FullName -c Release --no-restore -p:Version=$env:VERSION
+            dotnet build $project.FullName -c Release --no-restore -p:Version=${{ steps.meta.outputs.version }}
             if ($LASTEXITCODE -ne 0) {
               throw "Build failed: $($project.FullName)"
             }
           }
 
       - name: Publish app
-        run: dotnet publish src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ env.VERSION }} -o publish/${{ matrix.rid }}
+        run: dotnet publish src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ steps.meta.outputs.version }} -o publish/${{ matrix.rid }}
 
       - name: Copy bundled plugins into publish output
         shell: pwsh
@@ -87,18 +122,18 @@ jobs:
         run: |
           vpk pack `
             --packId TypeWhisper `
-            --packVersion $env:VERSION `
+            --packVersion ${{ steps.meta.outputs.version }} `
             --packDir "publish/${{ matrix.rid }}" `
             --mainExe TypeWhisper.exe `
             --icon src/TypeWhisper.Windows/Resources/Icons/app.ico `
-            --channel ${{ matrix.rid }} `
-            --outputDir "releases/${{ matrix.rid }}"
+            --channel ${{ steps.meta.outputs.velopack_channel }} `
+            --outputDir "releases/${{ steps.meta.outputs.velopack_channel }}"
 
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: package-dry-run-${{ matrix.rid }}
+          name: package-dry-run-${{ steps.meta.outputs.velopack_channel }}
           path: |
             artifacts/logs/*.binlog
-            releases/${{ matrix.rid }}/*
+            releases/${{ steps.meta.outputs.velopack_channel }}/*
           if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,135 @@
 name: Release
+
 on:
   push:
     tags: ['v*']
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: 'Base version for daily builds, without v or prerelease suffix. Defaults to latest stable patch + 1.'
+        required: false
+        type: string
+
 permissions:
   contents: write
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      channel_suffix: ${{ steps.resolve.outputs.channel_suffix }}
+      is_prerelease: ${{ steps.resolve.outputs.is_prerelease }}
+      is_stable: ${{ steps.resolve.outputs.is_stable }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      release_target: ${{ steps.resolve.outputs.release_target }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        id: resolve
+        env:
+          INPUT_BASE_VERSION: ${{ inputs.base_version || '' }}
+        run: |
+          set -euo pipefail
+
+          EVENT="${{ github.event_name }}"
+          RELEASE_TARGET=""
+
+          if [ "$EVENT" = "push" ]; then
+            TAG="${{ github.ref_name }}"
+            VERSION="${TAG#v}"
+          else
+            BASE_VERSION="${INPUT_BASE_VERSION#v}"
+
+            if [ -z "$BASE_VERSION" ]; then
+              LATEST_STABLE=$(git tag --list 'v[0-9]*' --sort=-v:refname \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | head -1 || true)
+
+              if [ -n "$LATEST_STABLE" ]; then
+                STABLE_VERSION="${LATEST_STABLE#v}"
+              else
+                STABLE_VERSION="0.0.0"
+              fi
+
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$STABLE_VERSION"
+              PATCH=$((PATCH + 1))
+              BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            fi
+
+            if ! echo "$BASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "base_version must look like 0.7.1, got: $BASE_VERSION" >&2
+              exit 1
+            fi
+
+            DATE=$(date -u +%Y%m%d)
+            TAG="v${BASE_VERSION}-daily.${DATE}"
+            VERSION="${BASE_VERSION}-daily.${DATE}"
+            RELEASE_TARGET="${{ github.sha }}"
+
+            if git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "Daily tag $TAG already exists; skipping."
+              {
+                echo "tag=$TAG"
+                echo "version=$VERSION"
+                echo "channel_suffix=-daily"
+                echo "is_prerelease=true"
+                echo "is_stable=false"
+                echo "should_run=false"
+                echo "release_target=$RELEASE_TARGET"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          CHANNEL_SUFFIX=""
+          IS_PRERELEASE="false"
+          IS_STABLE="true"
+
+          if [[ "$VERSION" == *"-daily."* ]]; then
+            CHANNEL_SUFFIX="-daily"
+            IS_PRERELEASE="true"
+            IS_STABLE="false"
+          elif [[ "$VERSION" == *"-rc"* ]]; then
+            CHANNEL_SUFFIX="-rc"
+            IS_PRERELEASE="true"
+            IS_STABLE="false"
+          elif [[ "$VERSION" == *"-"* ]]; then
+            echo "Unsupported prerelease version for Windows app release channels: $VERSION" >&2
+            exit 1
+          fi
+
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "channel_suffix=$CHANNEL_SUFFIX"
+            echo "is_prerelease=$IS_PRERELEASE"
+            echo "is_stable=$IS_STABLE"
+            echo "should_run=true"
+            echo "release_target=$RELEASE_TARGET"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Release tag: $TAG"
+          echo "Package version: $VERSION"
+          echo "Velopack channel suffix: ${CHANNEL_SUFFIX:-<stable>}"
+
   build:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         rid: [win-x64, win-arm64]
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+      VELOPACK_CHANNEL: ${{ matrix.rid }}${{ needs.prepare.outputs.channel_suffix }}
     steps:
       - uses: actions/checkout@v6
 
@@ -22,18 +141,11 @@ jobs:
             **/*.csproj
             Directory.Build.props
 
-      - name: Extract version from tag
-        id: ver
-        shell: pwsh
-        run: |
-          $v = "${{ github.ref_name }}" -replace '^v',''
-          echo "VERSION=$v" >> $env:GITHUB_OUTPUT
-
       - name: Restore solution
         run: dotnet restore TypeWhisper.slnx
 
       - name: Build solution
-        run: dotnet build TypeWhisper.slnx -c Release -p:Version=${{ steps.ver.outputs.VERSION }} --no-restore
+        run: dotnet build TypeWhisper.slnx -c Release -p:Version=${{ env.VERSION }} --no-restore
 
       - name: Build bundled plugins
         shell: pwsh
@@ -44,7 +156,7 @@ jobs:
               throw "Restore failed: $($project.FullName)"
             }
 
-            dotnet build $project.FullName -c Release --no-restore -p:Version=${{ steps.ver.outputs.VERSION }}
+            dotnet build $project.FullName -c Release --no-restore -p:Version=$env:VERSION
             if ($LASTEXITCODE -ne 0) {
               throw "Build failed: $($project.FullName)"
             }
@@ -59,7 +171,7 @@ jobs:
         if: matrix.rid == 'win-x64'
 
       - name: Publish app
-        run: dotnet publish src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ steps.ver.outputs.VERSION }} -o publish
+        run: dotnet publish src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ env.VERSION }} -o publish/${{ matrix.rid }}
 
       - name: Copy bundled plugins into publish output
         shell: pwsh
@@ -71,7 +183,7 @@ jobs:
             throw "No bundled plugins found in $pluginsSrc."
           }
 
-          Copy-Item -Path $pluginsSrc -Destination "publish/Plugins" -Recurse -Force
+          Copy-Item -Path $pluginsSrc -Destination "publish/${{ matrix.rid }}/Plugins" -Recurse -Force
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk
@@ -81,31 +193,23 @@ jobs:
         run: |
           vpk pack `
             --packId TypeWhisper `
-            --packVersion ${{ steps.ver.outputs.VERSION }} `
-            --packDir publish `
+            --packVersion $env:VERSION `
+            --packDir "publish/${{ matrix.rid }}" `
             --mainExe TypeWhisper.exe `
             --icon src/TypeWhisper.Windows/Resources/Icons/app.ico `
-            --channel ${{ matrix.rid }} `
-            --outputDir releases
+            --channel $env:VELOPACK_CHANNEL `
+            --outputDir "releases/$env:VELOPACK_CHANNEL"
 
       - uses: actions/upload-artifact@v7
         with:
-          name: release-${{ matrix.rid }}
-          path: releases/*
-
-  trigger-website:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger website rebuild
-        run: |
-          gh api repos/TypeWhisper/typewhisper.com/dispatches \
-            -f event_type=release-published
-        env:
-          GITHUB_TOKEN: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
+          name: release-${{ env.VELOPACK_CHANNEL }}
+          path: releases/${{ env.VELOPACK_CHANNEL }}/*
 
   release:
-    needs: build
+    needs:
+      - prepare
+      - build
+    if: needs.prepare.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -118,45 +222,78 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+          IS_STABLE: ${{ needs.prepare.outputs.is_stable }}
+          RELEASE_TARGET: ${{ needs.prepare.outputs.release_target }}
         run: |
-          TAG="${{ github.ref_name }}"
+          set -euo pipefail
+
           NOTES_FILE="docs/releases/${TAG}.md"
 
-          # Check if a draft release already exists (manual feature release notes)
           EXISTING_DRAFT=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null || echo "")
+
+          EDIT_ARGS=(--draft=false)
+          CREATE_FLAGS=()
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            EDIT_ARGS+=(--prerelease)
+            CREATE_FLAGS+=(--prerelease)
+          fi
 
           if [ "$EXISTING_DRAFT" = "true" ]; then
             echo "Draft release found for $TAG. Uploading assets and publishing..."
             gh release upload "$TAG" artifacts/* --clobber
-            gh release edit "$TAG" --draft=false ${{ contains(github.ref_name, '-') && '--prerelease' || '' }}
+            gh release edit "$TAG" "${EDIT_ARGS[@]}"
           elif [ "$EXISTING_DRAFT" = "false" ]; then
             echo "Published release found for $TAG. Uploading assets..."
             gh release upload "$TAG" artifacts/* --clobber
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              gh release edit "$TAG" --prerelease
+            fi
           elif [ -f "$NOTES_FILE" ]; then
             echo "Using curated release notes from $NOTES_FILE"
 
-            PRERELEASE_FLAG=""
-            if [[ "$TAG" == *-* ]]; then
-              PRERELEASE_FLAG="--prerelease"
+            CREATE_ARGS=(
+              "$TAG"
+              artifacts/*
+              --title "$TAG"
+              --notes-file "$NOTES_FILE"
+            )
+            CREATE_ARGS+=("${CREATE_FLAGS[@]}")
+
+            if [ -n "$RELEASE_TARGET" ]; then
+              CREATE_ARGS+=(--target "$RELEASE_TARGET")
             fi
 
-            gh release create "$TAG" artifacts/* \
-              --title "$TAG" \
-              --notes-file "$NOTES_FILE" \
-              $PRERELEASE_FLAG
+            gh release create "${CREATE_ARGS[@]}"
           else
             echo "No existing release. Generating notes from commits..."
 
-            # Find previous tag
-            PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | sed -n '2p')
-
-            if [ -n "$PREV_TAG" ]; then
-              RANGE="${PREV_TAG}..${TAG}"
+            if [ "$IS_STABLE" = "true" ]; then
+              PREV_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -v "^${TAG}$" \
+                | head -1 || true)
             else
-              RANGE="$TAG"
+              PREV_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname \
+                | grep -E '^v[0-9]' \
+                | grep -v "^${TAG}$" \
+                | head -1 || true)
             fi
 
-            # Parse commits into categories
+            RANGE_END="$TAG"
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              RANGE_END="$(git rev-parse HEAD)"
+            fi
+
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${RANGE_END}"
+            else
+              RANGE="$RANGE_END"
+            fi
+
             FEATURES=""
             FIXES=""
             OTHER=""
@@ -166,7 +303,6 @@ jobs:
 
               MSG=$(echo "$line" | sed 's/^[a-f0-9]* //')
 
-              # Filter out noise
               echo "$MSG" | grep -qiE '^(Merge |chore: bump|chore\(release\)|docs: update README)' && continue
 
               if echo "$MSG" | grep -qE '^feat(\(.*\))?:'; then
@@ -181,7 +317,6 @@ jobs:
               fi
             done <<< "$(git log --oneline --no-merges "$RANGE")"
 
-            # Build release notes
             NOTES=""
             if [ -n "$FEATURES" ]; then
               NOTES="${NOTES}## New Features\n${FEATURES}\n"
@@ -197,15 +332,31 @@ jobs:
               NOTES="Maintenance release ${TAG}"
             fi
 
-            PRERELEASE_FLAG=""
-            if [[ "$TAG" == *-* ]]; then
-              PRERELEASE_FLAG="--prerelease"
+            CREATE_ARGS=(
+              "$TAG"
+              artifacts/*
+              --title "$TAG"
+              --notes "$(printf '%b' "$NOTES")"
+            )
+            CREATE_ARGS+=("${CREATE_FLAGS[@]}")
+
+            if [ -n "$RELEASE_TARGET" ]; then
+              CREATE_ARGS+=(--target "$RELEASE_TARGET")
             fi
 
-            gh release create "$TAG" artifacts/* \
-              --title "$TAG" \
-              --notes "$(printf '%b' "$NOTES")" \
-              $PRERELEASE_FLAG
+            gh release create "${CREATE_ARGS[@]}"
           fi
+
+  trigger-website:
+    needs:
+      - prepare
+      - release
+    if: needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.is_stable == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website rebuild
+        run: |
+          gh api repos/TypeWhisper/typewhisper.com/dispatches \
+            -f event_type=release-published
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}

--- a/src/TypeWhisper.Windows/Services/UpdateService.cs
+++ b/src/TypeWhisper.Windows/Services/UpdateService.cs
@@ -46,22 +46,15 @@ public sealed class UpdateService
         _trayIcon = trayIcon;
     }
 
-    public void Initialize(ReleaseChannel channel = ReleaseChannel.Stable)
+    public void Initialize(ReleaseChannel? channel = null)
     {
-        Channel = channel;
+        var resolvedChannel = channel ?? InferReleaseChannel(CurrentVersion);
+        Channel = resolvedChannel;
         try
         {
-            var arch = RuntimeInformation.OSArchitecture == Architecture.Arm64
-                ? "win-arm64" : "win-x64";
-            var channelSuffix = channel switch
-            {
-                ReleaseChannel.ReleaseCandidate => "-rc",
-                ReleaseChannel.Daily => "-daily",
-                _ => ""
-            };
             _updateManager = new UpdateManager(
-                new GithubSource(TypeWhisperEnvironment.GithubRepoUrl, null, channel != ReleaseChannel.Stable),
-                new UpdateOptions { ExplicitChannel = $"{arch}{channelSuffix}" });
+                new GithubSource(TypeWhisperEnvironment.GithubRepoUrl, null, resolvedChannel != ReleaseChannel.Stable),
+                new UpdateOptions { ExplicitChannel = GetVelopackChannel(RuntimeInformation.OSArchitecture, resolvedChannel) });
         }
         catch
         {
@@ -109,6 +102,31 @@ public sealed class UpdateService
             _trayIcon.ShowBalloon(Loc.Instance["Update.BalloonFailedTitle"],
                 Loc.Instance["Update.BalloonFailedMessage"]);
         }
+    }
+
+    internal static ReleaseChannel InferReleaseChannel(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return ReleaseChannel.Stable;
+
+        if (version.Contains("-daily.", StringComparison.OrdinalIgnoreCase))
+            return ReleaseChannel.Daily;
+
+        if (version.Contains("-rc", StringComparison.OrdinalIgnoreCase))
+            return ReleaseChannel.ReleaseCandidate;
+
+        return ReleaseChannel.Stable;
+    }
+
+    internal static string GetVelopackChannel(Architecture architecture, ReleaseChannel channel)
+    {
+        var arch = architecture == Architecture.Arm64 ? "win-arm64" : "win-x64";
+        return channel switch
+        {
+            ReleaseChannel.ReleaseCandidate => $"{arch}-rc",
+            ReleaseChannel.Daily => $"{arch}-daily",
+            _ => arch
+        };
     }
 }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
@@ -1,0 +1,35 @@
+using System.Runtime.InteropServices;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class UpdateServiceTests
+{
+    [Theory]
+    [InlineData("0.7.1-daily.20260423", ReleaseChannel.Daily)]
+    [InlineData("0.7.1-DAILY.20260423+build", ReleaseChannel.Daily)]
+    [InlineData("0.7.0-rc1", ReleaseChannel.ReleaseCandidate)]
+    [InlineData("0.7.0-rc.2", ReleaseChannel.ReleaseCandidate)]
+    [InlineData("0.7.0", ReleaseChannel.Stable)]
+    [InlineData("0.7.0-preview.1", ReleaseChannel.Stable)]
+    [InlineData("", ReleaseChannel.Stable)]
+    public void InferReleaseChannel_UsesVersionPrereleaseTrack(string version, ReleaseChannel expected)
+    {
+        Assert.Equal(expected, UpdateService.InferReleaseChannel(version));
+    }
+
+    [Theory]
+    [InlineData(Architecture.X64, ReleaseChannel.Stable, "win-x64")]
+    [InlineData(Architecture.X64, ReleaseChannel.ReleaseCandidate, "win-x64-rc")]
+    [InlineData(Architecture.X64, ReleaseChannel.Daily, "win-x64-daily")]
+    [InlineData(Architecture.Arm64, ReleaseChannel.Stable, "win-arm64")]
+    [InlineData(Architecture.Arm64, ReleaseChannel.ReleaseCandidate, "win-arm64-rc")]
+    [InlineData(Architecture.Arm64, ReleaseChannel.Daily, "win-arm64-daily")]
+    public void GetVelopackChannel_CombinesArchitectureAndReleaseTrack(
+        Architecture architecture,
+        ReleaseChannel channel,
+        string expected)
+    {
+        Assert.Equal(expected, UpdateService.GetVelopackChannel(architecture, channel));
+    }
+}


### PR DESCRIPTION
## Summary

- Add Stable, RC, and Daily release-track handling to the Windows release workflow.
- Publish Velopack packages on architecture-specific channels: `win-x64`, `win-arm64`, `win-x64-rc`, `win-arm64-rc`, `win-x64-daily`, and `win-arm64-daily`.
- Keep RC and Daily builds as GitHub prereleases and restrict website rebuilds to stable releases.
- Infer the Windows updater track from the installed version so RC/Daily installs continue checking their matching Velopack channel.

## Validation

- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release`
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release`
- `git diff --check`

`actionlint` was not installed locally, so workflow syntax was reviewed manually.