### PR TITLE
Add About update channel selector

### DIFF
--- a/src/TypeWhisper.Core/Models/AppSettings.cs
+++ b/src/TypeWhisper.Core/Models/AppSettings.cs
@@ -77,6 +77,9 @@ public record AppSettings
     // UI Language (null = auto-detect from system)
     public string? UiLanguage { get; init; }
 
+    // Update channel preference (null = infer from installed version)
+    public string? UpdateChannel { get; init; }
+
     public static AppSettings Default => new();
 }
 

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -444,6 +444,9 @@
 
   "Info.Subtitle": "Sprache-zu-Text für deinen Windows-Desktop",
   "Info.Version": "Version",
+  "Info.VersionFormat": "Version {0}",
+  "Info.VersionWithChannelFormat": "Version {0} ({1})",
+  "Info.UpdateChannel": "Update-Channel",
   "Info.CheckUpdates": "Nach Updates suchen",
   "Info.UpdateNow": "Jetzt aktualisieren",
   "Info.PoweredBy": "Funktioniert mit lokalen und Cloud-Transkriptions-Engines",
@@ -482,6 +485,13 @@
   "Update.Failed": "Update fehlgeschlagen. Bitte erneut versuchen.",
   "Update.NoUpdate": "Kein Update",
   "Update.NoUpdateMessage": "Sie haben bereits die neueste Version.",
+  "Update.ChannelStable": "Stable",
+  "Update.ChannelReleaseCandidate": "Release Candidate",
+  "Update.ChannelDaily": "Daily",
+  "Update.ChannelStableDescription": "Stable bekommt nur Produktions-Releases.",
+  "Update.ChannelReleaseCandidateDescription": "Release Candidate folgt den RC-Preview-Builds.",
+  "Update.ChannelDailyDescription": "Daily folgt den neuesten Daily-Preview-Builds.",
+  "Update.ChannelChangedFormat": "Update-Channel auf {0} gesetzt.",
 
   "Tray.Settings": "Einstellungen...",
   "Tray.TranscribeFile": "Datei transkribieren...",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -444,6 +444,9 @@
 
   "Info.Subtitle": "Speech-to-text for your Windows desktop",
   "Info.Version": "Version",
+  "Info.VersionFormat": "Version {0}",
+  "Info.VersionWithChannelFormat": "Version {0} ({1})",
+  "Info.UpdateChannel": "Update Channel",
   "Info.CheckUpdates": "Check for Updates",
   "Info.UpdateNow": "Update Now",
   "Info.PoweredBy": "Works with local and cloud transcription engines",
@@ -482,6 +485,13 @@
   "Update.Failed": "Update failed. Please try again.",
   "Update.NoUpdate": "No Update",
   "Update.NoUpdateMessage": "You already have the latest version.",
+  "Update.ChannelStable": "Stable",
+  "Update.ChannelReleaseCandidate": "Release Candidate",
+  "Update.ChannelDaily": "Daily",
+  "Update.ChannelStableDescription": "Stable gets production releases only.",
+  "Update.ChannelReleaseCandidateDescription": "Release Candidate follows RC preview builds.",
+  "Update.ChannelDailyDescription": "Daily follows the latest daily preview builds.",
+  "Update.ChannelChangedFormat": "Update channel set to {0}.",
 
   "Tray.Settings": "Settings...",
   "Tray.TranscribeFile": "Transcribe file...",

--- a/src/TypeWhisper.Windows/Services/UpdateService.cs
+++ b/src/TypeWhisper.Windows/Services/UpdateService.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 using TypeWhisper.Core;
+using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Windows.Services.Localization;
 using Velopack;
 using Velopack.Sources;
@@ -9,7 +10,12 @@ namespace TypeWhisper.Windows.Services;
 
 public sealed class UpdateService
 {
+    internal const string StableChannelSetting = "stable";
+    internal const string ReleaseCandidateChannelSetting = "release-candidate";
+    internal const string DailyChannelSetting = "daily";
+
     private readonly TrayIconService _trayIcon;
+    private readonly ISettingsService _settings;
     private UpdateManager? _updateManager;
     private UpdateInfo? _pendingUpdate;
 
@@ -41,15 +47,18 @@ public sealed class UpdateService
 
     public event EventHandler? UpdateAvailable;
 
-    public UpdateService(TrayIconService trayIcon)
+    public UpdateService(TrayIconService trayIcon, ISettingsService settings)
     {
         _trayIcon = trayIcon;
+        _settings = settings;
     }
 
     public void Initialize(ReleaseChannel? channel = null)
     {
-        var resolvedChannel = channel ?? InferReleaseChannel(CurrentVersion);
+        var resolvedChannel = channel ?? ResolveReleaseChannel(_settings.Current.UpdateChannel, CurrentVersion);
         Channel = resolvedChannel;
+        _pendingUpdate = null;
+        _updateManager = null;
         try
         {
             _updateManager = new UpdateManager(
@@ -102,6 +111,32 @@ public sealed class UpdateService
             _trayIcon.ShowBalloon(Loc.Instance["Update.BalloonFailedTitle"],
                 Loc.Instance["Update.BalloonFailedMessage"]);
         }
+    }
+
+    internal static ReleaseChannel ResolveReleaseChannel(string? configuredChannel, string? installedVersion)
+    {
+        return ParseReleaseChannel(configuredChannel) ?? InferReleaseChannel(installedVersion);
+    }
+
+    internal static ReleaseChannel? ParseReleaseChannel(string? value)
+    {
+        return value?.Trim().ToLowerInvariant() switch
+        {
+            StableChannelSetting => ReleaseChannel.Stable,
+            ReleaseCandidateChannelSetting or "rc" => ReleaseChannel.ReleaseCandidate,
+            DailyChannelSetting => ReleaseChannel.Daily,
+            _ => null
+        };
+    }
+
+    internal static string ToSettingsValue(ReleaseChannel channel)
+    {
+        return channel switch
+        {
+            ReleaseChannel.ReleaseCandidate => ReleaseCandidateChannelSetting,
+            ReleaseChannel.Daily => DailyChannelSetting,
+            _ => StableChannelSetting
+        };
     }
 
     internal static ReleaseChannel InferReleaseChannel(string? version)

--- a/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
@@ -31,7 +31,9 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
     public FileTranscriptionViewModel FileTranscription { get; }
 
     private readonly UpdateService _updateService;
+    private readonly ISettingsService _settingsService;
     private readonly IErrorLogService _errorLog;
+    private bool _isSyncingUpdateChannel;
 
     [ObservableProperty] private UserControl? _currentSection;
     [ObservableProperty] private SettingsRoute _currentRoute = _lastOpenedRoute;
@@ -42,12 +44,17 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
     [ObservableProperty] private bool _isCheckingForUpdates;
     [ObservableProperty] private bool _isUpdateAvailable;
     [ObservableProperty] private int _pendingFileImporterRequestId;
+    [ObservableProperty] private ReleaseChannel _selectedUpdateChannel;
 
     public string CurrentAppVersion => _updateService.CurrentVersion;
+    public string CurrentAppVersionDisplay => BuildCurrentAppVersionDisplay();
     public double CurrentPageContentWidth => CurrentPageMetadata.ContentWidth;
     public bool CurrentPageShowsSummaryRow => CurrentPageMetadata.ShowsSummaryRow;
     public bool CurrentPageUsesStickyActions => CurrentPageMetadata.UsesStickyActions;
+    public string SelectedUpdateChannelDescription =>
+        UpdateChannelOptions.FirstOrDefault(option => option.Value == SelectedUpdateChannel)?.Description ?? string.Empty;
     public ObservableCollection<ErrorLogEntry> ErrorLogEntries { get; } = [];
+    public ObservableCollection<ReleaseChannelOption> UpdateChannelOptions { get; } = [];
     public bool HasErrorLogEntries => ErrorLogEntries.Count > 0;
     public ObservableCollection<SettingsNavigationGroup> NavigationGroups { get; } = [];
 
@@ -68,6 +75,7 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
         AudioRecorderViewModel recorder,
         FileTranscriptionViewModel fileTranscription,
         UpdateService updateService,
+        ISettingsService settingsService,
         IErrorLogService errorLog)
     {
         Settings = settings;
@@ -82,20 +90,27 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
         Recorder = recorder;
         FileTranscription = fileTranscription;
         _updateService = updateService;
+        _settingsService = settingsService;
         _errorLog = errorLog;
         Loc.Instance.LanguageChanged += (_, _) =>
         {
             System.Windows.Application.Current?.Dispatcher.Invoke(() =>
             {
+                RefreshUpdateChannelOptions();
                 BuildNavigation();
                 SyncRouteMetadata(CurrentRoute);
                 SyncNavigationSelection();
+                OnPropertyChanged(nameof(CurrentAppVersionDisplay));
+                OnPropertyChanged(nameof(SelectedUpdateChannelDescription));
             });
         };
 
+        RefreshUpdateChannelOptions();
+        SyncSelectedUpdateChannel(_settingsService.Current);
         BuildNavigation();
         RefreshErrorLog();
         _errorLog.EntriesChanged += RefreshErrorLog;
+        _settingsService.SettingsChanged += SyncSelectedUpdateChannel;
         SyncRouteMetadata(CurrentRoute);
         SyncNavigationSelection();
     }
@@ -154,6 +169,22 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
             IsUpdateAvailable = false;
             UpdateStatusText = Loc.Instance["Update.UpToDate"];
         }
+    }
+
+    partial void OnSelectedUpdateChannelChanged(ReleaseChannel value)
+    {
+        OnPropertyChanged(nameof(SelectedUpdateChannelDescription));
+
+        if (_isSyncingUpdateChannel)
+            return;
+
+        _settingsService.Save(_settingsService.Current with
+        {
+            UpdateChannel = UpdateService.ToSettingsValue(value)
+        });
+        _updateService.SwitchChannel(value);
+        IsUpdateAvailable = false;
+        UpdateStatusText = Loc.Instance.GetString("Update.ChannelChangedFormat", FormatReleaseChannelDisplayName(value));
     }
 
     [RelayCommand]
@@ -248,6 +279,69 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
                 ErrorLogEntries.Add(entry);
             OnPropertyChanged(nameof(HasErrorLogEntries));
         });
+    }
+
+    private void SyncSelectedUpdateChannel(AppSettings settings)
+    {
+        DispatchToUi(() =>
+        {
+            var resolvedChannel = UpdateService.ResolveReleaseChannel(settings.UpdateChannel, _updateService.CurrentVersion);
+            _isSyncingUpdateChannel = true;
+            SelectedUpdateChannel = resolvedChannel;
+            _isSyncingUpdateChannel = false;
+            OnPropertyChanged(nameof(SelectedUpdateChannelDescription));
+        });
+    }
+
+    private static void DispatchToUi(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        dispatcher.Invoke(action);
+    }
+
+    private void RefreshUpdateChannelOptions()
+    {
+        UpdateChannelOptions.Clear();
+        UpdateChannelOptions.Add(new ReleaseChannelOption(
+            ReleaseChannel.Stable,
+            Loc.Instance["Update.ChannelStable"],
+            Loc.Instance["Update.ChannelStableDescription"]));
+        UpdateChannelOptions.Add(new ReleaseChannelOption(
+            ReleaseChannel.ReleaseCandidate,
+            Loc.Instance["Update.ChannelReleaseCandidate"],
+            Loc.Instance["Update.ChannelReleaseCandidateDescription"]));
+        UpdateChannelOptions.Add(new ReleaseChannelOption(
+            ReleaseChannel.Daily,
+            Loc.Instance["Update.ChannelDaily"],
+            Loc.Instance["Update.ChannelDailyDescription"]));
+    }
+
+    private string BuildCurrentAppVersionDisplay()
+    {
+        var installedChannel = UpdateService.InferReleaseChannel(CurrentAppVersion);
+        if (installedChannel == ReleaseChannel.Stable)
+            return Loc.Instance.GetString("Info.VersionFormat", CurrentAppVersion);
+
+        return Loc.Instance.GetString(
+            "Info.VersionWithChannelFormat",
+            CurrentAppVersion,
+            FormatReleaseChannelDisplayName(installedChannel));
+    }
+
+    private static string FormatReleaseChannelDisplayName(ReleaseChannel channel)
+    {
+        return channel switch
+        {
+            ReleaseChannel.ReleaseCandidate => Loc.Instance["Update.ChannelReleaseCandidate"],
+            ReleaseChannel.Daily => Loc.Instance["Update.ChannelDaily"],
+            _ => Loc.Instance["Update.ChannelStable"]
+        };
     }
 
     private void BuildNavigation()
@@ -368,3 +462,5 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
         OnPropertyChanged(nameof(CurrentPageUsesStickyActions));
     }
 }
+
+public sealed record ReleaseChannelOption(ReleaseChannel Value, string DisplayName, string Description);

--- a/src/TypeWhisper.Windows/Views/Sections/InfoSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/InfoSection.xaml
@@ -30,11 +30,38 @@
                        HorizontalAlignment="Center" Margin="0,4,0,0"/>
 
             <!-- Version -->
-            <TextBlock HorizontalAlignment="Center" Margin="0,4,0,16"
-                       Foreground="{StaticResource HintBrush}" FontSize="12">
-                <Run Text="{loc:Str Info.Version}"/>
-                <Run Text="{Binding CurrentAppVersion, Mode=OneWay}"/>
-            </TextBlock>
+            <TextBlock Text="{Binding CurrentAppVersionDisplay, Mode=OneWay}"
+                       HorizontalAlignment="Center" Margin="0,4,0,16"
+                       Foreground="{StaticResource HintBrush}" FontSize="12"/>
+
+            <!-- Update channel -->
+            <StackPanel Width="420" Margin="0,0,0,16">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="{loc:Str Info.UpdateChannel}"
+                               Foreground="{StaticResource TextBrush}"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center"/>
+                    <ComboBox Grid.Column="1"
+                              Width="190"
+                              Style="{StaticResource SettingsAlignedComboBoxStyle}"
+                              ItemsSource="{Binding UpdateChannelOptions}"
+                              SelectedValue="{Binding SelectedUpdateChannel, Mode=TwoWay}"
+                              SelectedValuePath="Value"
+                              DisplayMemberPath="DisplayName"/>
+                </Grid>
+
+                <TextBlock Text="{Binding SelectedUpdateChannelDescription}"
+                           Foreground="{StaticResource HintBrush}"
+                           FontSize="12"
+                           TextWrapping="Wrap"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
 
             <!-- Update check -->
             <StackPanel HorizontalAlignment="Center" Margin="0,0,0,16">

--- a/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
@@ -32,4 +32,29 @@ public class UpdateServiceTests
     {
         Assert.Equal(expected, UpdateService.GetVelopackChannel(architecture, channel));
     }
+
+    [Theory]
+    [InlineData("stable", "0.7.0-rc1", ReleaseChannel.Stable)]
+    [InlineData("release-candidate", "0.7.0", ReleaseChannel.ReleaseCandidate)]
+    [InlineData("rc", "0.7.0", ReleaseChannel.ReleaseCandidate)]
+    [InlineData("daily", "0.7.0", ReleaseChannel.Daily)]
+    [InlineData(null, "0.7.1-daily.20260423", ReleaseChannel.Daily)]
+    [InlineData("", "0.7.0-rc1", ReleaseChannel.ReleaseCandidate)]
+    [InlineData("unknown", "0.7.0", ReleaseChannel.Stable)]
+    public void ResolveReleaseChannel_UsesSavedPreferenceBeforeInstalledVersion(
+        string? configuredChannel,
+        string installedVersion,
+        ReleaseChannel expected)
+    {
+        Assert.Equal(expected, UpdateService.ResolveReleaseChannel(configuredChannel, installedVersion));
+    }
+
+    [Theory]
+    [InlineData(ReleaseChannel.Stable, "stable")]
+    [InlineData(ReleaseChannel.ReleaseCandidate, "release-candidate")]
+    [InlineData(ReleaseChannel.Daily, "daily")]
+    public void ToSettingsValue_UsesStableRawValues(ReleaseChannel channel, string expected)
+    {
+        Assert.Equal(expected, UpdateService.ToSettingsValue(channel));
+    }
 }


### PR DESCRIPTION
## Summary
- Add a persisted Windows update channel preference for Stable, Release Candidate, and Daily.
- Show the selected update channel in Settings > About with localized descriptions.
- Make UpdateService use the saved channel first, then fall back to installed-version inference for RC/Daily builds.
- Add focused tests for saved channel resolution and settings raw values.

## Validation
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release`
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release`
- `git diff --check`