### PR TITLE
Fix Escape cancel hotkey registration for dictation

### DIFF
--- a/src/TypeWhisper.Windows/Services/HotkeyService.cs
+++ b/src/TypeWhisper.Windows/Services/HotkeyService.cs
@@ -133,6 +133,7 @@ public sealed class HotkeyService : IDisposable
             _copyLastTranscriptionHook.Start();
         }
 
+        _cancelHook.SetHotkey("Escape");
         _cancelHook.Start();
 
         ApplyWorkflowHotkeys();

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -676,6 +676,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         TranscribedText = "";
         IsOverlayVisible = true;
         RecordingSeconds = 0;
+        _hotkey.IsCancelShortcutEnabled = _isRecording || _pendingJobCount > 0;
 
         _durationTimer?.Dispose();
         _durationTimer = new System.Timers.Timer(100);


### PR DESCRIPTION
## Summary

Fix the dictation cancel path so `Escape` reliably cancels an active recording instead of being lost after hotkey reinitialization.

The change does two things:
- re-registers the `Escape` cancel hotkey every time hotkeys are applied
- ensures the cancel shortcut is enabled while dictation is recording or processing

## Related Issue

None

## Test Plan

- [ ] `dotnet test`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

## Notes

The root cause was that `HotkeyService.ApplySettings()` stopped all hooks, which cleared the `Escape` binding. Re-adding the binding there keeps cancel available after settings/hotkey refreshes.
