### PR TITLE
Reduce short repeated transcription phrases

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1580,8 +1580,8 @@ internal enum ShortSpeechDecision
 internal static class DictationFinalTextPolicy
 {
     private const float NoSpeechProbabilityThreshold = 0.8f;
-    private const int MinimumRepeatedPhraseWords = 5;
-    private const int MinimumRepeatedPhraseCharacters = 20;
+    private const int MinimumRepeatedPhraseWords = 3;
+    private const int MinimumRepeatedPhraseCharacters = 8;
     private const int MaximumRepeatReductionPasses = 8;
 
     public static string JoinPreviewSegments(IReadOnlyList<string> previewSegments) =>

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
@@ -150,6 +150,21 @@ public class DictationFinalTextPolicyTests
     }
 
     [Fact]
+    public void SelectRawText_CollapsesIssue108ShortAdjacentRepeatedPhrase()
+    {
+        const string rawText =
+            "Now go back to the appearance screen. and set the and set the preview text size to the maximum. " +
+            "Dictate more text and note that the size of the preview bubble text is unchanged.";
+        const string expected =
+            "Now go back to the appearance screen. and set the preview text size to the maximum. " +
+            "Dictate more text and note that the size of the preview bubble text is unchanged.";
+
+        var result = DictationFinalTextPolicy.SelectRawText(rawText);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
     public void SelectRawText_CollapsesExactAdjacentRepeatedPhrase()
     {
         var result = DictationFinalTextPolicy.SelectRawText(


### PR DESCRIPTION
## Summary
- Reduce the adjacent repeated phrase threshold so short transcript repeats such as `and set the and set the` are collapsed.
- Add a regression test covering the Issue #108 sample text.
- Keep intentional 1-2 word repeats, such as `Yes yes`, outside the collapse policy.

## Root Cause
The final dictation cleanup only collapsed adjacent repeated phrases at 5+ words and 20+ normalized characters, so shorter exact repeats from transcription output could still reach the final pasted text.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`

Fixes #108