### PR TITLE
Fix whisper.cpp native runtime packaging

### DIFF
--- a/eng/Copy-WhisperCppMsvcRuntime.ps1
+++ b/eng/Copy-WhisperCppMsvcRuntime.ps1
@@ -1,0 +1,184 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDirectory,
+
+    [string[]]$RuntimeIdentifiers = @("win-x64", "win-arm64"),
+
+    [switch]$Required
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$requiredDlls = @(
+    "msvcp140.dll",
+    "vcruntime140.dll",
+    "vcruntime140_1.dll",
+    "VCOMP140.DLL"
+)
+
+$architectureByRuntime = @{
+    "win-x64" = "x64"
+    "win-arm64" = "arm64"
+}
+
+$normalizedRuntimeIdentifiers = @(
+    $RuntimeIdentifiers |
+        ForEach-Object { $_ -split "[,;]" } |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_.Length -gt 0 } |
+        Select-Object -Unique
+)
+
+function Add-UniquePath {
+    param(
+        [System.Collections.Generic.List[string]]$Paths,
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+
+    try {
+        $resolvedPath = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    }
+    catch {
+        return
+    }
+
+    if (-not $Paths.Contains($resolvedPath)) {
+        [void]$Paths.Add($resolvedPath)
+    }
+}
+
+function Get-VisualStudioInstallPaths {
+    $paths = New-Object "System.Collections.Generic.List[string]"
+    $vswhereCandidates = @(
+        (Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"),
+        (Join-Path $env:ProgramFiles "Microsoft Visual Studio\Installer\vswhere.exe")
+    )
+
+    foreach ($vswhere in $vswhereCandidates) {
+        if (Test-Path -LiteralPath $vswhere) {
+            $installPaths = & $vswhere -all -products * -property installationPath 2>$null
+            foreach ($installPath in $installPaths) {
+                Add-UniquePath -Paths $paths -Path $installPath
+            }
+        }
+    }
+
+    $visualStudioRoots = @(
+        (Join-Path $env:ProgramFiles "Microsoft Visual Studio"),
+        (Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio")
+    )
+
+    foreach ($root in $visualStudioRoots) {
+        if (-not (Test-Path -LiteralPath $root)) {
+            continue
+        }
+
+        foreach ($yearDirectory in Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue) {
+            foreach ($editionDirectory in Get-ChildItem -LiteralPath $yearDirectory.FullName -Directory -ErrorAction SilentlyContinue) {
+                Add-UniquePath -Paths $paths -Path $editionDirectory.FullName
+            }
+        }
+    }
+
+    return $paths.ToArray()
+}
+
+function Convert-ToVersion {
+    param([string]$Value)
+
+    $version = $null
+    if ([Version]::TryParse($Value, [ref]$version)) {
+        return $version
+    }
+
+    return [Version]"0.0"
+}
+
+function Find-RedistFile {
+    param(
+        [string[]]$InstallPaths,
+        [string]$Architecture,
+        [string]$FileName
+    )
+
+    $matches = New-Object "System.Collections.Generic.List[object]"
+
+    foreach ($installPath in $InstallPaths) {
+        $redistRoot = Join-Path $installPath "VC\Redist\MSVC"
+        if (-not (Test-Path -LiteralPath $redistRoot)) {
+            continue
+        }
+
+        foreach ($versionDirectory in Get-ChildItem -LiteralPath $redistRoot -Directory -ErrorAction SilentlyContinue) {
+            $architectureDirectory = Join-Path $versionDirectory.FullName $Architecture
+            if (-not (Test-Path -LiteralPath $architectureDirectory)) {
+                continue
+            }
+
+            foreach ($componentDirectory in Get-ChildItem -LiteralPath $architectureDirectory -Directory -Filter "Microsoft.VC*" -ErrorAction SilentlyContinue) {
+                $candidate = Join-Path $componentDirectory.FullName $FileName
+                if (Test-Path -LiteralPath $candidate) {
+                    [void]$matches.Add([pscustomobject]@{
+                        Path = $candidate
+                        Version = Convert-ToVersion -Value $versionDirectory.Name
+                    })
+                }
+            }
+        }
+    }
+
+    return $matches |
+        Sort-Object -Property @{ Expression = { $_.Version }; Descending = $true }, @{ Expression = { $_.Path }; Descending = $false } |
+        Select-Object -First 1
+}
+
+$installPaths = @(Get-VisualStudioInstallPaths)
+if ($installPaths.Count -eq 0) {
+    $message = "Could not find a Visual Studio installation containing VC redistributable files."
+    if ($Required) {
+        throw $message
+    }
+
+    Write-Warning $message
+    exit 0
+}
+
+$missing = New-Object "System.Collections.Generic.List[string]"
+
+foreach ($runtimeIdentifier in $normalizedRuntimeIdentifiers) {
+    if (-not $architectureByRuntime.ContainsKey($runtimeIdentifier)) {
+        Write-Warning "Skipping unsupported runtime identifier: $runtimeIdentifier"
+        continue
+    }
+
+    $architecture = $architectureByRuntime[$runtimeIdentifier]
+    $runtimeDirectory = Join-Path (Join-Path $OutputDirectory "runtimes") $runtimeIdentifier
+    New-Item -ItemType Directory -Path $runtimeDirectory -Force | Out-Null
+
+    foreach ($dll in $requiredDlls) {
+        $source = Find-RedistFile -InstallPaths $installPaths -Architecture $architecture -FileName $dll
+        if ($null -eq $source) {
+            [void]$missing.Add("$runtimeIdentifier/$dll")
+            continue
+        }
+
+        $destination = Join-Path $runtimeDirectory $dll
+        Copy-Item -LiteralPath $source.Path -Destination $destination -Force
+        Write-Host "Copied $dll for $runtimeIdentifier from $($source.Path)"
+    }
+}
+
+if ($missing.Count -gt 0) {
+    $message = "Missing required MSVC redistributable files: $($missing -join ', ')"
+    if ($Required) {
+        throw $message
+    }
+
+    Write-Warning $message
+}

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/TypeWhisper.Plugin.WhisperCpp.csproj
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/TypeWhisper.Plugin.WhisperCpp.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
     <PackageReference Include="Whisper.net" Version="1.9.0" />
     <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
@@ -27,18 +31,54 @@
       <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.whisper-cpp\</PluginOutputDir>
     </PropertyGroup>
 
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\..\eng\Copy-WhisperCppMsvcRuntime.ps1&quot; -OutputDirectory &quot;$(TargetDir).&quot; -RuntimeIdentifiers win-x64,win-arm64 -Required"
+          Condition="'$(Configuration)' == 'Release'" />
+
     <ItemGroup>
       <_DependencyDlls Include="$(TargetDir)*.dll"
                        Exclude="$(TargetPath);$(TargetDir)TypeWhisper.PluginSDK.dll" />
-      <_RuntimeFiles Include="$(TargetDir)runtimes\**\*" />
+      <_RuntimeFiles Include="$(TargetDir)runtimes\win-x64\**\*.*">
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+      </_RuntimeFiles>
+      <_RuntimeFiles Include="$(TargetDir)runtimes\win-arm64\**\*.*">
+        <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+      </_RuntimeFiles>
     </ItemGroup>
 
+    <RemoveDir Directories="$(PluginOutputDir)" Condition="Exists('$(PluginOutputDir)')" />
     <MakeDir Directories="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="@(_DependencyDlls)" DestinationFolder="$(PluginOutputDir)" SkipUnchangedFiles="true" Condition="'@(_DependencyDlls)' != ''" />
-    <MakeDir Directories="$(PluginOutputDir)runtimes\win-x64\native" Condition="'@(_RuntimeFiles)' != ''" />
-    <Copy SourceFiles="@(_RuntimeFiles)" DestinationFolder="$(PluginOutputDir)runtimes\%(RecursiveDir)" SkipUnchangedFiles="true" Condition="'@(_RuntimeFiles)' != ''" />
+    <Copy SourceFiles="@(_RuntimeFiles)"
+          DestinationFiles="@(_RuntimeFiles->'$(PluginOutputDir)runtimes\%(RuntimeIdentifier)\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_RuntimeFiles)' != ''" />
+
+    <ItemGroup>
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\ggml-base-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\ggml-cpu-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\ggml-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\msvcp140.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\vcruntime140.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\vcruntime140_1.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\VCOMP140.DLL" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\ggml-base-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\ggml-cpu-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\ggml-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\msvcp140.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\vcruntime140.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\vcruntime140_1.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\VCOMP140.DLL" />
+      <_UnexpectedUcrtRuntimeFiles Include="$(PluginOutputDir)runtimes\**\api-ms-win-crt-*.dll" />
+    </ItemGroup>
+
+    <Error Condition="'$(Configuration)' == 'Release' and !Exists('%(_RequiredRuntimeFiles.Identity)')"
+           Text="Missing required whisper.cpp runtime file: %(_RequiredRuntimeFiles.Identity)" />
+    <Error Condition="'$(Configuration)' == 'Release' and '@(_UnexpectedUcrtRuntimeFiles)' != ''"
+           Text="Do not bundle UCRT API-set DLLs with the whisper.cpp plugin: @(_UnexpectedUcrtRuntimeFiles)" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -273,7 +273,12 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         string runtimeIdentifier,
         Exception error)
     {
-        var runtimeDirectory = Path.Combine(pluginDirectory, "runtimes", runtimeIdentifier);
+        var safeRuntimeIdentifier = Path.GetFileName(
+            runtimeIdentifier.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrWhiteSpace(safeRuntimeIdentifier))
+            safeRuntimeIdentifier = runtimeIdentifier;
+
+        var runtimeDirectory = Path.Join(pluginDirectory, "runtimes", safeRuntimeIdentifier);
         const string requiredFiles =
             "whisper.dll, ggml-whisper.dll, ggml-base-whisper.dll, ggml-cpu-whisper.dll, " +
             "msvcp140.dll, vcruntime140.dll, vcruntime140_1.dll, VCOMP140.DLL";

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Controls;
 using TypeWhisper.PluginSDK;
@@ -33,10 +34,11 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     private WhisperFactory? _factory;
     private string? _selectedModelId;
     private string? _loadedModelId;
+    private string? _pluginDirectory;
 
     public string PluginId => "com.typewhisper.whisper-cpp";
     public string PluginName => "whisper.cpp (Local)";
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.1";
 
     public string ProviderId => "whisper-cpp";
     public string ProviderDisplayName => "Local (whisper.cpp)";
@@ -58,6 +60,7 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     public Task ActivateAsync(IPluginHostServices host)
     {
         _host = host;
+        _pluginDirectory = Path.GetDirectoryName(typeof(WhisperCppPlugin).Assembly.Location);
         _selectedModelId = host.GetSetting<string>("selectedModel");
         host.Log(PluginLogLevel.Info, "Activated");
         return Task.CompletedTask;
@@ -67,6 +70,7 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     {
         await UnloadModelAsync();
         _host = null;
+        _pluginDirectory = null;
     }
 
     public UserControl? CreateSettingsView() => null;
@@ -153,7 +157,15 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         try
         {
             DisposeFactoryUnsafe();
-            _factory = WhisperFactory.FromPath(modelPath);
+            try
+            {
+                _factory = WhisperFactory.FromPath(modelPath);
+            }
+            catch (Exception ex) when (IsNativeLoadFailure(ex))
+            {
+                throw CreateNativeLoadFailureException(ex);
+            }
+
             _loadedModelId = modelId;
             _selectedModelId = modelId;
             _host?.SetSetting("selectedModel", modelId);
@@ -254,6 +266,52 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         var host = _host ?? throw new InvalidOperationException("Plugin is not activated.");
         var model = GetModel(modelId);
         return Path.Combine(host.PluginDataDirectory, "Models", model.FileName);
+    }
+
+    internal static string BuildNativeLoadFailureMessage(
+        string pluginDirectory,
+        string runtimeIdentifier,
+        Exception error)
+    {
+        var runtimeDirectory = Path.Combine(pluginDirectory, "runtimes", runtimeIdentifier);
+        const string requiredFiles =
+            "whisper.dll, ggml-whisper.dll, ggml-base-whisper.dll, ggml-cpu-whisper.dll, " +
+            "msvcp140.dll, vcruntime140.dll, vcruntime140_1.dll, VCOMP140.DLL";
+
+        return "Unable to load the whisper.cpp native runtime. " +
+            $"Expected native DLLs under '{runtimeDirectory}', including {requiredFiles}. " +
+            "Reinstall or update the whisper.cpp plugin. If the problem persists, install the " +
+            "Microsoft Visual C++ 2015-2022 Redistributable for your Windows architecture. " +
+            $"Original error: {error.Message}";
+    }
+
+    internal static bool IsNativeLoadFailure(Exception error)
+    {
+        for (var current = error; current is not null; current = current.InnerException)
+        {
+            if (current is DllNotFoundException or BadImageFormatException)
+                return true;
+
+            if (current.Message.Contains("Unable to load DLL", StringComparison.OrdinalIgnoreCase)
+                || current.Message.Contains("0x8007007E", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private InvalidOperationException CreateNativeLoadFailureException(Exception error)
+    {
+        var pluginDirectory = _pluginDirectory
+            ?? Path.GetDirectoryName(typeof(WhisperCppPlugin).Assembly.Location)
+            ?? AppContext.BaseDirectory;
+        var message = BuildNativeLoadFailureMessage(
+            pluginDirectory,
+            RuntimeInformation.RuntimeIdentifier,
+            error);
+        return new InvalidOperationException(message, error);
     }
 
     private void DisposeFactoryUnsafe()

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/manifest.json
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.whisper-cpp",
   "name": "whisper.cpp (Local)",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "TypeWhisper",
   "description": "Offline transcription via whisper.cpp using Whisper.net",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenAi\TypeWhisper.Plugin.OpenAi.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -10,10 +10,14 @@ public class WhisperCppPluginTests
     [Fact]
     public void PluginVersion_MatchesManifestVersion()
     {
-        var manifestPath = Path.GetFullPath(Path.Combine(
+        var repoRoot = Path.GetFullPath(Path.Join(
             AppContext.BaseDirectory,
-            "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.WhisperCpp", "manifest.json"));
+            "..", "..", "..", "..", ".."));
+        var manifestPath = Path.Join(
+            repoRoot,
+            "plugins",
+            "TypeWhisper.Plugin.WhisperCpp",
+            "manifest.json");
         var manifest = JsonSerializer.Deserialize<PluginManifest>(
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
@@ -28,8 +32,8 @@ public class WhisperCppPluginTests
     [Fact]
     public void BuildNativeLoadFailureMessage_NamesRuntimeFolderAndVcRedistFallback()
     {
-        var pluginDirectory = Path.Combine(
-            "C:", "Users", "Sal", "AppData", "Local", "TypeWhisper", "Plugins", "com.typewhisper.whisper-cpp");
+        var pluginDirectory = Path.Join(
+            @"C:\", "Users", "Sal", "AppData", "Local", "TypeWhisper", "Plugins", "com.typewhisper.whisper-cpp");
         var nativeError = new DllNotFoundException(
             "Unable to load DLL 'ggml-cpu-whisper.dll' or one of its dependencies: The specified module could not be found. (0x8007007E)");
 
@@ -38,10 +42,26 @@ public class WhisperCppPluginTests
             "win-x64",
             nativeError);
 
-        Assert.Contains(Path.Combine(pluginDirectory, "runtimes", "win-x64"), message);
+        Assert.Contains(Path.Join(pluginDirectory, "runtimes", "win-x64"), message);
         Assert.Contains("ggml-cpu-whisper.dll", message);
         Assert.Contains("VCOMP140.DLL", message);
         Assert.Contains("Microsoft Visual C++ 2015-2022 Redistributable", message);
         Assert.Contains("0x8007007E", message);
+    }
+
+    [Fact]
+    public void BuildNativeLoadFailureMessage_StripsPathLikeRuntimeIdentifier()
+    {
+        var pluginDirectory = Path.Join(
+            @"C:\", "Users", "Sal", "AppData", "Local", "TypeWhisper", "Plugins", "com.typewhisper.whisper-cpp");
+        var nativeError = new DllNotFoundException("Unable to load DLL 'ggml-cpu-whisper.dll'.");
+
+        var message = WhisperCppPlugin.BuildNativeLoadFailureMessage(
+            pluginDirectory,
+            Path.Join("unexpected", "win-x64"),
+            nativeError);
+
+        Assert.Contains(Path.Join(pluginDirectory, "runtimes", "win-x64"), message);
+        Assert.DoesNotContain(Path.Join(pluginDirectory, "runtimes", "unexpected"), message);
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Text.Json;
+using TypeWhisper.Plugin.WhisperCpp;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class WhisperCppPluginTests
+{
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifestPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.WhisperCpp", "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var sut = new WhisperCppPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal("1.0.1", manifest.Version);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
+    public void BuildNativeLoadFailureMessage_NamesRuntimeFolderAndVcRedistFallback()
+    {
+        var pluginDirectory = Path.Combine(
+            "C:", "Users", "Sal", "AppData", "Local", "TypeWhisper", "Plugins", "com.typewhisper.whisper-cpp");
+        var nativeError = new DllNotFoundException(
+            "Unable to load DLL 'ggml-cpu-whisper.dll' or one of its dependencies: The specified module could not be found. (0x8007007E)");
+
+        var message = WhisperCppPlugin.BuildNativeLoadFailureMessage(
+            pluginDirectory,
+            "win-x64",
+            nativeError);
+
+        Assert.Contains(Path.Combine(pluginDirectory, "runtimes", "win-x64"), message);
+        Assert.Contains("ggml-cpu-whisper.dll", message);
+        Assert.Contains("VCOMP140.DLL", message);
+        Assert.Contains("Microsoft Visual C++ 2015-2022 Redistributable", message);
+        Assert.Contains("0x8007007E", message);
+    }
+}


### PR DESCRIPTION
## Summary
- Bundle app-local MSVC redistributable DLLs for the whisper.cpp plugin on win-x64 and win-arm64.
- Copy only supported Windows runtime folders into the app/plugin bundle and fail Release builds when required runtime files are missing.
- Bump the whisper.cpp plugin to 1.0.1 and improve native-load failure guidance for missing DLL dependencies.

## Test Plan
- dotnet build plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj -c Release -v minimal
- dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release -v minimal
- Local smoke: installed the built plugin into LocalAppData, verified PluginLoader discovery, and verified NativeLibrary.Load for ggml-cpu-whisper.dll.

Closes #123