### PR TITLE
Fix live transcript no-speech dismissal

### DIFF
--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -51,6 +51,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _subscriptions.Add(host.EventBus.Subscribe<RecordingStoppedEvent>(OnRecordingStopped));
         _subscriptions.Add(host.EventBus.Subscribe<PartialTranscriptionUpdateEvent>(OnPartialTranscriptionUpdate));
         _subscriptions.Add(host.EventBus.Subscribe<TranscriptionCompletedEvent>(OnTranscriptionCompleted));
+        _subscriptions.Add(host.EventBus.Subscribe<TranscriptionFailedEvent>(OnTranscriptionFailed));
 
         host.Log(PluginLogLevel.Info, "Live Transcript plugin activated");
         return Task.CompletedTask;
@@ -151,6 +152,20 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
                 // Cancelled — a new recording started before auto-hide
             }
         }, token);
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnTranscriptionFailed(TranscriptionFailedEvent evt)
+    {
+        _autoHideCts?.Cancel();
+        _autoHideCts?.Dispose();
+        _autoHideCts = null;
+
+        Application.Current?.Dispatcher.InvokeAsync(() =>
+        {
+            _window?.Hide();
+        });
 
         return Task.CompletedTask;
     }

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -551,6 +551,16 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _activeApiDictationSessionId = null;
     }
 
+    private void PublishNoSpeechFailure(string? modelId, string? appName)
+    {
+        _eventBus.Publish(new TranscriptionFailedEvent
+        {
+            ErrorMessage = Loc.Instance["Status.NoSpeech"],
+            ModelId = modelId,
+            AppName = appName
+        });
+    }
+
     private void ShowTransientFeedback(string text, bool isError)
     {
         FeedbackText = text;
@@ -838,6 +848,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             if (shortSpeechDecision == ShortSpeechDecision.DiscardNoSpeech)
             {
                 FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.NoSpeech"]);
+                PublishNoSpeechFailure(_modelManager.ActiveModelId, _capturedWindowTitle);
                 ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]);
                 return;
             }
@@ -1020,6 +1031,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                             job.TranscribeShortQuietClipsAggressively))
                     {
                         FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
+                        PublishNoSpeechFailure(job.ActiveModelIdAtCapture, job.CapturedWindowTitle);
                         await Application.Current.Dispatcher.InvokeAsync(() =>
                             ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));
                         return;
@@ -1043,6 +1055,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             if (string.IsNullOrWhiteSpace(rawText))
             {
                 FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
+                PublishNoSpeechFailure(job.ActiveModelIdAtCapture, job.CapturedWindowTitle);
                 LogParakeetTailDiagnostics(job.Diagnostic);
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                     ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]));

--- a/tests/TypeWhisper.PluginSystem.Tests/LiveTranscriptPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/LiveTranscriptPluginTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Threading;
+using TypeWhisper.Plugin.LiveTranscript;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class LiveTranscriptPluginTests
+{
+    [Fact]
+    public void TranscriptionFailure_HidesProcessingWindow()
+    {
+        RunOnStaThread(() =>
+        {
+            var appCreated = Application.Current is null;
+            var app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            var eventBus = new TestPluginEventBus();
+            var host = new TestPluginHostServices(eventBus);
+            var plugin = new LiveTranscriptPlugin();
+
+            try
+            {
+                plugin.ActivateAsync(host).GetAwaiter().GetResult();
+
+                eventBus.Publish(new RecordingStartedEvent());
+                PumpDispatcher();
+
+                var window = GetWindow(plugin);
+                Assert.NotNull(window);
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new RecordingStoppedEvent());
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...\nProcessing...", window.CurrentText);
+
+                eventBus.Publish(new TranscriptionFailedEvent { ErrorMessage = "No speech detected" });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+            }
+            finally
+            {
+                plugin.DeactivateAsync().GetAwaiter().GetResult();
+                PumpDispatcher();
+                if (appCreated)
+                    app.Shutdown();
+            }
+        });
+    }
+
+    private static LiveTranscriptWindow? GetWindow(LiveTranscriptPlugin plugin)
+    {
+        var field = typeof(LiveTranscriptPlugin).GetField(
+            "_window",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        return (LiveTranscriptWindow?)field?.GetValue(plugin);
+    }
+
+    private static void RunOnStaThread(Action action)
+    {
+        Exception? exception = null;
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(
+                new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher));
+
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            finally
+            {
+                Dispatcher.CurrentDispatcher.InvokeShutdown();
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (exception is not null)
+            throw exception;
+    }
+
+    private static void PumpDispatcher()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.Background,
+            new DispatcherOperationCallback(_ =>
+            {
+                frame.Continue = false;
+                return null;
+            }),
+            null);
+        Dispatcher.PushFrame(frame);
+    }
+
+    private sealed class TestPluginHostServices(IPluginEventBus eventBus) : IPluginHostServices
+    {
+        private readonly Dictionary<string, JsonElement> _settings = [];
+
+        public Task StoreSecretAsync(string key, string value) => Task.CompletedTask;
+        public Task<string?> LoadSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value)
+                ? value.Deserialize<T>()
+                : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = eventBus;
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() { }
+        public IPluginLocalization Localization { get; } = new TestPluginLocalization();
+    }
+
+    private sealed class TestPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TestPluginEventBus : IPluginEventBus
+    {
+        private readonly ConcurrentDictionary<Type, List<Func<PluginEvent, Task>>> _handlers = new();
+
+        public void Publish<T>(T pluginEvent) where T : PluginEvent
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var handlers))
+                return;
+
+            foreach (var handler in handlers.ToArray())
+                handler(pluginEvent).GetAwaiter().GetResult();
+        }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent
+        {
+            Func<PluginEvent, Task> wrapped = pluginEvent => handler((T)pluginEvent);
+            var handlers = _handlers.GetOrAdd(typeof(T), _ => []);
+            lock (handlers)
+            {
+                handlers.Add(wrapped);
+            }
+
+            return new Subscription(() =>
+            {
+                lock (handlers)
+                {
+                    handlers.Remove(wrapped);
+                }
+            });
+        }
+    }
+
+    private sealed class Subscription(Action unsubscribe) : IDisposable
+    {
+        public void Dispose() => unsubscribe();
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenAi\TypeWhisper.Plugin.OpenAi.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Windows\TypeWhisper.Windows.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Publish a transcription failure event when dictation resolves to no speech.
- Hide the Live Transcript floating window when transcription fails.
- Add a regression test for the start, stop, processing, failure-hide flow.

## Root Cause
The Live Transcript plugin appended `Processing...` after recording stopped, but no-speech paths did not publish either a completion or failure event, so the plugin never received a terminal signal.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- Manual verification: start recording, say nothing, stop recording, and confirm the Live Transcript bubble disappears after the no-speech result.

Fixes #110