### PR TITLE
Fix plaintext insertion for email clients

### DIFF
--- a/src/TypeWhisper.Core/Services/AppFormatterService.cs
+++ b/src/TypeWhisper.Core/Services/AppFormatterService.cs
@@ -2,7 +2,7 @@ namespace TypeWhisper.Core.Services;
 
 /// <summary>
 /// Formats transcribed text based on the target application.
-/// Maps known processes to output formats (markdown, html, code, plaintext).
+/// Maps known processes to output formats (markdown, code, plaintext).
 /// </summary>
 public static class AppFormatterService
 {
@@ -15,9 +15,9 @@ public static class AppFormatterService
         ["Typora"] = "markdown",
         ["Bear"] = "markdown",
 
-        // HTML apps (email clients)
-        ["OUTLOOK"] = "html",
-        ["Thunderbird"] = "html",
+        // Email clients paste plain text through the current clipboard insertion path.
+        ["OUTLOOK"] = "plaintext",
+        ["Thunderbird"] = "plaintext",
 
         // Code editors
         ["Code"] = "code",          // VS Code
@@ -43,7 +43,6 @@ public static class AppFormatterService
         return format switch
         {
             "markdown" => FormatAsMarkdown(text),
-            "html" => FormatAsHtml(text),
             _ => text // code + plaintext = passthrough
         };
     }
@@ -75,41 +74,5 @@ public static class AppFormatterService
                 continue; // Already markdown list format
         }
         return string.Join('\n', lines);
-    }
-
-    private static string FormatAsHtml(string text)
-    {
-        var lines = text.Split('\n');
-        var result = new System.Text.StringBuilder();
-        var inList = false;
-
-        foreach (var line in lines)
-        {
-            var trimmed = line.TrimStart();
-            var bullet = ExtractBulletContent(trimmed);
-
-            if (bullet is not null)
-            {
-                if (!inList) { result.AppendLine("<ul>"); inList = true; }
-                result.AppendLine($"  <li>{System.Net.WebUtility.HtmlEncode(bullet)}</li>");
-            }
-            else
-            {
-                if (inList) { result.AppendLine("</ul>"); inList = false; }
-                if (!string.IsNullOrWhiteSpace(trimmed))
-                    result.AppendLine($"<p>{System.Net.WebUtility.HtmlEncode(trimmed)}</p>");
-            }
-        }
-
-        if (inList) result.AppendLine("</ul>");
-        return result.ToString().TrimEnd();
-    }
-
-    private static string? ExtractBulletContent(string line)
-    {
-        if (line.StartsWith("- ")) return line[2..];
-        if (line.StartsWith("* ")) return line[2..];
-        if (line.StartsWith("bullet ", StringComparison.OrdinalIgnoreCase)) return line[7..];
-        return null;
     }
 }

--- a/tests/TypeWhisper.Core.Tests/Services/AppFormatterServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/AppFormatterServiceTests.cs
@@ -1,0 +1,40 @@
+using TypeWhisper.Core.Services;
+
+namespace TypeWhisper.Core.Tests.Services;
+
+public class AppFormatterServiceTests
+{
+    [Fact]
+    public void Format_Outlook_ReturnsPlainText()
+    {
+        var result = AppFormatterService.Format("Hello from dictation.", "OUTLOOK");
+
+        Assert.Equal("Hello from dictation.", result);
+    }
+
+    [Fact]
+    public void Format_OutlookBulletText_DoesNotEmitHtmlTags()
+    {
+        var result = AppFormatterService.Format("- one\n- two", "OUTLOOK");
+
+        Assert.Equal("- one\n- two", result);
+        Assert.DoesNotContain("<", result);
+        Assert.DoesNotContain(">", result);
+    }
+
+    [Fact]
+    public void Format_Thunderbird_ReturnsPlainText()
+    {
+        var result = AppFormatterService.Format("Email body text.", "Thunderbird");
+
+        Assert.Equal("Email body text.", result);
+    }
+
+    [Fact]
+    public void Format_MarkdownApp_StillConvertsSpokenBullets()
+    {
+        var result = AppFormatterService.Format("bullet first\nplain line", "Obsidian");
+
+        Assert.Equal("- first\nplain line", result);
+    }
+}

--- a/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
@@ -326,4 +326,20 @@ public class PostProcessingPipelineTests
 
         Assert.Equal("type whisper", result.Text);
     }
+
+    [Fact]
+    public async Task ProcessAsync_OutlookFormatting_DoesNotEmitHtmlTags()
+    {
+        var options = new PipelineOptions
+        {
+            AppFormatter = AppFormatterService.Format,
+            TargetProcessName = "OUTLOOK"
+        };
+
+        var result = await _sut.ProcessAsync("- one\n- two", options);
+
+        Assert.Equal("- one\n- two", result.Text);
+        Assert.DoesNotContain("<", result.Text);
+        Assert.DoesNotContain(">", result.Text);
+    }
 }


### PR DESCRIPTION
## Summary
- Treat Outlook and Thunderbird formatting as plain text for the current clipboard insertion path.
- Remove automatic HTML generation that surfaced visible tags when pasting into Outlook 365.
- Add formatter and pipeline regression coverage for email-client plain text behavior.

Fixes #111.

## Test Plan
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj`