### PR TITLE
Fix dictation ellipsis cleanup

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -1583,6 +1584,7 @@ internal static class DictationFinalTextPolicy
     private const int MinimumRepeatedPhraseWords = 5;
     private const int MinimumRepeatedPhraseCharacters = 20;
     private const int MaximumRepeatReductionPasses = 8;
+    private static readonly Regex AutomaticEllipsisRegex = new(@"\s*(?:\.{3,}|\u2026)\s*", RegexOptions.CultureInvariant);
 
     public static string JoinPreviewSegments(IReadOnlyList<string> previewSegments) =>
         string.Join(" ", previewSegments.Where(segment => !string.IsNullOrWhiteSpace(segment))).Trim();
@@ -1602,7 +1604,7 @@ internal static class DictationFinalTextPolicy
     }
 
     public static string SelectRawText(string? finalText) =>
-        ReduceAdjacentRepeatedPhrases(finalText?.Trim() ?? "");
+        NormalizeDictationArtifacts(finalText?.Trim() ?? "");
 
     public static string? SelectTrustedLiveText(string? liveText)
     {
@@ -1614,9 +1616,17 @@ internal static class DictationFinalTextPolicy
     {
         var trusted = SelectTrustedLiveText(trustedLiveText);
         return trusted is not null
-            ? ReduceAdjacentRepeatedPhrases(trusted)
+            ? NormalizeDictationArtifacts(trusted)
             : SelectRawText(finalText);
     }
+
+    private static string NormalizeDictationArtifacts(string text) =>
+        RemoveAutomaticEllipses(ReduceAdjacentRepeatedPhrases(text));
+
+    private static string RemoveAutomaticEllipses(string text) =>
+        string.IsNullOrWhiteSpace(text)
+            ? ""
+            : AutomaticEllipsisRegex.Replace(text, " ").Trim();
 
     private static string ReduceAdjacentRepeatedPhrases(string text)
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
@@ -167,6 +167,49 @@ public class DictationFinalTextPolicyTests
     }
 
     [Fact]
+    public void SelectRawText_RemovesAsciiEllipsisBetweenWords()
+    {
+        var result = DictationFinalTextPolicy.SelectRawText("Dictated words should only... end up once.");
+
+        Assert.Equal("Dictated words should only end up once.", result);
+    }
+
+    [Fact]
+    public void SelectRawText_RemovesUnicodeEllipsisBetweenWords()
+    {
+        var result = DictationFinalTextPolicy.SelectRawText("Pause\u2026 then continue.");
+
+        Assert.Equal("Pause then continue.", result);
+    }
+
+    [Fact]
+    public void SelectRawText_RemovesTerminalEllipsis()
+    {
+        var result = DictationFinalTextPolicy.SelectRawText("Please wait...");
+
+        Assert.Equal("Please wait", result);
+    }
+
+    [Fact]
+    public void SelectRawText_RemovesTrustedLiveTextEllipsis()
+    {
+        var result = DictationFinalTextPolicy.SelectRawText(
+            "fallback text",
+            "Dictated words should only... end up once.");
+
+        Assert.Equal("Dictated words should only end up once.", result);
+    }
+
+    [Fact]
+    public void SelectRawText_RepeatedPhraseReductionStillRuns()
+    {
+        var result = DictationFinalTextPolicy.SelectRawText(
+            "Please send the updated draft tomorrow morning. Please send the updated draft tomorrow morning. Thanks.");
+
+        Assert.Equal("Please send the updated draft tomorrow morning. Thanks.", result);
+    }
+
+    [Fact]
     public void SelectRawText_WhitespaceOnlyReturnsEmptyText()
     {
         var result = DictationFinalTextPolicy.SelectRawText("   ");


### PR DESCRIPTION
## Summary
- Remove automatic ellipsis artifacts from final dictation text while preserving the existing repeated-phrase cleanup.
- Apply the cleanup to both full decode text and trusted live dictation text.
- Add regression coverage for ASCII ellipses, Unicode ellipses, terminal ellipses, and trusted live text.

## Root Cause
Groq Whisper Large V3 Turbo can sometimes emit `...` during short pauses. The dictation flow can accept trusted live text from the polling preview path as final text, so the artifact needed to be normalized in the dictation final text policy.

## Test Plan
- `dotnet test TypeWhisper.slnx`

Fixes #109