### PR TITLE
Polish Windows README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,93 +4,108 @@
 [![Windows](https://img.shields.io/badge/Windows-10%2B-0078D4.svg)](https://www.microsoft.com/windows)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4.svg)](https://dotnet.microsoft.com)
 
-Speech-to-text and AI text processing for Windows. Transcribe audio using on-device AI models or cloud APIs via extensions, then process the result with custom LLM prompts. Your voice data stays on your PC with local models — or use cloud APIs for faster processing.
+Speech-to-text and AI text processing for Windows. Dictate anywhere, transcribe files, and transform text with reusable workflows. Use local models when privacy matters, or add cloud providers through plugins when speed and scale matter more.
+
+TypeWhisper for Windows includes system-wide dictation, file transcription, workflows, history, dictionary, snippets, local and cloud transcription engines, and bundled integrations. Advanced surfaces like the HTTP API, CLI, plugin SDK, marketplace, and action plugins remain available for power users and automation.
+
+## What's New
+
+- **Workflows:** Prompt actions and matching rules live in one workflow surface with templates for cleanup, translation, email replies, meeting notes, checklists, JSON extraction, summaries, and custom prompts.
+- **Expanded engines:** Local SherpaOnnx, whisper.cpp, Granite Speech, and compatible server-based engines sit alongside cloud transcription providers.
+- **Streaming preview:** The recording overlay can show partial results while speech is still being captured.
+- **Automation refresh:** The local HTTP API and CLI support per-request engine/model overrides, language hints, translation targets, and dictionary term management.
+- **Plugin marketplace:** Browse, install, upgrade, and remove bundled or external plugins from Settings.
+- **Release channels:** Velopack powers stable, release-candidate, and daily build delivery.
 
 ## Features
 
 ### Transcription
 
-- **On-device models** — Parakeet TDT 0.6B (25+ languages, fast) and Canary 180M Flash (EN/DE/FR/ES with translation), running on CPU via SherpaOnnx with int8 quantization — no GPU required
-- **Cloud transcription** — Groq Whisper, OpenAI Whisper, AssemblyAI, Deepgram, and any OpenAI-compatible server (Ollama, LM Studio, vLLM). API keys encrypted at rest via DPAPI
-- **Streaming preview** — Silero VAD detects speech segments during recording and transcribes them in real time, showing partial results in the overlay before recording stops
-- **Live transcription** — Floating window with real-time continuous transcription (via LiveTranscript plugin)
-- **File transcription** — Drag-and-drop audio/video files. Supports WAV, MP3, M4A, AAC, OGG, FLAC, WMA, MP4, MKV, AVI, MOV, WebM
-- **Subtitle export** — Export transcriptions as TXT, SRT, or WebVTT
+- **On-device models:** Parakeet TDT 0.6B, Canary 180M Flash, whisper.cpp models, and Granite Speech run locally through plugins. Recommended local models run on CPU, with no GPU required.
+- **Cloud transcription:** Groq Whisper, OpenAI Whisper, AssemblyAI, Deepgram, Gladia, Google Cloud STT, Soniox, Speechmatics, Cloudflare ASR, Voxtral, and any OpenAI-compatible server can be added through plugins.
+- **Streaming preview:** Silero VAD detects speech segments during recording and shows partial transcription results in the overlay before recording stops.
+- **Short-clip handling:** Brief utterances are padded and retained more reliably across local and cloud engines.
+- **File transcription:** Drag and drop audio/video files. Supports WAV, MP3, M4A, AAC, OGG, FLAC, WMA, MP4, MKV, AVI, MOV, and WebM.
+- **Subtitle export:** Export transcriptions as TXT, SRT, or WebVTT.
 
 ### Dictation
 
-- **System-wide** — Three independent hotkeys: Hybrid (short press toggles, long press is push-to-talk), Toggle-only, and Hold-only. Per-profile hotkeys for direct profile activation. Auto-pastes into any app
-- **Non-blocking pipeline** — Multiple recordings can be queued while transcription runs in the background
-- **Sound feedback** — Audio cues for recording start and stop
-- **Silence detection** — Automatically stops recording after configurable silence period
-- **Whisper mode** — Boosted microphone gain for quiet speech
-- **Audio normalization** — Automatic gain control for consistent input levels
-- **Media pause** — Automatically pauses media playback during recording
-- **Audio ducking** — Reduces system volume while recording
+- **System-wide dictation:** Hybrid, Toggle-only, Hold-only, and workflow-specific hotkeys can paste text into any app.
+- **Non-blocking pipeline:** Queue multiple recordings while transcription runs in the background.
+- **Sound feedback:** Audio cues for recording start and stop.
+- **Silence detection:** Automatically stops recording after a configurable silence period.
+- **Whisper mode:** Boosted microphone gain for quiet speech.
+- **Audio normalization:** Automatic gain control for consistent input levels.
+- **Media pause:** Automatically pauses media playback during recording.
+- **Audio ducking:** Reduces system volume while recording.
 
 ### AI Processing
 
-- **Custom prompts** — Process transcriptions (or any text) with LLM prompts. Standalone Prompt Palette via global hotkey — a floating panel for AI text processing independent of dictation
-- **LLM providers** — Groq, OpenAI, Google Gemini, and any OpenAI-compatible server (Ollama, LM Studio, vLLM) — all via plugins
-- **Translation** — Cloud LLM translation with local Marian ONNX model fallback. 20 target languages: EN, DE, FR, ES, IT, NL, PL, SV, DA, FI, CS, RU, UK, HU, JA, ZH, AR, HI, VI, ID
+- **Workflows:** Build reusable transformations for cleanup, translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run by app, website, or dedicated hotkey.
+- **LLM providers:** Groq, OpenAI, Gemini, Claude, Cerebras, Cohere, Fireworks, OpenRouter, OpenAI Compatible, and local Gemma can be used through plugins.
+- **Custom prompts:** Add fine-tuning instructions per workflow, or use custom workflow prompts when the built-in templates are not specific enough.
+- **Translation:** Cloud LLM translation can fall back to local Marian ONNX translation. Supported target languages include EN, DE, FR, ES, IT, NL, PL, SV, DA, FI, CS, RU, UK, HU, JA, ZH, AR, HI, VI, and ID.
 
 ### Personalization
 
-- **Profiles** — Per-app and per-website overrides for language, task, transcription model, and whisper mode. Match by process name and/or URL pattern with wildcard support. Automatically activates when dictating in a matched application or website
-- **Dictionary** — Custom term corrections applied after transcription (e.g., fix names, jargon, or recurring misrecognitions). Regex support. 13 built-in term packs: Web Dev, .NET/C#, DevOps, Data & AI, Design, Game Dev, Mobile, Security, Databases, Medical, Legal, Finance, Music Production
-- **Snippets** — Text shortcuts with trigger→replacement. Placeholders: `{date}`, `{time}`, `{datetime}`, `{clipboard}`, `{day}`, `{year}`. Date/time support custom formats (e.g. `{date:dd.MM.yyyy}`)
-- **History** — Searchable transcription history with raw/final text tracking, app context, inline editing, and export (TXT, CSV, Markdown, JSON)
+- **Workflow triggers:** Match by process name, website pattern, or hotkey for language, task, model, whisper mode, prompt processing, output format, and action routing.
+- **Dictionary:** Custom term corrections fix names, jargon, and recurring misrecognitions. Includes regex support and built-in term packs for developer, medical, legal, finance, and creative domains.
+- **Snippets:** Text shortcuts with trigger -> replacement. Placeholders include `{date}`, `{time}`, `{datetime}`, `{clipboard}`, `{day}`, and `{year}`. Date/time placeholders support custom formats, such as `{date:dd.MM.yyyy}`.
+- **History:** Searchable transcription history with raw/final text tracking, app context, inline editing, export, retention controls, and recent-transcription access.
 
 ### Integration & Extensibility
 
-- **Plugin system** — Extensible plugin architecture with SDK and marketplace. Create custom plugins for transcription engines, LLM providers, post-processors, or action plugins
-- **Plugin marketplace** — Browse, install, update, and uninstall plugins directly from Settings. Auto-installs recommended extensions on first run
-- **Action plugins** — Linear (create issues), Obsidian (create notes), Script (run custom scripts), Webhook (HTTP notifications)
-- **HTTP API** — Local REST server for integration with external tools (status, models, transcription, history, profiles, dictation control)
-- **Model auto-unload** — Automatically unloads models after configurable idle timeout to save memory
+- **Plugin system:** Extend TypeWhisper with custom transcription engines, LLM providers, post-processors, memory providers, TTS providers, event observers, and action plugins.
+- **Plugin marketplace:** Browse, install, upgrade, and remove plugins directly from Settings. Recommended extensions can be installed automatically on first run.
+- **Action plugins:** Linear, Obsidian, Script, Webhook, and LiveTranscript can turn transcriptions into issues, notes, scripts, notifications, or live windows.
+- **HTTP API:** Local REST server for status, models, transcription, history, dictionary terms, and dictation control.
+- **CLI tool:** Shell-friendly transcription via the bundled `typewhisper` command.
 
 ### General
 
-- **Fluent Design** — WPF-UI with Mica backdrop, native title bar, and Fluent controls
-- **Dynamic Island overlay** — Configurable widgets (LED, timer, waveform) with multi-monitor support and real-time microphone level meter
-- **Home dashboard** — Usage statistics (words, WPM, apps, time saved) with activity chart
-- **Welcome wizard** — Guided 4-step onboarding: extension installation & model download, microphone test, hotkey setup. Re-accessible from the dashboard
-- **Auto-update** — Built-in updates via Velopack
-- **Windows autostart** — Optional start with Windows (via registry)
-- **System tray** — Minimizes to tray with quick access
-- **Localization** — English, German, French, Spanish, Italian, Portuguese, Dutch, Polish, Czech, Swedish, Danish, Finnish
+- **Fluent Design:** WPF-UI with Mica backdrop, native title bar, and Fluent controls.
+- **Dynamic Island overlay:** Configurable widgets for LED, timer, waveform, active workflow, and microphone level.
+- **Home dashboard:** Usage statistics, words per minute, app activity, time saved, and onboarding.
+- **Welcome wizard:** Guided setup for extension installation, model download, microphone test, and hotkeys.
+- **Release channels:** Velopack-powered delivery for stable, release-candidate, and daily builds.
+- **Windows autostart:** Optional start with Windows.
+- **System tray:** Minimizes to tray with quick access.
+- **Localization:** English, German, French, Spanish, Italian, Portuguese, Dutch, Polish, Czech, Swedish, Danish, and Finnish.
+
+## Install
+
+### Direct Download
+
+Download the latest installer from [GitHub Releases](https://github.com/TypeWhisper/typewhisper-win/releases/latest).
+
+Stable releases use the default Velopack channel. Release candidates and daily builds are published as prereleases on their own update channels. Installed builds can switch channels in Settings.
+
+## Quick Start
+
+1. Install TypeWhisper from the latest Windows release.
+2. Open Settings and grant microphone access if Windows asks for it.
+3. Pick a transcription engine and, if needed, download a local model.
+4. Set a global hotkey or create a workflow-specific hotkey.
+5. Trigger dictation and complete your first transcription.
 
 ## System Requirements
 
 - Windows 10 or later (x64 or ARM64)
-- 8 GB RAM minimum, 16 GB+ recommended for larger models
-- ~700 MB disk space for the Parakeet model, ~200 MB for Canary
+- 8 GB RAM minimum, 16 GB+ recommended for larger local models
+- Around 700 MB disk space for Parakeet, around 200 MB for Canary, more for whisper.cpp or Granite Speech models
+- .NET 10 SDK for building from source
 
-## Models
+## Model Recommendations
 
-### Local Models
+| Use Case | Recommended Models |
+|----------|--------------------|
+| Fast general dictation | Parakeet TDT 0.6B, whisper.cpp Base Q5_0 |
+| Multilingual dictation with translation | Canary 180M Flash, whisper.cpp Large V3 Turbo |
+| Lowest disk usage | whisper.cpp Tiny Q5_0 |
+| Higher local accuracy | whisper.cpp Small or Large V3 Turbo |
+| Experimental local speech | IBM Granite 4.0 1B Speech |
 
-| Use Case | Model | Size |
-|----------|-------|------|
-| General transcription (25+ languages) | Parakeet TDT 0.6B | 670 MB, int8 |
-| Multilingual with translation (EN/DE/FR/ES) | Canary 180M Flash | 198 MB, int8 |
-
-Both models run on CPU with int8 quantization — no GPU required. Local models are provided by the SherpaOnnx plugin, installed via the built-in marketplace.
-
-### Cloud Models (optional)
-
-| Provider | Model | Notes |
-|----------|-------|-------|
-| Groq | whisper-large-v3 | Fast cloud transcription, supports translation |
-| Groq | whisper-large-v3-turbo | Fastest, no translation |
-| OpenAI | gpt-4o-transcribe | Highest accuracy |
-| OpenAI | gpt-4o-mini-transcribe | Lower cost, good quality |
-| OpenAI | whisper-1 | Classic, supports translation |
-| AssemblyAI | various | Real-time and batch transcription |
-| Deepgram | nova-3 | Fast, accurate cloud ASR |
-| OpenAI Compatible | Any model | Local LLM servers (Ollama, LM Studio, vLLM) |
-
-Cloud providers are available as plugins and can be configured in Settings > Extensions.
+Local models are provided by bundled plugins and can be installed from the built-in marketplace.
 
 ## Build
 
@@ -102,7 +117,7 @@ Cloud providers are available as plugins and can be configured in Settings > Ext
 
 2. Build with .NET 10:
    ```bash
-   dotnet build
+   dotnet build TypeWhisper.slnx
    ```
 
 3. Run the app:
@@ -110,38 +125,43 @@ Cloud providers are available as plugins and can be configured in Settings > Ext
    dotnet run --project src/TypeWhisper.Windows
    ```
 
-4. The app appears in the system tray — the welcome wizard guides you through extension installation, model download, and setup.
+4. Run the automated checks before shipping changes:
+   ```bash
+   dotnet test TypeWhisper.slnx
+   ```
+
+The app appears in the system tray, and the welcome wizard guides you through extension installation, model download, and setup.
 
 ## HTTP API
 
-TypeWhisper can run a local HTTP server (default port 8978, configurable in Settings) for integration with external tools.
+The HTTP API is an advanced local automation surface. It binds to `localhost` and `127.0.0.1`, is configurable in Settings, and uses port `8978` by default.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/v1/status` | GET | App status and active model |
-| `/v1/models` | GET | List all available models (local + cloud) |
+| `/v1/status` | GET | App status, active engine, active model, API version, and capability flags |
+| `/v1/models` | GET | List all available local and cloud models |
 | `/v1/transcribe` | POST | Transcribe multipart or raw audio |
-| `/v1/history` | GET | Search history with pagination. Query params: `q`, `limit`, `offset` |
-| `/v1/history` | DELETE | Delete history entries by ID |
-| `/v1/profiles` | GET | List all profiles |
-| `/v1/profiles/toggle` | PUT | Toggle a profile on/off by ID |
+| `/v1/history` | GET | Search history with pagination |
+| `/v1/history` | DELETE | Delete a history entry by ID |
 | `/v1/dictation/start` | POST | Start recording |
 | `/v1/dictation/stop` | POST | Stop recording |
 | `/v1/dictation/status` | GET | Check current dictation state |
 | `/v1/dictation/transcription` | GET | Poll dictation result by session ID |
-| `/v1/dictionary/terms` | GET/PUT/DELETE | List, replace/append, or clear dictionary terms |
+| `/v1/dictionary/terms` | GET | List enabled dictionary terms |
+| `/v1/dictionary/terms` | PUT | Replace or append dictionary terms |
+| `/v1/dictionary/terms` | DELETE | Clear dictionary terms |
 
-`/v1/transcribe` accepts either `multipart/form-data` with a `file` part or a raw audio request body. Multipart fields are:
+`/v1/transcribe` accepts `multipart/form-data` with a `file` part or a raw audio request body. Multipart fields are:
 
-- `language` - exact source language, such as `en` or `de`
-- `language_hint` - repeatable language hints; do not combine with `language`
-- `task` - `transcribe` or `translate`
-- `target_language` - translate the final text to this language
-- `response_format` - `json` or `verbose_json`
-- `prompt` - request-specific transcription prompt/context
-- `engine` and `model` - per-request overrides using IDs from `/v1/models`
+- `language`: exact source language, such as `en` or `de`
+- `language_hint`: repeatable language hints; do not combine with `language`
+- `task`: `transcribe` or `translate`
+- `target_language`: translate the final text to this language
+- `response_format`: `json` or `verbose_json`
+- `prompt`: request-specific transcription prompt/context
+- `engine` and `model`: per-request overrides using IDs from `/v1/models`
 
-Raw audio requests can pass the same options with headers: `X-Language`, `X-Language-Hints`, `X-Task`, `X-Target-Language`, `X-Response-Format`, `X-Prompt`, `X-Engine`, and `X-Model`. Add `?await_download=1` to wait for a local model download/restore when supported.
+Raw audio requests can pass the same options with headers: `X-Language`, `X-Language-Hints`, `X-Task`, `X-Target-Language`, `X-Response-Format`, `X-Prompt`, `X-Engine`, and `X-Model`. Add `?await_download=1` to wait for a local model download or restore when supported.
 
 ```bash
 curl -X POST http://localhost:8978/v1/transcribe \
@@ -155,9 +175,11 @@ curl -X POST http://localhost:8978/v1/dictation/stop
 curl "http://localhost:8978/v1/dictation/transcription?id=<session-id>"
 ```
 
-## CLI
+## CLI Tool
 
-The optional `typewhisper` CLI talks to the local HTTP API.
+The optional `typewhisper` CLI talks to the local HTTP API and is intended for scripts, terminals, and batch workflows.
+
+### Commands
 
 ```bash
 typewhisper status
@@ -168,110 +190,95 @@ typewhisper transcribe recording.wav --engine groq --model whisper-large-v3-turb
 typewhisper transcribe - < audio.wav
 ```
 
-Useful flags: `--port`, `--json`, `--language`, repeatable `--language-hint`, `--task`, `--translate-to`, `--engine`, `--model`, and `--await-download`.
+### Options
 
-## Profiles
+| Option | Description |
+|--------|-------------|
+| `--port <N>` | Server port (default: `8978`) |
+| `--json` | Output as JSON |
+| `--language <code>` | Source language, such as `en` or `de` |
+| `--language-hint <code>` | Repeatable language hint for restricted auto-detection |
+| `--task <task>` | `transcribe` (default) or `translate` |
+| `--translate-to <code>` | Target language for translation |
+| `--engine <id>` | Override the transcription engine |
+| `--model <id>` | Override the transcription model |
+| `--await-download` | Wait for local model restore/download |
 
-Profiles let you configure transcription settings per application or website. For example:
+The CLI requires the API server to be running in Settings.
 
-- **Outlook** — German language
-- **Slack** — English language
-- **Terminal** — Whisper mode always on
-- **github.com** — English language (matches in any browser)
-- **docs.google.com** — German language, translate to English
+## Workflows
 
-Create profiles in Settings > Profiles. Assign process names and/or URL patterns, set language/task/model overrides, and adjust priority. URL patterns support wildcard matching — e.g. `*.github.com` matches `gist.github.com`.
+Workflows let you configure transcription, transformation, and automation behavior per application, website, or hotkey. For example:
 
-When you start dictating, TypeWhisper matches the active window and browser URL against your profiles with the following priority:
-1. **Process + URL match** — highest specificity (e.g. chrome.exe + github.com)
-2. **URL-only match** — cross-browser profiles (e.g. github.com in any browser)
-3. **Process-only match** — generic app profiles (e.g. all of Chrome)
+- **Outlook:** German dictation, email reply template, auto-submit enabled
+- **Slack:** English cleanup workflow with Groq or OpenAI prompt processing
+- **Terminal:** Whisper mode enabled with a command-focused dictionary
+- **github.com:** English cleanup workflow that matches in any browser
+- **docs.google.com:** German dictation workflow that translates to English
 
-The active profile is shown in the recording overlay.
+Create workflows in Settings > Workflows. Choose a template, assign an app, website, or hotkey trigger, then configure language/task/model overrides, prompt processing, output behavior, action routing, and priority. Website patterns support wildcard matching, so `*.github.com` matches `gist.github.com`.
+
+When you start dictating, TypeWhisper matches the active window and browser URL against enabled workflows with the following priority:
+
+1. **Website match:** browser URL patterns, such as `github.com` in any supported browser
+2. **App match:** process names, such as `OUTLOOK.EXE` or `Code.exe`
+3. **Hotkey match:** workflow-specific hotkeys that force a selected workflow
+
+The active workflow is shown in the recording overlay.
 
 ## Plugins
 
-TypeWhisper supports plugins for adding custom transcription engines, LLM providers, post-processors, and action plugins. Plugins are .NET class libraries with a `manifest.json`, installed to `%LocalAppData%/TypeWhisper/Plugins/`.
+TypeWhisper supports plugins for adding custom transcription engines, LLM providers, post-processors, memory providers, TTS providers, event observers, and action plugins. Plugins are .NET class libraries with a `manifest.json`, installed to `%LocalAppData%\TypeWhisper\Plugins\`.
 
-The built-in marketplace provides the following plugins:
+Bundled plugin families include:
 
-| Plugin | Type | Description |
-|--------|------|-------------|
-| SherpaOnnx | Transcription | Local ASR with Parakeet and Canary models |
-| OpenAI | Transcription + LLM | OpenAI Whisper and GPT models |
-| Groq | Transcription + LLM | Groq Whisper and Llama models |
-| Google Gemini | LLM | Gemini 2.5 Flash, Pro, and Flash Lite |
-| AssemblyAI | Transcription | AssemblyAI speech-to-text |
-| Deepgram | Transcription | Deepgram Nova ASR |
-| OpenAI Compatible | Transcription + LLM | Any OpenAI-compatible server (Ollama, LM Studio, vLLM) |
-| Linear | Action | Create Linear issues from transcriptions |
-| Obsidian | Action | Create Obsidian notes from transcriptions |
-| Script | Action | Run custom scripts with transcription data |
-| LiveTranscript | Action | Floating live transcription window |
-| Webhook | Event | HTTP notifications for transcription events |
+| Type | Plugins |
+|------|---------|
+| Local transcription | SherpaOnnx, whisper.cpp, Granite Speech |
+| Cloud transcription | OpenAI, Groq, AssemblyAI, Deepgram, Gladia, Google Cloud STT, Soniox, Speechmatics, Cloudflare ASR, Voxtral, OpenAI Compatible |
+| Server-backed transcription | Qwen3 STT |
+| LLM providers | OpenAI, Groq, Gemini, Claude, Cerebras, Cohere, Fireworks, OpenRouter, OpenAI Compatible, Gemma Local |
+| Actions | Linear, Obsidian, Script, LiveTranscript, Webhook |
+| Memory | File Memory, OpenAI Vector Memory |
 
 ### Plugin Types
 
 | Interface | Purpose |
 |-----------|---------|
-| `ITranscriptionEnginePlugin` | Cloud/custom transcription (e.g., Whisper API) |
-| `ILlmProviderPlugin` | LLM chat completions (e.g., translation, course correction) |
-| `IPostProcessorPlugin` | Post-processing pipeline (text cleanup, formatting) |
-| `IActionPlugin` | Custom actions triggered by transcription events |
-| `ITypeWhisperPlugin` | Event observer (e.g., webhook, logging) |
+| `ITranscriptionEnginePlugin` | Local, cloud, or custom speech-to-text engines |
+| `ILlmProviderPlugin` | LLM chat completions for workflow processing |
+| `IPostProcessorPlugin` | Post-processing pipeline for cleanup and formatting |
+| `IActionPlugin` | Custom actions triggered by workflow output |
+| `ITypeWhisperPlugin` | Event observer, lifecycle hook, or utility plugin |
 
 ### SDK Helpers
 
 The SDK includes helpers for OpenAI-compatible APIs:
-- `OpenAiTranscriptionHelper` — multipart/form-data upload for Whisper-compatible endpoints
-- `OpenAiChatHelper` — chat completion requests
-- `OpenAiApiHelper` — shared HTTP error handling
+
+- `OpenAiTranscriptionHelper`: multipart/form-data upload for Whisper-compatible endpoints
+- `OpenAiChatHelper`: chat completion requests
+- `OpenAiApiHelper`: shared HTTP error handling
 
 ## Architecture
 
-```
+```text
 typewhisper-win/
-├── src/
-│   ├── TypeWhisper.Core/           # Core logic (net10.0)
-│   │   ├── Data/                   # SQLite database with migrations
-│   │   ├── Interfaces/             # Service contracts
-│   │   ├── Models/                 # Profile, AppSettings, ModelInfo, TermPack, etc.
-│   │   └── Translation/            # MarianTokenizer, MarianConfig (local ONNX translation)
-│   ├── TypeWhisper.PluginSDK/      # Plugin SDK (net10.0-windows)
-│   │   ├── Helpers/                # OpenAiChatHelper, OpenAiTranscriptionHelper
-│   │   └── Models/                 # PluginManifest, PluginEvents, etc.
-│   └── TypeWhisper.Windows/        # WPF UI layer (net10.0-windows, WPF-UI Fluent Design)
-│       ├── Controls/               # HotkeyRecorderControl, MicLevelMeter
-│       ├── Native/                 # P/Invoke, KeyboardHook
-│       ├── Services/
-│       │   ├── Plugins/            # PluginLoader, PluginManager, PluginEventBus, PluginRegistryService
-│       │   └── Providers/          # LocalProviderBase
-│       ├── ViewModels/             # MVVM view models
-│       ├── Views/                  # MainWindow, SettingsWindow, WelcomeWindow, sections
-│       ├── Resources/              # Icons, sounds, silero_vad.onnx
-│       └── App.xaml.cs             # Composition root
-├── plugins/                        # Plugin source (distributed via marketplace)
-│   ├── TypeWhisper.Plugin.OpenAi/           # OpenAI transcription + LLM
-│   ├── TypeWhisper.Plugin.Groq/             # Groq transcription + LLM
-│   ├── TypeWhisper.Plugin.Gemini/           # Google Gemini LLM
-│   ├── TypeWhisper.Plugin.OpenAiCompatible/ # OpenAI-compatible servers
-│   ├── TypeWhisper.Plugin.SherpaOnnx/       # Local ASR (Parakeet, Canary)
-│   ├── TypeWhisper.Plugin.AssemblyAi/       # AssemblyAI transcription
-│   ├── TypeWhisper.Plugin.Deepgram/         # Deepgram transcription
-│   ├── TypeWhisper.Plugin.Linear/           # Linear issue creation
-│   ├── TypeWhisper.Plugin.Obsidian/         # Obsidian note creation
-│   ├── TypeWhisper.Plugin.Script/           # Custom script execution
-│   ├── TypeWhisper.Plugin.LiveTranscript/   # Live transcription window
-│   └── TypeWhisper.Plugin.Webhook/          # Webhook event notifications
-└── tests/
-    ├── TypeWhisper.Core.Tests/           # xUnit + Moq, in-memory SQLite
-    └── TypeWhisper.PluginSystem.Tests/   # Plugin infrastructure tests
+|-- src/
+|   |-- TypeWhisper.Core/           # Core logic, models, interfaces, persistence
+|   |-- TypeWhisper.PluginSDK/      # Plugin contracts, helpers, manifest models
+|   |-- TypeWhisper.Cli/            # typewhisper command-line client
+|   `-- TypeWhisper.Windows/        # WPF UI, services, view models, app composition
+|-- plugins/                        # Bundled plugin source
+|-- tests/
+|   |-- TypeWhisper.Core.Tests/     # Core xUnit tests
+|   `-- TypeWhisper.PluginSystem.Tests/
+`-- docs/                           # Design notes and implementation plans
 ```
 
-**Patterns:** MVVM with CommunityToolkit.Mvvm. `App.xaml.cs` is the composition root. SQLite for persistence with a custom migration pattern. Plugin system with AssemblyLoadContext isolation and manifest-based discovery. Post-processing pipeline with priority-based ordering.
+**Patterns:** MVVM with CommunityToolkit.Mvvm. `App.xaml.cs` is the composition root. SQLite is used for persistence with a custom migration pattern. Plugins load through AssemblyLoadContext isolation and manifest-based discovery. Workflows drive app/website/hotkey matching and prompt orchestration.
 
-**Key dependencies:** NAudio (audio), NHotkey.Wpf (hotkeys), WPF-UI (Fluent Design), Microsoft.ML.OnnxRuntime (local translation), Velopack (updates), H.NotifyIcon.Wpf (system tray).
+**Key dependencies:** NAudio (audio), NHotkey.Wpf (hotkeys), WPF-UI (Fluent Design), Microsoft.ML.OnnxRuntime (local translation), Velopack (updates), H.NotifyIcon.Wpf (system tray), and org.k2fsa.sherpa.onnx (local ASR).
 
 ## License
 
-GPLv3 — see [LICENSE](LICENSE) for details. Commercial licensing available — see [LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md). Trademark policy — see [TRADEMARK.md](TRADEMARK.md).
+GPLv3. See [LICENSE](LICENSE) for details. Commercial licensing is available under [LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md). See [TRADEMARK.md](TRADEMARK.md) for the trademark policy.


### PR DESCRIPTION
## Summary

- Reworked the Windows README to follow the same high-level structure as the Mac README.
- Added clearer release, install, quick start, workflow, plugin, API, CLI, and architecture sections.
- Removed long dash separators and awkward duplicated update wording.

## Why

The previous README had drifted from the Mac documentation style and still described older profile-focused behavior. This update makes the Windows README easier to scan and better aligned with the current workflow and plugin surface.

## Impact

Documentation only. No runtime behavior changes.

## Test Plan

- `git diff --cached --check`
- `rg -n "—|–|trigger→replacement|Auto-update|Built-in updates|Up-Updates|readme-template" README.md`
- `git show --check --stat --oneline HEAD`