### PR TITLE
Prepare v0.7.0 release notes

### DIFF
--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,30 @@
+# TypeWhisper v0.7.0
+
+TypeWhisper 0.7.0 is a major workflow and automation release for Windows. It brings the workflow system into the main settings experience, expands file transcription automation, adds new provider capabilities, and tightens dictation reliability for everyday use.
+
+## New Features
+
+- Added the unified Workflows surface for prompt actions, matching rules, workflow-specific hotkeys, language and model overrides, output formatting, and action routing.
+- Added batch file transcription queues with per-file status tracking, export options, and improved model selection behavior.
+- Added watch folder transcription so folders can be monitored and processed automatically with configurable export output.
+- Added the recent transcriptions palette for quickly finding, editing, copying, and reusing recent dictation results.
+- Added the ElevenLabs transcription plugin, including streaming support and localized settings.
+- Added TTS provider plugin support, including host services, playback sessions, voice metadata, and a built-in Windows SAPI provider.
+- Added stable, release-candidate, and daily update channel support in the app and release packaging.
+
+## Improvements
+
+- Expanded the local HTTP API and bundled CLI with per-request engine and model overrides, language hints, translation targets, dictionary term management, and dictation controls.
+- Improved automation compatibility for external tools through richer API parsing, status responses, and CLI installation support.
+- Improved file transcription handling for larger queues, subtitle export, media formats, and watch folder output.
+- Improved plugin marketplace and plugin host behavior so bundled and external plugins can expose more capabilities consistently.
+- Improved short and quiet speech handling with configurable padding and gain behavior.
+- Refined README, issue templates, PR templates, package dry runs, plugin smoke checks, and release workflow coverage.
+
+## Fixes
+
+- Fixed dictation tail clipping so the end of short recordings is less likely to be cut off.
+- Hardened automatic paste reliability after transcription completes.
+- Fixed prompt provider selection and related history/prompt provider race conditions.
+- Fixed autostart toggle handling.
+- Hardened watch folder exception handling so background folder processing is more resilient.


### PR DESCRIPTION
## Summary

- Add curated release notes for the TypeWhisper v0.7.0 stable release.
- Keep versioning driven by the release tag and leave build/release workflow behavior unchanged.

## Validation

- `dotnet test TypeWhisper.slnx -c Release`