### PR TITLE
Add ElevenLabs transcription plugin

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -42,6 +42,7 @@ jobs:
             'webhook'            = 'TypeWhisper.Plugin.Webhook'
             'deepgram'           = 'TypeWhisper.Plugin.Deepgram'
             'assemblyai'         = 'TypeWhisper.Plugin.AssemblyAi'
+            'elevenlabs'         = 'TypeWhisper.Plugin.ElevenLabs'
             'gemini'             = 'TypeWhisper.Plugin.Gemini'
             'linear'             = 'TypeWhisper.Plugin.Linear'
             'obsidian'           = 'TypeWhisper.Plugin.Obsidian'

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ The built-in marketplace provides the following plugins:
 | Google Gemini | LLM | Gemini 2.5 Flash, Pro, and Flash Lite |
 | AssemblyAI | Transcription | AssemblyAI speech-to-text |
 | Deepgram | Transcription | Deepgram Nova ASR |
+| ElevenLabs | Transcription | ElevenLabs Scribe speech-to-text |
 | OpenAI Compatible | Transcription + LLM | Any OpenAI-compatible server (Ollama, LM Studio, vLLM) |
 | Linear | Action | Create Linear issues from transcriptions |
 | Obsidian | Action | Create Obsidian notes from transcriptions |
@@ -258,6 +259,7 @@ typewhisper-win/
 │   ├── TypeWhisper.Plugin.SherpaOnnx/       # Local ASR (Parakeet, Canary)
 │   ├── TypeWhisper.Plugin.AssemblyAi/       # AssemblyAI transcription
 │   ├── TypeWhisper.Plugin.Deepgram/         # Deepgram transcription
+│   ├── TypeWhisper.Plugin.ElevenLabs/       # ElevenLabs Scribe transcription
 │   ├── TypeWhisper.Plugin.Linear/           # Linear issue creation
 │   ├── TypeWhisper.Plugin.Obsidian/         # Obsidian note creation
 │   ├── TypeWhisper.Plugin.Script/           # Custom script execution

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsPlugin.cs
@@ -1,0 +1,294 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Windows.Controls;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.ElevenLabs;
+
+public sealed class ElevenLabsPlugin : ITranscriptionEnginePlugin
+{
+    internal const string DefaultModelId = "scribe_v2";
+    private const string BaseUrl = "https://api.elevenlabs.io";
+    private const string ApiKeySecretName = "api-key";
+    private const string SelectedModelSettingName = "selectedModel";
+
+    private static readonly char[] InvalidKeytermCharacters = ['<', '>', '{', '}', '[', ']', '\\'];
+
+    private static readonly IReadOnlyList<ElevenLabsModelEntry> ModelEntries =
+    [
+        new(DefaultModelId, "Scribe v2", "scribe_v2", "scribe_v2_realtime"),
+    ];
+
+    private static readonly IReadOnlyList<string> Languages =
+    [
+        "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo",
+        "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es",
+        "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw",
+        "he", "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja",
+        "jw", "ka", "kk", "km", "kn", "ko", "la", "lb", "ln", "lo",
+        "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt",
+        "my", "ne", "nl", "nn", "no", "oc", "pa", "pl", "ps", "pt",
+        "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
+        "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl",
+        "tr", "tt", "uk", "ur", "uz", "vi", "vo", "yi", "yo", "yue",
+        "zh",
+    ];
+
+    private readonly HttpClient _httpClient;
+    private IPluginHostServices? _host;
+    private string? _apiKey;
+    private string? _selectedModelId;
+
+    public ElevenLabsPlugin()
+        : this(CreateHttpClient())
+    {
+    }
+
+    internal ElevenLabsPlugin(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    // ITypeWhisperPlugin
+
+    public string PluginId => "com.typewhisper.elevenlabs";
+    public string PluginName => "ElevenLabs";
+    public string PluginVersion => "1.0.0";
+
+    public async Task ActivateAsync(IPluginHostServices host)
+    {
+        _host = host;
+        _apiKey = await host.LoadSecretAsync(ApiKeySecretName);
+        _selectedModelId = NormalizeModelId(host.GetSetting<string>(SelectedModelSettingName));
+        host.Log(PluginLogLevel.Info, $"Activated (configured={IsConfigured})");
+    }
+
+    public Task DeactivateAsync()
+    {
+        _host = null;
+        return Task.CompletedTask;
+    }
+
+    public UserControl? CreateSettingsView() => new ElevenLabsSettingsView(this);
+
+    // ITranscriptionEnginePlugin
+
+    public string ProviderId => "elevenlabs";
+    public string ProviderDisplayName => "ElevenLabs";
+    public bool IsConfigured => !string.IsNullOrEmpty(_apiKey);
+
+    public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
+        ModelEntries.Select(m => new PluginModelInfo(m.Id, m.DisplayName) { IsRecommended = true }).ToList();
+
+    public string? SelectedModelId => _selectedModelId;
+
+    public bool SupportsTranslation => false;
+    public bool SupportsStreaming => true;
+    public IReadOnlyList<string> SupportedLanguages => Languages;
+
+    public void SelectModel(string modelId)
+    {
+        var entry = ResolveModelEntry(modelId);
+        _selectedModelId = entry.Id;
+        _host?.SetSetting(SelectedModelSettingName, entry.Id);
+    }
+
+    public async Task<PluginTranscriptionResult> TranscribeAsync(
+        byte[] wavAudio, string? language, bool translate, string? prompt, CancellationToken ct)
+    {
+        if (!IsConfigured || _selectedModelId is null)
+            throw new InvalidOperationException("Plugin not configured. API key and model required.");
+
+        var entry = ResolveModelEntry(_selectedModelId);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/speech-to-text");
+        request.Headers.TryAddWithoutValidation("xi-api-key", _apiKey);
+
+        using var form = new MultipartFormDataContent();
+        var audioContent = new ByteArrayContent(wavAudio);
+        audioContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
+        form.Add(audioContent, "file", "audio.wav");
+        form.Add(new StringContent(entry.RestModelId), "model_id");
+
+        if (NormalizeLanguage(language) is { } normalizedLanguage)
+            form.Add(new StringContent(normalizedLanguage), "language_code");
+
+        foreach (var term in ExtractKeyterms(prompt))
+            form.Add(new StringContent(term), "keyterms");
+
+        request.Content = form;
+
+        var response = await _httpClient.SendAsync(request, ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"ElevenLabs API error {(int)response.StatusCode}: {json}");
+
+        return ParseRestResponse(json, NormalizeLanguage(language));
+    }
+
+    public async Task<IStreamingSession> StartStreamingAsync(string? language, CancellationToken ct)
+    {
+        if (!IsConfigured || _selectedModelId is null)
+            throw new InvalidOperationException("Plugin not configured. API key and model required.");
+
+        var entry = ResolveModelEntry(_selectedModelId);
+        return await ElevenLabsStreamingSession.ConnectAsync(
+            _apiKey!,
+            entry.RealtimeModelId,
+            NormalizeLanguage(language),
+            ct);
+    }
+
+    // API key management (for settings view)
+
+    internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
+
+    internal async Task SetApiKeyAsync(string apiKey)
+    {
+        var normalized = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
+        var wasConfigured = IsConfigured;
+        var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
+
+        _apiKey = normalized;
+        if (_host is not null)
+        {
+            if (normalized is null)
+                await _host.DeleteSecretAsync(ApiKeySecretName);
+            else
+                await _host.StoreSecretAsync(ApiKeySecretName, normalized);
+
+            if (changed && wasConfigured != IsConfigured)
+                _host.NotifyCapabilitiesChanged();
+        }
+    }
+
+    internal async Task<bool> ValidateApiKeyAsync(string apiKey, CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/user");
+        request.Headers.TryAddWithoutValidation("xi-api-key", apiKey);
+
+        try
+        {
+            var response = await _httpClient.SendAsync(request, ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal static PluginTranscriptionResult ParseRestResponse(string json, string? fallbackLanguage)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var text = root.TryGetProperty("text", out var textEl)
+            ? textEl.GetString()?.Trim() ?? ""
+            : "";
+        var detectedLanguage = root.TryGetProperty("language_code", out var langEl)
+            ? langEl.GetString()
+            : fallbackLanguage;
+
+        var duration = 0.0;
+        var segments = new List<PluginTranscriptionSegment>();
+        if (root.TryGetProperty("words", out var wordsEl) && wordsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var wordEl in wordsEl.EnumerateArray())
+            {
+                if (wordEl.TryGetProperty("type", out var typeEl)
+                    && !string.Equals(typeEl.GetString(), "word", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var wordText = wordEl.TryGetProperty("text", out var wordTextEl)
+                    ? wordTextEl.GetString() ?? ""
+                    : "";
+
+                if (string.IsNullOrWhiteSpace(wordText)
+                    || !TryGetDouble(wordEl, "start", out var start)
+                    || !TryGetDouble(wordEl, "end", out var end))
+                {
+                    continue;
+                }
+
+                segments.Add(new PluginTranscriptionSegment(wordText, start, end));
+                duration = Math.Max(duration, end);
+            }
+        }
+
+        return new PluginTranscriptionResult(text, detectedLanguage, duration, NoSpeechProbability: null)
+        {
+            Segments = segments
+        };
+    }
+
+    internal static IReadOnlyList<string> ExtractKeyterms(string? prompt)
+    {
+        if (string.IsNullOrWhiteSpace(prompt))
+            return [];
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var terms = new List<string>();
+        foreach (var part in prompt.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            var term = part.Trim();
+            if (term.Length == 0
+                || term.Length >= 50
+                || term.IndexOfAny(InvalidKeytermCharacters) >= 0
+                || term.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length > 5
+                || !seen.Add(term))
+            {
+                continue;
+            }
+
+            terms.Add(term);
+            if (terms.Count == 1000)
+                break;
+        }
+
+        return terms;
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+
+    private static string? NormalizeLanguage(string? language) =>
+        string.IsNullOrWhiteSpace(language) || language.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : language;
+
+    private static string NormalizeModelId(string? modelId) =>
+        ModelEntries.Any(m => m.Id == modelId) ? modelId! : DefaultModelId;
+
+    private static ElevenLabsModelEntry ResolveModelEntry(string modelId) =>
+        ModelEntries.FirstOrDefault(m => m.Id == modelId)
+        ?? throw new ArgumentException($"Unknown model: {modelId}");
+
+    private static bool TryGetDouble(JsonElement element, string propertyName, out double value)
+    {
+        if (element.TryGetProperty(propertyName, out var property)
+            && property.ValueKind == JsonValueKind.Number
+            && property.TryGetDouble(out value))
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromSeconds(120) };
+
+    private sealed record ElevenLabsModelEntry(
+        string Id,
+        string DisplayName,
+        string RestModelId,
+        string RealtimeModelId);
+}

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsSettingsView.xaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="TypeWhisper.Plugin.ElevenLabs.ElevenLabsSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="0,4" MaxWidth="500">
+        <TextBlock Text="API Key" FontWeight="SemiBold" Margin="0,0,0,4" />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
+                    Click="OnTestClick" x:Name="TestButton" />
+        </Grid>
+        <TextBlock x:Name="ApiKeyHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        <TextBlock x:Name="StatusText" Margin="0,6,0,0" FontSize="12" />
+
+        <StackPanel x:Name="ModelsSection" Margin="0,16,0,0" Visibility="Collapsed">
+            <TextBlock x:Name="TranscriptionModelLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
+            <ComboBox x:Name="TranscriptionModelPicker"
+                      DisplayMemberPath="DisplayName"
+                      SelectionChanged="OnTranscriptionModelChanged" />
+            <TextBlock x:Name="ModelHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsSettingsView.xaml.cs
@@ -1,0 +1,105 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.ElevenLabs;
+
+public partial class ElevenLabsSettingsView : UserControl
+{
+    private readonly ElevenLabsPlugin _plugin;
+    private bool _suppressPasswordChanged;
+
+    public ElevenLabsSettingsView(ElevenLabsPlugin plugin)
+    {
+        _plugin = plugin;
+        InitializeComponent();
+
+        TestButton.Content = L("Settings.Test");
+        ApiKeyHintText.Text = L("Settings.ApiKeyHint");
+        TranscriptionModelLabel.Text = L("Settings.TranscriptionModel");
+        ModelHintText.Text = L("Settings.ModelHint");
+
+        if (!string.IsNullOrEmpty(plugin.ApiKey))
+        {
+            _suppressPasswordChanged = true;
+            ApiKeyBox.Password = plugin.ApiKey;
+            _suppressPasswordChanged = false;
+        }
+
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        PopulateModelPicker();
+        UpdateModelSectionVisibility();
+    }
+
+    private async void OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (_suppressPasswordChanged)
+            return;
+
+        var key = ApiKeyBox.Password;
+        await _plugin.SetApiKeyAsync(key);
+        StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
+        StatusText.Foreground = Brushes.Gray;
+        UpdateModelSectionVisibility();
+    }
+
+    private async void OnTestClick(object sender, RoutedEventArgs e)
+    {
+        var key = ApiKeyBox.Password;
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            StatusText.Text = L("Settings.EnterApiKey");
+            StatusText.Foreground = Brushes.Orange;
+            return;
+        }
+
+        TestButton.IsEnabled = false;
+        StatusText.Text = L("Settings.Testing");
+        StatusText.Foreground = Brushes.Gray;
+
+        try
+        {
+            var valid = await _plugin.ValidateApiKeyAsync(key);
+            StatusText.Text = valid ? L("Settings.ApiKeyValid") : L("Settings.ApiKeyInvalid");
+            StatusText.Foreground = valid ? Brushes.Green : Brushes.Red;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = L("Settings.Error", ex.Message);
+            StatusText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            TestButton.IsEnabled = true;
+            UpdateModelSectionVisibility();
+        }
+    }
+
+    private void OnTranscriptionModelChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (TranscriptionModelPicker.SelectedItem is PluginModelInfo model)
+            _plugin.SelectModel(model.Id);
+    }
+
+    private void PopulateModelPicker()
+    {
+        var models = _plugin.TranscriptionModels.ToList();
+        TranscriptionModelPicker.ItemsSource = models;
+        TranscriptionModelPicker.SelectedItem = models
+            .FirstOrDefault(m => m.Id == _plugin.SelectedModelId)
+            ?? models.FirstOrDefault();
+    }
+
+    private void UpdateModelSectionVisibility()
+    {
+        ModelsSection.Visibility = _plugin.IsConfigured ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
+}

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsStreamingSession.cs
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/ElevenLabsStreamingSession.cs
@@ -1,0 +1,255 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.PluginSDK;
+
+namespace TypeWhisper.Plugin.ElevenLabs;
+
+internal sealed class ElevenLabsStreamingSession : IStreamingSession
+{
+    internal const int MinimumBufferedChunkBytes = 3200; // 100ms at 16kHz, 16-bit mono
+
+    private readonly ClientWebSocket _ws = new();
+    private readonly CancellationTokenSource _receiveCts = new();
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly MemoryStream _audioBuffer = new();
+    private Task? _receiveTask;
+    private bool _disposed;
+
+    public event Action<StreamingTranscriptEvent>? TranscriptReceived;
+
+    public static async Task<ElevenLabsStreamingSession> ConnectAsync(
+        string apiKey,
+        string realtimeModelId,
+        string? language,
+        CancellationToken ct)
+    {
+        var session = new ElevenLabsStreamingSession();
+        session._ws.Options.SetRequestHeader("xi-api-key", apiKey);
+        await session._ws.ConnectAsync(BuildRealtimeUri(realtimeModelId, language), ct);
+        session._receiveTask = session.ReceiveLoopAsync(session._receiveCts.Token);
+        return session;
+    }
+
+    public async Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
+    {
+        if (_disposed || _ws.State != WebSocketState.Open || pcm16Audio.Length == 0)
+            return;
+
+        await _sendLock.WaitAsync(ct);
+        try
+        {
+            if (_disposed || _ws.State != WebSocketState.Open)
+                return;
+
+            _audioBuffer.Write(pcm16Audio.Span);
+            if (_audioBuffer.Length < MinimumBufferedChunkBytes)
+                return;
+
+            var chunk = _audioBuffer.ToArray();
+            _audioBuffer.SetLength(0);
+            await SendAudioPayloadAsync(chunk, commit: false, ct);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    public async Task FinalizeAsync(CancellationToken ct)
+    {
+        if (_disposed || _ws.State != WebSocketState.Open)
+            return;
+
+        await _sendLock.WaitAsync(ct);
+        try
+        {
+            if (_disposed || _ws.State != WebSocketState.Open)
+                return;
+
+            if (_audioBuffer.Length == 0)
+                return;
+
+            var chunk = _audioBuffer.ToArray();
+            _audioBuffer.SetLength(0);
+            await SendAudioPayloadAsync(chunk, commit: true, ct);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    internal static Uri BuildRealtimeUri(string realtimeModelId, string? language)
+    {
+        var query = new List<string>
+        {
+            $"model_id={Uri.EscapeDataString(realtimeModelId)}",
+            "audio_format=pcm_16000",
+            "commit_strategy=vad",
+            "include_timestamps=true",
+            "include_language_detection=true",
+        };
+
+        if (!string.IsNullOrWhiteSpace(language))
+            query.Add($"language_code={Uri.EscapeDataString(language)}");
+
+        return new Uri("wss://api.elevenlabs.io/v1/speech-to-text/realtime?" + string.Join("&", query));
+    }
+
+    internal static string BuildAudioChunkPayload(byte[] pcm16Audio, bool commit) =>
+        JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["message_type"] = "input_audio_chunk",
+            ["audio_base_64"] = Convert.ToBase64String(pcm16Audio),
+            ["sample_rate"] = 16000,
+            ["commit"] = commit,
+        });
+
+    internal static bool TryParseTranscriptEvent(
+        string json,
+        out StreamingTranscriptEvent? transcriptEvent,
+        out string? error)
+    {
+        transcriptEvent = null;
+        error = null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("message_type", out var messageTypeEl))
+                return false;
+
+            var messageType = messageTypeEl.GetString();
+            if (string.IsNullOrWhiteSpace(messageType) || messageType == "session_started")
+                return false;
+
+            if (messageType.Contains("error", StringComparison.OrdinalIgnoreCase))
+            {
+                error = ExtractErrorMessage(root) ?? json;
+                return false;
+            }
+
+            if (messageType is "partial_transcript")
+            {
+                var text = GetText(root);
+                if (string.IsNullOrWhiteSpace(text))
+                    return false;
+
+                transcriptEvent = new StreamingTranscriptEvent(text, IsFinal: false);
+                return true;
+            }
+
+            if (messageType is "committed_transcript" or "committed_transcript_with_timestamps")
+            {
+                var text = GetText(root);
+                if (string.IsNullOrWhiteSpace(text))
+                    return false;
+
+                transcriptEvent = new StreamingTranscriptEvent(text, IsFinal: true);
+                return true;
+            }
+        }
+        catch (JsonException ex)
+        {
+            error = ex.Message;
+        }
+
+        return false;
+    }
+
+    private async Task SendAudioPayloadAsync(byte[] chunk, bool commit, CancellationToken ct)
+    {
+        var payload = Encoding.UTF8.GetBytes(BuildAudioChunkPayload(chunk, commit));
+        await _ws.SendAsync(payload, WebSocketMessageType.Text, true, ct);
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        var messageBuffer = new MemoryStream();
+
+        try
+        {
+            while (!ct.IsCancellationRequested && _ws.State == WebSocketState.Open)
+            {
+                messageBuffer.SetLength(0);
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await _ws.ReceiveAsync(buffer, ct);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        return;
+                    messageBuffer.Write(buffer, 0, result.Count);
+                } while (!result.EndOfMessage);
+
+                if (result.MessageType != WebSocketMessageType.Text)
+                    continue;
+
+                var json = Encoding.UTF8.GetString(messageBuffer.GetBuffer(), 0, (int)messageBuffer.Length);
+                if (TryParseTranscriptEvent(json, out var transcriptEvent, out var error))
+                {
+                    TranscriptReceived?.Invoke(transcriptEvent!);
+                }
+                else if (!string.IsNullOrWhiteSpace(error))
+                {
+                    Debug.WriteLine($"ElevenLabs realtime error: {error}");
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (WebSocketException ex)
+        {
+            Debug.WriteLine($"ElevenLabs realtime WebSocket error: {ex.Message}");
+        }
+    }
+
+    private static string GetText(JsonElement root) =>
+        root.TryGetProperty("text", out var textEl) ? textEl.GetString() ?? "" : "";
+
+    private static string? ExtractErrorMessage(JsonElement root)
+    {
+        foreach (var propertyName in new[] { "error", "message", "details" })
+        {
+            if (root.TryGetProperty(propertyName, out var property)
+                && property.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(property.GetString()))
+            {
+                return property.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _receiveCts.Cancel();
+
+        if (_ws.State == WebSocketState.Open)
+        {
+            try { await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None); }
+            catch { /* best effort */ }
+        }
+
+        if (_receiveTask is not null)
+        {
+            try { await _receiveTask; }
+            catch { /* expected */ }
+        }
+
+        _audioBuffer.Dispose();
+        _sendLock.Dispose();
+        _receiveCts.Dispose();
+        _ws.Dispose();
+    }
+}

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/Localization/de.json
@@ -1,0 +1,12 @@
+{
+  "Settings.Test": "Testen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
+  "Settings.ApiKeyHint": "Wird sicher gespeichert und fuer ElevenLabs-Scribe-Transkription verwendet.",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Key gueltig!",
+  "Settings.ApiKeyInvalid": "Ungueltiger API-Key",
+  "Settings.TranscriptionModel": "Transkriptions-Modell",
+  "Settings.ModelHint": "Scribe v2 wird fuer Datei-Transkription verwendet; Live-Diktat nutzt Scribe v2 Realtime.",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/Localization/en.json
@@ -1,0 +1,12 @@
+{
+  "Settings.Test": "Test",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.ApiKeyHint": "Stored securely and used for ElevenLabs Scribe transcription.",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.TranscriptionModel": "Transcription Model",
+  "Settings.ModelHint": "Scribe v2 is used for file transcription; live dictation uses Scribe v2 Realtime.",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/TypeWhisper.Plugin.ElevenLabs.csproj
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/TypeWhisper.Plugin.ElevenLabs.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>TypeWhisper.Plugin.ElevenLabs</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Target Name="CopyToAppPlugins" AfterTargets="Build">
+    <PropertyGroup>
+      <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
+      <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.elevenlabs\</PluginOutputDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
+  </Target>
+</Project>

--- a/plugins/TypeWhisper.Plugin.ElevenLabs/manifest.json
+++ b/plugins/TypeWhisper.Plugin.ElevenLabs/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "com.typewhisper.elevenlabs",
+  "name": "ElevenLabs",
+  "version": "1.0.0",
+  "author": "TypeWhisper",
+  "description": "Cloud transcription via ElevenLabs Scribe with real-time WebSocket streaming",
+  "category": "transcription",
+  "isLocal": false,
+  "requiresApiKey": true,
+  "iconSystemName": "waveform.badge.mic",
+  "descriptions": {
+    "de": "Cloud-Transkription ueber ElevenLabs Scribe mit Echtzeit-WebSocket-Streaming"
+  },
+  "assemblyName": "TypeWhisper.Plugin.ElevenLabs.dll",
+  "pluginClass": "TypeWhisper.Plugin.ElevenLabs.ElevenLabsPlugin"
+}

--- a/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
@@ -18,7 +18,8 @@ internal sealed class StreamingTranscriptState
 
     public string StopSession()
     {
-        var finalText = _lastDisplayedText;
+        var hasUncommittedPreview = _lastDisplayedText != _confirmedText;
+        var finalText = hasUncommittedPreview ? "" : _confirmedText;
         InvalidateSession();
         _confirmedText = "";
         _lastDisplayedText = "";

--- a/src/TypeWhisper.Windows/ViewModels/PluginIconHelper.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginIconHelper.cs
@@ -8,6 +8,7 @@ internal static class PluginIconHelper
         "com.typewhisper.openai" => "\U0001F916",          // OpenAI - robot
         "com.typewhisper.openai-compatible" => "\U0001F310", // OpenAI Compatible - globe
         "com.typewhisper.sherpa-onnx" => "\U0001F3AF",     // SherpaOnnx - local/target
+        "com.typewhisper.elevenlabs" => "\U0001F399",       // ElevenLabs - studio microphone
         "com.typewhisper.webhook" => "\U0001F517",         // Webhook - link
         _ => "\U0001F9E9"                                   // Default - puzzle piece
     };
@@ -18,6 +19,7 @@ internal static class PluginIconHelper
         "com.typewhisper.openai" => "#10A37F",
         "com.typewhisper.openai-compatible" => "#6366F1",
         "com.typewhisper.sherpa-onnx" => "#F59E0B",
+        "com.typewhisper.elevenlabs" => "#111827",
         "com.typewhisper.webhook" => "#8B5CF6",
         _ => "#0078D4"
     };
@@ -28,6 +30,7 @@ internal static class PluginIconHelper
         "com.typewhisper.openai" => "#0D8A6A",
         "com.typewhisper.openai-compatible" => "#4F46E5",
         "com.typewhisper.sherpa-onnx" => "#D97706",
+        "com.typewhisper.elevenlabs" => "#F97316",
         "com.typewhisper.webhook" => "#7C3AED",
         _ => "#005A9E"
     };

--- a/tests/TypeWhisper.PluginSystem.Tests/ElevenLabsPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ElevenLabsPluginTests.cs
@@ -1,0 +1,311 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.Plugin.ElevenLabs;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class ElevenLabsPluginTests
+{
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifestPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.ElevenLabs", "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var sut = new ElevenLabsPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_UsesScribeV2AsDefaultModel()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "eleven-key";
+
+        var sut = new ElevenLabsPlugin();
+        await sut.ActivateAsync(host);
+
+        Assert.Equal("com.typewhisper.elevenlabs", sut.PluginId);
+        Assert.Equal("elevenlabs", sut.ProviderId);
+        Assert.Equal(ElevenLabsPlugin.DefaultModelId, sut.SelectedModelId);
+        Assert.Equal([ElevenLabsPlugin.DefaultModelId], sut.TranscriptionModels.Select(m => m.Id).ToArray());
+        Assert.True(sut.IsConfigured);
+        Assert.True(sut.SupportsStreaming);
+        Assert.False(sut.SupportsTranslation);
+        Assert.Contains("de", sut.SupportedLanguages);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_NormalizesStaleSelectedModel()
+    {
+        var host = new TestPluginHostServices();
+        host.SetSetting("selectedModel", "scribe_v1");
+
+        var sut = new ElevenLabsPlugin();
+        await sut.ActivateAsync(host);
+
+        Assert.Equal(ElevenLabsPlugin.DefaultModelId, sut.SelectedModelId);
+    }
+
+    [Fact]
+    public async Task SelectModel_PersistsSelectedModel()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new ElevenLabsPlugin();
+        await sut.ActivateAsync(host);
+
+        sut.SelectModel(ElevenLabsPlugin.DefaultModelId);
+
+        Assert.Equal(ElevenLabsPlugin.DefaultModelId, host.GetSetting<string>("selectedModel"));
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_NotifiesWhenConfigurationStateChanges()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new ElevenLabsPlugin();
+        await sut.ActivateAsync(host);
+
+        await sut.SetApiKeyAsync(" eleven-key ");
+        Assert.Equal("eleven-key", host.Secrets["api-key"]);
+
+        await sut.SetApiKeyAsync("");
+
+        Assert.False(host.Secrets.ContainsKey("api-key"));
+        Assert.Equal(2, host.NotifyCapabilitiesChangedCount);
+        Assert.False(sut.IsConfigured);
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsync_UsesUserEndpointAndXiApiKeyHeader()
+    {
+        var handler = new CapturingHandler((request, _) =>
+        {
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal("https://api.elevenlabs.io/v1/user", request.RequestUri?.ToString());
+            Assert.True(request.Headers.TryGetValues("xi-api-key", out var values));
+            Assert.Equal("eleven-key", Assert.Single(values));
+            return JsonResponse("""{"user_id":"u"}""");
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new ElevenLabsPlugin(httpClient);
+
+        Assert.True(await sut.ValidateApiKeyAsync("eleven-key"));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_SendsMultipartRequestAndParsesResponse()
+    {
+        var handler = new CapturingHandler((request, body) =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("https://api.elevenlabs.io/v1/speech-to-text", request.RequestUri?.ToString());
+            Assert.True(request.Headers.TryGetValues("xi-api-key", out var values));
+            Assert.Equal("eleven-key", Assert.Single(values));
+            Assert.StartsWith("multipart/form-data", request.Content?.Headers.ContentType?.MediaType);
+
+            Assert.NotNull(body);
+            Assert.Contains("model_id", body);
+            Assert.Contains("scribe_v2", body);
+            Assert.Contains("language_code", body);
+            Assert.Contains("de", body);
+            Assert.Contains("keyterms", body);
+            Assert.Contains("TypeWhisper", body);
+            Assert.Contains("ElevenLabs", body);
+            Assert.DoesNotContain("bad<term", body);
+
+            return JsonResponse("""
+                {
+                  "language_code": "de",
+                  "text": "Hallo Welt",
+                  "words": [
+                    { "text": "Hallo", "start": 0.1, "end": 0.5, "type": "word" },
+                    { "text": " ", "start": 0.5, "end": 0.6, "type": "spacing" },
+                    { "text": "Welt", "start": 0.6, "end": 1.0, "type": "word" }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "eleven-key";
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new ElevenLabsPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(
+            [1, 2, 3],
+            "de",
+            translate: false,
+            "TypeWhisper, TypeWhisper, bad<term, ElevenLabs",
+            CancellationToken.None);
+
+        Assert.Equal("Hallo Welt", result.Text);
+        Assert.Equal("de", result.DetectedLanguage);
+        Assert.Equal(1.0, result.DurationSeconds);
+        Assert.Equal(["Hallo", "Welt"], result.Segments.Select(s => s.Text).ToArray());
+    }
+
+    [Fact]
+    public void ExtractKeyterms_FiltersUnsupportedTerms()
+    {
+        var terms = ElevenLabsPlugin.ExtractKeyterms(
+            "TypeWhisper, TypeWhisper, too many words in this single keyterm, bad<term, ElevenLabs");
+
+        Assert.Equal(["TypeWhisper", "ElevenLabs"], terms);
+    }
+
+    [Fact]
+    public void BuildRealtimeUri_UsesScribeRealtimeAndVad()
+    {
+        var uri = ElevenLabsStreamingSession.BuildRealtimeUri("scribe_v2_realtime", "de").AbsoluteUri;
+
+        Assert.StartsWith("wss://api.elevenlabs.io/v1/speech-to-text/realtime?", uri);
+        Assert.Contains("model_id=scribe_v2_realtime", uri);
+        Assert.Contains("audio_format=pcm_16000", uri);
+        Assert.Contains("commit_strategy=vad", uri);
+        Assert.Contains("include_timestamps=true", uri);
+        Assert.Contains("include_language_detection=true", uri);
+        Assert.Contains("language_code=de", uri);
+    }
+
+    [Fact]
+    public void BuildAudioChunkPayload_EncodesAudioAndCommitFlag()
+    {
+        var json = ElevenLabsStreamingSession.BuildAudioChunkPayload([1, 2, 3], commit: true);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("input_audio_chunk", doc.RootElement.GetProperty("message_type").GetString());
+        Assert.Equal(Convert.ToBase64String([1, 2, 3]), doc.RootElement.GetProperty("audio_base_64").GetString());
+        Assert.Equal(16000, doc.RootElement.GetProperty("sample_rate").GetInt32());
+        Assert.True(doc.RootElement.GetProperty("commit").GetBoolean());
+    }
+
+    [Fact]
+    public void TryParseTranscriptEvent_ParsesPartialCommittedAndErrorMessages()
+    {
+        var parsedPartial = ElevenLabsStreamingSession.TryParseTranscriptEvent(
+            """{"message_type":"partial_transcript","text":"Hello"}""",
+            out var partial,
+            out var partialError);
+        var parsedFinal = ElevenLabsStreamingSession.TryParseTranscriptEvent(
+            """{"message_type":"committed_transcript_with_timestamps","text":"Hello world","language_code":"en"}""",
+            out var final,
+            out var finalError);
+        var parsedError = ElevenLabsStreamingSession.TryParseTranscriptEvent(
+            """{"message_type":"scribe_auth_error","message":"Invalid API key"}""",
+            out var errorEvent,
+            out var error);
+
+        Assert.True(parsedPartial);
+        Assert.Equal(new StreamingTranscriptEvent("Hello", false), partial);
+        Assert.Null(partialError);
+
+        Assert.True(parsedFinal);
+        Assert.Equal(new StreamingTranscriptEvent("Hello world", true), final);
+        Assert.Null(finalError);
+
+        Assert.False(parsedError);
+        Assert.Null(errorEvent);
+        Assert.Equal("Invalid API key", error);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class CapturingHandler(
+        Func<HttpRequestMessage, string?, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responder(request, body);
+        }
+    }
+
+    private sealed class TestPluginHostServices : IPluginHostServices
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private readonly Dictionary<string, JsonElement> _settings = [];
+        public Dictionary<string, string?> Secrets { get; } = [];
+        public int NotifyCapabilitiesChangedCount { get; private set; }
+
+        public Task StoreSecretAsync(string key, string value)
+        {
+            Secrets[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadSecretAsync(string key) =>
+            Task.FromResult(Secrets.TryGetValue(key, out var value) ? value : null);
+
+        public Task DeleteSecretAsync(string key)
+        {
+            Secrets.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value)
+                ? value.Deserialize<T>(JsonOptions)
+                : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new TestPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() => NotifyCapabilitiesChangedCount++;
+        public IPluginLocalization Localization { get; } = new TestPluginLocalization();
+    }
+
+    private sealed class TestPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TestPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -176,6 +176,26 @@ public class StabilizeTextTests
 public class StreamingTranscriptStateTests
 {
     [Fact]
+    public void StopSession_UsesOnlyConfirmedRealtimeText()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        var interimApplied = sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("Hello world", false),
+            text => text,
+            out var interimDisplay);
+
+        Assert.True(interimApplied);
+        Assert.Equal("Hello world", interimDisplay);
+
+        var finalText = sut.StopSession();
+
+        Assert.Equal("", finalText);
+    }
+
+    [Fact]
     public void StopSession_InvalidatesLateRealtimeEvents()
     {
         var sut = new StreamingTranscriptState();
@@ -183,7 +203,7 @@ public class StreamingTranscriptStateTests
 
         var appliedBeforeStop = sut.TryApplyRealtime(
             sessionVersion,
-            new StreamingTranscriptEvent("Hello world", false),
+            new StreamingTranscriptEvent("Hello world", true),
             text => text,
             out var displayBeforeStop);
 
@@ -202,6 +222,29 @@ public class StreamingTranscriptStateTests
 
         Assert.False(appliedAfterStop);
         Assert.Equal("", displayAfterStop);
+    }
+
+    [Fact]
+    public void StopSession_FallsBackWhenTrailingRealtimeInterimAfterConfirmedText()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        Assert.True(sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("Confirmed", true),
+            text => text,
+            out var confirmedDisplay));
+        Assert.Equal("Confirmed", confirmedDisplay);
+
+        Assert.True(sut.TryApplyRealtime(
+            sessionVersion,
+            new StreamingTranscriptEvent("still changing", false),
+            text => text,
+            out var interimDisplay));
+        Assert.Equal("Confirmed still changing", interimDisplay);
+
+        Assert.Equal("", sut.StopSession());
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Windows\TypeWhisper.Windows.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Adds a new ElevenLabs transcription plugin for the Windows plugin marketplace.
- Supports secure API key storage, Scribe v2 model selection, REST file/dictation transcription, and realtime WebSocket streaming.
- Registers the plugin in the plugin release workflow, README marketplace list, UI icon metadata, and plugin-system tests.

Closes #53.

## Validation

- `dotnet build plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj -c Release`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release`