### PR TITLE
Harden auto paste reliability

### DIFF
--- a/src/TypeWhisper.Core/Interfaces/IActiveWindowService.cs
+++ b/src/TypeWhisper.Core/Interfaces/IActiveWindowService.cs
@@ -2,6 +2,7 @@ namespace TypeWhisper.Core.Interfaces;
 
 public interface IActiveWindowService
 {
+    IntPtr GetActiveWindowHandle();
     string? GetActiveWindowProcessName();
     string? GetActiveWindowTitle();
     string? GetBrowserUrl();

--- a/src/TypeWhisper.Core/Models/ErrorLogEntry.cs
+++ b/src/TypeWhisper.Core/Models/ErrorLogEntry.cs
@@ -23,4 +23,5 @@ public static class ErrorCategory
     public const string Recording = "recording";
     public const string Prompt = "prompt";
     public const string Plugin = "plugin";
+    public const string Insertion = "insertion";
 }

--- a/src/TypeWhisper.Windows/Services/ActiveWindowService.cs
+++ b/src/TypeWhisper.Windows/Services/ActiveWindowService.cs
@@ -19,6 +19,15 @@ public sealed class ActiveWindowService : IActiveWindowService
     private string? _lastTitle;
     private string? _cachedUrl;
 
+    public IntPtr GetActiveWindowHandle()
+    {
+        var hwnd = NativeMethods.GetForegroundWindow();
+        if (hwnd == IntPtr.Zero) return IntPtr.Zero;
+
+        NativeMethods.GetWindowThreadProcessId(hwnd, out var processId);
+        return processId == 0 || processId == OwnProcessId ? IntPtr.Zero : hwnd;
+    }
+
     public IReadOnlyList<string> GetRunningAppProcessNames()
     {
         try

--- a/src/TypeWhisper.Windows/Services/RecentTranscriptionsService.cs
+++ b/src/TypeWhisper.Windows/Services/RecentTranscriptionsService.cs
@@ -108,7 +108,8 @@ public sealed class RecentTranscriptionsService
             var result = await _textInsertion.InsertTextAsync(
                 entry.FinalText,
                 _settings.Current.AutoPaste,
-                autoEnter: false);
+                autoEnter: false,
+                targetHwnd);
             FeedbackRequested?.Invoke(StatusTextFor(result), false);
         }
         catch (InvalidOperationException ex)

--- a/src/TypeWhisper.Windows/Services/TextInsertionService.cs
+++ b/src/TypeWhisper.Windows/Services/TextInsertionService.cs
@@ -1,80 +1,253 @@
 using System.Runtime.InteropServices;
 using System.Windows;
-using GregsStack.InputSimulatorStandard;
-using GregsStack.InputSimulatorStandard.Native;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Native;
 
 namespace TypeWhisper.Windows.Services;
 
 public sealed class TextInsertionService
 {
-    private readonly InputSimulator _inputSimulator = new();
+    private static readonly TimeSpan ModifierPollInterval = TimeSpan.FromMilliseconds(25);
+    private static readonly TimeSpan FocusDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan EnterDelay = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan ClipboardRestoreDelay = TimeSpan.FromMilliseconds(200);
+    private const int MaxModifierReleaseChecks = 32;
+    private const uint ExpectedPasteInputCount = 4;
+    private const uint ExpectedEnterInputCount = 2;
 
-    public async Task<InsertionResult> InsertTextAsync(string text, bool autoPaste = true, bool autoEnter = false)
+    private readonly ITextInsertionPlatform _platform;
+    private readonly IErrorLogService? _errorLog;
+
+    public TextInsertionService()
+        : this(new WindowsTextInsertionPlatform(), null)
+    {
+    }
+
+    public TextInsertionService(IErrorLogService errorLog)
+        : this(new WindowsTextInsertionPlatform(), errorLog)
+    {
+    }
+
+    internal TextInsertionService(ITextInsertionPlatform platform, IErrorLogService? errorLog = null)
+    {
+        _platform = platform;
+        _errorLog = errorLog;
+    }
+
+    public async Task<InsertionResult> InsertTextAsync(
+        string text,
+        bool autoPaste = true,
+        bool autoEnter = false,
+        IntPtr targetHwnd = default)
     {
         if (string.IsNullOrEmpty(text))
             return InsertionResult.NoText;
 
-        // Save current clipboard
-        string? previousClipboard = null;
+        var previousClipboard = await _platform.TryGetClipboardTextAsync();
+        await _platform.SetClipboardTextAsync(text);
+
+        if (!autoPaste)
+            return InsertionResult.CopiedToClipboard;
+
+        if (!await WaitForModifierKeysReleasedAsync())
+        {
+            LogInsertionFallback("Auto paste fell back to clipboard: modifier keys stayed pressed before paste.");
+            return InsertionResult.CopiedToClipboard;
+        }
+
+        if (!await FocusTargetWindowAsync(targetHwnd))
+        {
+            LogInsertionFallback("Auto paste fell back to clipboard: target window could not be focused.");
+            return InsertionResult.CopiedToClipboard;
+        }
+
+        var pasteInputCount = _platform.SendPasteInput();
+        if (pasteInputCount != ExpectedPasteInputCount)
+        {
+            LogInsertionFallback($"Auto paste fell back to clipboard: Ctrl+V input sent {pasteInputCount}/{ExpectedPasteInputCount} events.");
+            return InsertionResult.CopiedToClipboard;
+        }
+
+        if (autoEnter)
+        {
+            await _platform.DelayAsync(EnterDelay);
+            var enterInputCount = _platform.SendEnterInput();
+            if (enterInputCount != ExpectedEnterInputCount)
+            {
+                LogInsertionFallback($"Auto paste sent Ctrl+V, but Enter input sent {enterInputCount}/{ExpectedEnterInputCount} events.");
+            }
+        }
+
+        await RestorePreviousClipboardAsync(previousClipboard);
+        return InsertionResult.Pasted;
+    }
+
+    private async Task<bool> WaitForModifierKeysReleasedAsync()
+    {
+        for (var attempt = 0; attempt < MaxModifierReleaseChecks; attempt++)
+        {
+            if (!_platform.IsAnyModifierKeyDown())
+                return true;
+
+            await _platform.DelayAsync(ModifierPollInterval);
+        }
+
+        return !_platform.IsAnyModifierKeyDown();
+    }
+
+    private async Task<bool> FocusTargetWindowAsync(IntPtr targetHwnd)
+    {
+        if (targetHwnd == IntPtr.Zero)
+        {
+            await _platform.DelayAsync(FocusDelay);
+            return true;
+        }
+
+        if (_platform.GetForegroundWindow() == targetHwnd)
+        {
+            await _platform.DelayAsync(FocusDelay);
+            return true;
+        }
+
+        var focusRequested = _platform.SetForegroundWindow(targetHwnd);
+        await _platform.DelayAsync(FocusDelay);
+        return focusRequested || _platform.GetForegroundWindow() == targetHwnd;
+    }
+
+    private async Task RestorePreviousClipboardAsync(string? previousClipboard)
+    {
+        await _platform.DelayAsync(ClipboardRestoreDelay);
+        if (previousClipboard is null)
+            return;
+
         try
         {
-            await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                if (Clipboard.ContainsText())
-                    previousClipboard = Clipboard.GetText();
-            });
+            await _platform.SetClipboardTextAsync(previousClipboard);
         }
-        catch { /* Clipboard might be locked */ }
+        catch
+        {
+            // Best effort restore.
+        }
+    }
 
-        // Set text to clipboard (must be on UI thread)
-        await Application.Current.Dispatcher.InvokeAsync(() =>
+    private void LogInsertionFallback(string message)
+    {
+        try
+        {
+            _errorLog?.AddEntry(message, ErrorCategory.Insertion);
+        }
+        catch
+        {
+            // Diagnostics must never block dictation output.
+        }
+    }
+}
+
+internal interface ITextInsertionPlatform
+{
+    Task<string?> TryGetClipboardTextAsync();
+    Task SetClipboardTextAsync(string text);
+    Task DelayAsync(TimeSpan delay);
+    bool IsAnyModifierKeyDown();
+    IntPtr GetForegroundWindow();
+    bool SetForegroundWindow(IntPtr hwnd);
+    uint SendPasteInput();
+    uint SendEnterInput();
+}
+
+internal sealed class WindowsTextInsertionPlatform : ITextInsertionPlatform
+{
+    private const uint ExpectedPasteInputCount = 4;
+    private const uint ExpectedEnterInputCount = 2;
+
+    private static readonly int[] ModifierKeys =
+    [
+        NativeMethods.VK_SHIFT,
+        NativeMethods.VK_LSHIFT,
+        NativeMethods.VK_RSHIFT,
+        NativeMethods.VK_CONTROL,
+        NativeMethods.VK_LCONTROL,
+        NativeMethods.VK_RCONTROL,
+        NativeMethods.VK_MENU,
+        NativeMethods.VK_LMENU,
+        NativeMethods.VK_RMENU,
+        NativeMethods.VK_LWIN,
+        NativeMethods.VK_RWIN
+    ];
+
+    public async Task<string?> TryGetClipboardTextAsync()
+    {
+        try
+        {
+            return await Application.Current.Dispatcher.InvokeAsync(() =>
+                Clipboard.ContainsText() ? Clipboard.GetText() : null);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public Task SetClipboardTextAsync(string text) =>
+        Application.Current.Dispatcher.InvokeAsync(() =>
         {
             for (var attempt = 0; attempt < 3; attempt++)
             {
                 try
                 {
                     Clipboard.SetText(text);
-                    break;
+                    return;
                 }
                 catch (COMException) when (attempt < 2)
                 {
                     Thread.Sleep(50);
                 }
             }
-        });
+        }).Task;
 
-        if (!autoPaste)
-            return InsertionResult.CopiedToClipboard;
+    public Task DelayAsync(TimeSpan delay) => Task.Delay(delay);
 
-        // Small delay for focus to return to target window
-        await Task.Delay(100);
+    public bool IsAnyModifierKeyDown() =>
+        ModifierKeys.Any(key => (NativeMethods.GetAsyncKeyState(key) & unchecked((short)0x8000)) != 0);
 
-        // Simulate Ctrl+V using InputSimulator (same as old version)
-        _inputSimulator.Keyboard.ModifiedKeyStroke(
-            VirtualKeyCode.CONTROL, VirtualKeyCode.VK_V);
+    public IntPtr GetForegroundWindow() => NativeMethods.GetForegroundWindow();
 
-        if (autoEnter)
+    public bool SetForegroundWindow(IntPtr hwnd) => NativeMethods.SetForegroundWindow(hwnd);
+
+    public uint SendPasteInput() =>
+        NativeMethods.SendInput(
+            ExpectedPasteInputCount,
+            [
+                KeyInput(NativeMethods.VK_CONTROL, keyUp: false),
+                KeyInput(NativeMethods.VK_V, keyUp: false),
+                KeyInput(NativeMethods.VK_V, keyUp: true),
+                KeyInput(NativeMethods.VK_CONTROL, keyUp: true)
+            ],
+            Marshal.SizeOf<NativeMethods.INPUT>());
+
+    public uint SendEnterInput() =>
+        NativeMethods.SendInput(
+            ExpectedEnterInputCount,
+            [
+                KeyInput(NativeMethods.VK_RETURN, keyUp: false),
+                KeyInput(NativeMethods.VK_RETURN, keyUp: true)
+            ],
+            Marshal.SizeOf<NativeMethods.INPUT>());
+
+    private static NativeMethods.INPUT KeyInput(int virtualKey, bool keyUp) =>
+        new()
         {
-            await Task.Delay(50);
-            _inputSimulator.Keyboard.KeyPress(VirtualKeyCode.RETURN);
-        }
-
-        // Restore previous clipboard after a short delay
-        await Task.Delay(200);
-        if (previousClipboard is not null)
-        {
-            try
+            type = NativeMethods.INPUT_KEYBOARD,
+            u = new NativeMethods.INPUTUNION
             {
-                await Application.Current.Dispatcher.InvokeAsync(() =>
+                ki = new NativeMethods.KEYBDINPUT
                 {
-                    Clipboard.SetText(previousClipboard);
-                });
+                    wVk = (ushort)virtualKey,
+                    dwFlags = keyUp ? NativeMethods.KEYEVENTF_KEYUP : 0
+                }
             }
-            catch { /* Best effort restore */ }
-        }
-
-        return InsertionResult.Pasted;
-    }
+        };
 }
 
 public enum InsertionResult

--- a/src/TypeWhisper.Windows/TypeWhisper.Windows.csproj
+++ b/src/TypeWhisper.Windows/TypeWhisper.Windows.csproj
@@ -58,7 +58,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GregsStack.InputSimulatorStandard" Version="1.3.5" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -86,6 +86,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
     // Captured at recording start for the current session
     private Workflow? _activeWorkflow;
     private string? _workflowHotkeyOverrideId;
+    private IntPtr _capturedWindowHandle;
     private string? _capturedProcessName;
     private string? _capturedWindowTitle;
     private string? _capturedUrl;
@@ -392,6 +393,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         ActiveProcessName = null;
         ActiveWorkflowName = null;
         _activeWorkflow = null;
+        _capturedWindowHandle = IntPtr.Zero;
         _capturedProcessName = null;
         _capturedWindowTitle = null;
         _capturedUrl = null;
@@ -563,6 +565,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         ShowFeedback = false;
 
         // Capture active window context at recording start
+        _capturedWindowHandle = _activeWindow.GetActiveWindowHandle();
         _capturedProcessName = _activeWindow.GetActiveWindowProcessName();
         _capturedWindowTitle = _activeWindow.GetActiveWindowTitle();
         _capturedUrl = _activeWindow.GetBrowserUrl();
@@ -761,6 +764,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 samples,
                 partialSnapshot,
                 _activeWorkflow,
+                _capturedWindowHandle,
                 _capturedProcessName,
                 _capturedWindowTitle,
                 _capturedUrl,
@@ -1001,7 +1005,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     insertResult = await _textInsertion.InsertTextAsync(
                         finalText,
                         _settings.Current.AutoPaste,
-                        job.ActiveWorkflow?.Output.AutoEnter == true);
+                        job.ActiveWorkflow?.Output.AutoEnter == true,
+                        job.CapturedWindowHandle);
                 }
             }
             else
@@ -1015,7 +1020,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 insertResult = await _textInsertion.InsertTextAsync(
                     finalText,
                     _settings.Current.AutoPaste,
-                    job.ActiveWorkflow?.Output.AutoEnter == true);
+                    job.ActiveWorkflow?.Output.AutoEnter == true,
+                    job.CapturedWindowHandle);
             }
 
             _eventBus.Publish(new TextInsertedEvent
@@ -1295,6 +1301,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         float[] Samples,
         List<string> PartialSegments,
         Workflow? ActiveWorkflow,
+        IntPtr CapturedWindowHandle,
         string? CapturedProcessName,
         string? CapturedWindowTitle,
         string? CapturedUrl,

--- a/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
@@ -1,0 +1,214 @@
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class TextInsertionServiceTests
+{
+    [Fact]
+    public async Task AutoPasteDisabled_LeavesDictationInClipboardWithoutPasteInput()
+    {
+        var platform = new FakeTextInsertionPlatform { ClipboardText = "previous" };
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated", autoPaste: false);
+
+        Assert.Equal(InsertionResult.CopiedToClipboard, result);
+        Assert.Equal("dictated", platform.ClipboardText);
+        Assert.Equal(0, platform.PasteInputCalls);
+    }
+
+    [Fact]
+    public async Task ModifierTimeout_FallsBackToClipboardAndKeepsDictationAvailable()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            ModifierDefaultState = true
+        };
+        var errorLog = new FakeErrorLogService();
+        var sut = new TextInsertionService(platform, errorLog);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.CopiedToClipboard, result);
+        Assert.Equal("dictated", platform.ClipboardText);
+        Assert.Equal(0, platform.PasteInputCalls);
+        Assert.Contains(errorLog.Entries, entry =>
+            entry.Category == ErrorCategory.Insertion
+            && entry.Message.Contains("modifier keys", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ModifierRelease_WaitsBeforeSendingPasteInput()
+    {
+        var platform = new FakeTextInsertionPlatform { ClipboardText = "previous" };
+        platform.ModifierStates.Enqueue(true);
+        platform.ModifierStates.Enqueue(true);
+        platform.ModifierStates.Enqueue(false);
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal(1, platform.PasteInputCalls);
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.True(platform.DelayCalls >= 3);
+    }
+
+    [Fact]
+    public async Task FocusFailure_FallsBackToClipboardWithoutPasteInput()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            ForegroundWindow = new IntPtr(100),
+            SetForegroundWindowResult = false
+        };
+        var errorLog = new FakeErrorLogService();
+        var sut = new TextInsertionService(platform, errorLog);
+
+        var result = await sut.InsertTextAsync("dictated", targetHwnd: new IntPtr(200));
+
+        Assert.Equal(InsertionResult.CopiedToClipboard, result);
+        Assert.Equal("dictated", platform.ClipboardText);
+        Assert.Equal(0, platform.PasteInputCalls);
+        Assert.Equal(new IntPtr(200), platform.LastSetForegroundWindow);
+        Assert.Contains(errorLog.Entries, entry =>
+            entry.Category == ErrorCategory.Insertion
+            && entry.Message.Contains("target window", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PasteInputFailure_FallsBackToClipboardWithoutRestoringPreviousClipboard()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            PasteInputResult = 0
+        };
+        var errorLog = new FakeErrorLogService();
+        var sut = new TextInsertionService(platform, errorLog);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.CopiedToClipboard, result);
+        Assert.Equal("dictated", platform.ClipboardText);
+        Assert.Equal(1, platform.PasteInputCalls);
+        Assert.Contains(errorLog.Entries, entry =>
+            entry.Category == ErrorCategory.Insertion
+            && entry.Message.Contains("Ctrl+V", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SuccessfulPaste_RestoresPreviousClipboard()
+    {
+        var platform = new FakeTextInsertionPlatform { ClipboardText = "previous" };
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.Equal(1, platform.PasteInputCalls);
+        Assert.Equal(["dictated", "previous"], platform.ClipboardWrites);
+    }
+
+    [Fact]
+    public async Task EnterInputFailure_StillReportsPasteAndLogsDiagnostic()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            EnterInputResult = 0
+        };
+        var errorLog = new FakeErrorLogService();
+        var sut = new TextInsertionService(platform, errorLog);
+
+        var result = await sut.InsertTextAsync("dictated", autoEnter: true);
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.Equal(1, platform.EnterInputCalls);
+        Assert.Contains(errorLog.Entries, entry =>
+            entry.Category == ErrorCategory.Insertion
+            && entry.Message.Contains("Enter", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class FakeTextInsertionPlatform : ITextInsertionPlatform
+    {
+        public string? ClipboardText { get; set; }
+        public List<string> ClipboardWrites { get; } = [];
+        public Queue<bool> ModifierStates { get; } = [];
+        public bool ModifierDefaultState { get; set; }
+        public IntPtr ForegroundWindow { get; set; }
+        public bool SetForegroundWindowResult { get; set; } = true;
+        public IntPtr LastSetForegroundWindow { get; private set; }
+        public uint PasteInputResult { get; set; } = 4;
+        public uint EnterInputResult { get; set; } = 2;
+        public int PasteInputCalls { get; private set; }
+        public int EnterInputCalls { get; private set; }
+        public int DelayCalls { get; private set; }
+
+        public Task<string?> TryGetClipboardTextAsync() => Task.FromResult(ClipboardText);
+
+        public Task SetClipboardTextAsync(string text)
+        {
+            ClipboardText = text;
+            ClipboardWrites.Add(text);
+            return Task.CompletedTask;
+        }
+
+        public Task DelayAsync(TimeSpan delay)
+        {
+            DelayCalls++;
+            return Task.CompletedTask;
+        }
+
+        public bool IsAnyModifierKeyDown() =>
+            ModifierStates.Count > 0 ? ModifierStates.Dequeue() : ModifierDefaultState;
+
+        public IntPtr GetForegroundWindow() => ForegroundWindow;
+
+        public bool SetForegroundWindow(IntPtr hwnd)
+        {
+            LastSetForegroundWindow = hwnd;
+            if (SetForegroundWindowResult)
+                ForegroundWindow = hwnd;
+
+            return SetForegroundWindowResult;
+        }
+
+        public uint SendPasteInput()
+        {
+            PasteInputCalls++;
+            return PasteInputResult;
+        }
+
+        public uint SendEnterInput()
+        {
+            EnterInputCalls++;
+            return EnterInputResult;
+        }
+    }
+
+    private sealed class FakeErrorLogService : IErrorLogService
+    {
+        private readonly List<ErrorLogEntry> _entries = [];
+
+        public IReadOnlyList<ErrorLogEntry> Entries => _entries;
+
+        public event Action? EntriesChanged;
+
+        public void AddEntry(string message, string category = "general")
+        {
+            _entries.Add(ErrorLogEntry.Create(message, category));
+            EntriesChanged?.Invoke();
+        }
+
+        public void ClearAll() => _entries.Clear();
+
+        public string ExportDiagnostics() => "";
+    }
+}


### PR DESCRIPTION
## Summary
- Harden auto paste so TypeWhisper waits for physical modifier keys to be released before sending Ctrl+V.
- Capture and restore focus to the original target window before insertion.
- Fall back to leaving dictated text in the clipboard when focus or input delivery fails, and log non-sensitive insertion diagnostics.
- Replace the old InputSimulator path with checked SendInput calls and add targeted coverage for fallback behavior.

## Why
Fixes #74. The paste path could report `Pasted` after attempting Ctrl+V even when the target app did not actually receive input.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj`
- `dotnet test TypeWhisper.slnx`
- `git diff --check`