### PR TITLE
Limit Supertonic TTS runtime packaging

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -130,11 +130,19 @@ jobs:
             Write-Host "  Included dependency: $($_.Name)"
           }
 
-          # Copy native runtime directories (e.g. runtimes/win-x64/native/)
+          # Copy only Windows native runtime directories. NuGet packages such as
+          # ONNX Runtime include iOS/Android/macOS/Linux assets that TypeWhisper
+          # cannot use and that would bloat plugin ZIPs substantially.
           $runtimesDir = Join-Path $outputDir 'runtimes'
           if (Test-Path $runtimesDir) {
-            Copy-Item -Path $runtimesDir -Destination "$stagingDir/runtimes" -Recurse
-            Write-Host "  Included native runtimes"
+            New-Item -ItemType Directory -Path "$stagingDir/runtimes" -Force | Out-Null
+            foreach ($runtimeName in @('win-x64', 'win-arm64')) {
+              $runtimeDir = Join-Path $runtimesDir $runtimeName
+              if (Test-Path $runtimeDir) {
+                Copy-Item -Path $runtimeDir -Destination "$stagingDir/runtimes" -Recurse
+                Write-Host "  Included native runtime: $runtimeName"
+              }
+            }
           }
 
           # Create ZIP

--- a/plugins/TypeWhisper.Plugin.SupertonicTts/TypeWhisper.Plugin.SupertonicTts.csproj
+++ b/plugins/TypeWhisper.Plugin.SupertonicTts/TypeWhisper.Plugin.SupertonicTts.csproj
@@ -33,6 +33,7 @@
       <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
       <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.supertonic-tts\</PluginOutputDir>
     </PropertyGroup>
+    <RemoveDir Directories="$(PluginOutputDir)" Condition="Exists('$(PluginOutputDir)')" />
     <MakeDir Directories="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
@@ -47,10 +48,15 @@
     <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
     <Copy SourceFiles="@(_DependencyFiles)" DestinationFolder="$(PluginOutputDir)" />
     <ItemGroup>
-      <RuntimeFile Include="$(TargetDir)runtimes\**\*.*" />
+      <RuntimeFile Include="$(TargetDir)runtimes\win-x64\**\*.*">
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+      </RuntimeFile>
+      <RuntimeFile Include="$(TargetDir)runtimes\win-arm64\**\*.*">
+        <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+      </RuntimeFile>
     </ItemGroup>
     <Copy SourceFiles="@(RuntimeFile)"
-          DestinationFiles="@(RuntimeFile->'$(PluginOutputDir)runtimes\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(RuntimeFile->'$(PluginOutputDir)runtimes\%(RuntimeIdentifier)\%(RecursiveDir)%(Filename)%(Extension)')"
           Condition="'@(RuntimeFile)' != ''" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- Include only Windows native ONNX Runtime assets when publishing plugin ZIPs.
- Clean the local app plugin output before copying Supertonic TTS files so stale non-Windows runtimes are removed.
- Keep the release package small while preserving x64 and ARM64 Windows support.

## Validation
- `dotnet build plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj -c Release`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release --no-restore`
- Local ZIP probe for Supertonic TTS package: 10.42 MB