### PR TITLE
Support multi-category plugin marketplace

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -185,13 +185,60 @@ jobs:
               $registry = @(
                 Get-Content plugins.json | ConvertFrom-Json
               )
+              $manifestPath = Join-Path ".." "plugins/$env:PROJECT_NAME/manifest.json"
+              $manifest = Get-Content $manifestPath | ConvertFrom-Json
+
+              function Set-RegistryProperty($entry, [string]$name, $value) {
+                if ($entry.PSObject.Properties[$name]) {
+                  $entry.$name = $value
+                } else {
+                  $entry | Add-Member -NotePropertyName $name -NotePropertyValue $value
+                }
+              }
+
+              function Get-RegistryCategory($manifest, [string]$fallbackCategory) {
+                if ($manifest.category) {
+                  return [string]$manifest.category
+                }
+
+                if ($manifest.categories) {
+                  return [string]@($manifest.categories)[0]
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($fallbackCategory)) {
+                  return $fallbackCategory
+                }
+
+                return 'utility'
+              }
+
+              function Get-RegistryCategories($manifest, [string]$resolvedCategory) {
+                if ($manifest.categories) {
+                  return [string[]]@($manifest.categories)
+                }
+
+                return [string[]]@($resolvedCategory)
+              }
+
               $updated = $false
 
               for ($j = 0; $j -lt $registry.Count; $j++) {
                 if ($registry[$j].id -eq $env:PLUGIN_ID) {
-                  $registry[$j].version = $env:PLUGIN_VERSION
-                  $registry[$j].size = [long]$env:ZIP_SIZE
-                  $registry[$j].downloadUrl = $downloadUrl
+                  $category = Get-RegistryCategory $manifest $registry[$j].category
+                  $categories = Get-RegistryCategories $manifest $category
+
+                  Set-RegistryProperty $registry[$j] 'name' $manifest.name
+                  Set-RegistryProperty $registry[$j] 'version' $env:PLUGIN_VERSION
+                  Set-RegistryProperty $registry[$j] 'minHostVersion' $manifest.minHostVersion
+                  Set-RegistryProperty $registry[$j] 'author' $manifest.author
+                  Set-RegistryProperty $registry[$j] 'description' $manifest.description
+                  Set-RegistryProperty $registry[$j] 'category' $category
+                  Set-RegistryProperty $registry[$j] 'categories' $categories
+                  Set-RegistryProperty $registry[$j] 'size' ([long]$env:ZIP_SIZE)
+                  Set-RegistryProperty $registry[$j] 'downloadUrl' $downloadUrl
+                  Set-RegistryProperty $registry[$j] 'iconSystemName' $manifest.iconSystemName
+                  Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]($manifest.requiresApiKey))
+                  Set-RegistryProperty $registry[$j] 'descriptions' $manifest.descriptions
                   $updated = $true
                   Write-Host "Updated $($registry[$j].id) to v$env:PLUGIN_VERSION"
                   break
@@ -199,8 +246,8 @@ jobs:
               }
 
               if (-not $updated) {
-                $manifestPath = Join-Path ".." "plugins/$env:PROJECT_NAME/manifest.json"
-                $manifest = Get-Content $manifestPath | ConvertFrom-Json
+                $category = Get-RegistryCategory $manifest ''
+                $categories = Get-RegistryCategories $manifest $category
 
                 $registry += [pscustomobject]@{
                   id = $manifest.id
@@ -209,7 +256,8 @@ jobs:
                   minHostVersion = $manifest.minHostVersion
                   author = $manifest.author
                   description = $manifest.description
-                  category = $manifest.category
+                  category = $category
+                  categories = $categories
                   size = [long]$env:ZIP_SIZE
                   downloadUrl = $downloadUrl
                   iconSystemName = $manifest.iconSystemName
@@ -220,7 +268,7 @@ jobs:
                 Write-Host "Added $env:PLUGIN_ID to registry at v$env:PLUGIN_VERSION"
               }
 
-              $registry | ConvertTo-Json -Depth 4 | Set-Content plugins.json
+              $registry | ConvertTo-Json -Depth 6 | Set-Content plugins.json
 
               # Also copy the ZIP to plugins/ directory on gh-pages
               New-Item -ItemType Directory -Path "plugins" -Force | Out-Null

--- a/plugins/TypeWhisper.Plugin.Groq/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Groq/manifest.json
@@ -4,6 +4,8 @@
   "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Groq Whisper transcription and Llama translation",
+  "category": "transcription",
+  "categories": ["transcription", "llm"],
   "assemblyName": "TypeWhisper.Plugin.Groq.dll",
   "pluginClass": "TypeWhisper.Plugin.Groq.GroqPlugin"
 }

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
@@ -4,6 +4,8 @@
   "version": "1.0.1",
   "author": "TypeWhisper",
   "description": "Connect to any OpenAI-compatible server (Ollama, LM Studio, vLLM, etc.)",
+  "category": "transcription",
+  "categories": ["transcription", "llm"],
   "assemblyName": "TypeWhisper.Plugin.OpenAiCompatible.dll",
   "pluginClass": "TypeWhisper.Plugin.OpenAiCompatible.OpenAiCompatiblePlugin"
 }

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -236,6 +236,7 @@
   "Plugins.MarketplaceCategorySummaryFormat": "{0} Erweiterungen in {1}",
   "Plugins.Installed": "Installiert",
   "Plugins.Marketplace": "Marketplace",
+  "Plugins.AllFunctions": "Alle Funktionen",
   "Plugins.NoPlugins": "Keine Plugins installiert",
   "Plugins.NoPluginsHint": "Installiere Plugins \u00fcber den Marketplace-Tab.",
   "Plugins.Transcription": "Transkription",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -236,6 +236,7 @@
   "Plugins.MarketplaceCategorySummaryFormat": "{0} extensions in {1}",
   "Plugins.Installed": "Installed",
   "Plugins.Marketplace": "Marketplace",
+  "Plugins.AllFunctions": "All functions",
   "Plugins.NoPlugins": "No plugins installed",
   "Plugins.NoPluginsHint": "Install plugins via the Marketplace tab.",
   "Plugins.Transcription": "Transcription",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -229,6 +229,7 @@
   "Plugins.MarketplaceCategorySummaryFormat": "{1}に{0}個の拡張機能",
   "Plugins.Installed": "インストール済み",
   "Plugins.Marketplace": "マーケットプレイス",
+  "Plugins.AllFunctions": "すべての機能",
   "Plugins.NoPlugins": "プラグインがインストールされていません",
   "Plugins.NoPluginsHint": "マーケットプレイスタブからプラグインをインストールしてください。",
   "Plugins.Transcription": "文字起こし",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -229,6 +229,7 @@
   "Plugins.MarketplaceCategorySummaryFormat": "{0} расширений в {1}",
   "Plugins.Installed": "Установленные",
   "Plugins.Marketplace": "Магазин",
+  "Plugins.AllFunctions": "Все функции",
   "Plugins.NoPlugins": "Расширения не установлены",
   "Plugins.NoPluginsHint": "Установите расширения во вкладке «Магазин».",
   "Plugins.Transcription": "Транскрипция",

--- a/src/TypeWhisper.Windows/Services/Plugins/RegistryPlugin.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/RegistryPlugin.cs
@@ -14,6 +14,7 @@ public sealed record RegistryPlugin
     public string Author { get; init; } = "";
     public string Description { get; init; } = "";
     public string? Category { get; init; }
+    public IReadOnlyList<string>? Categories { get; init; }
     public long Size { get; init; }
     public string DownloadUrl { get; init; } = "";
     public string? IconSystemName { get; init; }

--- a/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
@@ -16,22 +16,29 @@ public partial class PluginsViewModel : ObservableObject
     public ObservableCollection<PluginItemViewModel> Plugins { get; } = [];
     public ObservableCollection<RegistryPluginItemViewModel> RegistryPlugins { get; } = [];
     public ObservableCollection<RegistryPluginCategoryGroupViewModel> MarketplaceGroups { get; } = [];
-    public ObservableCollection<MarketplaceCategoryTabViewModel> MarketplaceCategories { get; } = [];
+    public ObservableCollection<MarketplaceCapabilityFilterViewModel> MarketplaceCapabilityFilters { get; } = [];
     public ObservableCollection<RegistryPluginItemViewModel> FilteredMarketplacePlugins { get; } = [];
     public int InstalledPluginCount => Plugins.Count;
     public int EnabledPluginCount => Plugins.Count(static plugin => plugin.IsEnabled);
     public int MarketplacePluginCount => RegistryPlugins.Count;
     public string InstalledSummaryText => Loc.Instance.GetString("Plugins.InstalledSummaryFormat", InstalledPluginCount, EnabledPluginCount);
     public string MarketplaceSummaryText => Loc.Instance.GetString("Plugins.MarketplaceSummaryFormat", MarketplacePluginCount);
-    public string SelectedMarketplaceCategoryName => MarketplaceCategories.FirstOrDefault(category => category.IsSelected)?.DisplayName ?? string.Empty;
-    public string MarketplaceCategorySummaryText => string.IsNullOrWhiteSpace(SelectedMarketplaceCategoryName)
+    public string SelectedMarketplaceCapabilityFilterName => string.Join(
+        ", ",
+        MarketplaceCapabilityFilters
+            .Where(filter => filter.IsSelected)
+            .OrderBy(filter => filter.SortOrder)
+            .Select(filter => filter.DisplayName));
+    public string MarketplaceCategorySummaryText => string.IsNullOrWhiteSpace(SelectedMarketplaceCapabilityFilterName)
         ? MarketplaceSummaryText
-        : Loc.Instance.GetString("Plugins.MarketplaceCategorySummaryFormat", FilteredMarketplacePlugins.Count, SelectedMarketplaceCategoryName);
-    public bool HasMarketplaceCategories => MarketplaceCategories.Count > 0;
+        : Loc.Instance.GetString("Plugins.MarketplaceCategorySummaryFormat", FilteredMarketplacePlugins.Count, SelectedMarketplaceCapabilityFilterName);
+    public bool HasMarketplaceCategories => MarketplaceCapabilityFilters.Count > 0;
+    public bool HasActiveMarketplaceCapabilityFilters => _selectedMarketplaceCapabilityKeys.Count > 0;
 
     [ObservableProperty] private bool _isLoadingRegistry;
     [ObservableProperty] private bool _isMarketplaceSelected;
-    [ObservableProperty] private string? _selectedMarketplaceCategoryKey;
+
+    private readonly HashSet<string> _selectedMarketplaceCapabilityKeys = new(StringComparer.OrdinalIgnoreCase);
 
     public PluginsViewModel(PluginManager pluginManager, PluginRegistryService registryService)
     {
@@ -88,28 +95,14 @@ public partial class PluginsViewModel : ObservableObject
 
             RegistryPlugins.Clear();
             MarketplaceGroups.Clear();
-            MarketplaceCategories.Clear();
+            MarketplaceCapabilityFilters.Clear();
 
             foreach (var plugin in registryItems)
             {
                 RegistryPlugins.Add(plugin);
             }
 
-            foreach (var group in registryItems
-                         .GroupBy(plugin => plugin.CategoryKey)
-                         .OrderBy(group => group.First().CategorySortOrder))
-            {
-                var first = group.First();
-                MarketplaceGroups.Add(new RegistryPluginCategoryGroupViewModel(first.CategoryLabel, group));
-                MarketplaceCategories.Add(new MarketplaceCategoryTabViewModel(first.CategoryKey, first.CategoryLabel, group.Count()));
-            }
-
-            var selectedCategory = MarketplaceCategories.Any(category => category.Key == SelectedMarketplaceCategoryKey)
-                ? SelectedMarketplaceCategoryKey
-                : MarketplaceCategories.FirstOrDefault()?.Key;
-
-            SelectedMarketplaceCategoryKey = selectedCategory;
-
+            RebuildMarketplaceFilters();
             NotifyStateChanged();
         }
         finally
@@ -118,26 +111,31 @@ public partial class PluginsViewModel : ObservableObject
         }
     }
 
-    partial void OnSelectedMarketplaceCategoryKeyChanged(string? value)
-    {
-        foreach (var category in MarketplaceCategories)
-            category.IsSelected = string.Equals(category.Key, value, StringComparison.OrdinalIgnoreCase);
-
-        FilteredMarketplacePlugins.Clear();
-        foreach (var plugin in RegistryPlugins.Where(plugin => string.Equals(plugin.CategoryKey, value, StringComparison.OrdinalIgnoreCase)))
-            FilteredMarketplacePlugins.Add(plugin);
-
-        OnPropertyChanged(nameof(SelectedMarketplaceCategoryName));
-        OnPropertyChanged(nameof(MarketplaceCategorySummaryText));
-    }
-
     [RelayCommand]
-    private void SelectMarketplaceCategory(string? categoryKey)
+    private void ToggleMarketplaceCapabilityFilter(string? categoryKey)
     {
         if (string.IsNullOrWhiteSpace(categoryKey))
             return;
 
-        SelectedMarketplaceCategoryKey = categoryKey;
+        var normalizedKey = PluginMarketplaceCategories.Resolve(categoryKey).Key;
+        if (_selectedMarketplaceCapabilityKeys.Contains(normalizedKey))
+            _selectedMarketplaceCapabilityKeys.Remove(normalizedKey);
+        else
+            _selectedMarketplaceCapabilityKeys.Add(normalizedKey);
+
+        RebuildMarketplaceFilters();
+        NotifyStateChanged();
+    }
+
+    [RelayCommand]
+    private void ClearMarketplaceCapabilityFilters()
+    {
+        if (_selectedMarketplaceCapabilityKeys.Count == 0)
+            return;
+
+        _selectedMarketplaceCapabilityKeys.Clear();
+        RebuildMarketplaceFilters();
+        NotifyStateChanged();
     }
 
     private void NotifyStateChanged()
@@ -147,8 +145,10 @@ public partial class PluginsViewModel : ObservableObject
         OnPropertyChanged(nameof(MarketplacePluginCount));
         OnPropertyChanged(nameof(InstalledSummaryText));
         OnPropertyChanged(nameof(MarketplaceSummaryText));
+        OnPropertyChanged(nameof(SelectedMarketplaceCapabilityFilterName));
         OnPropertyChanged(nameof(MarketplaceCategorySummaryText));
         OnPropertyChanged(nameof(HasMarketplaceCategories));
+        OnPropertyChanged(nameof(HasActiveMarketplaceCapabilityFilters));
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)
@@ -161,17 +161,15 @@ public partial class PluginsViewModel : ObservableObject
             foreach (var plugin in RegistryPlugins)
                 plugin.NotifyLocalizationChanged();
 
-            RebuildMarketplaceGroups();
+            RebuildMarketplaceFilters();
             NotifyStateChanged();
         });
     }
 
-    private void RebuildMarketplaceGroups()
+    private void RebuildMarketplaceFilters()
     {
-        var selectedCategory = SelectedMarketplaceCategoryKey;
-
         MarketplaceGroups.Clear();
-        MarketplaceCategories.Clear();
+        MarketplaceCapabilityFilters.Clear();
 
         foreach (var group in RegistryPlugins
                      .GroupBy(plugin => plugin.CategoryKey)
@@ -179,12 +177,47 @@ public partial class PluginsViewModel : ObservableObject
         {
             var first = group.First();
             MarketplaceGroups.Add(new RegistryPluginCategoryGroupViewModel(first.CategoryLabel, group));
-            MarketplaceCategories.Add(new MarketplaceCategoryTabViewModel(first.CategoryKey, first.CategoryLabel, group.Count()));
         }
 
-        SelectedMarketplaceCategoryKey = MarketplaceCategories.Any(category => category.Key == selectedCategory)
-            ? selectedCategory
-            : MarketplaceCategories.FirstOrDefault()?.Key;
+        var categories = RegistryPlugins
+            .SelectMany(plugin => plugin.CategoryDescriptors)
+            .GroupBy(category => category.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => new
+            {
+                Descriptor = group.First(),
+                Count = RegistryPlugins.Count(plugin => plugin.CategoryKeys.Contains(group.Key, StringComparer.OrdinalIgnoreCase))
+            })
+            .OrderBy(item => item.Descriptor.SortOrder)
+            .ThenBy(item => item.Descriptor.DisplayName)
+            .ToList();
+
+        var availableKeys = categories.Select(item => item.Descriptor.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _selectedMarketplaceCapabilityKeys.IntersectWith(availableKeys);
+
+        foreach (var category in categories)
+        {
+            MarketplaceCapabilityFilters.Add(new MarketplaceCapabilityFilterViewModel(
+                category.Descriptor.Key,
+                category.Descriptor.DisplayName,
+                category.Descriptor.SortOrder,
+                category.Count,
+                _selectedMarketplaceCapabilityKeys.Contains(category.Descriptor.Key)));
+        }
+
+        RefreshFilteredMarketplacePlugins();
+    }
+
+    private void RefreshFilteredMarketplacePlugins()
+    {
+        FilteredMarketplacePlugins.Clear();
+
+        var plugins = _selectedMarketplaceCapabilityKeys.Count == 0
+            ? RegistryPlugins
+            : RegistryPlugins.Where(plugin =>
+                plugin.CategoryKeys.Any(key => _selectedMarketplaceCapabilityKeys.Contains(key)));
+
+        foreach (var plugin in plugins)
+            FilteredMarketplacePlugins.Add(plugin);
     }
 }
 
@@ -201,19 +234,22 @@ public partial class RegistryPluginCategoryGroupViewModel : ObservableObject
     }
 }
 
-public partial class MarketplaceCategoryTabViewModel : ObservableObject
+public partial class MarketplaceCapabilityFilterViewModel : ObservableObject
 {
     public string Key { get; }
     public string DisplayName { get; }
+    public int SortOrder { get; }
     public int Count { get; }
 
     [ObservableProperty] private bool _isSelected;
 
-    public MarketplaceCategoryTabViewModel(string key, string displayName, int count)
+    public MarketplaceCapabilityFilterViewModel(string key, string displayName, int sortOrder, int count, bool isSelected)
     {
         Key = key;
         DisplayName = displayName;
+        SortOrder = sortOrder;
         Count = count;
+        _isSelected = isSelected;
     }
 }
 
@@ -232,10 +268,16 @@ public partial class PluginItemViewModel : ObservableObject
     public string IconGradientStart => PluginIconHelper.GetGradientStart(Id);
     public string IconGradientEnd => PluginIconHelper.GetGradientEnd(Id);
     public string StatusLabel => IsEnabled ? Loc.Instance["Plugins.Enabled"] : Loc.Instance["Plugins.Disabled"];
+    public IReadOnlyList<PluginMarketplaceCategoryDescriptor> CategoryDescriptors =>
+        _categoryDescriptors ??= PluginMarketplaceCategories.ResolveAll(
+            _plugin.Manifest.Category ?? DetectPrimaryCategory(),
+            ResolveDeclaredAndDetectedCategories());
 
     [ObservableProperty] private bool _isEnabled;
     [ObservableProperty] private UserControl? _settingsView;
     [ObservableProperty] private bool _isExpanded;
+
+    private IReadOnlyList<PluginMarketplaceCategoryDescriptor>? _categoryDescriptors;
 
     // Capability badges
     public bool IsTranscriptionProvider => _plugin.Instance is TypeWhisper.PluginSDK.ITranscriptionEnginePlugin;
@@ -245,7 +287,7 @@ public partial class PluginItemViewModel : ObservableObject
     public bool IsActionProvider => _plugin.Instance is TypeWhisper.PluginSDK.IActionPlugin;
     public bool IsMemoryStorage => _plugin.Instance is TypeWhisper.PluginSDK.IMemoryStoragePlugin;
 
-    public string Category => PluginMarketplaceCategories.Resolve(_plugin.Manifest.Category ?? DetectCategory()).DisplayName;
+    public string Category => CategoryDescriptors[0].DisplayName;
 
     public bool IsLocal => _plugin.Manifest.IsLocal;
     public string LocationBadge => IsLocal ? Loc.Instance["Plugins.Local"] : Loc.Instance["Plugins.Cloud"];
@@ -299,20 +341,38 @@ public partial class PluginItemViewModel : ObservableObject
         await _registryService.UninstallPluginAsync(Id);
     }
 
-    private string DetectCategory() => _plugin.Instance switch
+    private IEnumerable<string> ResolveDeclaredAndDetectedCategories()
     {
-        TypeWhisper.PluginSDK.ITranscriptionEnginePlugin => "transcription",
-        TypeWhisper.PluginSDK.ILlmProviderPlugin => "llm",
-        TypeWhisper.PluginSDK.ITtsProviderPlugin => "tts",
-        TypeWhisper.PluginSDK.IMemoryStoragePlugin => "memory",
-        TypeWhisper.PluginSDK.IPostProcessorPlugin => "post-processing",
-        TypeWhisper.PluginSDK.IActionPlugin => "action",
-        _ => "utility"
-    };
+        foreach (var category in _plugin.Manifest.Categories ?? [])
+            yield return category;
+
+        foreach (var category in DetectCategories())
+            yield return category;
+    }
+
+    private string DetectPrimaryCategory() => DetectCategories().FirstOrDefault() ?? "utility";
+
+    private IEnumerable<string> DetectCategories()
+    {
+        if (_plugin.Instance is TypeWhisper.PluginSDK.ITranscriptionEnginePlugin)
+            yield return "transcription";
+        if (_plugin.Instance is TypeWhisper.PluginSDK.ILlmProviderPlugin)
+            yield return "llm";
+        if (_plugin.Instance is TypeWhisper.PluginSDK.ITtsProviderPlugin)
+            yield return "tts";
+        if (_plugin.Instance is TypeWhisper.PluginSDK.IMemoryStoragePlugin)
+            yield return "memory";
+        if (_plugin.Instance is TypeWhisper.PluginSDK.IPostProcessorPlugin)
+            yield return "post-processing";
+        if (_plugin.Instance is TypeWhisper.PluginSDK.IActionPlugin)
+            yield return "action";
+    }
 
     internal void NotifyLocalizationChanged()
     {
+        _categoryDescriptors = null;
         OnPropertyChanged(nameof(StatusLabel));
+        OnPropertyChanged(nameof(CategoryDescriptors));
         OnPropertyChanged(nameof(Category));
         OnPropertyChanged(nameof(LocationBadge));
     }

--- a/src/TypeWhisper.Windows/ViewModels/RegistryPluginItemViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/RegistryPluginItemViewModel.cs
@@ -16,14 +16,18 @@ public partial class RegistryPluginItemViewModel : ObservableObject
     public string Author => _registryPlugin.Author;
     public string Description => _registryPlugin.Description;
     public string? Category => _registryPlugin.Category;
+    public IReadOnlyList<string>? Categories => _registryPlugin.Categories;
     public bool RequiresApiKey => _registryPlugin.RequiresApiKey;
     public string SizeDisplay => FormatSize(_registryPlugin.Size);
     public string IconEmoji => PluginIconHelper.GetIcon(Id);
     public string IconGradientStart => PluginIconHelper.GetGradientStart(Id);
     public string IconGradientEnd => PluginIconHelper.GetGradientEnd(Id);
-    public string CategoryKey => PluginMarketplaceCategories.Resolve(Category).Key;
-    public string CategoryLabel => PluginMarketplaceCategories.Resolve(Category).DisplayName;
-    public int CategorySortOrder => PluginMarketplaceCategories.Resolve(Category).SortOrder;
+    public IReadOnlyList<PluginMarketplaceCategoryDescriptor> CategoryDescriptors =>
+        PluginMarketplaceCategories.ResolveAll(Category, Categories);
+    public IReadOnlyList<string> CategoryKeys => CategoryDescriptors.Select(category => category.Key).ToArray();
+    public string CategoryKey => CategoryDescriptors[0].Key;
+    public string CategoryLabel => CategoryDescriptors[0].DisplayName;
+    public int CategorySortOrder => CategoryDescriptors[0].SortOrder;
     public string LocationBadge => RequiresApiKey ? Loc.Instance["Plugins.Cloud"] : Loc.Instance["Plugins.Local"];
 
     [ObservableProperty] private PluginInstallState _installState;
@@ -117,14 +121,15 @@ public partial class RegistryPluginItemViewModel : ObservableObject
 
     internal void NotifyLocalizationChanged()
     {
+        OnPropertyChanged(nameof(CategoryDescriptors));
         OnPropertyChanged(nameof(CategoryLabel));
         OnPropertyChanged(nameof(LocationBadge));
     }
 }
 
-internal sealed record PluginMarketplaceCategoryDescriptor(string Key, string DisplayName, int SortOrder);
+public sealed record PluginMarketplaceCategoryDescriptor(string Key, string DisplayName, int SortOrder);
 
-internal static class PluginMarketplaceCategories
+public static class PluginMarketplaceCategories
 {
     public static PluginMarketplaceCategoryDescriptor Resolve(string? rawCategory) => Normalize(rawCategory) switch
     {
@@ -137,12 +142,42 @@ internal static class PluginMarketplaceCategories
         _ => new("utility", Loc.Instance["Plugins.CategoryUtilities"], 6)
     };
 
+    public static IReadOnlyList<PluginMarketplaceCategoryDescriptor> ResolveAll(
+        string? primaryCategory,
+        IEnumerable<string>? categories)
+    {
+        var descriptors = new List<PluginMarketplaceCategoryDescriptor>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Add(primaryCategory);
+        if (categories is not null)
+        {
+            foreach (var category in categories)
+                Add(category);
+        }
+
+        if (descriptors.Count == 0)
+            descriptors.Add(Resolve("utility"));
+
+        return descriptors;
+
+        void Add(string? rawCategory)
+        {
+            if (string.IsNullOrWhiteSpace(rawCategory))
+                return;
+
+            var descriptor = Resolve(rawCategory);
+            if (seen.Add(descriptor.Key))
+                descriptors.Add(descriptor);
+        }
+    }
+
     private static string Normalize(string? rawCategory) => rawCategory?.Trim().ToLowerInvariant() switch
     {
         "transcription" => "transcription",
         "llm" => "llm",
         "tts" or "texttospeech" or "text-to-speech" or "text to speech" => "tts",
-        "postprocessing" or "post-processing" or "postprocessor" or "post-processor" => "post-processing",
+        "postprocessing" or "post-processing" or "postprocessor" or "post-processor" or "processing" => "post-processing",
         "action" => "action",
         "memory" => "memory",
         _ => "utility"

--- a/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml
@@ -78,8 +78,6 @@
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
                 <StackPanel Orientation="Horizontal">
@@ -90,35 +88,6 @@
                         <TextBlock><Run Text="&#x1F6D2;  "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.Marketplace], Mode=OneWay}"/></TextBlock>
                     </Button>
                 </StackPanel>
-
-                <Border Grid.Column="1"
-                        Width="1"
-                        Height="26"
-                        Margin="18,0"
-                        Background="#16FFFFFF"
-                        VerticalAlignment="Center"
-                        Visibility="{Binding Plugins.IsMarketplaceSelected, Converter={StaticResource BoolToVis}}"/>
-
-                <ScrollViewer Grid.Column="2"
-                              HorizontalScrollBarVisibility="Hidden"
-                              VerticalScrollBarVisibility="Disabled"
-                              Visibility="{Binding Plugins.IsMarketplaceSelected, Converter={StaticResource BoolToVis}}">
-                    <ItemsControl ItemsSource="{Binding Plugins.MarketplaceCategories}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Orientation="Horizontal"/>
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="{x:Type vm:MarketplaceCategoryTabViewModel}">
-                                <Button Content="{Binding DisplayName}"
-                                        Style="{StaticResource MarketplaceCategoryTabButtonStyle}"
-                                        Command="{Binding DataContext.Plugins.SelectMarketplaceCategoryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                        CommandParameter="{Binding Key}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </ScrollViewer>
             </Grid>
         </Border>
 
@@ -176,9 +145,20 @@
                                                 </StackPanel>
                                                 <TextBlock Text="{Binding Description}" Foreground="{StaticResource HintBrush}" FontSize="12" TextTrimming="CharacterEllipsis" MaxHeight="18" Margin="0,4,0,0"/>
                                                 <WrapPanel Margin="0,7,0,0">
-                                                    <Border Style="{StaticResource BadgeStyle}" Margin="0,0,6,0">
-                                                        <TextBlock Text="{Binding Category}" Foreground="#D6DEE9" FontSize="10"/>
-                                                    </Border>
+                                                    <ItemsControl ItemsSource="{Binding CategoryDescriptors}">
+                                                        <ItemsControl.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <WrapPanel/>
+                                                            </ItemsPanelTemplate>
+                                                        </ItemsControl.ItemsPanel>
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate DataType="{x:Type vm:PluginMarketplaceCategoryDescriptor}">
+                                                                <Border Style="{StaticResource BadgeStyle}" Margin="0,0,6,0">
+                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="#D6DEE9" FontSize="10"/>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
                                                     <Border Style="{StaticResource BadgeStyle}" Margin="0,0,6,0">
                                                         <TextBlock Text="{Binding LocationBadge}" Foreground="#D6DEE9" FontSize="10"/>
                                                     </Border>
@@ -243,6 +223,35 @@
                             <StackPanel Margin="0,0,16,0">
                                 <TextBlock Text="{Binding Plugins.MarketplaceCategorySummaryText}" Style="{StaticResource PageSubtitleStyle}" Margin="0,0,0,4"/>
                                 <TextBlock Text="{loc:Str Plugins.MarketplaceDescription}" Style="{StaticResource HintStyle}" Margin="0"/>
+                                <WrapPanel Margin="0,10,0,0">
+                                    <ui:Button Appearance="Secondary"
+                                               Content="{loc:Str Plugins.AllFunctions}"
+                                               Command="{Binding Plugins.ClearMarketplaceCapabilityFiltersCommand}"
+                                               Visibility="{Binding Plugins.HasActiveMarketplaceCapabilityFilters, Converter={StaticResource BoolToVis}}"
+                                               Margin="0,0,10,6"/>
+                                    <ItemsControl ItemsSource="{Binding Plugins.MarketplaceCapabilityFilters}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate DataType="{x:Type vm:MarketplaceCapabilityFilterViewModel}">
+                                                <CheckBox IsChecked="{Binding IsSelected, Mode=OneWay}"
+                                                          Command="{Binding DataContext.Plugins.ToggleMarketplaceCapabilityFilterCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                          CommandParameter="{Binding Key}"
+                                                          Style="{StaticResource InputCheckBoxStyle}"
+                                                          Margin="0,0,12,6">
+                                                    <TextBlock Foreground="{StaticResource LabelBrush}" FontSize="12">
+                                                        <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                                        <Run Text=" "/>
+                                                        <Run Text="{Binding Count, StringFormat='({0})', Mode=OneWay}"/>
+                                                    </TextBlock>
+                                                </CheckBox>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </WrapPanel>
                             </StackPanel>
                             <ui:Button Grid.Column="1"
                                        Appearance="Secondary"
@@ -285,6 +294,20 @@
                                                 </StackPanel>
                                                 <TextBlock Text="{Binding Description}" Foreground="{StaticResource HintBrush}" FontSize="12" TextTrimming="CharacterEllipsis" MaxHeight="18" Margin="0,4,0,0"/>
                                                 <WrapPanel Margin="0,7,0,0">
+                                                    <ItemsControl ItemsSource="{Binding CategoryDescriptors}">
+                                                        <ItemsControl.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <WrapPanel/>
+                                                            </ItemsPanelTemplate>
+                                                        </ItemsControl.ItemsPanel>
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate DataType="{x:Type vm:PluginMarketplaceCategoryDescriptor}">
+                                                                <Border Style="{StaticResource BadgeStyle}" Margin="0,0,6,0">
+                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="#D6DEE9" FontSize="10"/>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
                                                     <Border Style="{StaticResource BadgeStyle}" Margin="0,0,6,0">
                                                         <TextBlock Text="{Binding LocationBadge}" Foreground="#D6DEE9" FontSize="10"/>
                                                     </Border>

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -29,6 +29,22 @@ public class GroqPluginTests
     }
 
     [Fact]
+    public void Manifest_AdvertisesTranscriptionAndLlmCategories()
+    {
+        var manifestPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.Groq", "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(manifest);
+        Assert.Equal("transcription", manifest.Category);
+        Assert.Equal(["transcription", "llm"], manifest.Categories);
+    }
+
+    [Fact]
     public void TranscriptionModels_RemainCuratedWhisperModels()
     {
         var sut = new GroqPlugin();

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -14,10 +14,11 @@ public class GroqPluginTests
     [Fact]
     public void PluginVersion_MatchesManifestVersion()
     {
-        var manifestPath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory,
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
             "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.Groq", "manifest.json"));
+            "plugins", "TypeWhisper.Plugin.Groq", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
         var manifest = JsonSerializer.Deserialize<PluginManifest>(
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
@@ -31,10 +32,11 @@ public class GroqPluginTests
     [Fact]
     public void Manifest_AdvertisesTranscriptionAndLlmCategories()
     {
-        var manifestPath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory,
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
             "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.Groq", "manifest.json"));
+            "plugins", "TypeWhisper.Plugin.Groq", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
         var manifest = JsonSerializer.Deserialize<PluginManifest>(
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/tests/TypeWhisper.PluginSystem.Tests/MarketplaceCategoryTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/MarketplaceCategoryTests.cs
@@ -28,4 +28,42 @@ public class MarketplaceCategoryTests
         Assert.True(llm.SortOrder < tts.SortOrder);
         Assert.True(tts.SortOrder < postProcessing.SortOrder);
     }
+
+    [Theory]
+    [InlineData("post-processor")]
+    [InlineData("postprocessor")]
+    [InlineData("postprocessing")]
+    [InlineData("processing")]
+    public void Resolve_MapsPostProcessingAliases(string rawCategory)
+    {
+        var category = PluginMarketplaceCategories.Resolve(rawCategory);
+
+        Assert.Equal("post-processing", category.Key);
+    }
+
+    [Fact]
+    public void ResolveAll_CombinesPrimaryAndCategoriesWithPrimaryFirst()
+    {
+        var categories = PluginMarketplaceCategories.ResolveAll(
+            "transcription",
+            ["llm", "tts", "transcription", "text-to-speech"]);
+
+        Assert.Equal(["transcription", "llm", "tts"], categories.Select(category => category.Key).ToArray());
+    }
+
+    [Fact]
+    public void ResolveAll_FallsBackToPrimaryCategoryForLegacyMetadata()
+    {
+        var categories = PluginMarketplaceCategories.ResolveAll("LLM", null);
+
+        Assert.Equal(["llm"], categories.Select(category => category.Key).ToArray());
+    }
+
+    [Fact]
+    public void ResolveAll_FallsBackToUtilityWhenMetadataIsMissing()
+    {
+        var categories = PluginMarketplaceCategories.ResolveAll(null, []);
+
+        Assert.Equal(["utility"], categories.Select(category => category.Key).ToArray());
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Text.Json;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class OpenAiCompatiblePluginTests
+{
+    [Fact]
+    public void Manifest_AdvertisesTranscriptionAndLlmCategories()
+    {
+        var manifestPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.OpenAiCompatible", "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(manifest);
+        Assert.Equal("transcription", manifest.Category);
+        Assert.Equal(["transcription", "llm"], manifest.Categories);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -9,10 +9,11 @@ public class OpenAiCompatiblePluginTests
     [Fact]
     public void Manifest_AdvertisesTranscriptionAndLlmCategories()
     {
-        var manifestPath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory,
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
             "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.OpenAiCompatible", "manifest.json"));
+            "plugins", "TypeWhisper.Plugin.OpenAiCompatible", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
         var manifest = JsonSerializer.Deserialize<PluginManifest>(
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -80,6 +80,70 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FetchRegistryAsync_DeserializesMultipleCategories()
+    {
+        var plugins = new[]
+        {
+            new
+            {
+                Id = "com.test.openai",
+                Name = "OpenAI",
+                Version = "1.0.0",
+                Author = "Tester",
+                Description = "A multi-capability plugin",
+                Category = "transcription",
+                Categories = new[] { "transcription", "llm", "tts" },
+                Size = 1024L,
+                DownloadUrl = "https://example.com/plugin.zip",
+                RequiresApiKey = true
+            }
+        };
+
+        var json = JsonSerializer.Serialize(plugins);
+        var httpClient = CreateMockHttpClient(json);
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, httpClient);
+
+        var result = await service.FetchRegistryAsync();
+
+        Assert.Single(result);
+        Assert.Equal("transcription", result[0].Category);
+        Assert.Equal(["transcription", "llm", "tts"], result[0].Categories);
+    }
+
+    [Fact]
+    public async Task FetchRegistryAsync_PreservesLegacyCategoryWhenCategoriesMissing()
+    {
+        var plugins = new[]
+        {
+            new
+            {
+                Id = "com.test.legacy",
+                Name = "Legacy",
+                Version = "1.0.0",
+                Author = "Tester",
+                Description = "A legacy plugin",
+                Category = "LLM",
+                Size = 1024L,
+                DownloadUrl = "https://example.com/plugin.zip",
+                RequiresApiKey = true
+            }
+        };
+
+        var json = JsonSerializer.Serialize(plugins);
+        var httpClient = CreateMockHttpClient(json);
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, httpClient);
+
+        var result = await service.FetchRegistryAsync();
+
+        Assert.Single(result);
+        Assert.Equal("LLM", result[0].Category);
+        Assert.Null(result[0].Categories);
+    }
+
+
+    [Fact]
     public async Task FetchRegistryAsync_CachesResults()
     {
         var plugins = new[] { new { Id = "p1", Name = "P", Version = "1.0", Author = "A", Description = "D", Size = 100L, DownloadUrl = "u", RequiresApiKey = false } };

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using Moq;
+using Moq.Protected;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class PluginsViewModelMarketplaceFilterTests : IDisposable
+{
+    private readonly Mock<IActiveWindowService> _activeWindow = new();
+    private readonly Mock<IWorkflowService> _workflows = new();
+    private readonly Mock<ISettingsService> _settings = new();
+    private readonly PluginEventBus _eventBus = new();
+    private readonly PluginLoader _loader = new();
+    private PluginManager? _manager;
+
+    public PluginsViewModelMarketplaceFilterTests()
+    {
+        _workflows.Setup(w => w.Workflows).Returns(new List<Workflow>());
+        _settings.Setup(s => s.Current).Returns(new AppSettings());
+    }
+
+    [Fact]
+    public async Task MarketplaceFilter_NoSelectionShowsAllPlugins()
+    {
+        var viewModel = await CreateViewModelAsync();
+
+        Assert.Equal(
+            ["Groq", "OpenAI", "OpenAI Compatible", "Supertonic TTS"],
+            viewModel.FilteredMarketplacePlugins.Select(plugin => plugin.Name).OrderBy(name => name).ToArray());
+    }
+
+    [Fact]
+    public async Task MarketplaceFilter_TextToSpeechShowsEveryPluginWithTtsCapability()
+    {
+        var viewModel = await CreateViewModelAsync();
+
+        viewModel.ToggleMarketplaceCapabilityFilterCommand.Execute("tts");
+
+        Assert.Equal(
+            ["OpenAI", "Supertonic TTS"],
+            viewModel.FilteredMarketplacePlugins.Select(plugin => plugin.Name).OrderBy(name => name).ToArray());
+    }
+
+    [Fact]
+    public async Task MarketplaceFilter_LlmShowsEveryPluginWithLlmCapability()
+    {
+        var viewModel = await CreateViewModelAsync();
+
+        viewModel.ToggleMarketplaceCapabilityFilterCommand.Execute("llm");
+
+        Assert.Equal(
+            ["Groq", "OpenAI", "OpenAI Compatible"],
+            viewModel.FilteredMarketplacePlugins.Select(plugin => plugin.Name).OrderBy(name => name).ToArray());
+    }
+
+    [Fact]
+    public async Task MarketplaceFilter_MultipleSelectionsUseOrLogicWithoutDuplicates()
+    {
+        var viewModel = await CreateViewModelAsync();
+
+        viewModel.ToggleMarketplaceCapabilityFilterCommand.Execute("llm");
+        viewModel.ToggleMarketplaceCapabilityFilterCommand.Execute("tts");
+
+        Assert.Equal(
+            ["Groq", "OpenAI", "OpenAI Compatible", "Supertonic TTS"],
+            viewModel.FilteredMarketplacePlugins.Select(plugin => plugin.Name).OrderBy(name => name).ToArray());
+        Assert.Equal(
+            viewModel.FilteredMarketplacePlugins.Select(plugin => plugin.Id).Distinct().Count(),
+            viewModel.FilteredMarketplacePlugins.Count);
+    }
+
+    [Fact]
+    public async Task MarketplaceCapabilityFilters_CountPluginsPerNormalizedCategory()
+    {
+        var viewModel = await CreateViewModelAsync();
+
+        var counts = viewModel.MarketplaceCapabilityFilters.ToDictionary(filter => filter.Key, filter => filter.Count);
+
+        Assert.Equal(3, counts["transcription"]);
+        Assert.Equal(3, counts["llm"]);
+        Assert.Equal(2, counts["tts"]);
+    }
+
+    private async Task<PluginsViewModel> CreateViewModelAsync()
+    {
+        var json = JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                Id = "com.typewhisper.openai",
+                Name = "OpenAI",
+                Version = "1.0.0",
+                Author = "TypeWhisper",
+                Description = "OpenAI transcription, prompts, and text-to-speech.",
+                Category = "transcription",
+                Categories = new[] { "transcription", "llm", "tts" },
+                Size = 1024L,
+                DownloadUrl = "https://example.com/openai.zip",
+                RequiresApiKey = true
+            },
+            new
+            {
+                Id = "com.typewhisper.groq",
+                Name = "Groq",
+                Version = "1.0.0",
+                Author = "TypeWhisper",
+                Description = "Groq transcription and prompts.",
+                Category = "Transcription",
+                Categories = new[] { "Transcription", "LLM" },
+                Size = 1024L,
+                DownloadUrl = "https://example.com/groq.zip",
+                RequiresApiKey = true
+            },
+            new
+            {
+                Id = "com.typewhisper.openai-compatible",
+                Name = "OpenAI Compatible",
+                Version = "1.0.0",
+                Author = "TypeWhisper",
+                Description = "OpenAI-compatible transcription and prompts.",
+                Category = "transcription",
+                Categories = new[] { "transcription", "llm" },
+                Size = 1024L,
+                DownloadUrl = "https://example.com/openai-compatible.zip",
+                RequiresApiKey = false
+            },
+            new
+            {
+                Id = "com.typewhisper.supertonic-tts",
+                Name = "Supertonic TTS",
+                Version = "1.0.0",
+                Author = "TypeWhisper",
+                Description = "Local text-to-speech.",
+                Category = "text-to-speech",
+                Categories = new[] { "text-to-speech" },
+                Size = 1024L,
+                DownloadUrl = "https://example.com/supertonic.zip",
+                RequiresApiKey = false
+            }
+        });
+
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, CreateMockHttpClient(json));
+        var viewModel = new PluginsViewModel(manager, service);
+
+        await viewModel.RefreshRegistryCommand.ExecuteAsync(null);
+        return viewModel;
+    }
+
+    private PluginManager CreateManager()
+    {
+        _manager = new PluginManager(_loader, _eventBus, _activeWindow.Object, _workflows.Object, _settings.Object);
+        return _manager;
+    }
+
+    private static HttpClient CreateMockHttpClient(string responseJson)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson)
+            });
+
+        return new HttpClient(handler.Object);
+    }
+
+    public void Dispose()
+    {
+        _manager?.Dispose();
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
@@ -167,7 +167,7 @@ public class PluginsViewModelMarketplaceFilterTests : IDisposable
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(responseJson)
             });


### PR DESCRIPTION
## Summary
- Add optional registry `categories` metadata with normalized marketplace capability keys, aliases, primary-first ordering, de-duplication, and legacy `category` fallback.
- Replace the Windows Marketplace single-category tabs with multi-select capability filters and render multiple capability badges for installed and marketplace plugins.
- Update Groq and OpenAI Compatible manifests, localization, tests, and the plugin publishing workflow so existing and new registry entries refresh category, categories, description, descriptions, and API-key metadata from manifests.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- `dotnet build src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release`
- Local plugin metadata validation from `plugins-smoke.yml`
- Local publish workflow metadata smoke for existing and new registry entries