### PR TITLE
Fix marketplace plugin uninstall state

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
@@ -38,7 +38,11 @@ public partial class PluginsViewModel : ObservableObject
         _pluginManager = pluginManager;
         _registryService = registryService;
         _pluginManager.PluginStateChanged += (_, _) =>
-            Application.Current.Dispatcher.Invoke(RefreshPlugins);
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                RefreshPlugins();
+                RefreshMarketplaceInstallStates();
+            });
         Loc.Instance.LanguageChanged += OnLanguageChanged;
         RefreshPlugins();
         _ = RefreshRegistryAsync();
@@ -60,6 +64,12 @@ public partial class PluginsViewModel : ObservableObject
         }
 
         NotifyStateChanged();
+    }
+
+    private void RefreshMarketplaceInstallStates()
+    {
+        foreach (var plugin in RegistryPlugins)
+            plugin.RefreshInstallState();
     }
 
     [RelayCommand]

--- a/src/TypeWhisper.Windows/ViewModels/RegistryPluginItemViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/RegistryPluginItemViewModel.cs
@@ -37,6 +37,11 @@ public partial class RegistryPluginItemViewModel : ObservableObject
         _installState = registryService.GetInstallState(registryPlugin);
     }
 
+    internal void RefreshInstallState()
+    {
+        InstallState = _registryService.GetInstallState(_registryPlugin);
+    }
+
     [RelayCommand]
     private async Task InstallAsync()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -5,7 +5,10 @@ using Moq;
 using Moq.Protected;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
 using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.ViewModels;
 
 namespace TypeWhisper.PluginSystem.Tests;
 
@@ -149,6 +152,49 @@ public class PluginRegistryServiceTests : IDisposable
         };
 
         Assert.Equal(PluginInstallState.NotInstalled, service.GetInstallState(registryPlugin));
+    }
+
+    [Fact]
+    public async Task RegistryPluginItem_RefreshInstallState_ReflectsUninstalledPlugin()
+    {
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object);
+        var registryPlugin = new RegistryPlugin
+        {
+            Id = "com.test.plugin",
+            Name = "Test Plugin",
+            Version = "1.0.0",
+            Author = "A",
+            Description = "D",
+            Size = 100,
+            DownloadUrl = "u"
+        };
+
+        var plugin = new Mock<ITypeWhisperPlugin>();
+        plugin.Setup(p => p.PluginId).Returns(registryPlugin.Id);
+        plugin.Setup(p => p.PluginName).Returns(registryPlugin.Name);
+        plugin.Setup(p => p.PluginVersion).Returns(registryPlugin.Version);
+        plugin.Setup(p => p.DeactivateAsync()).Returns(Task.CompletedTask);
+
+        var manifest = new PluginManifest
+        {
+            Id = registryPlugin.Id,
+            Name = registryPlugin.Name,
+            Version = registryPlugin.Version,
+            AssemblyName = "TestPlugin.dll",
+            PluginClass = "TestPlugin"
+        };
+        var loadContext = new PluginAssemblyLoadContext(typeof(PluginRegistryServiceTests).Assembly.Location);
+        var loadedPlugin = new LoadedPlugin(manifest, plugin.Object, loadContext, AppContext.BaseDirectory);
+        TestPluginManagerFactory.SetPrivateField(manager, "_allPlugins", new List<LoadedPlugin> { loadedPlugin });
+
+        var item = new RegistryPluginItemViewModel(registryPlugin, service);
+        Assert.Equal(PluginInstallState.Installed, item.InstallState);
+
+        await manager.UnloadPluginAsync(registryPlugin.Id);
+        item.RefreshInstallState();
+
+        Assert.Equal(PluginInstallState.NotInstalled, item.InstallState);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Refresh existing marketplace plugin items when plugin state changes.
- Add an install-state refresh method for registry plugin items.
- Cover uninstall-state synchronization with a regression test.

## Root Cause
Marketplace plugin rows cached their install state when the registry item view models were created. Uninstalling a plugin from the installed plugin list updated the loaded plugin collection, but existing marketplace rows were not asked to recompute their install state.

## Test Plan
- dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj