### PR TITLE
Prepare v0.7.2 release

### DIFF
--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,0 +1,21 @@
+# TypeWhisper v0.7.2
+
+TypeWhisper 0.7.2 is a stability and polish release for Windows. It improves dictation reliability, adds Japanese localization, makes the preview bubble easier to control, and hardens the newest workflow and paste behavior from the 0.7 line.
+
+## New Features
+
+- Added Japanese localization for the Windows app.
+- Added an auto-hide setting for the preview bubble.
+- Added manual workflow controls and advanced workflow triggers on Windows.
+
+## Improvements
+
+- Kept the preview bubble compact and scrolled so longer live transcription output stays easier to follow.
+- Improved Parakeet transcription tail handling with optional tail padding, better final-result selection, and internal diagnostics for clipped endings.
+- Added audio tail telemetry around recording stop so hard-to-reproduce tail clipping can be diagnosed more clearly.
+
+## Fixes
+
+- Reduced repeated transcription phrases in final dictation output.
+- Fixed paste handoff latency so inserted text is less likely to race with the target app.
+- Preserved clean no-speech handling for short and quiet clips while improving final transcription padding.

--- a/src/TypeWhisper.Core/Models/AppSettings.cs
+++ b/src/TypeWhisper.Core/Models/AppSettings.cs
@@ -43,6 +43,14 @@ public record AppSettings
     // Live transcription (streaming preview while recording)
     public bool LiveTranscriptionEnabled { get; init; } = true;
 
+    // Silence detection
+    public bool SilenceAutoStopEnabled { get; init; }
+    public int SilenceAutoStopSeconds { get; init; } = 10;
+
+    // Internal diagnostics / experimental hardening
+    public bool InternalParakeetTailDiagnosticsEnabled { get; init; }
+    public bool InternalParakeetTailHardeningEnabled { get; init; }
+
     // Overlay
     public OverlayPosition OverlayPosition { get; init; } = OverlayPosition.Bottom;
     public OverlayWidget OverlayLeftWidget { get; init; } = OverlayWidget.Waveform;

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -36,6 +36,9 @@ public sealed class AudioRecordingService : IDisposable
     private float _currentRmsLevel;
     private System.Timers.Timer? _devicePollTimer;
     private int _lastKnownDeviceCount;
+    private const int TailDiagnosticChunkLimit = 8;
+    private readonly Queue<AudioChunkTelemetry> _recentChunks = new();
+    private DateTime? _lastSamplesAvailableUtc;
 
     public event EventHandler<AudioLevelEventArgs>? AudioLevelChanged;
     public event EventHandler<AudioLevelEventArgs>? PreviewLevelChanged;
@@ -138,6 +141,12 @@ public sealed class AudioRecordingService : IDisposable
         _sampleBuffer = new List<float>(SampleRate * 60); // Pre-alloc ~1 min
         _peakRmsLevel = 0;
         _preGainPeakRms = 0;
+        _currentRmsLevel = 0;
+        lock (_bufferLock)
+        {
+            _recentChunks.Clear();
+            _lastSamplesAvailableUtc = null;
+        }
         _recordingStartTime = DateTime.UtcNow;
         _isRecording = true;
     }
@@ -188,6 +197,16 @@ public sealed class AudioRecordingService : IDisposable
         return StopRecording();
     }
 
+    internal AudioTailSnapshot CaptureTailSnapshot()
+    {
+        lock (_bufferLock)
+        {
+            return new AudioTailSnapshot(
+                _lastSamplesAvailableUtc,
+                [.. _recentChunks]);
+        }
+    }
+
     private void OnDataAvailable(object? sender, WaveInEventArgs e)
     {
         if (!_isRecording) return;
@@ -229,12 +248,22 @@ public sealed class AudioRecordingService : IDisposable
             sumSquares += sample * sample;
         }
 
+        var rms = MathF.Sqrt(sumSquares / sampleCount);
+
         lock (_bufferLock)
         {
             _sampleBuffer?.AddRange(chunkBuffer);
+            _lastSamplesAvailableUtc = DateTime.UtcNow;
+            _recentChunks.Enqueue(new AudioChunkTelemetry(
+                _lastSamplesAvailableUtc.Value,
+                peak,
+                rms,
+                preGainRms,
+                sampleCount));
+            while (_recentChunks.Count > TailDiagnosticChunkLimit)
+                _recentChunks.Dequeue();
         }
 
-        var rms = MathF.Sqrt(sumSquares / sampleCount);
         _currentRmsLevel = rms;
         if (rms > _peakRmsLevel) _peakRmsLevel = rms;
 
@@ -427,3 +456,14 @@ public sealed class SamplesAvailableEventArgs(float[] samples) : EventArgs
 {
     public float[] Samples { get; } = samples;
 }
+
+public sealed record AudioTailSnapshot(
+    DateTime? LastSamplesAvailableUtc,
+    IReadOnlyList<AudioChunkTelemetry> RecentChunks);
+
+public sealed record AudioChunkTelemetry(
+    DateTime TimestampUtc,
+    float Peak,
+    float Rms,
+    float PreGainRms,
+    int SampleCount);

--- a/src/TypeWhisper.Windows/Services/ParakeetTailHelper.cs
+++ b/src/TypeWhisper.Windows/Services/ParakeetTailHelper.cs
@@ -1,0 +1,90 @@
+using System.Text.RegularExpressions;
+
+namespace TypeWhisper.Windows.Services;
+
+internal static class ParakeetTailHelper
+{
+    internal const string ParakeetModelId = "plugin:com.typewhisper.sherpa-onnx:parakeet-tdt-0.6b";
+    internal const int TailGuardMilliseconds = 200;
+    private const int SampleRate = 16000;
+
+    public static bool IsParakeetModel(string? activeModelId) =>
+        string.Equals(activeModelId, ParakeetModelId, StringComparison.Ordinal);
+
+    public static float[] AppendTailGuard(float[] samples)
+    {
+        var tailSamples = SampleRate * TailGuardMilliseconds / 1000;
+        if (tailSamples <= 0) return samples;
+
+        var guarded = new float[samples.Length + tailSamples];
+        Array.Copy(samples, guarded, samples.Length);
+        return guarded;
+    }
+
+    public static ParakeetTranscriptionSelection SelectResult(
+        string? activeModelId,
+        string? fullDecodeText,
+        IReadOnlyList<string> partialSegments)
+    {
+        var partialText = string.Join(" ", partialSegments.Where(s => !string.IsNullOrWhiteSpace(s))).Trim();
+        var fullText = fullDecodeText?.Trim() ?? "";
+        var isParakeet = IsParakeetModel(activeModelId);
+
+        if (!isParakeet)
+        {
+            if (!string.IsNullOrWhiteSpace(partialText))
+                return new ParakeetTranscriptionSelection(partialText, "partials", false, partialText.Length, fullText.Length);
+
+            return new ParakeetTranscriptionSelection(fullText, string.IsNullOrWhiteSpace(fullText) ? "empty" : "full_decode", false, partialText.Length, fullText.Length);
+        }
+
+        if (!string.IsNullOrWhiteSpace(fullText))
+        {
+            return new ParakeetTranscriptionSelection(
+                fullText,
+                "full_decode",
+                AreDivergent(fullText, partialText),
+                partialText.Length,
+                fullText.Length);
+        }
+
+        if (!string.IsNullOrWhiteSpace(partialText))
+        {
+            return new ParakeetTranscriptionSelection(
+                partialText,
+                "fallback_partials_after_empty_full_decode",
+                false,
+                partialText.Length,
+                fullText.Length);
+        }
+
+        return new ParakeetTranscriptionSelection("", "empty", false, 0, 0);
+    }
+
+    internal static bool AreDivergent(string fullText, string partialText)
+    {
+        var normalizedFull = Normalize(fullText);
+        var normalizedPartial = Normalize(partialText);
+        if (normalizedFull.Length == 0 || normalizedPartial.Length == 0)
+            return false;
+
+        if (string.Equals(normalizedFull, normalizedPartial, StringComparison.Ordinal))
+            return false;
+
+        if (normalizedFull.Contains(normalizedPartial, StringComparison.Ordinal) ||
+            normalizedPartial.Contains(normalizedFull, StringComparison.Ordinal))
+            return false;
+
+        return true;
+    }
+
+    private static string Normalize(string text) =>
+        Regex.Replace(text.Trim().ToLowerInvariant(), "\\s+", " ");
+}
+
+internal sealed record ParakeetTranscriptionSelection(
+    string Text,
+    string Source,
+    bool DivergedFromPartials,
+    int PartialTextLength,
+    int FullDecodeTextLength);

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Channels;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -101,6 +102,9 @@ public partial class DictationViewModel : ObservableObject, IDisposable
     private readonly List<string> _partialSegments = [];
     private readonly SemaphoreSlim _vadLock = new(1, 1);
     private bool _disposed;
+    private int _lastVadFlushedSegmentCount;
+    private int _lastVadDiscardedShortSegmentCount;
+    private int _lastVadSegmentLength;
 
     [ObservableProperty] private DictationState _state = DictationState.Idle;
     [ObservableProperty] private float _audioLevel;
@@ -754,13 +758,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
         try
         {
+            var stopRequestedAtUtc = DateTime.UtcNow;
             var streamingText = _streamingHandler.Stop();
             _audio.SamplesAvailable -= OnSamplesAvailable;
 
             var samples = await _audio.StopRecordingAsync();
             _isRecording = false;
+            var audioTailSnapshot = _audio.CaptureTailSnapshot();
+            var originalSamples = samples ?? [];
             var rawPeakRmsLevel = _audio.PreGainPeakRmsLevel;
-            var rawDuration = samples is null ? 0 : samples.Length / 16000.0;
+            var rawDuration = originalSamples.Length / 16000.0;
             _eventBus.Publish(new RecordingStoppedEvent { DurationSeconds = rawDuration });
             _durationTimer?.Stop();
             _durationTimer?.Dispose();
@@ -771,13 +778,26 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             CurrentHotkeyMode = null;
 
             // Flush remaining VAD segments
+            _lastVadFlushedSegmentCount = 0;
+            _lastVadDiscardedShortSegmentCount = 0;
+            _lastVadSegmentLength = 0;
+            var vadWasContendedOnStop = false;
             List<string> partialSnapshot;
             if (_vad is not null)
             {
-                _vad.Flush();
-                await ProcessVadSegments();
-                _vad.Dispose();
-                _vad = null;
+                vadWasContendedOnStop = _vadLock.CurrentCount == 0;
+                await _vadLock.WaitAsync();
+                try
+                {
+                    _vad.Flush();
+                    await ProcessVadSegments();
+                    _vad.Dispose();
+                    _vad = null;
+                }
+                finally
+                {
+                    _vadLock.Release();
+                }
             }
 
             // Confirmed live text can skip the second full-buffer transcription;
@@ -808,8 +828,6 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            samples = DictationShortSpeechPolicy.PadSamplesForFinalTranscription(samples ?? [], rawDuration);
-
             var apiSessionId = _activeApiDictationSessionId;
             if (apiSessionId is not null)
             {
@@ -818,8 +836,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             }
 
             // Snapshot all context and enqueue — returns immediately
+            var transcriptionSamples = DictationShortSpeechPolicy.PadSamplesForFinalTranscription(originalSamples, rawDuration);
             var job = new TranscriptionJob(
-                samples,
+                transcriptionSamples,
+                originalSamples,
                 partialSnapshot,
                 _activeWorkflow,
                 _capturedWindowHandle,
@@ -831,7 +851,29 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 _modelManager.ActiveModelId,
                 apiSessionId,
                 trustedLiveText,
-                aggressiveShortQuietHandling);
+                aggressiveShortQuietHandling,
+                new RecordingTailDiagnosticSnapshot(
+                    _modelManager.ActiveModelId,
+                    "local",
+                    stopRequestedAtUtc,
+                    rawDuration,
+                    originalSamples.Length,
+                    audioTailSnapshot.LastSamplesAvailableUtc,
+                    audioTailSnapshot.RecentChunks,
+                    _settings.Current.SilenceAutoStopEnabled,
+                    _lastVadFlushedSegmentCount,
+                    _lastVadDiscardedShortSegmentCount,
+                    _lastVadSegmentLength,
+                    vadWasContendedOnStop,
+                    false,
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null));
 
             Interlocked.Increment(ref _pendingJobCount);
             await _jobChannel.Writer.WriteAsync(job);
@@ -897,41 +939,123 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
             string rawText;
             string? detectedLanguage = null;
-            double audioDuration = job.Samples.Length / 16000.0;
+            double audioDuration = job.OriginalSamples.Length / 16000.0;
+            var diagnosticsEnabled = _settings.Current.InternalParakeetTailDiagnosticsEnabled;
+            var tailHardeningEnabled = _settings.Current.InternalParakeetTailHardeningEnabled;
+            var isParakeetJob = ParakeetTailHelper.IsParakeetModel(job.ActiveModelIdAtCapture);
+            var decodeSamples = isParakeetJob && tailHardeningEnabled
+                ? ParakeetTailHelper.AppendTailGuard(job.Samples)
+                : job.Samples;
+            var tailGuardApplied = !ReferenceEquals(decodeSamples, job.Samples);
+            var tailSamplesAdded = decodeSamples.Length - job.Samples.Length;
+            string fullDecodeText = "";
+            string? fullDecodeDetectedLanguage = null;
+            long? fullDecodeDurationMs = null;
 
             var previewText = DictationFinalTextPolicy.JoinPreviewSegments(job.PartialSegments);
-            if (job.TrustedLiveText is not null)
+            if (!isParakeetJob && job.TrustedLiveText is not null)
             {
                 rawText = DictationFinalTextPolicy.SelectRawText(null, job.TrustedLiveText);
+                job = job with
+                {
+                    Diagnostic = job.Diagnostic with
+                    {
+                        FinalTextSource = "trusted_live",
+                        PartialTextLength = previewText.Length
+                    }
+                };
             }
             else
             {
                 var language = job.EffectiveLanguage == "auto" ? null : job.EffectiveLanguage;
+                var decodeStartedAt = DateTime.UtcNow;
                 var result = await _modelManager.Engine.TranscribeAsync(
-                    job.Samples, language, job.EffectiveTask, ct);
+                    decodeSamples, language, job.EffectiveTask, ct);
+                fullDecodeDurationMs = (long)(DateTime.UtcNow - decodeStartedAt).TotalMilliseconds;
+                fullDecodeText = result.Text ?? "";
+                fullDecodeDetectedLanguage = result.DetectedLanguage;
 
-                if (DictationFinalTextPolicy.ShouldRejectAsNoSpeech(
-                        result.Text,
-                        result.NoSpeechProbability,
-                        hasPreviewText: !string.IsNullOrWhiteSpace(previewText),
-                        job.TranscribeShortQuietClipsAggressively))
+                if (isParakeetJob)
                 {
-                    FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
-                    await Application.Current.Dispatcher.InvokeAsync(() =>
-                        ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
-                    return;
+                    var selection = ParakeetTailHelper.SelectResult(
+                        job.ActiveModelIdAtCapture,
+                        fullDecodeText,
+                        job.PartialSegments);
+                    rawText = DictationFinalTextPolicy.SelectRawText(selection.Text);
+                    detectedLanguage = fullDecodeDetectedLanguage;
+                    job = job with
+                    {
+                        Diagnostic = job.Diagnostic with
+                        {
+                            TailGuardApplied = tailGuardApplied,
+                            TailSamplesAdded = tailSamplesAdded,
+                            FinalTextSource = selection.Source,
+                            FullDecodeTextLength = selection.FullDecodeTextLength,
+                            PartialTextLength = selection.PartialTextLength,
+                            DivergedFromPartials = selection.DivergedFromPartials,
+                            FullDecodeDurationMs = fullDecodeDurationMs
+                        }
+                    };
                 }
+                else
+                {
+                    if (DictationFinalTextPolicy.ShouldRejectAsNoSpeech(
+                            result.Text,
+                            result.NoSpeechProbability,
+                            hasPreviewText: !string.IsNullOrWhiteSpace(previewText),
+                            job.TranscribeShortQuietClipsAggressively))
+                    {
+                        FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
+                        await Application.Current.Dispatcher.InvokeAsync(() =>
+                            ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
+                        return;
+                    }
 
-                rawText = DictationFinalTextPolicy.SelectRawText(result.Text);
-                detectedLanguage = result.DetectedLanguage;
+                    rawText = DictationFinalTextPolicy.SelectRawText(result.Text);
+                    detectedLanguage = result.DetectedLanguage;
+                    job = job with
+                    {
+                        Diagnostic = job.Diagnostic with
+                        {
+                            FinalTextSource = string.IsNullOrWhiteSpace(fullDecodeText) ? "empty" : "full_decode",
+                            FullDecodeTextLength = fullDecodeText.Length,
+                            PartialTextLength = previewText.Length,
+                            FullDecodeDurationMs = fullDecodeDurationMs
+                        }
+                    };
+                }
             }
 
             if (string.IsNullOrWhiteSpace(rawText))
             {
                 FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
+                LogParakeetTailDiagnostics(job.Diagnostic);
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                     ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                 return;
+            }
+
+            if (diagnosticsEnabled && isParakeetJob)
+            {
+                if (!tailHardeningEnabled)
+                {
+                    var compareStartedAt = DateTime.UtcNow;
+                    var compareResult = await _modelManager.Engine.TranscribeAsync(
+                        ParakeetTailHelper.AppendTailGuard(job.Samples),
+                        job.EffectiveLanguage == "auto" ? null : job.EffectiveLanguage,
+                        job.EffectiveTask,
+                        ct);
+                    job = job with
+                    {
+                        Diagnostic = job.Diagnostic with
+                        {
+                            CompareDecodeTextLength = compareResult.Text?.Length ?? 0,
+                            CompareDecodeDurationMs = (long)(DateTime.UtcNow - compareStartedAt).TotalMilliseconds
+                        }
+                    };
+                }
+
+                LogParakeetTailDiagnostics(job.Diagnostic);
             }
 
             _eventBus.Publish(new TranscriptionCompletedEvent
@@ -1140,7 +1264,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 {
                     audioFileName = $"{Guid.NewGuid():N}.wav";
                     var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, audioFileName);
-                    var wav = TypeWhisper.Core.Audio.WavEncoder.Encode(job.Samples);
+                    var wav = TypeWhisper.Core.Audio.WavEncoder.Encode(job.OriginalSamples);
                     await File.WriteAllBytesAsync(audioPath, wav, ct);
                 }
                 catch
@@ -1267,8 +1391,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         {
             var segment = _vad.Front();
             _vad.Pop();
+            _lastVadSegmentLength = segment.Samples.Length;
 
-            if (segment.Samples.Length < 1600) continue; // Skip very short segments
+            if (segment.Samples.Length < 1600)
+            {
+                _lastVadDiscardedShortSegmentCount++;
+                continue; // Skip very short segments
+            }
 
             try
             {
@@ -1276,6 +1405,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 if (!string.IsNullOrWhiteSpace(result.Text))
                 {
                     _partialSegments.Add(result.Text);
+                    _lastVadFlushedSegmentCount++;
                     PartialText = string.Join(" ", _partialSegments);
                 }
             }
@@ -1367,8 +1497,50 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         }
     }
 
+    private void LogParakeetTailDiagnostics(RecordingTailDiagnosticSnapshot diagnostic)
+    {
+        if (!_settings.Current.InternalParakeetTailDiagnosticsEnabled ||
+            !ParakeetTailHelper.IsParakeetModel(diagnostic.ModelId))
+            return;
+
+        var payload = new
+        {
+            model_id = diagnostic.ModelId,
+            engine_type = diagnostic.EngineType,
+            stop_requested_at_utc = diagnostic.StopRequestedAtUtc.ToString("o"),
+            recording_duration_seconds = diagnostic.RecordingDurationSeconds,
+            sample_count = diagnostic.SampleCount,
+            last_samples_available_utc = diagnostic.LastSamplesAvailableUtc?.ToString("o"),
+            silence_auto_stop_enabled = diagnostic.SilenceAutoStopEnabled,
+            vad_flushed_segments = diagnostic.VadFlushedSegmentCount,
+            vad_discarded_short_segments = diagnostic.VadDiscardedShortSegmentCount,
+            last_vad_segment_length = diagnostic.LastVadSegmentLength,
+            vad_contended_on_stop = diagnostic.VadWasContendedOnStop,
+            tail_guard_applied = diagnostic.TailGuardApplied,
+            tail_samples_added = diagnostic.TailSamplesAdded,
+            final_text_source = diagnostic.FinalTextSource,
+            full_decode_text_length = diagnostic.FullDecodeTextLength,
+            partial_text_length = diagnostic.PartialTextLength,
+            diverged_from_partials = diagnostic.DivergedFromPartials,
+            full_decode_duration_ms = diagnostic.FullDecodeDurationMs,
+            compare_decode_text_length = diagnostic.CompareDecodeTextLength,
+            compare_decode_duration_ms = diagnostic.CompareDecodeDurationMs,
+            recent_chunks = diagnostic.RecentChunks.Select(chunk => new
+            {
+                timestamp_utc = chunk.TimestampUtc.ToString("o"),
+                peak = chunk.Peak,
+                rms = chunk.Rms,
+                pre_gain_rms = chunk.PreGainRms,
+                sample_count = chunk.SampleCount
+            })
+        };
+
+        _errorLog.AddEntry(JsonSerializer.Serialize(payload), "parakeet-tail");
+    }
+
     private sealed record TranscriptionJob(
         float[] Samples,
+        float[] OriginalSamples,
         List<string> PartialSegments,
         Workflow? ActiveWorkflow,
         IntPtr CapturedWindowHandle,
@@ -1380,7 +1552,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         string? ActiveModelIdAtCapture,
         Guid? ApiSessionId,
         string? TrustedLiveText,
-        bool TranscribeShortQuietClipsAggressively);
+        bool TranscribeShortQuietClipsAggressively,
+        RecordingTailDiagnosticSnapshot Diagnostic);
 }
 
 internal enum ShortSpeechDecision
@@ -1636,6 +1809,29 @@ internal static class DictationShortSpeechPolicy
         return paddedSamples;
     }
 }
+
+internal sealed record RecordingTailDiagnosticSnapshot(
+    string? ModelId,
+    string EngineType,
+    DateTime StopRequestedAtUtc,
+    double RecordingDurationSeconds,
+    int SampleCount,
+    DateTime? LastSamplesAvailableUtc,
+    IReadOnlyList<AudioChunkTelemetry> RecentChunks,
+    bool SilenceAutoStopEnabled,
+    int VadFlushedSegmentCount,
+    int VadDiscardedShortSegmentCount,
+    int LastVadSegmentLength,
+    bool VadWasContendedOnStop,
+    bool TailGuardApplied,
+    int TailSamplesAdded,
+    string? FinalTextSource,
+    int? FullDecodeTextLength,
+    int? PartialTextLength,
+    bool? DivergedFromPartials,
+    long? FullDecodeDurationMs,
+    int? CompareDecodeTextLength,
+    long? CompareDecodeDurationMs);
 
 public enum DictationState
 {

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -379,3 +379,58 @@ public class StreamingTranscriptStateTests
         Assert.Equal("Fresh session text", currentDisplay);
     }
 }
+
+public class ParakeetTailHelperTests
+{
+    [Fact]
+    public void AppendTailGuard_AddsExpectedSilenceSamples()
+    {
+        var samples = new float[] { 0.1f, -0.2f, 0.3f };
+
+        var guarded = ParakeetTailHelper.AppendTailGuard(samples);
+
+        Assert.Equal(samples.Length + 3200, guarded.Length);
+        Assert.Equal(samples[0], guarded[0]);
+        Assert.Equal(samples[1], guarded[1]);
+        Assert.Equal(samples[2], guarded[2]);
+        Assert.All(guarded.Skip(samples.Length), sample => Assert.Equal(0f, sample));
+    }
+
+    [Fact]
+    public void SelectResult_ForParakeet_PrefersFullDecodeOverPartials()
+    {
+        var selection = ParakeetTailHelper.SelectResult(
+            ParakeetTailHelper.ParakeetModelId,
+            "final full decode",
+            ["partial text"]);
+
+        Assert.Equal("final full decode", selection.Text);
+        Assert.Equal("full_decode", selection.Source);
+        Assert.True(selection.DivergedFromPartials);
+    }
+
+    [Fact]
+    public void SelectResult_ForParakeet_FallsBackToPartialsWhenFullDecodeIsEmpty()
+    {
+        var selection = ParakeetTailHelper.SelectResult(
+            ParakeetTailHelper.ParakeetModelId,
+            "",
+            ["tail segment"]);
+
+        Assert.Equal("tail segment", selection.Text);
+        Assert.Equal("fallback_partials_after_empty_full_decode", selection.Source);
+        Assert.False(selection.DivergedFromPartials);
+    }
+
+    [Fact]
+    public void SelectResult_ForNonParakeet_KeepsExistingPartialPreference()
+    {
+        var selection = ParakeetTailHelper.SelectResult(
+            "plugin:other:model",
+            "full decode",
+            ["partial text"]);
+
+        Assert.Equal("partial text", selection.Text);
+        Assert.Equal("partials", selection.Source);
+    }
+}


### PR DESCRIPTION
## Summary
- Add curated release notes for v0.7.2.
- Harden Parakeet tail handling with optional tail guard padding and diagnostic logging.
- Preserve original recording audio for history while using padded samples for final transcription.
- Add coverage for Parakeet tail result selection and tail guard behavior.

## Validation
- `dotnet restore TypeWhisper.slnx`
- `dotnet build TypeWhisper.slnx -c Release --no-restore -p:Version=0.7.2`
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-build`
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release --no-build`