### PR TITLE
fix: enable touch scroll on all ScrollViewer controls

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml
+++ b/src/TypeWhisper.Windows/App.xaml
@@ -30,6 +30,11 @@
                 <Setter Property="FontSize" Value="12"/>
             </Style>
 
+            <Style TargetType="ScrollViewer">
+                <Setter Property="PanningMode" Value="VerticalFirst"/>
+                <Setter Property="PanningDeceleration" Value="15"/>
+            </Style>
+
             <!-- Accent color -->
             <SolidColorBrush x:Key="AccentBrush" Color="#0078D4"/>
             <SolidColorBrush x:Key="AccentHoverBrush" Color="#198EE8"/>

--- a/src/TypeWhisper.Windows/App.xaml
+++ b/src/TypeWhisper.Windows/App.xaml
@@ -30,10 +30,11 @@
                 <Setter Property="FontSize" Value="12"/>
             </Style>
 
-            <Style TargetType="ScrollViewer">
+            <Style x:Key="TouchScrollViewerStyle" TargetType="ScrollViewer">
                 <Setter Property="PanningMode" Value="VerticalFirst"/>
                 <Setter Property="PanningDeceleration" Value="15"/>
             </Style>
+            <Style TargetType="ScrollViewer" BasedOn="{StaticResource TouchScrollViewerStyle}"/>
 
             <!-- Accent color -->
             <SolidColorBrush x:Key="AccentBrush" Color="#0078D4"/>

--- a/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
@@ -348,7 +348,7 @@
                     <Style TargetType="ScrollBar" BasedOn="{StaticResource SettingsScrollBarStyle}"/>
                 </ScrollViewer.Resources>
                 <ScrollViewer.Style>
-                    <Style TargetType="ScrollViewer">
+                    <Style TargetType="ScrollViewer" BasedOn="{StaticResource TouchScrollViewerStyle}">
                         <Setter Property="Visibility" Value="Visible"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Dictionary.SelectedTab}" Value="3">
@@ -613,7 +613,7 @@
                     <Style TargetType="ScrollBar" BasedOn="{StaticResource SettingsScrollBarStyle}"/>
                 </ScrollViewer.Resources>
                 <ScrollViewer.Style>
-                    <Style TargetType="ScrollViewer">
+                    <Style TargetType="ScrollViewer" BasedOn="{StaticResource TouchScrollViewerStyle}">
                         <Setter Property="Visibility" Value="Collapsed"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Dictionary.SelectedTab}" Value="3">

--- a/tests/TypeWhisper.PluginSystem.Tests/ScrollViewerTouchStyleTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ScrollViewerTouchStyleTests.cs
@@ -1,0 +1,63 @@
+using System.IO;
+using System.Xml.Linq;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class ScrollViewerTouchStyleTests
+{
+    private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+    private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    [Fact]
+    public void AppDefinesReusableTouchScrollViewerStyleAndGlobalDefault()
+    {
+        var app = XDocument.Load(ProjectFile("src", "TypeWhisper.Windows", "App.xaml"));
+        var scrollViewerStyles = app
+            .Descendants(Presentation + "Style")
+            .Where(IsScrollViewerStyle)
+            .ToList();
+
+        var touchStyle = Assert.Single(scrollViewerStyles, style => (string?)style.Attribute(Xaml + "Key") == "TouchScrollViewerStyle");
+        Assert.Contains(touchStyle.Elements(Presentation + "Setter"), setter => IsSetter(setter, "PanningMode", "VerticalFirst"));
+        Assert.Contains(touchStyle.Elements(Presentation + "Setter"), setter => IsSetter(setter, "PanningDeceleration", "15"));
+
+        var implicitStyle = Assert.Single(scrollViewerStyles, style => style.Attribute(Xaml + "Key") is null);
+        Assert.Equal("{StaticResource TouchScrollViewerStyle}", (string?)implicitStyle.Attribute("BasedOn"));
+    }
+
+    [Fact]
+    public void LocalDictionaryScrollViewerStylesInheritTouchPanningStyle()
+    {
+        var dictionarySection = XDocument.Load(ProjectFile("src", "TypeWhisper.Windows", "Views", "Sections", "DictionarySection.xaml"));
+        var localScrollViewerStyles = dictionarySection
+            .Descendants(Presentation + "ScrollViewer.Style")
+            .SelectMany(styleProperty => styleProperty.Elements(Presentation + "Style"))
+            .Where(IsScrollViewerStyle)
+            .ToList();
+
+        Assert.Equal(2, localScrollViewerStyles.Count);
+        Assert.All(localScrollViewerStyles, style =>
+            Assert.Equal("{StaticResource TouchScrollViewerStyle}", (string?)style.Attribute("BasedOn")));
+    }
+
+    private static bool IsScrollViewerStyle(XElement style)
+    {
+        return (string?)style.Attribute("TargetType") == "ScrollViewer";
+    }
+
+    private static bool IsSetter(XElement setter, string property, string value)
+    {
+        return (string?)setter.Attribute("Property") == property
+            && (string?)setter.Attribute("Value") == value;
+    }
+
+    private static string ProjectFile(params string[] parts)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TypeWhisper.slnx")))
+            directory = directory.Parent;
+
+        Assert.NotNull(directory);
+        return Path.Combine([directory.FullName, .. parts]);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/ScrollViewerTouchStyleTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ScrollViewerTouchStyleTests.cs
@@ -54,10 +54,10 @@ public class ScrollViewerTouchStyleTests
     private static string ProjectFile(params string[] parts)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TypeWhisper.slnx")))
+        while (directory is not null && !File.Exists(Path.Join(directory.FullName, "TypeWhisper.slnx")))
             directory = directory.Parent;
 
         Assert.NotNull(directory);
-        return Path.Combine([directory.FullName, .. parts]);
+        return Path.Join([directory.FullName, .. parts]);
     }
 }


### PR DESCRIPTION
## Summary

Enables finger scrolling on touch devices

## Test Plan

- [x] `dotnet test`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

## Notes

**Original behaviour**

https://github.com/user-attachments/assets/9328e7d1-a968-4bd9-a5aa-453e1599a6f5

**New behaviour**

https://github.com/user-attachments/assets/32320205-ecf4-4c40-a91f-638be53d1eb2

https://github.com/user-attachments/assets/f3f2c0f2-9e53-4724-a67c-7248743554fb

