### PR TITLE
Add Raycast-compatible Windows API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Cloud providers are available as plugins and can be configured in Settings > Ext
 
 ## HTTP API
 
-TypeWhisper can run a local HTTP server (default port 9876, configurable in Settings) for integration with external tools.
+TypeWhisper can run a local HTTP server (default port 8978, configurable in Settings) for integration with external tools.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -144,15 +144,15 @@ TypeWhisper can run a local HTTP server (default port 9876, configurable in Sett
 Raw audio requests can pass the same options with headers: `X-Language`, `X-Language-Hints`, `X-Task`, `X-Target-Language`, `X-Response-Format`, `X-Prompt`, `X-Engine`, and `X-Model`. Add `?await_download=1` to wait for a local model download/restore when supported.
 
 ```bash
-curl -X POST http://localhost:9876/v1/transcribe \
+curl -X POST http://localhost:8978/v1/transcribe \
   -F "file=@recording.wav" \
   -F "language_hint=de" \
   -F "language_hint=en" \
   -F "response_format=verbose_json"
 
-curl -X POST http://localhost:9876/v1/dictation/start
-curl -X POST http://localhost:9876/v1/dictation/stop
-curl "http://localhost:9876/v1/dictation/transcription?id=<session-id>"
+curl -X POST http://localhost:8978/v1/dictation/start
+curl -X POST http://localhost:8978/v1/dictation/stop
+curl "http://localhost:8978/v1/dictation/transcription?id=<session-id>"
 ```
 
 ## CLI

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -45,40 +45,40 @@
 
 ### 2.1 Basis-Status
 ```bash
-curl http://localhost:9876/v1/status
+curl http://localhost:8978/v1/status
 ```
 → JSON mit `version`, `is_recording`, `supports_streaming`, `supports_translation`
 
 ### 2.2 History
 ```bash
 # Alle Einträge
-curl "http://localhost:9876/v1/history?limit=5"
+curl "http://localhost:8978/v1/history?limit=5"
 # Suche
-curl "http://localhost:9876/v1/history?q=test"
+curl "http://localhost:8978/v1/history?q=test"
 # Löschen (mit echter ID)
-curl -X DELETE "http://localhost:9876/v1/history?id=SOME_ID"
+curl -X DELETE "http://localhost:8978/v1/history?id=SOME_ID"
 ```
 
 ### 2.3 Profile
 ```bash
 # Alle Profile
-curl http://localhost:9876/v1/profiles
+curl http://localhost:8978/v1/profiles
 ```
 
 ### 2.4 Dictation Control
 ```bash
 # Status prüfen
-curl http://localhost:9876/v1/dictation/status
+curl http://localhost:8978/v1/dictation/status
 # Starten
-curl -X POST http://localhost:9876/v1/dictation/start
+curl -X POST http://localhost:8978/v1/dictation/start
 # Stoppen
-curl -X POST http://localhost:9876/v1/dictation/stop
+curl -X POST http://localhost:8978/v1/dictation/stop
 ```
 
 ### 2.5 Transcribe
 ```bash
 # Audio-Datei senden
-curl -X POST http://localhost:9876/v1/transcribe \
+curl -X POST http://localhost:8978/v1/transcribe \
   -F "file=@test.wav" \
   -F "language=de"
 ```

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -9,7 +9,7 @@ namespace TypeWhisper.Cli;
 /// </summary>
 static class Program
 {
-    private const int DefaultPort = 9876;
+    private const int DefaultPort = 8978;
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromMinutes(5) };
 
     static async Task<int> Main(string[] args)
@@ -187,7 +187,7 @@ static class Program
               transcribe <file|->       Transcribe an audio file, or - for stdin
 
             Global options:
-              --port <N>                API server port (default: 9876)
+              --port <N>                API server port (default: 8978)
               --json                    Output as JSON
               --version                 Show version
               --help, -h                Show this help

--- a/src/TypeWhisper.Core/Models/AppSettings.cs
+++ b/src/TypeWhisper.Core/Models/AppSettings.cs
@@ -45,7 +45,7 @@ public record AppSettings
 
     // API Server
     public bool ApiServerEnabled { get; init; }
-    public int ApiServerPort { get; init; } = 9876;
+    public int ApiServerPort { get; init; } = 8978;
 
     // Dictionary
     public string[] EnabledPackIds { get; init; } = [];

--- a/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
+++ b/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
@@ -15,6 +15,7 @@ public static class TypeWhisperEnvironment
     public static string PluginsPath => Path.Combine(_basePath, "Plugins");
     public static string AudioPath => Path.Combine(_basePath, "Audio");
     public static string PluginDataPath => Path.Combine(_basePath, "PluginData");
+    public static string ApiPortFilePath => Path.Combine(_basePath, "api-port");
     public static string SettingsFilePath => Path.Combine(_basePath, "settings.json");
     public static string DatabasePath => Path.Combine(DataPath, "typewhisper.db");
 

--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -153,12 +153,9 @@ public partial class App : Application
         if (!audio.WarmUp())
             System.Diagnostics.Debug.WriteLine("No audio input device available at startup. Polling for device...");
 
-        // Start API server if enabled
-        if (settings.Current.ApiServerEnabled)
-        {
-            var api = _serviceProvider.GetRequiredService<HttpApiService>();
-            api.Start(settings.Current.ApiServerPort);
-        }
+        // Initialize API server so settings changes can start, stop, or restart it immediately.
+        var api = _serviceProvider.GetRequiredService<HttpApiService>();
+        api.ApplySettings(settings.Current);
 
         // Show onboarding if first run (skip when started minimized)
         if (!settings.Current.HasCompletedOnboarding && !Program.StartMinimized)

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -1,8 +1,10 @@
 using System.IO;
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Windows;
+using TypeWhisper.Core;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.Windows.ViewModels;
@@ -25,6 +27,7 @@ public sealed class HttpApiService : IDisposable
     private HttpListener? _listener;
     private CancellationTokenSource? _cts;
     private Task? _listenTask;
+    private int? _runningPort;
     private bool _disposed;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -58,26 +61,73 @@ public sealed class HttpApiService : IDisposable
         _pipeline = pipeline;
         _translation = translation;
         _dictation = dictation;
+        _settings.SettingsChanged += OnSettingsChanged;
     }
 
     public void Start(int port)
     {
-        if (_listener is { IsListening: true }) return;
+        if (_listener is { IsListening: true } && _runningPort == port) return;
+        if (_listener is { IsListening: true }) Stop();
 
         _cts = new CancellationTokenSource();
         _listener = new HttpListener();
         _listener.Prefixes.Add($"http://localhost:{port}/");
+        _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
         _listener.Start();
+        _runningPort = port;
+        WriteApiPortFile(port);
 
         _listenTask = Task.Run(() => ListenLoop(_cts.Token));
     }
 
+    public void ApplySettings(AppSettings settings)
+    {
+        if (_disposed) return;
+
+        if (settings.ApiServerEnabled)
+            Start(settings.ApiServerPort);
+        else
+            Stop();
+    }
+
     public void Stop()
     {
-        _cts?.Cancel();
+        var cts = _cts;
+        _cts = null;
+        cts?.Cancel();
         _listener?.Stop();
         _listener?.Close();
         _listener = null;
+        _listenTask = null;
+        _runningPort = null;
+        cts?.Dispose();
+    }
+
+    private void OnSettingsChanged(AppSettings settings)
+    {
+        try
+        {
+            ApplySettings(settings);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to apply settings: {ex.Message}");
+        }
+    }
+
+    private static void WriteApiPortFile(int port)
+    {
+        try
+        {
+            Directory.CreateDirectory(TypeWhisperEnvironment.BasePath);
+            File.WriteAllText(
+                TypeWhisperEnvironment.ApiPortFilePath,
+                port.ToString(CultureInfo.InvariantCulture));
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to write API port file: {ex.Message}");
+        }
     }
 
     private async Task ListenLoop(CancellationToken ct)
@@ -335,20 +385,26 @@ public sealed class HttpApiService : IDisposable
             text = r.FinalText,
             raw_text = r.RawText,
             app = r.AppProcessName,
+            app_name = r.AppName ?? r.AppProcessName,
+            app_process_name = r.AppProcessName,
+            app_bundle_id = (string?)null,
+            app_url = r.AppUrl,
             duration = r.DurationSeconds,
             language = r.Language,
             engine = r.EngineUsed,
             model = r.ModelUsed,
             profile = r.ProfileName,
-            words = r.WordCount
-        });
+            words = r.WordCount,
+            words_count = r.WordCount
+        }).ToList();
 
         return Json(new
         {
             total = records.Count,
             offset,
             limit,
-            records = paged
+            records = paged,
+            entries = paged
         });
     }
 
@@ -371,9 +427,11 @@ public sealed class HttpApiService : IDisposable
             is_enabled = p.IsEnabled,
             priority = p.Priority,
             process_names = p.ProcessNames,
+            bundle_identifiers = p.ProcessNames,
             url_patterns = p.UrlPatterns,
             input_language = p.InputLanguage,
             translation_target = p.TranslationTarget,
+            translation_target_language = p.TranslationTarget,
             selected_task = p.SelectedTask,
             model_override = p.TranscriptionModelOverride,
             prompt_action_id = p.PromptActionId
@@ -451,6 +509,8 @@ public sealed class HttpApiService : IDisposable
                 timestamp = session.Transcription.Timestamp,
                 app_name = session.Transcription.AppName,
                 app_process_name = session.Transcription.AppProcessName,
+                app_bundle_id = (string?)null,
+                app_url = session.Transcription.AppUrl,
                 duration = session.Transcription.Duration,
                 language = session.Transcription.Language,
                 engine = session.Transcription.Engine,
@@ -515,8 +575,8 @@ public sealed class HttpApiService : IDisposable
     {
         if (!_disposed)
         {
+            _settings.SettingsChanged -= OnSettingsChanged;
             Stop();
-            _cts?.Dispose();
             _disposed = true;
         }
     }

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -22,6 +22,7 @@ public sealed record ApiDictationTranscription(
     DateTime Timestamp,
     string? AppName,
     string? AppProcessName,
+    string? AppUrl,
     double Duration,
     string? Language,
     string Engine,
@@ -86,6 +87,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
     private string? _profileHotkeyOverrideId;
     private string? _capturedProcessName;
     private string? _capturedWindowTitle;
+    private string? _capturedUrl;
 
     // Live transcription
     private readonly StreamingHandler _streamingHandler;
@@ -343,6 +345,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 record.Timestamp,
                 record.AppName,
                 record.AppProcessName,
+                record.AppUrl,
                 record.DurationSeconds,
                 record.Language,
                 record.EngineUsed,
@@ -365,6 +368,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         _activeProfile = null;
         _capturedProcessName = null;
         _capturedWindowTitle = null;
+        _capturedUrl = null;
     }
 
     private void ClearPartialPreview()
@@ -524,7 +528,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         // Capture active window context at recording start
         _capturedProcessName = _activeWindow.GetActiveWindowProcessName();
         _capturedWindowTitle = _activeWindow.GetActiveWindowTitle();
-        var url = _activeWindow.GetBrowserUrl();
+        _capturedUrl = _activeWindow.GetBrowserUrl();
         if (_profileHotkeyOverrideId is not null)
         {
             _activeProfile = _profiles.Profiles.FirstOrDefault(p => p.Id == _profileHotkeyOverrideId);
@@ -532,7 +536,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         }
         else
         {
-            _activeProfile = _profiles.MatchProfile(_capturedProcessName, url);
+            _activeProfile = _profiles.MatchProfile(_capturedProcessName, _capturedUrl);
         }
 
         var desiredModelId = EffectiveModelId ?? _settings.Current.SelectedModelId;
@@ -707,6 +711,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _activeProfile,
             _capturedProcessName,
             _capturedWindowTitle,
+            _capturedUrl,
             EffectiveLanguage,
             EffectiveTask,
             _modelManager.ActiveModelId,
@@ -977,6 +982,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 timestamp,
                 job.CapturedWindowTitle,
                 job.CapturedProcessName,
+                job.CapturedUrl,
                 audioDuration,
                 detectedLanguage,
                 engineUsed,
@@ -1007,6 +1013,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     FinalText = finalText,
                     AppName = job.CapturedWindowTitle,
                     AppProcessName = job.CapturedProcessName,
+                    AppUrl = job.CapturedUrl,
                     DurationSeconds = audioDuration,
                     Language = detectedLanguage,
                     ProfileName = job.ActiveProfile?.Name,
@@ -1219,6 +1226,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         Profile? ActiveProfile,
         string? CapturedProcessName,
         string? CapturedWindowTitle,
+        string? CapturedUrl,
         string? EffectiveLanguage,
         TranscriptionTask EffectiveTask,
         string? ActiveModelIdAtCapture,

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -41,7 +41,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _autostartEnabled;
     [ObservableProperty] private string? _translationTargetLanguage;
     [ObservableProperty] private bool _apiServerEnabled;
-    [ObservableProperty] private int _apiServerPort = 9876;
+    [ObservableProperty] private int _apiServerPort = 8978;
     [ObservableProperty] private OverlayWidget _overlayLeftWidget = OverlayWidget.Waveform;
     [ObservableProperty] private OverlayWidget _overlayRightWidget = OverlayWidget.Timer;
     [ObservableProperty] private string _promptPaletteHotkey = "";

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -22,12 +22,14 @@ public class HttpApiServiceTests : IDisposable
     private readonly Mock<IActiveWindowService> _activeWindow = new();
     private readonly Mock<IProfileService> _profiles = new();
     private readonly Mock<ISettingsService> _settings = new();
+    private readonly Mock<IHistoryService> _history = new();
     private readonly PluginEventBus _eventBus = new();
     private readonly PluginLoader _loader = new();
 
     public HttpApiServiceTests()
     {
         _profiles.Setup(p => p.Profiles).Returns([]);
+        _history.Setup(h => h.Records).Returns([]);
     }
 
     [Fact]
@@ -123,6 +125,82 @@ public class HttpApiServiceTests : IDisposable
         Assert.Single(json["segments"].EnumerateArray());
     }
 
+    [Fact]
+    public async Task HistorySearch_IncludesRaycastCompatibleAliases()
+    {
+        var record = new TranscriptionRecord
+        {
+            Id = Guid.NewGuid().ToString(),
+            Timestamp = new DateTime(2026, 4, 23, 10, 15, 0, DateTimeKind.Utc),
+            RawText = "raw transcript",
+            FinalText = "final transcript",
+            AppName = "Notepad",
+            AppProcessName = "notepad.exe",
+            AppUrl = "https://example.com",
+            DurationSeconds = 2.5,
+            Language = "en",
+            ProfileName = "Writing",
+            EngineUsed = "mock",
+            ModelUsed = "tiny"
+        };
+        _history.Setup(h => h.Records).Returns([record]);
+
+        var service = CreateService();
+        var response = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/history",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+        var json = JsonObject(response);
+        var records = json["records"].EnumerateArray().ToList();
+        var entries = json["entries"].EnumerateArray().ToList();
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Single(records);
+        Assert.Single(entries);
+        Assert.Equal("Notepad", entries[0].GetProperty("app_name").GetString());
+        Assert.Equal("notepad.exe", entries[0].GetProperty("app_process_name").GetString());
+        Assert.Equal(JsonValueKind.Null, entries[0].GetProperty("app_bundle_id").ValueKind);
+        Assert.Equal("https://example.com", entries[0].GetProperty("app_url").GetString());
+        Assert.Equal(2, entries[0].GetProperty("words_count").GetInt32());
+        Assert.Equal(2, records[0].GetProperty("words").GetInt32());
+    }
+
+    [Fact]
+    public async Task ProfilesList_IncludesRaycastCompatibleAliases()
+    {
+        _profiles.Setup(p => p.Profiles).Returns([
+            new Profile
+            {
+                Id = "profile-1",
+                Name = "Browser",
+                IsEnabled = true,
+                Priority = 10,
+                ProcessNames = ["chrome.exe"],
+                UrlPatterns = ["*.example.com"],
+                InputLanguage = "de",
+                TranslationTarget = "en"
+            }
+        ]);
+
+        var service = CreateService();
+        var response = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/profiles",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+        var json = JsonObject(response);
+        var profile = json["profiles"].EnumerateArray().Single();
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal("chrome.exe", profile.GetProperty("process_names").EnumerateArray().Single().GetString());
+        Assert.Equal("chrome.exe", profile.GetProperty("bundle_identifiers").EnumerateArray().Single().GetString());
+        Assert.Equal("en", profile.GetProperty("translation_target").GetString());
+        Assert.Equal("en", profile.GetProperty("translation_target_language").GetString());
+    }
+
     private HttpApiService CreateService(params ITranscriptionEnginePlugin[] plugins)
     {
         var selectedModel = plugins.Length > 0
@@ -148,8 +226,6 @@ public class HttpApiServiceTests : IDisposable
         var dictionary = new DictionaryService(_dictionaryPath);
         var vocabulary = new Mock<IVocabularyBoostingService>();
         vocabulary.Setup(v => v.Apply(It.IsAny<string>())).Returns((string text) => text);
-        var history = new Mock<IHistoryService>();
-        history.Setup(h => h.Records).Returns([]);
         var translation = new Mock<ITranslationService>();
         translation.Setup(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string text, string _, string _, CancellationToken _) => text);
@@ -158,7 +234,7 @@ public class HttpApiServiceTests : IDisposable
             modelManager,
             _settings.Object,
             new AudioFileService(),
-            history.Object,
+            _history.Object,
             _profiles.Object,
             dictionary,
             vocabulary.Object,


### PR DESCRIPTION
## Summary

Adds the Windows API compatibility needed for the TypeWhisper Raycast extension while keeping the extension itself platform-neutral.

## Changes

- Use port `8978` as the default local API port to match the existing Raycast extension behavior
- Listen on both `localhost` and `127.0.0.1`
- Write the active API port to `%LOCALAPPDATA%\TypeWhisper\api-port` when the server starts
- Start, stop, or restart the API server immediately when API settings change
- Add Raycast-compatible aliases to history, profile, and dictation responses
- Carry app URL metadata through API dictation/history results
- Update API docs and test guide examples to the new default port

## Validation

- `dotnet test TypeWhisper.slnx`
  - 125 TypeWhisper.Core tests passed
  - 297 TypeWhisper.PluginSystem tests passed