### PR TITLE
Align Windows automation API and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ TypeWhisper can run a local HTTP server (default port 9876, configurable in Sett
 |----------|--------|-------------|
 | `/v1/status` | GET | App status and active model |
 | `/v1/models` | GET | List all available models (local + cloud) |
-| `/v1/transcribe` | POST | Transcribe audio from request body. Query params: `language`, `task` (transcribe/translate) |
+| `/v1/transcribe` | POST | Transcribe multipart or raw audio |
 | `/v1/history` | GET | Search history with pagination. Query params: `q`, `limit`, `offset` |
 | `/v1/history` | DELETE | Delete history entries by ID |
 | `/v1/profiles` | GET | List all profiles |
@@ -128,6 +128,47 @@ TypeWhisper can run a local HTTP server (default port 9876, configurable in Sett
 | `/v1/dictation/start` | POST | Start recording |
 | `/v1/dictation/stop` | POST | Stop recording |
 | `/v1/dictation/status` | GET | Check current dictation state |
+| `/v1/dictation/transcription` | GET | Poll dictation result by session ID |
+| `/v1/dictionary/terms` | GET/PUT/DELETE | List, replace/append, or clear dictionary terms |
+
+`/v1/transcribe` accepts either `multipart/form-data` with a `file` part or a raw audio request body. Multipart fields are:
+
+- `language` - exact source language, such as `en` or `de`
+- `language_hint` - repeatable language hints; do not combine with `language`
+- `task` - `transcribe` or `translate`
+- `target_language` - translate the final text to this language
+- `response_format` - `json` or `verbose_json`
+- `prompt` - request-specific transcription prompt/context
+- `engine` and `model` - per-request overrides using IDs from `/v1/models`
+
+Raw audio requests can pass the same options with headers: `X-Language`, `X-Language-Hints`, `X-Task`, `X-Target-Language`, `X-Response-Format`, `X-Prompt`, `X-Engine`, and `X-Model`. Add `?await_download=1` to wait for a local model download/restore when supported.
+
+```bash
+curl -X POST http://localhost:9876/v1/transcribe \
+  -F "file=@recording.wav" \
+  -F "language_hint=de" \
+  -F "language_hint=en" \
+  -F "response_format=verbose_json"
+
+curl -X POST http://localhost:9876/v1/dictation/start
+curl -X POST http://localhost:9876/v1/dictation/stop
+curl "http://localhost:9876/v1/dictation/transcription?id=<session-id>"
+```
+
+## CLI
+
+The optional `typewhisper` CLI talks to the local HTTP API.
+
+```bash
+typewhisper status
+typewhisper models
+typewhisper transcribe recording.wav --language de --json
+typewhisper transcribe recording.wav --language-hint de --language-hint en
+typewhisper transcribe recording.wav --engine groq --model whisper-large-v3-turbo
+typewhisper transcribe - < audio.wav
+```
+
+Useful flags: `--port`, `--json`, `--language`, repeatable `--language-hint`, `--task`, `--translate-to`, `--engine`, `--model`, and `--await-download`.
 
 ## Profiles
 

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -114,7 +114,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
 
         return await OpenAiTranscriptionHelper.TranscribeAsync(
             _httpClient, BaseUrl, _apiKey!, _selectedApiModelName,
-            wavAudio, language, translate, "verbose_json", ct);
+            wavAudio, language, translate, "verbose_json", ct, prompt);
     }
 
     // ILlmProviderPlugin

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
@@ -86,7 +86,7 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
 
         return await OpenAiTranscriptionHelper.TranscribeAsync(
             _httpClient, BaseUrl, _apiKey!, _selectedApiModelName,
-            wavAudio, language, translate, _selectedResponseFormat, ct);
+            wavAudio, language, translate, _selectedResponseFormat, ct, prompt);
     }
 
     // ILlmProviderPlugin

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -91,7 +91,7 @@ public sealed class OpenAiCompatiblePlugin : ITranscriptionEnginePlugin, ILlmPro
 
         return await OpenAiTranscriptionHelper.TranscribeAsync(
             _httpClient, _baseUrl!, _apiKey ?? "", _selectedModelId!,
-            wavAudio, language, translate, "verbose_json", ct);
+            wavAudio, language, translate, "verbose_json", ct, prompt);
     }
 
     // ILlmProviderPlugin

--- a/plugins/TypeWhisper.Plugin.Qwen3Stt/Qwen3SttPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Qwen3Stt/Qwen3SttPlugin.cs
@@ -143,7 +143,7 @@ public sealed class Qwen3SttPlugin : ITranscriptionEnginePlugin
 
         return await OpenAiTranscriptionHelper.TranscribeAsync(
             _httpClient, baseUrl, apiKey, model,
-            wavAudio, language, translate: false, "verbose_json", ct);
+            wavAudio, language, translate: false, "verbose_json", ct, prompt);
     }
 
     public void Dispose() => _httpClient.Dispose();

--- a/plugins/TypeWhisper.Plugin.Voxtral/VoxtralPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Voxtral/VoxtralPlugin.cs
@@ -112,7 +112,7 @@ public sealed class VoxtralPlugin : ITranscriptionEnginePlugin
 
         return await OpenAiTranscriptionHelper.TranscribeAsync(
             _httpClient, BaseUrl, _apiKey!, ModelId,
-            wavAudio, language, translate, "verbose_json", ct);
+            wavAudio, language, translate, "verbose_json", ct, prompt);
     }
 
     internal string? ApiKey => _apiKey;

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -1,4 +1,3 @@
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text.Json;
@@ -7,8 +6,6 @@ namespace TypeWhisper.Cli;
 
 /// <summary>
 /// TypeWhisper CLI - communicates with the running TypeWhisper app via its REST API.
-/// Usage: typewhisper [command] [options]
-/// Commands: status, models, transcribe <file>
 /// </summary>
 static class Program
 {
@@ -17,28 +14,36 @@ static class Program
 
     static async Task<int> Main(string[] args)
     {
-        if (args.Length == 0 || args[0] is "--help" or "-h")
+        var options = CliOptions.Parse(args);
+        if (options.ShowHelp)
         {
             PrintUsage();
             return 0;
         }
 
-        if (args[0] == "--version")
+        if (options.ShowVersion)
         {
             Console.WriteLine($"typewhisper-cli {GetVersion()}");
             return 0;
         }
 
-        var port = GetPort(args);
-        var json = HasFlag(args, "--json");
-        var baseUrl = $"http://127.0.0.1:{port}";
+        if (options.Error is not null)
+            return Error(options.Error);
 
-        return args[0] switch
+        if (options.Command is null)
         {
-            "status" => await StatusAsync(baseUrl, json),
-            "models" => await ModelsAsync(baseUrl, json),
-            "transcribe" => await TranscribeAsync(baseUrl, args, json),
-            _ => Error($"Unknown command: {args[0]}")
+            PrintUsage();
+            return 1;
+        }
+
+        var baseUrl = $"http://localhost:{options.Port}";
+
+        return options.Command switch
+        {
+            "status" => await StatusAsync(baseUrl, options.Json),
+            "models" => await ModelsAsync(baseUrl, options.Json),
+            "transcribe" => await TranscribeAsync(baseUrl, options),
+            _ => Error($"Unknown command: {options.Command}")
         };
     }
 
@@ -47,13 +52,16 @@ static class Program
         try
         {
             var response = await Http.GetStringAsync($"{baseUrl}/v1/status");
-            if (json) { Console.WriteLine(response); return 0; }
+            if (json) { Console.WriteLine(PrettyJson(response)); return 0; }
 
             using var doc = JsonDocument.Parse(response);
             var root = doc.RootElement;
-            Console.WriteLine($"Status: {Prop(root, "status")}");
-            Console.WriteLine($"Model:  {Prop(root, "model")}");
-            Console.WriteLine($"Engine: {Prop(root, "engine")}");
+            var status = Prop(root, "status") == "ready" ? "Ready" : "No model loaded";
+            var engine = Prop(root, "engine");
+            var model = Prop(root, "model");
+            Console.WriteLine(string.IsNullOrEmpty(model)
+                ? $"{status} - {engine}"
+                : $"{status} - {engine} ({model})");
             return 0;
         }
         catch (HttpRequestException)
@@ -67,17 +75,33 @@ static class Program
         try
         {
             var response = await Http.GetStringAsync($"{baseUrl}/v1/models");
-            if (json) { Console.WriteLine(response); return 0; }
+            if (json) { Console.WriteLine(PrettyJson(response)); return 0; }
 
             using var doc = JsonDocument.Parse(response);
-            if (doc.RootElement.TryGetProperty("models", out var models))
+            if (!doc.RootElement.TryGetProperty("models", out var models))
+                return 0;
+
+            var rows = models.EnumerateArray().ToList();
+            if (rows.Count == 0)
             {
-                foreach (var m in models.EnumerateArray())
-                {
-                    var selected = m.TryGetProperty("selected", out var sel) && sel.GetBoolean() ? " *" : "";
-                    Console.WriteLine($"  {Prop(m, "id"),-40} {Prop(m, "name")}{selected}");
-                }
+                Console.WriteLine("No models available.");
+                return 0;
             }
+
+            var idWidth = Math.Max(2, rows.Max(m => Prop(m, "id").Length));
+            var engineWidth = Math.Max(6, rows.Max(m => Prop(m, "engine").Length));
+            var nameWidth = Math.Max(4, rows.Max(m => Prop(m, "name").Length));
+
+            Console.WriteLine($"{Pad("ID", idWidth)}  {Pad("ENGINE", engineWidth)}  {Pad("NAME", nameWidth)}  STATUS");
+            Console.WriteLine(new string('-', idWidth + engineWidth + nameWidth + 10));
+
+            foreach (var m in rows)
+            {
+                var selected = m.TryGetProperty("selected", out var sel) && sel.GetBoolean() ? " *" : "";
+                Console.WriteLine(
+                    $"{Pad(Prop(m, "id"), idWidth)}  {Pad(Prop(m, "engine"), engineWidth)}  {Pad(Prop(m, "name"), nameWidth)}  {Prop(m, "status")}{selected}");
+            }
+
             return 0;
         }
         catch (HttpRequestException)
@@ -86,32 +110,59 @@ static class Program
         }
     }
 
-    static async Task<int> TranscribeAsync(string baseUrl, string[] args, bool json)
+    static async Task<int> TranscribeAsync(string baseUrl, CliOptions options)
     {
-        var file = args.Length > 1 ? args[1] : null;
-        if (file is null || !File.Exists(file))
-            return Error(file is null ? "Usage: typewhisper transcribe <file>" : $"File not found: {file}");
+        if (!string.IsNullOrEmpty(options.Language) && options.LanguageHints.Count > 0)
+            return Error("--language and --language-hint cannot be used together.");
 
-        var language = GetOption(args, "--language");
-        var task = GetOption(args, "--task") ?? "transcribe";
+        var file = options.Positionals.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(file))
+            return Error("Usage: typewhisper transcribe <file|->");
+
+        byte[] audioBytes;
+        var fileName = "audio.wav";
+
+        if (file == "-")
+        {
+            await using var stdin = Console.OpenStandardInput();
+            using var buffer = new MemoryStream();
+            await stdin.CopyToAsync(buffer);
+            audioBytes = buffer.ToArray();
+            if (audioBytes.Length == 0)
+                return Error("No data received from stdin.");
+        }
+        else
+        {
+            if (!File.Exists(file))
+                return Error($"File not found: {file}");
+
+            audioBytes = await File.ReadAllBytesAsync(file);
+            fileName = Path.GetFileName(file);
+        }
 
         try
         {
             using var content = new MultipartFormDataContent();
-            var fileBytes = await File.ReadAllBytesAsync(file);
-            var fileContent = new ByteArrayContent(fileBytes);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
-            content.Add(fileContent, "file", Path.GetFileName(file));
-            content.Add(new StringContent(task), "task");
-            if (language is not null) content.Add(new StringContent(language), "language");
+            var fileContent = new ByteArrayContent(audioBytes);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            content.Add(fileContent, "file", fileName);
 
-            var response = await Http.PostAsync($"{baseUrl}/v1/transcribe", content);
+            AddString(content, "language", options.Language);
+            foreach (var hint in options.LanguageHints)
+                AddString(content, "language_hint", hint);
+            AddString(content, "task", options.Task);
+            AddString(content, "target_language", options.TranslateTo);
+            AddString(content, "engine", options.Engine);
+            AddString(content, "model", options.Model);
+
+            var path = options.AwaitDownload ? "/v1/transcribe?await_download=1" : "/v1/transcribe";
+            var response = await Http.PostAsync($"{baseUrl}{path}", content);
             var body = await response.Content.ReadAsStringAsync();
 
             if (!response.IsSuccessStatusCode)
-                return Error($"Transcription failed ({(int)response.StatusCode}): {body}");
+                return Error($"Transcription failed ({(int)response.StatusCode}): {ExtractErrorMessage(body)}");
 
-            if (json) { Console.WriteLine(body); return 0; }
+            if (options.Json) { Console.WriteLine(PrettyJson(body)); return 0; }
 
             using var doc = JsonDocument.Parse(body);
             Console.WriteLine(Prop(doc.RootElement, "text"));
@@ -133,33 +184,38 @@ static class Program
             Commands:
               status                    Show TypeWhisper status
               models                    List available models
-              transcribe <file>         Transcribe an audio file
+              transcribe <file|->       Transcribe an audio file, or - for stdin
 
-            Options:
+            Global options:
               --port <N>                API server port (default: 9876)
               --json                    Output as JSON
-              --language <code>         Source language (e.g. "en", "de")
-              --task <task>             "transcribe" or "translate"
               --version                 Show version
-              --help                    Show this help
+              --help, -h                Show this help
+
+            Transcribe options:
+              --language <code>         Source language (e.g. en, de)
+              --language-hint <code>    Repeatable language hint for auto-detection
+              --task <task>             transcribe (default) or translate
+              --translate-to <code>     Target language for translation
+              --engine <id>             Override the engine for this request
+              --model <id>              Override the model for this request
+              --await-download          Wait for local model restore/download
+
+            Examples:
+              typewhisper status
+              typewhisper transcribe recording.wav
+              typewhisper transcribe recording.wav --language de --json
+              typewhisper transcribe recording.wav --language-hint de --language-hint en
+              typewhisper transcribe recording.wav --engine groq --model whisper-large-v3-turbo
+              typewhisper transcribe - < audio.wav
             """);
     }
 
-    static int GetPort(string[] args)
+    static void AddString(MultipartFormDataContent content, string name, string? value)
     {
-        var idx = Array.IndexOf(args, "--port");
-        if (idx >= 0 && idx + 1 < args.Length && int.TryParse(args[idx + 1], out var port))
-            return port;
-        return DefaultPort;
+        if (!string.IsNullOrWhiteSpace(value))
+            content.Add(new StringContent(value), name);
     }
-
-    static string? GetOption(string[] args, string flag)
-    {
-        var idx = Array.IndexOf(args, flag);
-        return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
-    }
-
-    static bool HasFlag(string[] args, string flag) => Array.IndexOf(args, flag) >= 0;
 
     static string GetVersion()
     {
@@ -179,8 +235,175 @@ static class Program
             .ToString() ?? "dev";
     }
 
-    static string Prop(JsonElement el, string name) =>
-        el.TryGetProperty(name, out var v) ? v.GetString() ?? "" : "";
+    static string Prop(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var value))
+            return "";
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? "",
+            JsonValueKind.Number => value.ToString(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => ""
+        };
+    }
+
+    static string PrettyJson(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch
+        {
+            return json;
+        }
+    }
+
+    static string ExtractErrorMessage(string body)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("error", out var error))
+            {
+                if (error.ValueKind == JsonValueKind.Object
+                    && error.TryGetProperty("message", out var message))
+                    return message.GetString() ?? body;
+
+                if (error.ValueKind == JsonValueKind.String)
+                    return error.GetString() ?? body;
+            }
+        }
+        catch { }
+
+        return body;
+    }
+
+    static string Pad(string value, int width) =>
+        value.PadRight(width);
 
     static int Error(string message) { Console.Error.WriteLine($"Error: {message}"); return 1; }
+
+    private sealed record CliOptions
+    {
+        public string? Command { get; private init; }
+        public List<string> Positionals { get; private init; } = [];
+        public int Port { get; private init; } = DefaultPort;
+        public bool Json { get; private init; }
+        public bool ShowHelp { get; private init; }
+        public bool ShowVersion { get; private init; }
+        public string? Language { get; private init; }
+        public List<string> LanguageHints { get; private init; } = [];
+        public string Task { get; private init; } = "transcribe";
+        public string? TranslateTo { get; private init; }
+        public string? Engine { get; private init; }
+        public string? Model { get; private init; }
+        public bool AwaitDownload { get; private init; }
+        public string? Error { get; private init; }
+
+        public static CliOptions Parse(string[] args)
+        {
+            var options = new CliOptions();
+            var positionals = new List<string>();
+            var languageHints = new List<string>();
+            string? command = null;
+            string? language = null;
+            string task = "transcribe";
+            string? translateTo = null;
+            string? engine = null;
+            string? model = null;
+            var port = DefaultPort;
+            var json = false;
+            var awaitDownload = false;
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                var arg = args[i];
+                switch (arg)
+                {
+                    case "--help":
+                    case "-h":
+                        return options with { ShowHelp = true };
+                    case "--version":
+                        return options with { ShowVersion = true };
+                    case "--json":
+                        json = true;
+                        break;
+                    case "--await-download":
+                        awaitDownload = true;
+                        break;
+                    case "--port":
+                        if (!TryReadValue(args, ref i, out var portValue) || !int.TryParse(portValue, out port))
+                            return options with { Error = "--port requires a number." };
+                        break;
+                    case "--language":
+                        if (!TryReadValue(args, ref i, out language))
+                            return options with { Error = "--language requires a value." };
+                        break;
+                    case "--language-hint":
+                        if (!TryReadValue(args, ref i, out var hint))
+                            return options with { Error = "--language-hint requires a value." };
+                        languageHints.Add(hint);
+                        break;
+                    case "--task":
+                        if (!TryReadValue(args, ref i, out task))
+                            return options with { Error = "--task requires a value." };
+                        break;
+                    case "--translate-to":
+                        if (!TryReadValue(args, ref i, out translateTo))
+                            return options with { Error = "--translate-to requires a value." };
+                        break;
+                    case "--engine":
+                        if (!TryReadValue(args, ref i, out engine))
+                            return options with { Error = "--engine requires a value." };
+                        break;
+                    case "--model":
+                        if (!TryReadValue(args, ref i, out model))
+                            return options with { Error = "--model requires a value." };
+                        break;
+                    default:
+                        if (arg.StartsWith('-') && arg != "-")
+                            return options with { Error = $"Unknown option '{arg}'." };
+
+                        if (command is null)
+                            command = arg;
+                        else
+                            positionals.Add(arg);
+                        break;
+                }
+            }
+
+            return options with
+            {
+                Command = command,
+                Positionals = positionals,
+                Port = port,
+                Json = json,
+                Language = language,
+                LanguageHints = languageHints,
+                Task = task,
+                TranslateTo = translateTo,
+                Engine = engine,
+                Model = model,
+                AwaitDownload = awaitDownload
+            };
+        }
+
+        private static bool TryReadValue(string[] args, ref int index, out string value)
+        {
+            if (index + 1 >= args.Length)
+            {
+                value = "";
+                return false;
+            }
+
+            value = args[++index];
+            return true;
+        }
+    }
 }

--- a/src/TypeWhisper.Core/Interfaces/IDictionaryService.cs
+++ b/src/TypeWhisper.Core/Interfaces/IDictionaryService.cs
@@ -15,6 +15,17 @@ public interface IDictionaryService
 
     string ApplyCorrections(string text);
     string? GetTermsForPrompt();
+    IReadOnlyList<string> GetEnabledTerms() => Entries
+        .Where(e => e.IsEnabled && e.EntryType == DictionaryEntryType.Term)
+        .Select(e => e.Original)
+        .ToList();
+
+    void SetTerms(IEnumerable<string> terms, bool replaceExisting) =>
+        throw new NotSupportedException();
+
+    void RemoveAllTerms() =>
+        throw new NotSupportedException();
+
     void LearnCorrection(string original, string replacement);
 
     void ActivatePack(TermPack pack);

--- a/src/TypeWhisper.Core/Services/DictionaryService.cs
+++ b/src/TypeWhisper.Core/Services/DictionaryService.cs
@@ -98,13 +98,64 @@ public sealed class DictionaryService : IDictionaryService
     public string? GetTermsForPrompt()
     {
         EnsureCacheLoaded();
-        var terms = _cache
-            .Where(e => e.IsEnabled && e.EntryType == DictionaryEntryType.Term)
-            .Select(e => e.Original)
-            .ToList();
+        var terms = GetEnabledTerms();
 
         if (terms.Count == 0) return null;
         return string.Join(", ", terms);
+    }
+
+    public IReadOnlyList<string> GetEnabledTerms()
+    {
+        EnsureCacheLoaded();
+        return NormalizeTerms(_cache
+            .Where(e => e.IsEnabled && e.EntryType == DictionaryEntryType.Term)
+            .Select(e => e.Original));
+    }
+
+    public void SetTerms(IEnumerable<string> terms, bool replaceExisting)
+    {
+        EnsureCacheLoaded();
+
+        var normalized = NormalizeTerms(terms);
+        var desiredByKey = normalized.ToDictionary(TermKey, term => term);
+        var existingTerms = _cache.Where(e => e.EntryType == DictionaryEntryType.Term).ToList();
+
+        foreach (var entry in existingTerms)
+        {
+            var key = TermKey(entry.Original);
+            if (desiredByKey.TryGetValue(key, out var desiredTerm))
+            {
+                var idx = _cache.FindIndex(e => e.Id == entry.Id);
+                if (idx >= 0)
+                    _cache[idx] = entry with { Original = desiredTerm, IsEnabled = true };
+            }
+            else if (replaceExisting)
+            {
+                _cache.Remove(entry);
+            }
+        }
+
+        var existingKeys = existingTerms.Select(e => TermKey(e.Original)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var term in normalized.Where(term => !existingKeys.Contains(TermKey(term))))
+        {
+            _cache.Add(new DictionaryEntry
+            {
+                Id = Guid.NewGuid().ToString(),
+                EntryType = DictionaryEntryType.Term,
+                Original = term
+            });
+        }
+
+        SaveToDisk();
+        EntriesChanged?.Invoke();
+    }
+
+    public void RemoveAllTerms()
+    {
+        EnsureCacheLoaded();
+        _cache.RemoveAll(e => e.EntryType == DictionaryEntryType.Term);
+        SaveToDisk();
+        EntriesChanged?.Invoke();
     }
 
     public void LearnCorrection(string original, string replacement)
@@ -215,4 +266,24 @@ public sealed class DictionaryService : IDictionaryService
         }
         catch { }
     }
+
+    private static IReadOnlyList<string> NormalizeTerms(IEnumerable<string> terms)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var normalized = new List<string>();
+
+        foreach (var rawTerm in terms)
+        {
+            var term = rawTerm.Trim();
+            if (term.Length == 0)
+                continue;
+
+            if (seen.Add(TermKey(term)))
+                normalized.Add(term);
+        }
+
+        return normalized;
+    }
+
+    private static string TermKey(string term) => term.Trim().ToUpperInvariant();
 }

--- a/src/TypeWhisper.PluginSDK/Helpers/OpenAiTranscriptionHelper.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/OpenAiTranscriptionHelper.cs
@@ -27,7 +27,7 @@ public static class OpenAiTranscriptionHelper
     public static async Task<PluginTranscriptionResult> TranscribeAsync(
         HttpClient httpClient, string baseUrl, string apiKey,
         string model, byte[] wavAudio, string? language, bool translate,
-        string responseFormat, CancellationToken ct)
+        string responseFormat, CancellationToken ct, string? prompt = null)
     {
         var endpoint = translate
             ? $"{baseUrl}/v1/audio/translations"
@@ -42,6 +42,9 @@ public static class OpenAiTranscriptionHelper
 
         if (!string.IsNullOrEmpty(language) && language != "auto")
             content.Add(new StringContent(language), "language");
+
+        if (!string.IsNullOrWhiteSpace(prompt))
+            content.Add(new StringContent(prompt), "prompt");
 
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
@@ -64,6 +67,8 @@ public static class OpenAiTranscriptionHelper
         var language = root.TryGetProperty("language", out var langEl) ? langEl.GetString() : null;
         var duration = root.TryGetProperty("duration", out var durEl) ? durEl.GetDouble() : 0;
 
+        var segments = new List<PluginTranscriptionSegment>();
+
         // Extract min no_speech_prob from segments (verbose_json format).
         // Using min so that the filter only triggers when ALL segments are silence.
         float? minNoSpeechProb = null;
@@ -72,6 +77,17 @@ public static class OpenAiTranscriptionHelper
         {
             foreach (var seg in segmentsEl.EnumerateArray())
             {
+                var segmentText = seg.TryGetProperty("text", out var segTextEl)
+                    ? segTextEl.GetString() ?? ""
+                    : "";
+                var start = seg.TryGetProperty("start", out var startEl)
+                    ? startEl.GetDouble()
+                    : 0;
+                var end = seg.TryGetProperty("end", out var endEl)
+                    ? endEl.GetDouble()
+                    : 0;
+                segments.Add(new PluginTranscriptionSegment(segmentText, start, end));
+
                 if (seg.TryGetProperty("no_speech_prob", out var nspEl))
                 {
                     var prob = (float)nspEl.GetDouble();
@@ -82,6 +98,9 @@ public static class OpenAiTranscriptionHelper
             }
         }
 
-        return new PluginTranscriptionResult(text.Trim(), language, duration, minNoSpeechProb);
+        return new PluginTranscriptionResult(text.Trim(), language, duration, minNoSpeechProb)
+        {
+            Segments = segments
+        };
     }
 }

--- a/src/TypeWhisper.PluginSDK/Models/PluginTranscriptionResult.cs
+++ b/src/TypeWhisper.PluginSDK/Models/PluginTranscriptionResult.cs
@@ -10,9 +10,13 @@ public sealed record PluginTranscriptionResult(
     string Text, string? DetectedLanguage, double DurationSeconds,
     float? NoSpeechProbability = null)
 {
+    public IReadOnlyList<PluginTranscriptionSegment> Segments { get; init; } = [];
+
     /// <summary>
     /// Backward-compatible constructor for plugins compiled against SDK &lt; 1.1.
     /// </summary>
     public PluginTranscriptionResult(string text, string detectedLanguage, double durationSeconds)
         : this(text, detectedLanguage, durationSeconds, null) { }
 }
+
+public sealed record PluginTranscriptionSegment(string Text, double Start, double End);

--- a/src/TypeWhisper.Windows/Services/HttpApiRequestParser.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiRequestParser.cs
@@ -1,0 +1,362 @@
+using System.Collections.Specialized;
+using System.IO;
+using System.Net;
+using System.Text;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+
+namespace TypeWhisper.Windows.Services;
+
+internal sealed record HttpApiRequest(
+    string Method,
+    string Path,
+    NameValueCollection QueryString,
+    IReadOnlyDictionary<string, string> Headers,
+    byte[] Body)
+{
+    public static async Task<HttpApiRequest> FromListenerRequestAsync(
+        HttpListenerRequest request,
+        CancellationToken ct)
+    {
+        byte[] body;
+        await using (var buffer = new MemoryStream())
+        {
+            await request.InputStream.CopyToAsync(buffer, ct);
+            body = buffer.ToArray();
+        }
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in request.Headers.AllKeys)
+        {
+            if (key is not null && request.Headers[key] is { } value)
+                headers[key] = value;
+        }
+
+        return new HttpApiRequest(
+            request.HttpMethod,
+            request.Url?.AbsolutePath ?? "",
+            request.QueryString,
+            headers,
+            body);
+    }
+}
+
+internal sealed record HttpApiResponse(int StatusCode, string Body, string ContentType = "application/json");
+
+internal sealed class HttpApiRequestException : Exception
+{
+    public int StatusCode { get; }
+
+    public HttpApiRequestException(int statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}
+
+internal sealed record TranscribeApiRequest(
+    byte[] AudioData,
+    string FileExtension,
+    string? Language,
+    IReadOnlyList<string> LanguageHints,
+    TranscriptionTask Task,
+    string? TargetLanguage,
+    string ResponseFormat,
+    string? Prompt,
+    string? Engine,
+    string? Model,
+    bool AwaitDownload);
+
+internal sealed record MultipartPart(
+    string Name,
+    string? FileName,
+    string? ContentType,
+    byte[] Data);
+
+internal static class HttpApiRequestParser
+{
+    public static TranscribeApiRequest ParseTranscribe(HttpApiRequest request)
+    {
+        var contentType = Header(request.Headers, "content-type") ?? "";
+        byte[] audioData;
+        var fileExtension = "wav";
+        string? language = null;
+        var languageHints = new List<string>();
+        var task = TranscriptionTask.Transcribe;
+        string? targetLanguage = null;
+        var responseFormat = "json";
+        string? prompt = null;
+        string? engine = null;
+        string? model = null;
+
+        if (contentType.Contains("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+        {
+            var boundary = ExtractBoundary(contentType)
+                ?? throw new HttpApiRequestException(400, "Missing multipart boundary");
+            var parts = ParseMultipart(request.Body, boundary);
+            var filePart = parts.FirstOrDefault(p => p.Name == "file")
+                ?? throw new HttpApiRequestException(400, "Missing 'file' part in multipart form data");
+
+            audioData = filePart.Data;
+            fileExtension = ExtensionFromFileName(filePart.FileName)
+                ?? ExtensionFromMime(filePart.ContentType)
+                ?? "wav";
+
+            language = Field(parts, "language");
+            languageHints.AddRange(Fields(parts, "language_hint"));
+            task = ParseTask(Field(parts, "task"));
+            targetLanguage = Field(parts, "target_language");
+            responseFormat = Field(parts, "response_format") ?? "json";
+            prompt = Field(parts, "prompt");
+            engine = Field(parts, "engine");
+            model = Field(parts, "model");
+        }
+        else if (request.Body.Length > 0)
+        {
+            audioData = request.Body;
+            fileExtension = ExtensionFromMime(contentType) ?? "wav";
+            language = Clean(Header(request.Headers, "x-language"));
+            languageHints.AddRange(
+                (Header(request.Headers, "x-language-hints") ?? "")
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Where(v => !string.IsNullOrWhiteSpace(v)));
+            task = ParseTask(Header(request.Headers, "x-task"));
+            targetLanguage = Clean(Header(request.Headers, "x-target-language"));
+            responseFormat = Clean(Header(request.Headers, "x-response-format")) ?? "json";
+            prompt = Clean(Header(request.Headers, "x-prompt"));
+            engine = Clean(Header(request.Headers, "x-engine"));
+            model = Clean(Header(request.Headers, "x-model"));
+        }
+        else
+        {
+            throw new HttpApiRequestException(400, "No audio data provided");
+        }
+
+        if (audioData.Length == 0)
+            throw new HttpApiRequestException(400, "Empty audio data");
+
+        if (!string.IsNullOrWhiteSpace(language) && languageHints.Count > 0)
+            throw new HttpApiRequestException(400, "Use either 'language' or 'language_hint', not both");
+
+        var awaitDownload = string.Equals(request.QueryString["await_download"], "1", StringComparison.Ordinal)
+            || string.Equals(request.QueryString["await_download"], "true", StringComparison.OrdinalIgnoreCase);
+
+        return new TranscribeApiRequest(
+            audioData,
+            fileExtension,
+            language,
+            languageHints,
+            task,
+            targetLanguage,
+            responseFormat,
+            prompt,
+            engine,
+            model,
+            awaitDownload);
+    }
+
+    public static IReadOnlyList<MultipartPart> ParseMultipart(byte[] body, string boundary)
+    {
+        var boundaryBytes = Encoding.UTF8.GetBytes("--" + boundary);
+        var doubleCrlf = Encoding.UTF8.GetBytes("\r\n\r\n");
+        var parts = new List<MultipartPart>();
+        var searchStart = 0;
+
+        while (searchStart < body.Length)
+        {
+            var boundaryStart = IndexOf(body, boundaryBytes, searchStart);
+            if (boundaryStart < 0)
+                break;
+
+            var afterBoundary = boundaryStart + boundaryBytes.Length;
+            if (afterBoundary + 1 < body.Length && body[afterBoundary] == (byte)'-' && body[afterBoundary + 1] == (byte)'-')
+                break;
+
+            var partHeaderStart = afterBoundary;
+            if (partHeaderStart + 1 < body.Length && body[partHeaderStart] == (byte)'\r' && body[partHeaderStart + 1] == (byte)'\n')
+                partHeaderStart += 2;
+
+            var headerEnd = IndexOf(body, doubleCrlf, partHeaderStart);
+            if (headerEnd < 0)
+                break;
+
+            var partBodyStart = headerEnd + doubleCrlf.Length;
+            var nextBoundary = IndexOf(body, boundaryBytes, partBodyStart);
+            if (nextBoundary < 0)
+                break;
+
+            var partBodyEnd = nextBoundary;
+            if (partBodyEnd >= 2 && body[partBodyEnd - 2] == (byte)'\r' && body[partBodyEnd - 1] == (byte)'\n')
+                partBodyEnd -= 2;
+
+            if (partBodyEnd < partBodyStart)
+            {
+                searchStart = nextBoundary;
+                continue;
+            }
+
+            var headers = Encoding.UTF8.GetString(body, partHeaderStart, headerEnd - partHeaderStart);
+            var parsedHeaders = ParsePartHeaders(headers);
+            if (!string.IsNullOrEmpty(parsedHeaders.Name))
+            {
+                var data = new byte[partBodyEnd - partBodyStart];
+                Buffer.BlockCopy(body, partBodyStart, data, 0, data.Length);
+                parts.Add(new MultipartPart(
+                    parsedHeaders.Name,
+                    parsedHeaders.FileName,
+                    parsedHeaders.ContentType,
+                    data));
+            }
+
+            searchStart = nextBoundary;
+        }
+
+        return parts;
+    }
+
+    internal static string? ExtractBoundary(string contentType)
+    {
+        foreach (var part in contentType.Split(';', StringSplitOptions.TrimEntries))
+        {
+            if (!part.StartsWith("boundary=", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var boundary = part["boundary=".Length..].Trim();
+            if (boundary.Length >= 2 && boundary[0] == '"' && boundary[^1] == '"')
+                boundary = boundary[1..^1];
+            return string.IsNullOrWhiteSpace(boundary) ? null : boundary;
+        }
+
+        return null;
+    }
+
+    private static (string Name, string? FileName, string? ContentType) ParsePartHeaders(string headers)
+    {
+        string? name = null;
+        string? fileName = null;
+        string? contentType = null;
+
+        foreach (var line in headers.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            var colon = line.IndexOf(':');
+            if (colon < 0)
+                continue;
+
+            var headerName = line[..colon].Trim();
+            var value = line[(colon + 1)..].Trim();
+
+            if (headerName.Equals("Content-Disposition", StringComparison.OrdinalIgnoreCase))
+            {
+                name = ExtractDispositionParameter(value, "name");
+                fileName = ExtractDispositionParameter(value, "filename")
+                    ?? ExtractDispositionParameter(value, "filename*");
+            }
+            else if (headerName.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
+            {
+                contentType = value;
+            }
+        }
+
+        return (name ?? "", fileName, contentType);
+    }
+
+    private static string? ExtractDispositionParameter(string value, string key)
+    {
+        foreach (var part in value.Split(';', StringSplitOptions.TrimEntries))
+        {
+            var equals = part.IndexOf('=');
+            if (equals < 0)
+                continue;
+
+            var partKey = part[..equals].Trim();
+            if (!partKey.Equals(key, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var parameterValue = part[(equals + 1)..].Trim();
+            if (parameterValue.Length >= 2 && parameterValue[0] == '"' && parameterValue[^1] == '"')
+                parameterValue = parameterValue[1..^1];
+
+            if (key.EndsWith('*') && parameterValue.Contains("''", StringComparison.Ordinal))
+                parameterValue = parameterValue[(parameterValue.IndexOf("''", StringComparison.Ordinal) + 2)..];
+
+            return string.IsNullOrWhiteSpace(parameterValue)
+                ? null
+                : Uri.UnescapeDataString(parameterValue);
+        }
+
+        return null;
+    }
+
+    private static string? Header(IReadOnlyDictionary<string, string> headers, string name) =>
+        headers.TryGetValue(name, out var value) ? value : null;
+
+    private static string? Field(IEnumerable<MultipartPart> parts, string name) =>
+        parts.Where(p => p.Name == name)
+            .Select(p => Clean(Encoding.UTF8.GetString(p.Data)))
+            .FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+
+    private static IEnumerable<string> Fields(IEnumerable<MultipartPart> parts, string name) =>
+        parts.Where(p => p.Name == name)
+            .Select(p => Clean(Encoding.UTF8.GetString(p.Data)))
+            .Where(v => !string.IsNullOrWhiteSpace(v))!;
+
+    private static string? Clean(string? value)
+    {
+        var cleaned = value?.Trim();
+        return string.IsNullOrWhiteSpace(cleaned) ? null : cleaned;
+    }
+
+    private static TranscriptionTask ParseTask(string? value) =>
+        string.Equals(value?.Trim(), "translate", StringComparison.OrdinalIgnoreCase)
+            ? TranscriptionTask.Translate
+            : TranscriptionTask.Transcribe;
+
+    private static string? ExtensionFromFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+
+        var extension = Path.GetExtension(fileName).TrimStart('.').Trim();
+        return string.IsNullOrWhiteSpace(extension) ? null : extension.ToLowerInvariant();
+    }
+
+    private static string? ExtensionFromMime(string? mime)
+    {
+        if (string.IsNullOrWhiteSpace(mime))
+            return null;
+
+        var lower = mime.ToLowerInvariant();
+        if (lower.Contains("wav") || lower.Contains("wave")) return "wav";
+        if (lower.Contains("mp3") || lower.Contains("mpeg")) return "mp3";
+        if (lower.Contains("m4a") || lower.Contains("mp4")) return "m4a";
+        if (lower.Contains("flac")) return "flac";
+        if (lower.Contains("ogg")) return "ogg";
+        if (lower.Contains("aac")) return "aac";
+        if (lower.Contains("webm")) return "webm";
+        return null;
+    }
+
+    private static int IndexOf(byte[] haystack, byte[] needle, int startIndex)
+    {
+        if (needle.Length == 0)
+            return startIndex;
+
+        for (var i = startIndex; i <= haystack.Length - needle.Length; i++)
+        {
+            var found = true;
+            for (var j = 0; j < needle.Length; j++)
+            {
+                if (haystack[i + j] == needle[j])
+                    continue;
+
+                found = false;
+                break;
+            }
+
+            if (found)
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Windows;
 using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
 using TypeWhisper.Windows.ViewModels;
 
 namespace TypeWhisper.Windows.Services;
@@ -18,6 +19,7 @@ public sealed class HttpApiService : IDisposable
     private readonly IDictionaryService _dictionary;
     private readonly IVocabularyBoostingService _vocabularyBoosting;
     private readonly IPostProcessingPipeline _pipeline;
+    private readonly ITranslationService _translation;
     private readonly DictationViewModel _dictation;
 
     private HttpListener? _listener;
@@ -28,6 +30,7 @@ public sealed class HttpApiService : IDisposable
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
         WriteIndented = false
     };
 
@@ -42,6 +45,7 @@ public sealed class HttpApiService : IDisposable
         IDictionaryService dictionary,
         IVocabularyBoostingService vocabularyBoosting,
         IPostProcessingPipeline pipeline,
+        ITranslationService translation,
         DictationViewModel dictation)
     {
         _modelManager = modelManager;
@@ -52,6 +56,7 @@ public sealed class HttpApiService : IDisposable
         _dictionary = dictionary;
         _vocabularyBoosting = vocabularyBoosting;
         _pipeline = pipeline;
+        _translation = translation;
         _dictation = dictation;
     }
 
@@ -92,15 +97,46 @@ public sealed class HttpApiService : IDisposable
 
     private async Task HandleRequest(HttpListenerContext context, CancellationToken ct)
     {
-        var request = context.Request;
         var response = context.Response;
 
         try
         {
-            var path = request.Url?.AbsolutePath ?? "";
-            var method = request.HttpMethod;
+            var request = await HttpApiRequest.FromListenerRequestAsync(context.Request, ct);
+            var apiResponse = await HandleRequestAsync(request, ct);
 
-            var (statusCode, body) = (path, method) switch
+            response.StatusCode = apiResponse.StatusCode;
+            response.ContentType = apiResponse.ContentType;
+            response.Headers["Access-Control-Allow-Origin"] = "*";
+            response.Headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS";
+            response.Headers["Access-Control-Allow-Headers"] = "Content-Type, X-Language, X-Language-Hints, X-Task, X-Target-Language, X-Response-Format, X-Prompt, X-Engine, X-Model";
+
+            var bytes = Encoding.UTF8.GetBytes(apiResponse.Body);
+            response.ContentLength64 = bytes.Length;
+            await response.OutputStream.WriteAsync(bytes, ct);
+        }
+        catch (Exception ex)
+        {
+            var apiResponse = Error(500, ex.Message);
+            response.StatusCode = apiResponse.StatusCode;
+            response.ContentType = apiResponse.ContentType;
+            var errorBytes = Encoding.UTF8.GetBytes(apiResponse.Body);
+            response.ContentLength64 = errorBytes.Length;
+            await response.OutputStream.WriteAsync(errorBytes, ct);
+        }
+        finally
+        {
+            response.Close();
+        }
+    }
+
+    internal async Task<HttpApiResponse> HandleRequestAsync(HttpApiRequest request, CancellationToken ct)
+    {
+        if (request.Method == "OPTIONS")
+            return Json(new { ok = true });
+
+        try
+        {
+            return (request.Path, request.Method) switch
             {
                 ("/v1/status", "GET") => HandleStatus(),
                 ("/v1/models", "GET") => HandleModels(),
@@ -112,106 +148,169 @@ public sealed class HttpApiService : IDisposable
                 ("/v1/dictation/start", "POST") => await HandleDictationStart(),
                 ("/v1/dictation/stop", "POST") => await HandleDictationStop(),
                 ("/v1/dictation/status", "GET") => HandleDictationStatus(),
-                _ => (404, JsonSerializer.Serialize(new { error = "Not found" }))
+                ("/v1/dictation/transcription", "GET") => HandleDictationTranscription(request),
+                ("/v1/dictionary/terms", "GET") => HandleGetDictionaryTerms(),
+                ("/v1/dictionary/terms", "PUT") => await HandlePutDictionaryTerms(request),
+                ("/v1/dictionary/terms", "DELETE") => await HandleDeleteDictionaryTerms(),
+                _ => Error(404, "Not found")
             };
-
-            response.StatusCode = statusCode;
-            response.ContentType = "application/json";
-            var bytes = Encoding.UTF8.GetBytes(body);
-            response.ContentLength64 = bytes.Length;
-            await response.OutputStream.WriteAsync(bytes, ct);
+        }
+        catch (HttpApiRequestException ex)
+        {
+            return Error(ex.StatusCode, ex.Message);
+        }
+        catch (ModelManagerRequestException ex)
+        {
+            return Error(ex.StatusCode, ex.Message);
         }
         catch (Exception ex)
         {
-            response.StatusCode = 500;
-            response.ContentType = "application/json";
-            var errorBytes = Encoding.UTF8.GetBytes(
-                JsonSerializer.Serialize(new { error = ex.Message }));
-            response.ContentLength64 = errorBytes.Length;
-            await response.OutputStream.WriteAsync(errorBytes, ct);
-        }
-        finally
-        {
-            response.Close();
+            return Error(500, ex.Message);
         }
     }
 
-    private (int, string) HandleStatus()
+    private HttpApiResponse HandleStatus()
     {
         var activePlugin = _modelManager.ActiveTranscriptionPlugin;
-        var result = new
+        var activeModel = _modelManager.ActiveModelId is { } activeModelId && ModelManagerService.IsPluginModel(activeModelId)
+            ? ModelManagerService.ParsePluginModelId(activeModelId).ModelId
+            : activePlugin?.SelectedModelId;
+
+        return Json(new
         {
-            status = _modelManager.ActiveModelId is not null ? "ready" : "no_model",
-            activeModel = _modelManager.ActiveModelId,
-            apiVersion = "1.0",
+            status = activePlugin is not null && _modelManager.Engine.IsModelLoaded ? "ready" : "no_model",
+            engine = activePlugin?.ProviderId,
+            model = activeModel,
+            active_model = _modelManager.ActiveModelId,
+            api_version = "1.0",
             supports_streaming = activePlugin?.SupportsStreaming ?? false,
             supports_translation = activePlugin?.SupportsTranslation ?? false
-        };
-        return (200, JsonSerializer.Serialize(result));
+        });
     }
 
-    private (int, string) HandleModels()
+    private HttpApiResponse HandleModels()
     {
+        var selectedModelId = _settings.Current.SelectedModelId;
         var models = _modelManager.PluginManager.TranscriptionEngines
-            .SelectMany(e => e.TranscriptionModels.Select(m =>
+            .SelectMany(engine => engine.TranscriptionModels.Select(model =>
             {
-                var fullId = ModelManagerService.GetPluginModelId(e.PluginId, m.Id);
+                var fullId = ModelManagerService.GetPluginModelId(engine.PluginId, model.Id);
+                var downloaded = _modelManager.IsDownloaded(fullId);
+                var status = engine.SupportsModelDownload
+                    ? downloaded ? "ready" : "not_downloaded"
+                    : engine.IsConfigured ? "ready" : "not_configured";
+
                 return new
                 {
-                    id = fullId,
-                    name = $"{e.ProviderDisplayName}: {m.DisplayName}",
-                    size = m.SizeDescription ?? (e.SupportsModelDownload ? "Local" : "Cloud"),
-                    engine = e.PluginId,
-                    downloaded = _modelManager.IsDownloaded(fullId),
-                    active = _modelManager.ActiveModelId == fullId
+                    id = model.Id,
+                    full_id = fullId,
+                    engine = engine.ProviderId,
+                    name = model.DisplayName,
+                    size_description = model.SizeDescription ?? (engine.SupportsModelDownload ? "Local" : "Cloud"),
+                    language_count = model.LanguageCount,
+                    status,
+                    selected = selectedModelId == fullId,
+                    active = _modelManager.ActiveModelId == fullId,
+                    downloaded,
+                    loaded = _modelManager.ActiveModelId == fullId
                 };
-            }));
-        return (200, JsonSerializer.Serialize(new { models }));
+            }))
+            .ToList();
+
+        return Json(new { models });
     }
 
-    private async Task<(int, string)> HandleTranscribe(HttpListenerRequest request, CancellationToken ct)
+    private async Task<HttpApiResponse> HandleTranscribe(HttpApiRequest request, CancellationToken ct)
     {
-        if (!await _modelManager.EnsureModelLoadedAsync(cancellationToken: ct))
-            return (503, JsonSerializer.Serialize(new { error = "No model loaded" }));
+        var transcribeRequest = HttpApiRequestParser.ParseTranscribe(request);
 
-        var tempPath = Path.Combine(Path.GetTempPath(), $"tw_api_{Guid.NewGuid()}.tmp");
+        await using var modelScope = await _modelManager.BeginTranscriptionRequestAsync(
+            transcribeRequest.Engine,
+            transcribeRequest.Model,
+            transcribeRequest.AwaitDownload,
+            ct);
+
+        var tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"tw_api_{Guid.NewGuid():N}.{SanitizeExtension(transcribeRequest.FileExtension)}");
+
         try
         {
-            await using (var fs = File.Create(tempPath))
-            {
-                await request.InputStream.CopyToAsync(fs, ct);
-            }
-
+            await File.WriteAllBytesAsync(tempPath, transcribeRequest.AudioData, ct);
             var samples = await _audioFile.LoadAudioAsync(tempPath, ct);
 
-            var s = _settings.Current;
-            var language = request.QueryString["language"] ?? (s.Language == "auto" ? null : s.Language);
-            var taskStr = request.QueryString["task"] ?? s.TranscriptionTask;
-            var task = taskStr == "translate" ? TranscriptionTask.Translate : TranscriptionTask.Transcribe;
-            var responseFormat = request.QueryString["response_format"] ?? "json";
+            var prompt = MergePrompt(
+                transcribeRequest.Prompt,
+                BuildLanguageHintsPrompt(transcribeRequest.LanguageHints),
+                _dictionary.GetTermsForPrompt());
 
-            var result = await _modelManager.Engine.TranscribeAsync(samples, language, task, ct);
+            var activeResult = await _modelManager.TranscribeActiveAsync(
+                samples,
+                transcribeRequest.Language,
+                transcribeRequest.Task,
+                prompt,
+                ct);
+
+            var result = activeResult.Result;
             var pipelineResult = await _pipeline.ProcessAsync(result.Text, new PipelineOptions
             {
                 VocabularyBooster = GetVocabularyBooster(),
                 DictionaryCorrector = _dictionary.ApplyCorrections
             }, ct);
 
-            var response = new
+            var finalText = pipelineResult.Text;
+            if (!string.IsNullOrWhiteSpace(transcribeRequest.TargetLanguage))
             {
-                text = pipelineResult.Text,
+                var sourceLanguage = result.DetectedLanguage
+                    ?? transcribeRequest.Language
+                    ?? "en";
+
+                try
+                {
+                    finalText = await _translation.TranslateAsync(
+                        finalText,
+                        sourceLanguage,
+                        transcribeRequest.TargetLanguage,
+                        ct);
+                }
+                catch (NotSupportedException ex)
+                {
+                    return Error(501, ex.Message);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    return Error(501, ex.Message);
+                }
+            }
+
+            if (transcribeRequest.ResponseFormat.Equals("verbose_json", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(new
+                {
+                    text = finalText,
+                    language = result.DetectedLanguage,
+                    duration = result.Duration,
+                    processing_time = result.ProcessingTime,
+                    engine = activeResult.EngineId,
+                    model = activeResult.ModelId,
+                    segments = result.Segments.Select(seg => new
+                    {
+                        text = seg.Text,
+                        start = seg.Start,
+                        end = seg.End
+                    })
+                });
+            }
+
+            return Json(new
+            {
+                text = finalText,
                 language = result.DetectedLanguage,
                 duration = result.Duration,
                 processing_time = result.ProcessingTime,
-                segments = result.Segments.Select(seg => new
-                {
-                    text = seg.Text,
-                    start = seg.Start,
-                    end = seg.End
-                })
-            };
-
-            return (200, JsonSerializer.Serialize(response));
+                engine = activeResult.EngineId,
+                model = activeResult.ModelId
+            });
         }
         finally
         {
@@ -219,15 +318,11 @@ public sealed class HttpApiService : IDisposable
         }
     }
 
-    // GET /v1/history?q=&limit=&offset=
-    private (int, string) HandleHistorySearch(HttpListenerRequest request)
+    private HttpApiResponse HandleHistorySearch(HttpApiRequest request)
     {
         var query = request.QueryString["q"] ?? "";
-        var limitStr = request.QueryString["limit"];
-        var offsetStr = request.QueryString["offset"];
-
-        var limit = int.TryParse(limitStr, out var l) ? l : 50;
-        var offset = int.TryParse(offsetStr, out var o) ? o : 0;
+        var limit = Math.Min(ParseInt(request.QueryString["limit"], 50), 200);
+        var offset = Math.Max(ParseInt(request.QueryString["offset"], 0), 0);
 
         var records = string.IsNullOrWhiteSpace(query)
             ? _history.Records
@@ -236,7 +331,7 @@ public sealed class HttpApiService : IDisposable
         var paged = records.Skip(offset).Take(limit).Select(r => new
         {
             id = r.Id,
-            timestamp = r.Timestamp.ToString("o"),
+            timestamp = r.Timestamp,
             text = r.FinalText,
             raw_text = r.RawText,
             app = r.AppProcessName,
@@ -248,29 +343,26 @@ public sealed class HttpApiService : IDisposable
             words = r.WordCount
         });
 
-        var result = new
+        return Json(new
         {
             total = records.Count,
             offset,
             limit,
             records = paged
-        };
-        return (200, JsonSerializer.Serialize(result));
+        });
     }
 
-    // DELETE /v1/history?id=
-    private (int, string) HandleHistoryDelete(HttpListenerRequest request)
+    private HttpApiResponse HandleHistoryDelete(HttpApiRequest request)
     {
         var id = request.QueryString["id"];
         if (string.IsNullOrEmpty(id))
-            return (400, JsonSerializer.Serialize(new { error = "Missing id parameter" }));
+            return Error(400, "Missing id parameter");
 
         _history.DeleteRecord(id);
-        return (200, JsonSerializer.Serialize(new { deleted = true, id }));
+        return Json(new { deleted = true, id });
     }
 
-    // GET /v1/profiles
-    private (int, string) HandleProfilesList()
+    private HttpApiResponse HandleProfilesList()
     {
         var profiles = _profiles.Profiles.Select(p => new
         {
@@ -287,57 +379,136 @@ public sealed class HttpApiService : IDisposable
             prompt_action_id = p.PromptActionId
         });
 
-        return (200, JsonSerializer.Serialize(new { profiles }));
+        return Json(new { profiles });
     }
 
-    // PUT /v1/profiles/toggle?id=
-    private (int, string) HandleProfileToggle(HttpListenerRequest request)
+    private HttpApiResponse HandleProfileToggle(HttpApiRequest request)
     {
         var id = request.QueryString["id"];
         if (string.IsNullOrEmpty(id))
-            return (400, JsonSerializer.Serialize(new { error = "Missing id parameter" }));
+            return Error(400, "Missing id parameter");
 
         var profile = _profiles.Profiles.FirstOrDefault(p => p.Id == id);
         if (profile is null)
-            return (404, JsonSerializer.Serialize(new { error = "Profile not found" }));
+            return Error(404, "Profile not found");
 
         _profiles.UpdateProfile(profile with { IsEnabled = !profile.IsEnabled });
-        return (200, JsonSerializer.Serialize(new { id, is_enabled = !profile.IsEnabled }));
+        return Json(new { id, is_enabled = !profile.IsEnabled });
     }
 
-    // POST /v1/dictation/start
-    private async Task<(int, string)> HandleDictationStart()
+    private async Task<HttpApiResponse> HandleDictationStart()
     {
         if (_dictation.IsRecording)
-            return (409, JsonSerializer.Serialize(new { error = "Already recording" }));
+            return Error(409, "Already recording");
 
-        await Application.Current.Dispatcher.InvokeAsync(
-            () => _dictation.StartRecordingAsync());
-        return (200, JsonSerializer.Serialize(new { started = true }));
+        var id = await InvokeOnDispatcherAsync(() => _dictation.StartRecordingForApiAsync());
+        var session = _dictation.GetApiDictationSession(id);
+        if (session?.Status == ApiDictationSessionStatus.Failed)
+            return Error(409, session.Error ?? "Failed to start dictation");
+
+        return Json(new { id, status = "recording" });
     }
 
-    // POST /v1/dictation/stop
-    private async Task<(int, string)> HandleDictationStop()
+    private async Task<HttpApiResponse> HandleDictationStop()
     {
         if (!_dictation.IsRecording)
-            return (409, JsonSerializer.Serialize(new { error = "Not recording" }));
+            return Error(409, "Not recording");
 
-        await Application.Current.Dispatcher.InvokeAsync(
-            () => _dictation.StopRecordingAsync());
-        return (200, JsonSerializer.Serialize(new { stopped = true }));
+        var id = await InvokeOnDispatcherAsync(() => _dictation.StopRecordingForApiAsync());
+        if (id is null)
+            return Error(500, "Missing active dictation session");
+
+        return Json(new { id, status = "stopped" });
     }
 
-    // GET /v1/dictation/status
-    private (int, string) HandleDictationStatus()
+    private HttpApiResponse HandleDictationStatus()
     {
-        var result = new
+        return Json(new
         {
             state = _dictation.State.ToString().ToLowerInvariant(),
             is_recording = _dictation.IsRecording,
             active_model = _modelManager.ActiveModelId,
             active_profile = _dictation.ActiveProfileName
-        };
-        return (200, JsonSerializer.Serialize(result));
+        });
+    }
+
+    private HttpApiResponse HandleDictationTranscription(HttpApiRequest request)
+    {
+        var idString = request.QueryString["id"];
+        if (!Guid.TryParse(idString, out var id))
+            return Error(400, "Missing or invalid 'id' query parameter");
+
+        var session = _dictation.GetApiDictationSession(id);
+        if (session is null)
+            return Error(404, "Dictation session not found");
+
+        var transcription = session.Transcription is null
+            ? null
+            : new
+            {
+                text = session.Transcription.Text,
+                raw_text = session.Transcription.RawText,
+                timestamp = session.Transcription.Timestamp,
+                app_name = session.Transcription.AppName,
+                app_process_name = session.Transcription.AppProcessName,
+                duration = session.Transcription.Duration,
+                language = session.Transcription.Language,
+                engine = session.Transcription.Engine,
+                model = session.Transcription.Model,
+                words_count = session.Transcription.WordsCount
+            };
+
+        return Json(new
+        {
+            id = session.Id,
+            status = session.Status.ToString().ToLowerInvariant(),
+            transcription,
+            error = session.Error
+        });
+    }
+
+    private HttpApiResponse HandleGetDictionaryTerms()
+    {
+        var terms = _dictionary.GetEnabledTerms();
+        return Json(new { terms, count = terms.Count });
+    }
+
+    private async Task<HttpApiResponse> HandlePutDictionaryTerms(HttpApiRequest request)
+    {
+        if (request.Body.Length == 0)
+            return Error(400, "Missing JSON body");
+
+        DictionaryTermsRequest? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<DictionaryTermsRequest>(request.Body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return Error(400, "Invalid JSON body");
+        }
+
+        if (payload is null)
+            return Error(400, "Invalid JSON body");
+
+        var terms = await InvokeOnDispatcherAsync(() =>
+        {
+            _dictionary.SetTerms(payload.Terms, payload.Replace ?? false);
+            return Task.FromResult(_dictionary.GetEnabledTerms());
+        });
+
+        return Json(new { terms, count = terms.Count });
+    }
+
+    private async Task<HttpApiResponse> HandleDeleteDictionaryTerms()
+    {
+        await InvokeOnDispatcherAsync(() =>
+        {
+            _dictionary.RemoveAllTerms();
+            return Task.FromResult(true);
+        });
+
+        return Json(new { deleted = true, count = 0 });
     }
 
     public void Dispose()
@@ -352,4 +523,66 @@ public sealed class HttpApiService : IDisposable
 
     private Func<string, string>? GetVocabularyBooster() =>
         _settings.Current.VocabularyBoostingEnabled ? _vocabularyBoosting.Apply : null;
+
+    private static HttpApiResponse Json<T>(T value, int statusCode = 200) =>
+        new(statusCode, JsonSerializer.Serialize(value, JsonOptions));
+
+    private static HttpApiResponse Error(int statusCode, string message) =>
+        Json(new
+        {
+            error = new
+            {
+                code = ErrorCode(statusCode),
+                message
+            }
+        }, statusCode);
+
+    private static string ErrorCode(int statusCode) => statusCode switch
+    {
+        400 => "bad_request",
+        404 => "not_found",
+        409 => "conflict",
+        413 => "payload_too_large",
+        501 => "not_implemented",
+        503 => "service_unavailable",
+        _ => "error"
+    };
+
+    private static int ParseInt(string? value, int fallback) =>
+        int.TryParse(value, out var parsed) ? parsed : fallback;
+
+    private static string SanitizeExtension(string extension)
+    {
+        var sanitized = new string(extension.Where(char.IsLetterOrDigit).ToArray());
+        return string.IsNullOrWhiteSpace(sanitized) ? "tmp" : sanitized.ToLowerInvariant();
+    }
+
+    private static string? BuildLanguageHintsPrompt(IReadOnlyList<string> languageHints) =>
+        languageHints.Count == 0 ? null : "Language hints: " + string.Join(", ", languageHints);
+
+    private static string? MergePrompt(params string?[] prompts)
+    {
+        var parts = prompts
+            .Select(p => p?.Trim())
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToList();
+
+        return parts.Count == 0 ? null : string.Join("\n", parts);
+    }
+
+    private static async Task<T> InvokeOnDispatcherAsync<T>(Func<Task<T>> action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            return await action();
+
+        var operation = dispatcher.InvokeAsync(action);
+        return await await operation.Task;
+    }
+
+    private sealed record DictionaryTermsRequest
+    {
+        public IReadOnlyList<string> Terms { get; init; } = [];
+        public bool? Replace { get; init; }
+    }
 }

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using TypeWhisper.Core.Audio;
@@ -9,6 +10,22 @@ using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
 
 namespace TypeWhisper.Windows.Services;
+
+internal sealed class ModelManagerRequestException : Exception
+{
+    public int StatusCode { get; }
+
+    public ModelManagerRequestException(int statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}
+
+internal sealed record ActiveModelTranscriptionResult(
+    TranscriptionResult Result,
+    string? EngineId,
+    string? ModelId);
 
 public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
 {
@@ -259,6 +276,172 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         return true;
     }
 
+    internal async Task<TranscriptionRequestModelScope> BeginTranscriptionRequestAsync(
+        string? engineOverride,
+        string? modelOverride,
+        bool awaitDownload,
+        CancellationToken cancellationToken = default)
+    {
+        var previousActiveModelId = ActiveModelId;
+        var hasOverride = !string.IsNullOrWhiteSpace(engineOverride)
+            || !string.IsNullOrWhiteSpace(modelOverride);
+
+        if (!hasOverride)
+        {
+            var targetModelId = _settings.Current.SelectedModelId;
+            if (string.IsNullOrWhiteSpace(targetModelId))
+                throw new ModelManagerRequestException(503, "No model loaded");
+
+            if (awaitDownload && IsPluginModel(targetModelId))
+            {
+                var (pluginId, pluginModelId) = ParsePluginModelId(targetModelId);
+                var plugin = _pluginManager.TranscriptionEngines
+                    .FirstOrDefault(e => e.PluginId == pluginId);
+
+                if (plugin?.SupportsModelDownload == true && !plugin.IsModelDownloaded(pluginModelId))
+                {
+                    await DownloadAndLoadModelAsync(targetModelId, cancellationToken);
+                    return new TranscriptionRequestModelScope(this, previousActiveModelId, restore: false);
+                }
+            }
+
+            if (!await EnsureModelLoadedAsync(targetModelId, cancellationToken))
+                throw new ModelManagerRequestException(503, "No model loaded");
+
+            return new TranscriptionRequestModelScope(this, previousActiveModelId, restore: false);
+        }
+
+        var resolved = ResolveRequestModel(engineOverride, modelOverride, awaitDownload);
+        var fullModelId = GetPluginModelId(resolved.Plugin.PluginId, resolved.ModelId);
+
+        if (resolved.Plugin.SupportsModelDownload
+            && !resolved.Plugin.IsModelDownloaded(resolved.ModelId)
+            && awaitDownload)
+        {
+            await DownloadAndLoadModelAsync(fullModelId, cancellationToken);
+        }
+        else
+        {
+            if (!await EnsureModelLoadedAsync(fullModelId, cancellationToken))
+                throw new ModelManagerRequestException(503, $"Model '{resolved.ModelId}' could not be loaded");
+        }
+
+        return new TranscriptionRequestModelScope(this, previousActiveModelId, restore: true);
+    }
+
+    internal async Task<ActiveModelTranscriptionResult> TranscribeActiveAsync(
+        float[] audioSamples,
+        string? language = null,
+        TranscriptionTask task = TranscriptionTask.Transcribe,
+        string? prompt = null,
+        CancellationToken cancellationToken = default)
+    {
+        var plugin = ActiveTranscriptionPlugin
+            ?? throw new InvalidOperationException("No active transcription engine");
+
+        var modelId = ActiveModelId is { } activeModelId && IsPluginModel(activeModelId)
+            ? ParsePluginModelId(activeModelId).ModelId
+            : plugin.SelectedModelId;
+
+        var wavBytes = WavEncoder.Encode(audioSamples);
+        var translate = task == TranscriptionTask.Translate;
+        var stopwatch = Stopwatch.StartNew();
+        var result = await plugin.TranscribeAsync(wavBytes, language, translate, prompt, cancellationToken);
+        stopwatch.Stop();
+
+        var transcription = new TranscriptionResult
+        {
+            Text = result.Text,
+            DetectedLanguage = result.DetectedLanguage,
+            Duration = result.DurationSeconds,
+            ProcessingTime = stopwatch.Elapsed.TotalSeconds,
+            NoSpeechProbability = result.NoSpeechProbability,
+            Segments = result.Segments.Select(seg => new TranscriptionSegment(seg.Text, seg.Start, seg.End)).ToList()
+        };
+
+        return new ActiveModelTranscriptionResult(transcription, plugin.ProviderId, modelId);
+    }
+
+    private RequestModel ResolveRequestModel(string? engineOverride, string? modelOverride, bool awaitDownload)
+    {
+        var engines = _pluginManager.TranscriptionEngines;
+        var engine = string.IsNullOrWhiteSpace(engineOverride)
+            ? null
+            : engines.FirstOrDefault(e => e.ProviderId.Equals(engineOverride, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrWhiteSpace(engineOverride) && engine is null)
+            throw new ModelManagerRequestException(400, $"Unknown engine '{engineOverride}'");
+
+        if (engine is null && !string.IsNullOrWhiteSpace(modelOverride))
+        {
+            var matches = engines
+                .Where(e => e.TranscriptionModels.Any(m => m.Id.Equals(modelOverride, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            if (matches.Count == 0)
+                throw new ModelManagerRequestException(400, $"Unknown model '{modelOverride}'");
+
+            if (matches.Count > 1)
+            {
+                var engineIds = string.Join(", ", matches.Select(e => e.ProviderId));
+                throw new ModelManagerRequestException(
+                    400,
+                    $"Ambiguous model id '{modelOverride}' -- matches engines: {engineIds}. Specify 'engine' too.");
+            }
+
+            engine = matches[0];
+        }
+
+        if (engine is null)
+            throw new ModelManagerRequestException(503, "No engine selected");
+
+        var modelId = string.IsNullOrWhiteSpace(modelOverride)
+            ? engine.SelectedModelId ?? engine.TranscriptionModels.FirstOrDefault()?.Id
+            : engine.TranscriptionModels.FirstOrDefault(m => m.Id.Equals(modelOverride, StringComparison.OrdinalIgnoreCase))?.Id
+                ?? modelOverride;
+
+        if (string.IsNullOrWhiteSpace(modelId))
+            throw new ModelManagerRequestException(400, $"Engine '{engine.ProviderId}' has no available models");
+
+        if (engine.TranscriptionModels.Count > 0
+            && !engine.TranscriptionModels.Any(m => m.Id.Equals(modelId, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ModelManagerRequestException(
+                400,
+                $"Model '{modelId}' is not offered by engine '{engine.ProviderId}'");
+        }
+
+        if (engine.SupportsModelDownload && !engine.IsModelDownloaded(modelId) && !awaitDownload)
+        {
+            throw new ModelManagerRequestException(
+                409,
+                $"Engine '{engine.ProviderId}' is not configured (missing API key or downloaded weights). Pass ?await_download=1 to wait for restore.");
+        }
+
+        if (!engine.SupportsModelDownload && !engine.IsConfigured)
+        {
+            throw new ModelManagerRequestException(
+                409,
+                $"Engine '{engine.ProviderId}' is not configured (missing API key or downloaded weights).");
+        }
+
+        return new RequestModel(engine, modelId);
+    }
+
+    private Task RestoreRequestModelAsync(string? previousActiveModelId)
+    {
+        if (previousActiveModelId is null)
+        {
+            ActiveModelId = null;
+            return Task.CompletedTask;
+        }
+
+        if (ActiveModelId == previousActiveModelId)
+            return Task.CompletedTask;
+
+        return LoadModelAsync(previousActiveModelId);
+    }
+
     /// <summary>
     /// Migrates old local model IDs to plugin-prefixed IDs.
     /// Call on startup before loading models.
@@ -305,6 +488,45 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         {
             CancelAutoUnload();
             _disposed = true;
+        }
+    }
+
+    private sealed record RequestModel(ITranscriptionEnginePlugin Plugin, string ModelId);
+
+    internal sealed class TranscriptionRequestModelScope : IAsyncDisposable
+    {
+        private readonly ModelManagerService _owner;
+        private readonly string? _previousActiveModelId;
+        private readonly bool _restore;
+        private bool _disposed;
+
+        internal TranscriptionRequestModelScope(
+            ModelManagerService owner,
+            string? previousActiveModelId,
+            bool restore)
+        {
+            _owner = owner;
+            _previousActiveModelId = previousActiveModelId;
+            _restore = restore;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            if (!_restore)
+                return;
+
+            try
+            {
+                await _owner.RestoreRequestModelAsync(_previousActiveModelId);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to restore API request model: {ex.Message}");
+            }
         }
     }
 }
@@ -361,7 +583,8 @@ internal sealed class PluginTranscriptionEngineAdapter : ITranscriptionEngine
             Text = result.Text,
             DetectedLanguage = result.DetectedLanguage,
             Duration = result.DurationSeconds,
-            NoSpeechProbability = result.NoSpeechProbability
+            NoSpeechProbability = result.NoSpeechProbability,
+            Segments = result.Segments.Select(seg => new TranscriptionSegment(seg.Text, seg.Start, seg.End)).ToList()
         };
     }
 }

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -16,6 +16,32 @@ using TypeWhisper.Windows.Services.Plugins;
 
 namespace TypeWhisper.Windows.ViewModels;
 
+public sealed record ApiDictationTranscription(
+    string Text,
+    string RawText,
+    DateTime Timestamp,
+    string? AppName,
+    string? AppProcessName,
+    double Duration,
+    string? Language,
+    string Engine,
+    string? Model,
+    int WordsCount);
+
+public sealed record ApiDictationSessionSnapshot(
+    Guid Id,
+    ApiDictationSessionStatus Status,
+    ApiDictationTranscription? Transcription,
+    string? Error);
+
+public enum ApiDictationSessionStatus
+{
+    Recording,
+    Processing,
+    Completed,
+    Failed
+}
+
 public partial class DictationViewModel : ObservableObject, IDisposable
 {
     private readonly ISettingsService _settings;
@@ -45,6 +71,11 @@ public partial class DictationViewModel : ObservableObject, IDisposable
     private System.Timers.Timer? _durationTimer;
     private bool _isRecording;
     private int _pendingJobCount;
+    private const int MaxTrackedApiDictationSessions = 50;
+    private readonly object _apiSessionLock = new();
+    private readonly Dictionary<Guid, ApiDictationSessionSnapshot> _apiDictationSessions = [];
+    private readonly List<Guid> _apiDictationSessionOrder = [];
+    private Guid? _activeApiDictationSessionId;
 
     private readonly Channel<TranscriptionJob> _jobChannel =
         Channel.CreateBounded<TranscriptionJob>(new BoundedChannelOptions(5)
@@ -262,6 +293,64 @@ public partial class DictationViewModel : ObservableObject, IDisposable
     /// <summary>Whether the service is currently recording.</summary>
     public bool IsRecording => _isRecording;
 
+    public async Task<Guid> StartRecordingForApiAsync()
+    {
+        var sessionId = Guid.NewGuid();
+        _activeApiDictationSessionId = sessionId;
+        StoreApiDictationSession(new ApiDictationSessionSnapshot(
+            sessionId,
+            ApiDictationSessionStatus.Recording,
+            null,
+            null));
+
+        await StartRecording();
+
+        if (!_isRecording)
+            FailApiDictationSession(sessionId, StatusText);
+
+        return sessionId;
+    }
+
+    public async Task<Guid?> StopRecordingForApiAsync()
+    {
+        var sessionId = _activeApiDictationSessionId;
+        if (sessionId is not null)
+            MarkApiDictationSessionProcessing(sessionId.Value);
+
+        await StopRecording();
+        return sessionId;
+    }
+
+    public ApiDictationSessionSnapshot? GetApiDictationSession(Guid id)
+    {
+        lock (_apiSessionLock)
+        {
+            if (_apiDictationSessions.TryGetValue(id, out var session))
+                return session;
+        }
+
+        var record = _history.Records.FirstOrDefault(r =>
+            Guid.TryParse(r.Id, out var recordId) && recordId == id);
+        if (record is null)
+            return null;
+
+        return new ApiDictationSessionSnapshot(
+            id,
+            ApiDictationSessionStatus.Completed,
+            new ApiDictationTranscription(
+                record.FinalText,
+                record.RawText,
+                record.Timestamp,
+                record.AppName,
+                record.AppProcessName,
+                record.DurationSeconds,
+                record.Language,
+                record.EngineUsed,
+                record.ModelUsed,
+                record.WordCount),
+            null);
+    }
+
     private void RaiseOverlayPresentationChanged()
     {
         OnPropertyChanged(nameof(ShowInlineFeedback));
@@ -297,6 +386,62 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             if (Interlocked.CompareExchange(ref _pendingJobCount, next, current) == current)
                 return next;
         }
+    }
+
+    private void StoreApiDictationSession(ApiDictationSessionSnapshot session)
+    {
+        lock (_apiSessionLock)
+        {
+            _apiDictationSessions[session.Id] = session;
+            _apiDictationSessionOrder.Remove(session.Id);
+            _apiDictationSessionOrder.Add(session.Id);
+
+            while (_apiDictationSessionOrder.Count > MaxTrackedApiDictationSessions)
+            {
+                var removedId = _apiDictationSessionOrder[0];
+                _apiDictationSessionOrder.RemoveAt(0);
+                _apiDictationSessions.Remove(removedId);
+            }
+        }
+    }
+
+    private void MarkApiDictationSessionProcessing(Guid sessionId)
+    {
+        StoreApiDictationSession(new ApiDictationSessionSnapshot(
+            sessionId,
+            ApiDictationSessionStatus.Processing,
+            null,
+            null));
+    }
+
+    private void CompleteApiDictationSession(Guid? sessionId, ApiDictationTranscription transcription)
+    {
+        if (sessionId is null)
+            return;
+
+        StoreApiDictationSession(new ApiDictationSessionSnapshot(
+            sessionId.Value,
+            ApiDictationSessionStatus.Completed,
+            transcription,
+            null));
+
+        if (_activeApiDictationSessionId == sessionId)
+            _activeApiDictationSessionId = null;
+    }
+
+    private void FailApiDictationSession(Guid? sessionId, string error)
+    {
+        if (sessionId is null)
+            return;
+
+        StoreApiDictationSession(new ApiDictationSessionSnapshot(
+            sessionId.Value,
+            ApiDictationSessionStatus.Failed,
+            null,
+            error));
+
+        if (_activeApiDictationSessionId == sessionId)
+            _activeApiDictationSessionId = null;
     }
 
     private void ShowTransientFeedback(string text, bool isError)
@@ -535,6 +680,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
         if (samples is null || samples.Length < 1600) // < 100ms
         {
+            FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.TooShort"]);
             ApplyTransientIdleFeedback(Loc.Instance["Status.TooShort"]);
             return;
         }
@@ -542,8 +688,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         // Skip transcription if audio is essentially silence (prevents cloud model hallucinations)
         if (!_audio.HasSpeechEnergy && partialSnapshot.Count == 0)
         {
+            FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.NoSpeech"]);
             ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]);
             return;
+        }
+
+        var apiSessionId = _activeApiDictationSessionId;
+        if (apiSessionId is not null)
+        {
+            MarkApiDictationSessionProcessing(apiSessionId.Value);
+            _activeApiDictationSessionId = null;
         }
 
         // Snapshot all context and enqueue — returns immediately
@@ -555,7 +709,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _capturedWindowTitle,
             EffectiveLanguage,
             EffectiveTask,
-            _modelManager.ActiveModelId);
+            _modelManager.ActiveModelId,
+            apiSessionId);
 
         Interlocked.Increment(ref _pendingJobCount);
         await _jobChannel.Writer.WriteAsync(job);
@@ -569,6 +724,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _isRecording = false;
             _audio.StopRecording();
             StopActiveRecordingInfrastructure();
+            FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.Cancelled"]);
             ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]);
             return Task.CompletedTask;
         }
@@ -625,6 +781,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
                 if (result.NoSpeechProbability is > 0.8f)
                 {
+                    FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                         ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                     return;
@@ -632,6 +789,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
                 if (string.IsNullOrWhiteSpace(result.Text))
                 {
+                    FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                         ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                     return;
@@ -643,6 +801,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
             if (string.IsNullOrWhiteSpace(rawText))
             {
+                FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                     ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                 return;
@@ -809,6 +968,21 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 await _modelManager.LoadModelAsync(_settings.Current.SelectedModelId);
             }
 
+            var timestamp = DateTime.UtcNow;
+            var engineUsed = ResolveEngineUsed(job.ActiveModelIdAtCapture);
+            var wordsCount = CountWords(finalText);
+            CompleteApiDictationSession(job.ApiSessionId, new ApiDictationTranscription(
+                finalText,
+                rawText,
+                timestamp,
+                job.CapturedWindowTitle,
+                job.CapturedProcessName,
+                audioDuration,
+                detectedLanguage,
+                engineUsed,
+                job.ActiveModelIdAtCapture,
+                wordsCount));
+
             // Save to history (if enabled)
             if (_settings.Current.SaveToHistoryEnabled)
             {
@@ -825,13 +999,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     audioFileName = null;
                 }
 
-                var engineUsed = job.ActiveModelIdAtCapture is not null && ModelManagerService.IsPluginModel(job.ActiveModelIdAtCapture)
-                    ? job.ActiveModelIdAtCapture
-                    : "parakeet";
                 _history.AddRecord(new TranscriptionRecord
                 {
-                    Id = Guid.NewGuid().ToString(),
-                    Timestamp = DateTime.UtcNow,
+                    Id = job.ApiSessionId?.ToString() ?? Guid.NewGuid().ToString(),
+                    Timestamp = timestamp,
                     RawText = rawText,
                     FinalText = finalText,
                     AppName = job.CapturedWindowTitle,
@@ -866,11 +1037,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         }
         catch (OperationCanceledException)
         {
+            FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.Cancelled"]);
             await Application.Current.Dispatcher.InvokeAsync(() =>
                 ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]));
         }
         catch (Exception ex)
         {
+            FailApiDictationSession(job.ApiSessionId, ex.Message);
             _errorLog.AddEntry(ex.Message, ErrorCategory.Transcription);
             _eventBus.Publish(new TranscriptionFailedEvent
             {
@@ -982,8 +1155,11 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         // Cancel current consumer, drain pending jobs
         _consumerCts.Cancel();
 
-        while (_jobChannel.Reader.TryRead(out _))
+        while (_jobChannel.Reader.TryRead(out var pendingJob))
+        {
+            FailApiDictationSession(pendingJob.ApiSessionId, Loc.Instance["Status.Cancelled"]);
             DecrementPendingJobCount();
+        }
 
         // Restart consumer with fresh CTS
         _consumerCts = new CancellationTokenSource();
@@ -999,6 +1175,22 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
     private Func<string, string>? GetVocabularyBooster() =>
         _settings.Current.VocabularyBoostingEnabled ? _vocabularyBoosting.Apply : null;
+
+    private string ResolveEngineUsed(string? activeModelId)
+    {
+        if (activeModelId is not null && ModelManagerService.IsPluginModel(activeModelId))
+        {
+            var (pluginId, _) = ModelManagerService.ParsePluginModelId(activeModelId);
+            return _modelManager.PluginManager.TranscriptionEngines
+                .FirstOrDefault(plugin => plugin.PluginId == pluginId)
+                ?.ProviderId ?? activeModelId;
+        }
+
+        return "parakeet";
+    }
+
+    private static int CountWords(string text) =>
+        text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
 
     public void Dispose()
     {
@@ -1029,7 +1221,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         string? CapturedWindowTitle,
         string? EffectiveLanguage,
         TranscriptionTask EffectiveTask,
-        string? ActiveModelIdAtCapture);
+        string? ActiveModelIdAtCapture,
+        Guid? ApiSessionId);
 }
 
 public enum DictationState

--- a/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
@@ -137,6 +137,43 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void SetTerms_AppendsNormalizedTerms()
+    {
+        _sut.SetTerms([" TypeWhisper ", "WhisperKit", "typewhisper"], replaceExisting: false);
+        _sut.SetTerms(["Kubernetes"], replaceExisting: false);
+
+        Assert.Equal(["TypeWhisper", "WhisperKit", "Kubernetes"], _sut.GetEnabledTerms());
+    }
+
+    [Fact]
+    public void SetTerms_ReplacesExistingTerms()
+    {
+        _sut.SetTerms(["TypeWhisper", "WhisperKit"], replaceExisting: false);
+        _sut.SetTerms(["Kubernetes"], replaceExisting: true);
+
+        Assert.Equal(["Kubernetes"], _sut.GetEnabledTerms());
+    }
+
+    [Fact]
+    public void RemoveAllTerms_LeavesCorrections()
+    {
+        _sut.SetTerms(["TypeWhisper"], replaceExisting: false);
+        _sut.AddEntry(new DictionaryEntry
+        {
+            Id = "correction",
+            EntryType = DictionaryEntryType.Correction,
+            Original = "typo",
+            Replacement = "term"
+        });
+
+        _sut.RemoveAllTerms();
+
+        Assert.Empty(_sut.GetEnabledTerms());
+        Assert.Single(_sut.Entries);
+        Assert.Equal(DictionaryEntryType.Correction, _sut.Entries[0].EntryType);
+    }
+
+    [Fact]
     public void LearnCorrection_AddsNewCorrection()
     {
         _sut.LearnCorrection("kubernets", "Kubernetes");

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiRequestParserTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiRequestParserTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Specialized;
+using System.IO;
+using System.Text;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class HttpApiRequestParserTests
+{
+    [Fact]
+    public void ParseTranscribe_ReadsMultipartFileAndFields()
+    {
+        var boundary = "Boundary123";
+        var body = Multipart(boundary,
+            ("language_hint", null, null, "de"u8.ToArray()),
+            ("language_hint", null, null, "en"u8.ToArray()),
+            ("task", null, null, "translate"u8.ToArray()),
+            ("target_language", null, null, "fr"u8.ToArray()),
+            ("response_format", null, null, "verbose_json"u8.ToArray()),
+            ("prompt", null, null, "Project names"u8.ToArray()),
+            ("engine", null, null, "groq"u8.ToArray()),
+            ("model", null, null, "whisper-large-v3"u8.ToArray()),
+            ("file", "audio.wav", "audio/wav", [1, 2, 3, 4]));
+
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/transcribe",
+            new NameValueCollection { ["await_download"] = "1" },
+            new Dictionary<string, string> { ["content-type"] = $"multipart/form-data; boundary={boundary}" },
+            body);
+
+        var parsed = HttpApiRequestParser.ParseTranscribe(request);
+
+        Assert.Equal([1, 2, 3, 4], parsed.AudioData);
+        Assert.Equal("wav", parsed.FileExtension);
+        Assert.Null(parsed.Language);
+        Assert.Equal(["de", "en"], parsed.LanguageHints);
+        Assert.Equal(TranscriptionTask.Translate, parsed.Task);
+        Assert.Equal("fr", parsed.TargetLanguage);
+        Assert.Equal("verbose_json", parsed.ResponseFormat);
+        Assert.Equal("Project names", parsed.Prompt);
+        Assert.Equal("groq", parsed.Engine);
+        Assert.Equal("whisper-large-v3", parsed.Model);
+        Assert.True(parsed.AwaitDownload);
+    }
+
+    [Fact]
+    public void ParseTranscribe_ReadsUnquotedMultipartDispositionParameters()
+    {
+        var body = Encoding.UTF8.GetBytes(
+            "--Boundary123\r\n" +
+            "Content-Type: text/plain; charset=utf-8\r\n" +
+            "Content-Disposition: form-data; name=engine\r\n" +
+            "\r\n" +
+            "sherpa-onnx\r\n" +
+            "--Boundary123\r\n" +
+            "Content-Disposition: form-data; name=file; filename=audio.wav; filename*=utf-8''audio.wav\r\n" +
+            "Content-Type: audio/wav\r\n" +
+            "\r\n" +
+            "audio-bytes\r\n" +
+            "--Boundary123--\r\n");
+
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/transcribe",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["content-type"] = "multipart/form-data; boundary=\"Boundary123\"" },
+            body);
+
+        var parsed = HttpApiRequestParser.ParseTranscribe(request);
+
+        Assert.Equal("sherpa-onnx", parsed.Engine);
+        Assert.Equal("wav", parsed.FileExtension);
+        Assert.Equal(Encoding.UTF8.GetBytes("audio-bytes"), parsed.AudioData);
+    }
+
+    [Fact]
+    public void ParseTranscribe_ReadsRawBodyHeaders()
+    {
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/transcribe",
+            new NameValueCollection(),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["content-type"] = "audio/mpeg",
+                ["x-language-hints"] = "de, en",
+                ["x-task"] = "translate",
+                ["x-target-language"] = "es",
+                ["x-response-format"] = "verbose_json",
+                ["x-prompt"] = "Names",
+                ["x-engine"] = "openai",
+                ["x-model"] = "gpt-4o-transcribe"
+            },
+            [9, 8, 7]);
+
+        var parsed = HttpApiRequestParser.ParseTranscribe(request);
+
+        Assert.Equal("mp3", parsed.FileExtension);
+        Assert.Equal(["de", "en"], parsed.LanguageHints);
+        Assert.Equal(TranscriptionTask.Translate, parsed.Task);
+        Assert.Equal("es", parsed.TargetLanguage);
+        Assert.Equal("verbose_json", parsed.ResponseFormat);
+        Assert.Equal("Names", parsed.Prompt);
+        Assert.Equal("openai", parsed.Engine);
+        Assert.Equal("gpt-4o-transcribe", parsed.Model);
+    }
+
+    [Fact]
+    public void ParseTranscribe_RejectsLanguageAndHintsTogether()
+    {
+        var boundary = "Boundary123";
+        var body = Multipart(boundary,
+            ("language", null, null, "de"u8.ToArray()),
+            ("language_hint", null, null, "en"u8.ToArray()),
+            ("file", "audio.wav", "audio/wav", [1]));
+
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/transcribe",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["content-type"] = $"multipart/form-data; boundary={boundary}" },
+            body);
+
+        var ex = Assert.Throws<HttpApiRequestException>(() => HttpApiRequestParser.ParseTranscribe(request));
+        Assert.Equal(400, ex.StatusCode);
+        Assert.Contains("language", ex.Message);
+    }
+
+    [Fact]
+    public void ParseTranscribe_RejectsMultipartWithoutFile()
+    {
+        var boundary = "Boundary123";
+        var body = Multipart(boundary, ("language", null, null, "de"u8.ToArray()));
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/transcribe",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["content-type"] = $"multipart/form-data; boundary={boundary}" },
+            body);
+
+        var ex = Assert.Throws<HttpApiRequestException>(() => HttpApiRequestParser.ParseTranscribe(request));
+        Assert.Equal(400, ex.StatusCode);
+        Assert.Contains("file", ex.Message);
+    }
+
+    private static byte[] Multipart(
+        string boundary,
+        params (string Name, string? FileName, string? ContentType, byte[] Data)[] parts)
+    {
+        using var body = new MemoryStream();
+        foreach (var part in parts)
+        {
+            Write(body, $"--{boundary}\r\n");
+            var disposition = $"Content-Disposition: form-data; name=\"{part.Name}\"";
+            if (part.FileName is not null)
+                disposition += $"; filename=\"{part.FileName}\"";
+            Write(body, disposition + "\r\n");
+            if (part.ContentType is not null)
+                Write(body, $"Content-Type: {part.ContentType}\r\n");
+            Write(body, "\r\n");
+            body.Write(part.Data);
+            Write(body, "\r\n");
+        }
+
+        Write(body, $"--{boundary}--\r\n");
+        return body.ToArray();
+    }
+
+    private static void Write(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        stream.Write(bytes);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -1,0 +1,277 @@
+using System.Collections.Specialized;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Moq;
+using TypeWhisper.Core.Audio;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.Core.Services;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class HttpApiServiceTests : IDisposable
+{
+    private readonly string _dictionaryPath = Path.GetTempFileName();
+    private readonly Mock<IActiveWindowService> _activeWindow = new();
+    private readonly Mock<IProfileService> _profiles = new();
+    private readonly Mock<ISettingsService> _settings = new();
+    private readonly PluginEventBus _eventBus = new();
+    private readonly PluginLoader _loader = new();
+
+    public HttpApiServiceTests()
+    {
+        _profiles.Setup(p => p.Profiles).Returns([]);
+    }
+
+    [Fact]
+    public async Task DictionaryTermsEndpoints_SetAppendAndDeleteTerms()
+    {
+        var service = CreateService();
+
+        var put = await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/terms",
+            """{"terms":[" TypeWhisper ","WhisperKit","typewhisper"],"replace":true}"""), CancellationToken.None);
+        var putJson = JsonObject(put);
+
+        Assert.Equal(200, put.StatusCode);
+        Assert.Equal(2, putJson["count"].GetInt32());
+
+        await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/terms",
+            """{"terms":["Kubernetes"],"replace":false}"""), CancellationToken.None);
+
+        var get = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/dictionary/terms",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+
+        var terms = get["terms"].EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(["TypeWhisper", "WhisperKit", "Kubernetes"], terms);
+
+        var delete = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "DELETE",
+            "/v1/dictionary/terms",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+
+        Assert.True(delete["deleted"].GetBoolean());
+        Assert.Equal(0, delete["count"].GetInt32());
+    }
+
+    [Fact]
+    public async Task TranscribeRejectsLanguageAndLanguageHintsTogether()
+    {
+        var service = CreateService();
+        var request = MultipartTranscribeRequest(
+            ("language", null, null, "de"u8.ToArray()),
+            ("language_hint", null, null, "en"u8.ToArray()),
+            ("file", "audio.wav", "audio/wav", WavEncoder.Encode([0f, 0f, 0f, 0f])));
+
+        var response = await service.HandleRequestAsync(request, CancellationToken.None);
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.Contains("language", ErrorMessage(response));
+    }
+
+    [Fact]
+    public async Task TranscribeRejectsUnknownEngineOverride()
+    {
+        var service = CreateService(new FakeTranscriptionPlugin());
+        var request = MultipartTranscribeRequest(
+            ("engine", null, null, "missing"u8.ToArray()),
+            ("file", "audio.wav", "audio/wav", WavEncoder.Encode([0f, 0f, 0f, 0f])));
+
+        var response = await service.HandleRequestAsync(request, CancellationToken.None);
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.Contains("Unknown engine", ErrorMessage(response));
+    }
+
+    [Fact]
+    public async Task TranscribeMultipartRoutesEngineOverrideAndVerboseResponse()
+    {
+        var plugin = new FakeTranscriptionPlugin();
+        var service = CreateService(plugin);
+        var wav = WavEncoder.Encode(Enumerable.Repeat(0.05f, 1600).ToArray());
+        var request = MultipartTranscribeRequest(
+            ("engine", null, null, "mock"u8.ToArray()),
+            ("language_hint", null, null, "de"u8.ToArray()),
+            ("language_hint", null, null, "en"u8.ToArray()),
+            ("response_format", null, null, "verbose_json"u8.ToArray()),
+            ("file", "audio.wav", "audio/wav", wav));
+
+        var response = await service.HandleRequestAsync(request, CancellationToken.None);
+        var json = JsonObject(response);
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal("mock", json["engine"].GetString());
+        Assert.Equal("tiny", json["model"].GetString());
+        Assert.Equal("transcribed", json["text"].GetString());
+        Assert.Contains("Language hints: de, en", plugin.LastPrompt);
+        Assert.Single(json["segments"].EnumerateArray());
+    }
+
+    private HttpApiService CreateService(params ITranscriptionEnginePlugin[] plugins)
+    {
+        var selectedModel = plugins.Length > 0
+            ? ModelManagerService.GetPluginModelId(plugins[0].PluginId, plugins[0].TranscriptionModels[0].Id)
+            : null;
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            SelectedModelId = selectedModel,
+            SaveToHistoryEnabled = true
+        });
+
+        var pluginManager = new PluginManager(
+            _loader,
+            _eventBus,
+            _activeWindow.Object,
+            _profiles.Object,
+            _settings.Object,
+            []);
+        SetPrivateField(pluginManager, "_transcriptionEngines", plugins.ToList());
+
+        var modelManager = new ModelManagerService(pluginManager, _settings.Object);
+        var dictionary = new DictionaryService(_dictionaryPath);
+        var vocabulary = new Mock<IVocabularyBoostingService>();
+        vocabulary.Setup(v => v.Apply(It.IsAny<string>())).Returns((string text) => text);
+        var history = new Mock<IHistoryService>();
+        history.Setup(h => h.Records).Returns([]);
+        var translation = new Mock<ITranslationService>();
+        translation.Setup(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string text, string _, string _, CancellationToken _) => text);
+
+        return new HttpApiService(
+            modelManager,
+            _settings.Object,
+            new AudioFileService(),
+            history.Object,
+            _profiles.Object,
+            dictionary,
+            vocabulary.Object,
+            new PostProcessingPipeline(),
+            translation.Object,
+            null!);
+    }
+
+    private static HttpApiRequest JsonRequest(string method, string path, string json) =>
+        new(
+            method,
+            path,
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["content-type"] = "application/json" },
+            Encoding.UTF8.GetBytes(json));
+
+    private static HttpApiRequest MultipartTranscribeRequest(
+        params (string Name, string? FileName, string? ContentType, byte[] Data)[] parts)
+    {
+        var boundary = "Boundary-" + Guid.NewGuid().ToString("N");
+        using var body = new MemoryStream();
+        foreach (var part in parts)
+        {
+            Write(body, $"--{boundary}\r\n");
+            var disposition = $"Content-Disposition: form-data; name=\"{part.Name}\"";
+            if (part.FileName is not null)
+                disposition += $"; filename=\"{part.FileName}\"";
+            Write(body, disposition + "\r\n");
+            if (part.ContentType is not null)
+                Write(body, $"Content-Type: {part.ContentType}\r\n");
+            Write(body, "\r\n");
+            body.Write(part.Data);
+            Write(body, "\r\n");
+        }
+
+        Write(body, $"--{boundary}--\r\n");
+
+        return new HttpApiRequest(
+            "POST",
+            "/v1/transcribe",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["content-type"] = $"multipart/form-data; boundary={boundary}" },
+            body.ToArray());
+    }
+
+    private static Dictionary<string, JsonElement> JsonObject(HttpApiResponse response)
+    {
+        using var doc = JsonDocument.Parse(response.Body);
+        return doc.RootElement.EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value.Clone());
+    }
+
+    private static string ErrorMessage(HttpApiResponse response)
+    {
+        using var doc = JsonDocument.Parse(response.Body);
+        return doc.RootElement
+            .GetProperty("error")
+            .GetProperty("message")
+            .GetString() ?? "";
+    }
+
+    private static void Write(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        stream.Write(bytes);
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        field.SetValue(target, value);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_dictionaryPath))
+            File.Delete(_dictionaryPath);
+    }
+
+    private sealed class FakeTranscriptionPlugin : ITranscriptionEnginePlugin
+    {
+        public string? LastPrompt { get; private set; }
+
+        public string PluginId => "com.typewhisper.mock";
+        public string PluginName => "Mock";
+        public string PluginVersion => "1.0.0";
+        public string ProviderId => "mock";
+        public string ProviderDisplayName => "Mock";
+        public bool IsConfigured => true;
+        public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } = [new("tiny", "Tiny")];
+        public string? SelectedModelId { get; private set; } = "tiny";
+        public bool SupportsTranslation => true;
+
+        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
+        public Task DeactivateAsync() => Task.CompletedTask;
+        public System.Windows.Controls.UserControl? CreateSettingsView() => null;
+        public void SelectModel(string modelId) => SelectedModelId = modelId;
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(
+            byte[] wavAudio,
+            string? language,
+            bool translate,
+            string? prompt,
+            CancellationToken ct)
+        {
+            LastPrompt = prompt;
+            return Task.FromResult(new PluginTranscriptionResult("transcribed", language ?? "en", 1.25)
+            {
+                Segments = [new PluginTranscriptionSegment("transcribed", 0, 1.25)]
+            });
+        }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary
- Add macOS-compatible Windows automation handling for multipart and raw transcribe requests, language options, engine/model overrides, verbose JSON, dictionary terms, and dictation polling.
- Extend per-request model resolution so API overrides do not permanently change the user-selected model.
- Update the CLI to send multipart uploads, support stdin, language hints, translation/model flags, and JSON output.
- Add parser, API handler, dictionary, and CLI-focused coverage, plus README documentation.

## Validation
- `dotnet test TypeWhisper.slnx`
- `dotnet build src\TypeWhisper.Cli\TypeWhisper.Cli.csproj`
- Live smoke against `http://localhost:9876` for status, models, dictionary terms, and CLI multipart/stdin validation.

Fixes #47