### PR TITLE
Fix live preview text size updates

### DIFF
--- a/src/TypeWhisper.Windows/Controls/Overlay/DictationOverlayView.xaml.cs
+++ b/src/TypeWhisper.Windows/Controls/Overlay/DictationOverlayView.xaml.cs
@@ -16,6 +16,7 @@ public partial class DictationOverlayView : UserControl
     private const string ShowBuiltInPartialPreviewProperty = "ShowBuiltInPartialPreview";
     private const string PartialTextProperty = "PartialText";
     private const string OverlayPositionProperty = "OverlayPosition";
+    private const string LiveTranscriptionFontSizeProperty = "LiveTranscriptionFontSize";
 
     private INotifyPropertyChanged? _observableDataContext;
     private bool _partialPreviewUpdateQueued;
@@ -93,7 +94,8 @@ public partial class DictationOverlayView : UserControl
             or ""
             or ShowBuiltInPartialPreviewProperty
             or PartialTextProperty
-            or OverlayPositionProperty)
+            or OverlayPositionProperty
+            or LiveTranscriptionFontSizeProperty)
         {
             var propertyChanged = e.PropertyName is null or "";
             QueuePartialPreviewUpdate(

--- a/src/TypeWhisper.Windows/Controls/Overlay/EdgeDockIndicatorView.xaml.cs
+++ b/src/TypeWhisper.Windows/Controls/Overlay/EdgeDockIndicatorView.xaml.cs
@@ -17,6 +17,7 @@ public partial class EdgeDockIndicatorView : UserControl
     private const string ShowBuiltInPartialPreviewProperty = "ShowBuiltInPartialPreview";
     private const string PartialTextProperty = "PartialText";
     private const string OverlayPositionProperty = "OverlayPosition";
+    private const string LiveTranscriptionFontSizeProperty = "LiveTranscriptionFontSize";
 
     private bool _isPartialPreviewScrollPending;
     private INotifyPropertyChanged? _observableDataContext;
@@ -107,7 +108,8 @@ public partial class EdgeDockIndicatorView : UserControl
             or ""
             or ShowBuiltInPartialPreviewProperty
             or PartialTextProperty
-            or OverlayPositionProperty)
+            or OverlayPositionProperty
+            or LiveTranscriptionFontSizeProperty)
         {
             var propertyChanged = e.PropertyName is null or "";
             QueuePartialPreviewUpdate(

--- a/tests/TypeWhisper.PluginSystem.Tests/EdgeDockLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/EdgeDockLayoutTests.cs
@@ -54,6 +54,8 @@ public sealed class EdgeDockLayoutTests
         Assert.Contains("BeginAnimation(FrameworkElement.HeightProperty", codeBehind);
         Assert.Contains("AnimatePartialText", codeBehind);
         Assert.Contains("PartialPreviewScrollViewer.ScrollToEnd", codeBehind);
+        Assert.Contains("LiveTranscriptionFontSizeProperty = \"LiveTranscriptionFontSize\"", codeBehind);
+        Assert.Contains("or LiveTranscriptionFontSizeProperty", codeBehind);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/StatusIslandLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StatusIslandLayoutTests.cs
@@ -95,6 +95,8 @@ public sealed class StatusIslandLayoutTests
         Assert.Contains("\"ShowBuiltInPartialPreview\"", codeBehind);
         Assert.Contains("\"PartialText\"", codeBehind);
         Assert.Contains("\"OverlayPosition\"", codeBehind);
+        Assert.Contains("LiveTranscriptionFontSizeProperty = \"LiveTranscriptionFontSize\"", codeBehind);
+        Assert.Contains("or LiveTranscriptionFontSizeProperty", codeBehind);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Recalculate the built-in live preview bubble layout when the live transcription font size changes.
- Apply the same behavior to Status Island and Edge Dock preview variants.
- Add regression coverage so both overlay controls keep listening for live text size updates.

## Root cause
The live preview text was already bound to the saved font size setting, but the overlay code-behind only recalculated the animated partial-preview height for text, visibility, and position changes. A font size change could therefore leave the preview measured with the previous size.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~StatusIslandLayoutTests|FullyQualifiedName~EdgeDockLayoutTests|FullyQualifiedName~AppearanceSectionLayoutTests|FullyQualifiedName~SettingsViewModelIndicatorTests"`
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj --filter "FullyQualifiedName~SettingsServiceTests|FullyQualifiedName~AppSettingsTests"`

Fixes #107