### PR TITLE
Localize dictionary usage count

### DIFF
--- a/src/TypeWhisper.Windows/Converters/ValueConverters.cs
+++ b/src/TypeWhisper.Windows/Converters/ValueConverters.cs
@@ -30,6 +30,27 @@ public sealed class AudioLevelWidthConverter : IMultiValueConverter
         => throw new NotSupportedException();
 }
 
+public sealed class LocalizedFormatConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 0 || values[0] is not string template || string.IsNullOrEmpty(template))
+            return "";
+
+        try
+        {
+            return string.Format(culture, template, values[1..]);
+        }
+        catch (FormatException)
+        {
+            return template;
+        }
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
 /// <summary>
 /// Converts audio level (0..1 float) into a subtle scale factor for live overlay motion.
 /// </summary>

--- a/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
@@ -11,6 +11,7 @@
             </ResourceDictionary.MergedDictionaries>
             <converters:BoolToVisibilityConverter x:Key="BoolToVis"/>
             <converters:InverseBoolToVisibilityConverter x:Key="InverseBoolToVis"/>
+            <converters:LocalizedFormatConverter x:Key="LocalizedFormat"/>
 
             <!-- Small icon button -->
             <Style x:Key="IconButtonStyle" TargetType="Button">
@@ -569,7 +570,12 @@
                                                                 </Style.Triggers>
                                                             </Style>
                                                         </TextBlock.Style>
-                                                        <Run Text="{Binding UsageCount, StringFormat='{}{0}x verwendet', Mode=OneWay}"/>
+                                                        <TextBlock.Text>
+                                                            <MultiBinding Converter="{StaticResource LocalizedFormat}">
+                                                                <Binding Source="{x:Static loc:Loc.Instance}" Path="[Dictionary.UsageCount]"/>
+                                                                <Binding Path="UsageCount"/>
+                                                            </MultiBinding>
+                                                        </TextBlock.Text>
                                                     </TextBlock>
                                                 </StackPanel>
 

--- a/tests/TypeWhisper.PluginSystem.Tests/LocalizedFormatConverterTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/LocalizedFormatConverterTests.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using TypeWhisper.Windows.Converters;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class LocalizedFormatConverterTests
+{
+    [Fact]
+    public void Convert_EnglishUsageTemplate_FormatsCount()
+    {
+        var converter = new LocalizedFormatConverter();
+
+        var result = converter.Convert(["{0}x used", 2], typeof(string), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal("2x used", result);
+    }
+
+    [Fact]
+    public void Convert_JapaneseUsageTemplate_FormatsCount()
+    {
+        var converter = new LocalizedFormatConverter();
+
+        var result = converter.Convert(["{0}回使用", 2], typeof(string), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal("2回使用", result);
+    }
+
+    [Fact]
+    public void Convert_InvalidTemplate_ReturnsTemplate()
+    {
+        var converter = new LocalizedFormatConverter();
+
+        var result = converter.Convert(["{0}x {1}", 2], typeof(string), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal("{0}x {1}", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Convert_MissingTemplate_ReturnsEmptyString(string? template)
+    {
+        var converter = new LocalizedFormatConverter();
+
+        var result = converter.Convert([template!, 2], typeof(string), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal("", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the hard-coded German dictionary usage count label with the existing localized `Dictionary.UsageCount` string.
- Add a reusable localized format converter for WPF multi-bindings.
- Cover English, Japanese, invalid-template, and missing-template formatting behavior with tests.

## Root Cause
The dictionary settings view had a hard-coded `StringFormat` value of `{0}x verwendet`, even though localized strings already existed for the usage-count label.

## Test Plan
- `dotnet test TypeWhisper.slnx --no-restore`

Closes #106