### PR TITLE
Allow side-specific modifier hotkeys

### DIFF
--- a/src/TypeWhisper.Windows/Controls/HotkeyRecorderControl.cs
+++ b/src/TypeWhisper.Windows/Controls/HotkeyRecorderControl.cs
@@ -199,6 +199,17 @@ public sealed class HotkeyRecorderControl : Control
         return string.Join("+", parts);
     }
 
+    internal static string FormatSingleModifier(Key key) => key switch
+    {
+        Key.LeftCtrl => "Left Ctrl",
+        Key.RightCtrl => "Right Ctrl",
+        Key.LeftShift => "Left Shift",
+        Key.RightShift => "Right Shift",
+        Key.LeftAlt => "Left Alt",
+        Key.RightAlt => "Right Alt",
+        _ => ""
+    };
+
     internal static string FormatKeyName(Key key) =>
         HotkeyKeyMap.TryGetToken(key, out var token) ? token : "";
 
@@ -250,10 +261,21 @@ internal sealed class HotkeyRecorderSession
         var modifiers = GetCurrentModifiers();
         var hotkey = HotkeyRecorderControl.CountModifiers(modifiers) >= 2
             ? HotkeyRecorderControl.FormatModifierOnly(modifiers)
-            : "";
+            : TryFormatSinglePressedModifier();
 
         _pressedModifiers.Remove(key);
         return hotkey;
+    }
+
+    private string TryFormatSinglePressedModifier()
+    {
+        if (_pressedModifiers.Count != 1)
+            return "";
+
+        foreach (var pressedModifier in _pressedModifiers)
+            return HotkeyRecorderControl.FormatSingleModifier(pressedModifier);
+
+        return "";
     }
 
     internal ModifierKeys GetCurrentModifiers()

--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -409,6 +409,9 @@ internal static class HotkeyParser
         vk = 0;
         if (string.IsNullOrWhiteSpace(hotkeyString)) return false;
 
+        if (TryParseSideSpecificSingleModifier(hotkeyString.Trim(), out vk))
+            return true;
+
         foreach (var part in hotkeyString.Split('+'))
         {
             var upper = part.Trim().ToUpperInvariant();
@@ -433,6 +436,22 @@ internal static class HotkeyParser
             return CountModifiers(modifiers) >= 2;
 
         return true;
+    }
+
+    private static bool TryParseSideSpecificSingleModifier(string hotkeyString, out uint vk)
+    {
+        vk = hotkeyString.ToUpperInvariant() switch
+        {
+            "LEFT CTRL" => NativeMethods.VK_LCONTROL,
+            "RIGHT CTRL" => NativeMethods.VK_RCONTROL,
+            "LEFT SHIFT" => NativeMethods.VK_LSHIFT,
+            "RIGHT SHIFT" => NativeMethods.VK_RSHIFT,
+            "LEFT ALT" => NativeMethods.VK_LMENU,
+            "RIGHT ALT" => NativeMethods.VK_RMENU,
+            _ => 0
+        };
+
+        return vk != 0;
     }
 
     private static uint ParseKey(string key) =>

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -698,7 +698,7 @@
 
   "Hotkey.Placeholder": "Tastenkombination dr\u00fccken...",
   "Hotkey.ClickToAssign": "Klicken zum Belegen",
-  "Hotkey.ModifierOnlyHint": "Einzelne Modifikatortasten wie Win sind nicht erlaubt. Nutze eine Kombination wie Ctrl+Shift oder Alt+Win, damit Windows-Shortcuts weiter funktionieren.",
+  "Hotkey.ModifierOnlyHint": "Einzelne linke/rechte Ctrl-, Alt- und Shift-Tasten sind erlaubt. Win allein bleibt reserviert; nutze Kombinationen wie Ctrl+Shift oder Alt+Win für Windows-Shortcuts.",
 
   "PromptPalette.NoActions": "Keine Aktionen gefunden",
 

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -698,7 +698,7 @@
 
   "Hotkey.Placeholder": "Press key combination...",
   "Hotkey.ClickToAssign": "Click to assign",
-  "Hotkey.ModifierOnlyHint": "Single modifier keys like Win are not allowed. Use a combination like Ctrl+Shift or Alt+Win so Windows shortcuts keep working.",
+  "Hotkey.ModifierOnlyHint": "Single left/right Ctrl, Alt, and Shift keys are allowed. Win alone is reserved; use combinations like Ctrl+Shift or Alt+Win for Windows-key shortcuts.",
 
   "PromptPalette.NoActions": "No actions found",
 

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -665,7 +665,7 @@
   "App.ErrorFormat": "エラーが発生しました:\n{0}",
   "Hotkey.Placeholder": "キーの組み合わせを押してください...",
   "Hotkey.ClickToAssign": "クリックして割り当て",
-  "Hotkey.ModifierOnlyHint": "Winキー単独などの修飾キーのみは使用できません。Ctrl+ShiftやAlt+Winなどの組み合わせを使用してください。",
+  "Hotkey.ModifierOnlyHint": "左右のCtrl、Alt、Shiftキー単独を使用できます。Winキー単独は予約されています。Winキーを使う場合はCtrl+ShiftやAlt+Winなどの組み合わせを使用してください。",
   "PromptPalette.NoActions": "アクションが見つかりません",
   "Profiles.NoAssignment": "割り当てなし",
   "Profiles.GlobalDefault": "グローバル（デフォルト）",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -675,7 +675,7 @@
   "App.ErrorFormat": "Произошла ошибка:\n{0}",
   "Hotkey.Placeholder": "Нажмите сочетание клавиш…",
   "Hotkey.ClickToAssign": "Нажмите для назначения",
-  "Hotkey.ModifierOnlyHint": "Один модификатор (например Win) недопустим. Используйте сочетание вроде Ctrl+Shift или Alt+Win, чтобы не ломать системные горячие клавиши.",
+  "Hotkey.ModifierOnlyHint": "Отдельные левые/правые клавиши Ctrl, Alt и Shift можно использовать. Win отдельно зарезервирован; используйте сочетания вроде Ctrl+Shift или Alt+Win.",
   "PromptPalette.NoActions": "Действий не найдено",
   "Profiles.NoAssignment": "Не назначено",
   "Profiles.GlobalDefault": "Общее (по умолчанию)",

--- a/src/TypeWhisper.Windows/Views/Sections/WorkflowsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/WorkflowsSection.xaml
@@ -1105,7 +1105,10 @@
                                                    Style="{StaticResource HintStyle}"
                                                    Margin="0,0,0,8"/>
                                         <TextBlock Text="{loc:Str Hotkey.ModifierOnlyHint}" Style="{StaticResource HintStyle}" Margin="0,0,0,8"/>
-                                        <controls:HotkeyRecorderControl Hotkey="{Binding Workflows.EditHotkey, Mode=TwoWay}" Width="260" HorizontalAlignment="Left"/>
+                                        <controls:HotkeyRecorderControl Hotkey="{Binding Workflows.EditHotkey, Mode=TwoWay}"
+                                                                        AllowModifierOnly="True"
+                                                                        Width="260"
+                                                                        HorizontalAlignment="Left"/>
                                     </StackPanel>
 
                                     <Border Style="{StaticResource WorkflowPickerPanelStyle}"

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -229,6 +229,24 @@ public class HotkeyInputTests
         Assert.Equal(ModifierKeys.Windows, sut.GetCurrentModifiers());
     }
 
+    [Theory]
+    [InlineData(Key.LeftCtrl, "Left Ctrl")]
+    [InlineData(Key.RightCtrl, "Right Ctrl")]
+    [InlineData(Key.LeftShift, "Left Shift")]
+    [InlineData(Key.RightShift, "Right Shift")]
+    [InlineData(Key.LeftAlt, "Left Alt")]
+    [InlineData(Key.RightAlt, "Right Alt")]
+    public void RecorderSession_RecordsSideSpecificSingleModifier(Key key, string expectedHotkey)
+    {
+        var sut = new HotkeyRecorderSession();
+        sut.NoteModifierDown(key);
+
+        var hotkey = sut.TryRecordModifierOnlyOnRelease(key);
+
+        Assert.Equal(expectedHotkey, hotkey);
+        Assert.Equal(ModifierKeys.None, sut.GetCurrentModifiers());
+    }
+
     [Fact]
     public void KeyboardHook_OnlyIgnoresSelfInjectedInput()
     {
@@ -316,10 +334,25 @@ public class HotkeyInputTests
     [InlineData("Shift")]
     [InlineData("Alt")]
     [InlineData("Win")]
-    public void Parser_RejectsSingleModifierOnlyHotkeys(string hotkey)
+    public void Parser_RejectsGenericSingleModifierOnlyHotkeys(string hotkey)
     {
         Assert.False(HotkeyParser.Parse(hotkey, out _, out _));
         Assert.Equal("", HotkeyParser.Normalize(hotkey));
+    }
+
+    [Theory]
+    [InlineData("Left Ctrl", NativeMethods.VK_LCONTROL)]
+    [InlineData("Right Ctrl", NativeMethods.VK_RCONTROL)]
+    [InlineData("Left Shift", NativeMethods.VK_LSHIFT)]
+    [InlineData("Right Shift", NativeMethods.VK_RSHIFT)]
+    [InlineData("Left Alt", NativeMethods.VK_LMENU)]
+    [InlineData("Right Alt", NativeMethods.VK_RMENU)]
+    public void Parser_AllowsSideSpecificSingleModifierHotkeys(string hotkey, uint expectedVk)
+    {
+        Assert.True(HotkeyParser.Parse(hotkey, out var modifiers, out var vk));
+        Assert.Equal(0u, modifiers);
+        Assert.Equal(expectedVk, vk);
+        Assert.Equal(hotkey, HotkeyParser.Normalize(hotkey));
     }
 
     [Theory]
@@ -346,6 +379,25 @@ public class HotkeyInputTests
     public void Parser_NormalizesInvalidRecentActionDefaultsToEmpty(string hotkey)
     {
         Assert.Equal("", HotkeyParser.Normalize(hotkey));
+    }
+
+    [Fact]
+    public void SideSpecificSingleModifier_OnlyActivatesMatchingSide()
+    {
+        var sut = CreateStateMachine(0, NativeMethods.VK_RCONTROL);
+
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: false, isKeyUp: true));
+
+        var rightCtrlDown = sut.ProcessKeyEvent(NativeMethods.VK_RCONTROL, isKeyDown: true, isKeyUp: false);
+        Assert.True(rightCtrlDown.RaiseKeyDown);
+        Assert.False(rightCtrlDown.RaiseKeyUp);
+        Assert.True(rightCtrlDown.Swallow);
+
+        var rightCtrlUp = sut.ProcessKeyEvent(NativeMethods.VK_RCONTROL, isKeyDown: false, isKeyUp: true);
+        Assert.False(rightCtrlUp.RaiseKeyDown);
+        Assert.True(rightCtrlUp.RaiseKeyUp);
+        Assert.True(rightCtrlUp.Swallow);
     }
 
     private static HotkeyMatchStateMachine CreateStateMachine(uint modifiers, uint vk = 0)


### PR DESCRIPTION
## Summary
- Allow side-specific single modifier hotkeys for left/right Ctrl, Alt, and Shift.
- Preserve existing modifier chord behavior and keep standalone Win reserved.
- Enable modifier-only recording for workflow hotkeys and update shortcut guidance text.

## Root cause
Single modifier hotkeys were explicitly rejected by recorder and parser logic, so users could not assign keys such as Right Ctrl as dedicated dictation triggers.

## Validation
- `dotnet test TypeWhisper.slnx`
- Manual debug app check: assigned and used a side-specific single modifier hotkey successfully.

Fixes #126
