### PR TITLE
Fix microphone reconnect handling

### DIFF
--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -699,6 +699,7 @@
   "Widget.AppName": "App-Name",
 
   "Microphone.Default": "Standard",
+  "Microphone.Disconnected": "Ausgewähltes Mikrofon getrennt",
 
   "App.ErrorTitle": "TypeWhisper - Fehler",
   "App.ErrorFormat": "Ein Fehler ist aufgetreten:\n{0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -699,6 +699,7 @@
   "Widget.AppName": "App Name",
 
   "Microphone.Default": "Default",
+  "Microphone.Disconnected": "Selected microphone disconnected",
 
   "App.ErrorTitle": "TypeWhisper - Error",
   "App.ErrorFormat": "An error occurred:\n{0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -668,6 +668,7 @@
   "Widget.HotkeyMode": "ホットキーモード",
   "Widget.AppName": "アプリ名",
   "Microphone.Default": "デフォルト",
+  "Microphone.Disconnected": "選択したマイクが切断されています",
   "App.ErrorTitle": "TypeWhisper - エラー",
   "App.ErrorFormat": "エラーが発生しました:\n{0}",
   "Hotkey.Placeholder": "キーの組み合わせを押してください...",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -678,6 +678,7 @@
   "Widget.HotkeyMode": "Режим горячей клавиши",
   "Widget.AppName": "Приложение",
   "Microphone.Default": "По умолчанию",
+  "Microphone.Disconnected": "Выбранный микрофон отключён",
   "App.ErrorTitle": "TypeWhisper — ошибка",
   "App.ErrorFormat": "Произошла ошибка:\n{0}",
   "Hotkey.Placeholder": "Нажмите сочетание клавиш…",

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -1,3 +1,4 @@
+using NAudio;
 using NAudio.Wave;
 
 namespace TypeWhisper.Windows.Services;
@@ -388,14 +389,12 @@ public sealed class AudioRecordingService : IDisposable
         if (_configuredDeviceNumber is int configuredDeviceNumber)
         {
             var configuredDeviceName = TryGetDeviceName(configuredDeviceNumber);
-            if (configuredDeviceName is not null)
+            if (configuredDeviceName is not null
+                && (string.IsNullOrWhiteSpace(_configuredDeviceName)
+                    || string.Equals(configuredDeviceName, _configuredDeviceName, StringComparison.OrdinalIgnoreCase)))
             {
-                if (string.IsNullOrWhiteSpace(_configuredDeviceName)
-                    || string.Equals(configuredDeviceName, _configuredDeviceName, StringComparison.OrdinalIgnoreCase))
-                {
-                    _configuredDeviceName = configuredDeviceName;
-                    return configuredDeviceNumber;
-                }
+                _configuredDeviceName = configuredDeviceName;
+                return configuredDeviceNumber;
             }
 
             var rememberedDeviceNumber = FindDeviceByName(_configuredDeviceName);
@@ -432,7 +431,7 @@ public sealed class AudioRecordingService : IDisposable
         {
             return _deviceProvider.GetDeviceName(deviceNumber);
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException or MmException)
         {
             return null;
         }
@@ -494,7 +493,7 @@ public sealed class AudioRecordingService : IDisposable
             {
                 HandleDeviceLost();
                 WarmUp();
-                if ((!previousHadDevices && currentHasDevices)
+                if (!previousHadDevices
                     || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
                 {
                     DeviceAvailable?.Invoke(this, EventArgs.Empty);
@@ -512,7 +511,7 @@ public sealed class AudioRecordingService : IDisposable
                 WarmUp();
             }
 
-            if ((!previousHadDevices && currentHasDevices)
+            if (!previousHadDevices
                 || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
             {
                 DeviceAvailable?.Invoke(this, EventArgs.Empty);
@@ -628,11 +627,23 @@ public sealed class AudioRecordingService : IDisposable
         if (_previewWaveIn is not null)
         {
             _previewWaveIn.DataAvailable -= OnPreviewDataAvailable;
-            try { _previewWaveIn.StopRecording(); } catch { }
+            StopRecordingForCleanup(_previewWaveIn);
             _previewWaveIn.Dispose();
             _previewWaveIn = null;
         }
         _isPreviewing = false;
+    }
+
+    private static void StopRecordingForCleanup(IAudioInputCapture waveIn)
+    {
+        try
+        {
+            waveIn.StopRecording();
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or MmException)
+        {
+            System.Diagnostics.Debug.WriteLine($"StopRecording during audio cleanup failed: {ex.Message}");
+        }
     }
 
     public bool IsPreviewing => _isPreviewing;
@@ -666,7 +677,7 @@ public sealed class AudioRecordingService : IDisposable
             waveIn.RecordingStopped -= OnRecordingStopped;
             if (stopRecording)
             {
-                try { waveIn.StopRecording(); } catch { }
+                StopRecordingForCleanup(waveIn);
             }
             waveIn.Dispose();
         }

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -13,6 +13,7 @@ public sealed class AudioRecordingService : IDisposable
     private const float AgcMinGain = 1f;
     private const float NormalizationTarget = 0.707f;
     private static readonly TimeSpan StopDrainDuration = TimeSpan.FromMilliseconds(120);
+    private static readonly TimeSpan DefaultDevicePollInterval = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Minimum per-chunk RMS level to consider as containing speech.
@@ -20,8 +21,11 @@ public sealed class AudioRecordingService : IDisposable
     /// </summary>
     public const float SpeechEnergyThreshold = 0.01f;
 
-    private WaveInEvent? _waveIn;
-    private WaveInEvent? _previewWaveIn;
+    private readonly IAudioInputDeviceProvider _deviceProvider;
+    private readonly IAudioInputCaptureFactory _captureFactory;
+    private readonly TimeSpan _devicePollInterval;
+    private IAudioInputCapture? _waveIn;
+    private IAudioInputCapture? _previewWaveIn;
     private List<float>? _sampleBuffer;
     private readonly object _bufferLock = new();
     private bool _isRecording;
@@ -30,15 +34,35 @@ public sealed class AudioRecordingService : IDisposable
     private bool _disposed;
     private DateTime _recordingStartTime;
     private int? _configuredDeviceNumber;
-    private int _activeDeviceNumber;
+    private string? _configuredDeviceName;
+    private int _activeDeviceNumber = -1;
+    private string? _activeDeviceName;
     private float _peakRmsLevel;
     private float _preGainPeakRms;
     private float _currentRmsLevel;
     private System.Timers.Timer? _devicePollTimer;
-    private int _lastKnownDeviceCount;
+    private string _lastKnownDeviceSignature = "";
+    private bool _lastKnownHasDevices;
+    private bool _lastKnownPreferredDeviceAvailable;
+    private bool _lastKnownSnapshotInitialized;
     private const int TailDiagnosticChunkLimit = 8;
     private readonly Queue<AudioChunkTelemetry> _recentChunks = new();
     private DateTime? _lastSamplesAvailableUtc;
+
+    public AudioRecordingService()
+        : this(new WaveInAudioInputDeviceProvider(), new WaveInAudioInputCaptureFactory(), DefaultDevicePollInterval)
+    {
+    }
+
+    internal AudioRecordingService(
+        IAudioInputDeviceProvider deviceProvider,
+        IAudioInputCaptureFactory captureFactory,
+        TimeSpan devicePollInterval)
+    {
+        _deviceProvider = deviceProvider;
+        _captureFactory = captureFactory;
+        _devicePollInterval = devicePollInterval;
+    }
 
     public event EventHandler<AudioLevelEventArgs>? AudioLevelChanged;
     public event EventHandler<AudioLevelEventArgs>? PreviewLevelChanged;
@@ -47,7 +71,7 @@ public sealed class AudioRecordingService : IDisposable
     public event EventHandler? DeviceLost;
     public event EventHandler? DeviceAvailable;
 
-    public bool HasDevice => WaveInEvent.DeviceCount > 0;
+    public bool HasDevice => _deviceProvider.DeviceCount > 0;
     public bool WhisperModeEnabled { get; set; }
     public bool NormalizationEnabled { get; set; } = true;
     public bool IsRecording => _isRecording;
@@ -59,28 +83,48 @@ public sealed class AudioRecordingService : IDisposable
 
     public void SetMicrophoneDevice(int? deviceNumber)
     {
-        var newDevice = deviceNumber ?? FindBestMicrophoneDevice();
+        var previousDeviceNumber = _configuredDeviceNumber;
+        _configuredDeviceNumber = deviceNumber;
+
+        if (deviceNumber is int explicitDeviceNumber)
+        {
+            var deviceName = TryGetDeviceName(explicitDeviceNumber);
+            if (deviceName is not null
+                && (previousDeviceNumber != explicitDeviceNumber || string.IsNullOrWhiteSpace(_configuredDeviceName)))
+            {
+                _configuredDeviceName = deviceName;
+            }
+        }
+        else
+        {
+            _configuredDeviceName = null;
+        }
+
+        var newDevice = ResolvePreferredDeviceNumber(allowFallback: true);
         if (_isWarmedUp && newDevice != _activeDeviceNumber)
         {
             DisposeWaveIn();
-            _isWarmedUp = false;
+            if (newDevice >= 0)
+                WarmUp();
         }
-        _configuredDeviceNumber = deviceNumber;
-        _activeDeviceNumber = newDevice;
+        else if (newDevice >= 0)
+        {
+            _activeDeviceNumber = newDevice;
+        }
     }
 
     public bool WarmUp()
     {
         if (_isWarmedUp || _disposed) return _isWarmedUp;
 
-        if (WaveInEvent.DeviceCount == 0)
+        if (_deviceProvider.DeviceCount == 0)
         {
             System.Diagnostics.Debug.WriteLine("WarmUp: No audio input devices available.");
             StartDevicePolling();
             return false;
         }
 
-        _activeDeviceNumber = _configuredDeviceNumber ?? FindBestMicrophoneDevice();
+        _activeDeviceNumber = ResolvePreferredDeviceNumber(allowFallback: true);
         if (_activeDeviceNumber < 0)
         {
             StartDevicePolling();
@@ -89,39 +133,33 @@ public sealed class AudioRecordingService : IDisposable
 
         try
         {
-            _waveIn = new WaveInEvent
-            {
-                DeviceNumber = _activeDeviceNumber,
-                WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
-                BufferMilliseconds = 30
-            };
+            _waveIn = _captureFactory.Create(
+                _activeDeviceNumber,
+                new WaveFormat(SampleRate, BitsPerSample, Channels),
+                bufferMilliseconds: 30);
 
             _waveIn.DataAvailable += OnDataAvailable;
             _waveIn.RecordingStopped += OnRecordingStopped;
             _waveIn.StartRecording();
 
+            _activeDeviceName = TryGetDeviceName(_activeDeviceNumber);
             _isWarmedUp = true;
         }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"WarmUp failed: {ex.Message}");
-            DisposeWaveIn();
+            DisposeWaveIn(stopRecording: false);
         }
 
         StartDevicePolling();
         return _isWarmedUp;
     }
 
-    public static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices()
-    {
-        var devices = new List<(int, string)>();
-        for (var i = 0; i < WaveInEvent.DeviceCount; i++)
-        {
-            var caps = WaveInEvent.GetCapabilities(i);
-            devices.Add((i, caps.ProductName));
-        }
-        return devices;
-    }
+    public static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices() =>
+        GetAvailableDevices(new WaveInAudioInputDeviceProvider());
+
+    public IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableInputDevices() =>
+        GetAvailableDevices(_deviceProvider);
 
     public void StartRecording()
     {
@@ -159,8 +197,14 @@ public sealed class AudioRecordingService : IDisposable
 
     public float[]? StopRecording()
     {
-        if (!_isRecording || _waveIn is null)
+        if (!_isRecording)
             return null;
+
+        if (_waveIn is null)
+        {
+            ClearRecordingState();
+            return null;
+        }
 
         _isRecording = false;
 
@@ -207,11 +251,13 @@ public sealed class AudioRecordingService : IDisposable
         }
     }
 
-    private void OnDataAvailable(object? sender, WaveInEventArgs e)
+    private void OnDataAvailable(object? sender, AudioInputDataAvailableEventArgs e)
     {
         if (!_isRecording) return;
 
         var sampleCount = e.BytesRecorded / 2;
+        if (sampleCount == 0) return;
+
         float agcGain = 1f;
 
         // Compute pre-gain RMS for speech energy detection (unaffected by AGC)
@@ -275,7 +321,20 @@ public sealed class AudioRecordingService : IDisposable
         }
     }
 
-    private void OnRecordingStopped(object? sender, StoppedEventArgs e) { }
+    private void OnRecordingStopped(object? sender, AudioInputRecordingStoppedEventArgs e)
+    {
+        if (_waveIn is null || !ReferenceEquals(sender, _waveIn))
+            return;
+
+        System.Diagnostics.Debug.WriteLine(e.Exception is null
+            ? "Audio input capture stopped unexpectedly."
+            : $"Audio input capture stopped unexpectedly: {e.Exception.Message}");
+
+        ClearRecordingState();
+        DisposeWaveIn(stopRecording: false);
+        StartDevicePolling();
+        DeviceLost?.Invoke(this, EventArgs.Empty);
+    }
 
     private static void NormalizeAudio(float[] samples)
     {
@@ -295,70 +354,243 @@ public sealed class AudioRecordingService : IDisposable
             samples[i] = Math.Clamp(samples[i] * gain, -1f, 1f);
     }
 
-    private static int FindBestMicrophoneDevice()
+    private int FindBestMicrophoneDevice()
     {
-        var deviceCount = WaveInEvent.DeviceCount;
+        var deviceCount = _deviceProvider.DeviceCount;
 
         for (var i = 0; i < deviceCount; i++)
         {
-            var caps = WaveInEvent.GetCapabilities(i);
-            if (caps.ProductName.Contains("Microphone", StringComparison.OrdinalIgnoreCase) ||
-                caps.ProductName.Contains("Mikrofon", StringComparison.OrdinalIgnoreCase))
+            var name = TryGetDeviceName(i);
+            if (name is not null
+                && (name.Contains("Microphone", StringComparison.OrdinalIgnoreCase) ||
+                    name.Contains("Mikrofon", StringComparison.OrdinalIgnoreCase)))
+            {
                 return i;
+            }
         }
 
         for (var i = 0; i < deviceCount; i++)
         {
-            var caps = WaveInEvent.GetCapabilities(i);
-            if (!caps.ProductName.Contains("Virtual", StringComparison.OrdinalIgnoreCase) &&
-                !caps.ProductName.Contains("Mix", StringComparison.OrdinalIgnoreCase))
+            var name = TryGetDeviceName(i);
+            if (name is not null
+                && !name.Contains("Virtual", StringComparison.OrdinalIgnoreCase)
+                && !name.Contains("Mix", StringComparison.OrdinalIgnoreCase))
+            {
                 return i;
+            }
         }
 
         return deviceCount > 0 ? 0 : -1;
     }
 
+    private int ResolvePreferredDeviceNumber(bool allowFallback)
+    {
+        if (_configuredDeviceNumber is int configuredDeviceNumber)
+        {
+            var configuredDeviceName = TryGetDeviceName(configuredDeviceNumber);
+            if (configuredDeviceName is not null)
+            {
+                if (string.IsNullOrWhiteSpace(_configuredDeviceName)
+                    || string.Equals(configuredDeviceName, _configuredDeviceName, StringComparison.OrdinalIgnoreCase))
+                {
+                    _configuredDeviceName = configuredDeviceName;
+                    return configuredDeviceNumber;
+                }
+            }
+
+            var rememberedDeviceNumber = FindDeviceByName(_configuredDeviceName);
+            if (rememberedDeviceNumber >= 0)
+                return rememberedDeviceNumber;
+
+            return allowFallback ? FindBestMicrophoneDevice() : -1;
+        }
+
+        return FindBestMicrophoneDevice();
+    }
+
+    private int FindDeviceByName(string? deviceName)
+    {
+        if (string.IsNullOrWhiteSpace(deviceName))
+            return -1;
+
+        for (var i = 0; i < _deviceProvider.DeviceCount; i++)
+        {
+            var currentName = TryGetDeviceName(i);
+            if (string.Equals(currentName, deviceName, StringComparison.OrdinalIgnoreCase))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private string? TryGetDeviceName(int deviceNumber)
+    {
+        if (deviceNumber < 0 || deviceNumber >= _deviceProvider.DeviceCount)
+            return null;
+
+        try
+        {
+            return _deviceProvider.GetDeviceName(deviceNumber);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private void StartDevicePolling()
     {
-        _lastKnownDeviceCount = WaveInEvent.DeviceCount;
+        UpdateKnownDeviceSnapshot();
         _devicePollTimer?.Dispose();
-        _devicePollTimer = new System.Timers.Timer(2000);
+        _devicePollTimer = null;
+
+        if (_devicePollInterval == Timeout.InfiniteTimeSpan || _devicePollInterval <= TimeSpan.Zero)
+            return;
+
+        _devicePollTimer = new System.Timers.Timer(_devicePollInterval.TotalMilliseconds);
         _devicePollTimer.Elapsed += (_, _) => CheckForDeviceChanges();
         _devicePollTimer.AutoReset = true;
         _devicePollTimer.Start();
     }
 
-    private void CheckForDeviceChanges()
+    private void UpdateKnownDeviceSnapshot()
+    {
+        var snapshot = GetDeviceSnapshot();
+        _lastKnownDeviceSignature = BuildDeviceSignature(snapshot);
+        _lastKnownHasDevices = snapshot.Count > 0;
+        _lastKnownPreferredDeviceAvailable = IsPreferredDeviceAvailable(snapshot);
+        _lastKnownSnapshotInitialized = true;
+    }
+
+    internal void CheckForDeviceChanges()
     {
         try
         {
-            var currentCount = WaveInEvent.DeviceCount;
-            if (currentCount == _lastKnownDeviceCount) return;
+            var snapshot = GetDeviceSnapshot();
+            var signature = BuildDeviceSignature(snapshot);
+            if (_lastKnownSnapshotInitialized && signature == _lastKnownDeviceSignature)
+                return;
 
-            var previousCount = _lastKnownDeviceCount;
-            _lastKnownDeviceCount = currentCount;
+            var previousHadDevices = _lastKnownHasDevices;
+            var previousPreferredDeviceAvailable = _lastKnownPreferredDeviceAvailable;
+            var currentHasDevices = snapshot.Count > 0;
+            var currentPreferredDeviceAvailable = IsPreferredDeviceAvailable(snapshot);
+
+            _lastKnownDeviceSignature = signature;
+            _lastKnownHasDevices = currentHasDevices;
+            _lastKnownPreferredDeviceAvailable = currentPreferredDeviceAvailable;
+            _lastKnownSnapshotInitialized = true;
+
             DevicesChanged?.Invoke(this, EventArgs.Empty);
 
-            if (currentCount == 0 && _isWarmedUp)
+            if (!currentHasDevices)
             {
-                DeviceLost?.Invoke(this, EventArgs.Empty);
-                DisposeWaveIn();
-                _configuredDeviceNumber = null;
+                if (_isWarmedUp || _waveIn is not null)
+                    HandleDeviceLost();
+                return;
             }
-            else if (currentCount > 0 && previousCount == 0)
+
+            if (_isWarmedUp && !IsActiveDeviceAvailable(snapshot))
+            {
+                HandleDeviceLost();
+                WarmUp();
+                if ((!previousHadDevices && currentHasDevices)
+                    || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
+                {
+                    DeviceAvailable?.Invoke(this, EventArgs.Empty);
+                }
+                return;
+            }
+
+            if (_isWarmedUp && currentPreferredDeviceAvailable && !IsActiveDevicePreferred())
+            {
+                DisposeWaveIn();
+                WarmUp();
+            }
+            else if (!_isWarmedUp)
+            {
+                WarmUp();
+            }
+
+            if ((!previousHadDevices && currentHasDevices)
+                || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
             {
                 DeviceAvailable?.Invoke(this, EventArgs.Empty);
-                WarmUp();
-            }
-            else if (_isWarmedUp && _activeDeviceNumber >= currentCount)
-            {
-                DeviceLost?.Invoke(this, EventArgs.Empty);
-                DisposeWaveIn();
-                _configuredDeviceNumber = null;
-                WarmUp();
             }
         }
         catch { }
+    }
+
+    private void HandleDeviceLost()
+    {
+        ClearRecordingState();
+        DisposeWaveIn();
+        DeviceLost?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ClearRecordingState()
+    {
+        _isRecording = false;
+        lock (_bufferLock)
+        {
+            _sampleBuffer = null;
+        }
+    }
+
+    private IReadOnlyList<AudioInputDeviceSnapshot> GetDeviceSnapshot()
+    {
+        var devices = new List<AudioInputDeviceSnapshot>();
+        for (var i = 0; i < _deviceProvider.DeviceCount; i++)
+        {
+            var name = TryGetDeviceName(i);
+            if (name is not null)
+                devices.Add(new AudioInputDeviceSnapshot(i, name));
+        }
+
+        return devices;
+    }
+
+    private static string BuildDeviceSignature(IReadOnlyList<AudioInputDeviceSnapshot> devices) =>
+        string.Join('\n', devices.Select(device => $"{device.DeviceNumber}:{device.Name}"));
+
+    private bool IsPreferredDeviceAvailable(IReadOnlyList<AudioInputDeviceSnapshot> devices)
+    {
+        if (_configuredDeviceNumber is not int configuredDeviceNumber)
+            return devices.Count > 0;
+
+        if (!string.IsNullOrWhiteSpace(_configuredDeviceName)
+            && devices.Any(device => string.Equals(device.Name, _configuredDeviceName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        return devices.Any(device => device.DeviceNumber == configuredDeviceNumber);
+    }
+
+    private bool IsActiveDeviceAvailable(IReadOnlyList<AudioInputDeviceSnapshot> devices)
+    {
+        if (_activeDeviceNumber < 0)
+            return false;
+
+        var active = devices.FirstOrDefault(device => device.DeviceNumber == _activeDeviceNumber);
+        if (active is null)
+            return false;
+
+        return string.IsNullOrWhiteSpace(_activeDeviceName)
+            || string.Equals(active.Name, _activeDeviceName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsActiveDevicePreferred()
+    {
+        if (_configuredDeviceNumber is not int configuredDeviceNumber)
+            return _activeDeviceNumber >= 0;
+
+        if (!string.IsNullOrWhiteSpace(_configuredDeviceName))
+        {
+            return string.Equals(_activeDeviceName, _configuredDeviceName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return _activeDeviceNumber == configuredDeviceNumber;
     }
 
     public void StartPreview(int? deviceNumber)
@@ -367,19 +599,19 @@ public sealed class AudioRecordingService : IDisposable
             return;
 
         StopPreview();
-        if (_disposed || WaveInEvent.DeviceCount == 0) return;
+        if (_disposed || _deviceProvider.DeviceCount == 0) return;
 
-        var deviceIndex = deviceNumber ?? FindBestMicrophoneDevice();
+        var deviceIndex = deviceNumber.HasValue
+            ? ResolvePreferredDeviceNumber(allowFallback: true)
+            : FindBestMicrophoneDevice();
         if (deviceIndex < 0) return;
 
         try
         {
-            _previewWaveIn = new WaveInEvent
-            {
-                DeviceNumber = deviceIndex,
-                WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
-                BufferMilliseconds = 50
-            };
+            _previewWaveIn = _captureFactory.Create(
+                deviceIndex,
+                new WaveFormat(SampleRate, BitsPerSample, Channels),
+                bufferMilliseconds: 50);
             _previewWaveIn.DataAvailable += OnPreviewDataAvailable;
             _previewWaveIn.StartRecording();
             _isPreviewing = true;
@@ -405,7 +637,7 @@ public sealed class AudioRecordingService : IDisposable
 
     public bool IsPreviewing => _isPreviewing;
 
-    private void OnPreviewDataAvailable(object? sender, WaveInEventArgs e)
+    private void OnPreviewDataAvailable(object? sender, AudioInputDataAvailableEventArgs e)
     {
         var sampleCount = e.BytesRecorded / 2;
         if (sampleCount == 0) return;
@@ -424,17 +656,23 @@ public sealed class AudioRecordingService : IDisposable
         PreviewLevelChanged?.Invoke(this, new AudioLevelEventArgs(peak, rms));
     }
 
-    private void DisposeWaveIn()
+    private void DisposeWaveIn(bool stopRecording = true)
     {
         if (_waveIn is not null)
         {
-            _waveIn.DataAvailable -= OnDataAvailable;
-            _waveIn.RecordingStopped -= OnRecordingStopped;
-            try { _waveIn.StopRecording(); } catch { }
-            _waveIn.Dispose();
+            var waveIn = _waveIn;
             _waveIn = null;
+            waveIn.DataAvailable -= OnDataAvailable;
+            waveIn.RecordingStopped -= OnRecordingStopped;
+            if (stopRecording)
+            {
+                try { waveIn.StopRecording(); } catch { }
+            }
+            waveIn.Dispose();
         }
         _isWarmedUp = false;
+        _activeDeviceNumber = -1;
+        _activeDeviceName = null;
     }
 
     public void Dispose()
@@ -447,6 +685,16 @@ public sealed class AudioRecordingService : IDisposable
             DisposeWaveIn();
             _disposed = true;
         }
+    }
+
+    private static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices(IAudioInputDeviceProvider provider)
+    {
+        var devices = new List<(int, string)>();
+        for (var i = 0; i < provider.DeviceCount; i++)
+        {
+            devices.Add((i, provider.GetDeviceName(i)));
+        }
+        return devices;
     }
 }
 
@@ -467,3 +715,87 @@ public sealed record AudioChunkTelemetry(
     float Rms,
     float PreGainRms,
     int SampleCount);
+
+internal sealed record AudioInputDeviceSnapshot(int DeviceNumber, string Name);
+
+internal interface IAudioInputDeviceProvider
+{
+    int DeviceCount { get; }
+    string GetDeviceName(int deviceNumber);
+}
+
+internal interface IAudioInputCaptureFactory
+{
+    IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds);
+}
+
+internal interface IAudioInputCapture : IDisposable
+{
+    event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
+    event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+    void StartRecording();
+    void StopRecording();
+}
+
+internal sealed class AudioInputDataAvailableEventArgs(byte[] buffer, int bytesRecorded) : EventArgs
+{
+    public byte[] Buffer { get; } = buffer;
+    public int BytesRecorded { get; } = bytesRecorded;
+}
+
+internal sealed class AudioInputRecordingStoppedEventArgs(Exception? exception = null) : EventArgs
+{
+    public Exception? Exception { get; } = exception;
+}
+
+internal sealed class WaveInAudioInputDeviceProvider : IAudioInputDeviceProvider
+{
+    public int DeviceCount => WaveInEvent.DeviceCount;
+
+    public string GetDeviceName(int deviceNumber) =>
+        WaveInEvent.GetCapabilities(deviceNumber).ProductName;
+}
+
+internal sealed class WaveInAudioInputCaptureFactory : IAudioInputCaptureFactory
+{
+    public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds) =>
+        new WaveInAudioInputCapture(deviceNumber, waveFormat, bufferMilliseconds);
+}
+
+internal sealed class WaveInAudioInputCapture : IAudioInputCapture
+{
+    private readonly WaveInEvent _waveIn;
+
+    public WaveInAudioInputCapture(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
+    {
+        _waveIn = new WaveInEvent
+        {
+            DeviceNumber = deviceNumber,
+            WaveFormat = waveFormat,
+            BufferMilliseconds = bufferMilliseconds
+        };
+
+        _waveIn.DataAvailable += OnDataAvailable;
+        _waveIn.RecordingStopped += OnRecordingStopped;
+    }
+
+    public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
+    public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+
+    public void StartRecording() => _waveIn.StartRecording();
+
+    public void StopRecording() => _waveIn.StopRecording();
+
+    public void Dispose()
+    {
+        _waveIn.DataAvailable -= OnDataAvailable;
+        _waveIn.RecordingStopped -= OnRecordingStopped;
+        _waveIn.Dispose();
+    }
+
+    private void OnDataAvailable(object? sender, WaveInEventArgs e) =>
+        DataAvailable?.Invoke(this, new AudioInputDataAvailableEventArgs(e.Buffer, e.BytesRecorded));
+
+    private void OnRecordingStopped(object? sender, StoppedEventArgs e) =>
+        RecordingStopped?.Invoke(this, new AudioInputRecordingStoppedEventArgs(e.Exception));
+}

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -540,7 +540,7 @@ public partial class SettingsViewModel : ObservableObject
         var dispatcher = Application.Current?.Dispatcher;
         if (dispatcher is not null && !dispatcher.CheckAccess())
         {
-            dispatcher.InvokeAsync(HandleAudioDevicesChanged);
+            dispatcher.Invoke(HandleAudioDevicesChanged);
             return;
         }
 

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -108,6 +108,24 @@ public partial class SettingsViewModel : ObservableObject
     public ObservableCollection<MicrophoneItem> Microphones { get; } = [];
     public ObservableCollection<OverlayWidgetOption> WidgetOptions { get; } = [];
 
+    private MicrophoneItem? _selectedMicrophoneItem;
+    private bool _isSyncingMicrophoneSelection;
+
+    public MicrophoneItem? SelectedMicrophoneItem
+    {
+        get => _selectedMicrophoneItem;
+        set
+        {
+            if (!SetProperty(ref _selectedMicrophoneItem, value))
+                return;
+
+            if (_isSyncingMicrophoneSelection || _isLoading)
+                return;
+
+            SelectedMicrophoneDevice = value?.DeviceNumber;
+        }
+    }
+
     public string PreviewBubbleAutoHideSecondsText =>
         Loc.Instance.GetString("Appearance.AutoHideSecondsFormat", PreviewBubbleAutoHideSeconds);
     public string LiveTranscriptionFontSizeText =>
@@ -127,6 +145,7 @@ public partial class SettingsViewModel : ObservableObject
         if (_isLoading) return;
         _audio.SetMicrophoneDevice(value);
         StopMicrophonePreview();
+        SyncSelectedMicrophoneItem();
     }
 
     partial void OnSelectedSpokenFeedbackProviderIdChanged(string value)
@@ -162,6 +181,7 @@ public partial class SettingsViewModel : ObservableObject
         Loc.Instance.LanguageChanged += OnLanguageChanged;
         _apiServer.StateChanged += OnApiServerStateChanged;
         _speechFeedback.ProvidersChanged += OnTtsProvidersChanged;
+        _audio.DevicesChanged += OnAudioDevicesChanged;
 
         _isLoading = true;
         RefreshLocalizedCollections();
@@ -180,6 +200,9 @@ public partial class SettingsViewModel : ObservableObject
         PropertyChanged += (_, args) =>
         {
             if (_isLoading) return;
+
+            if (args.PropertyName == nameof(SelectedMicrophoneItem))
+                return;
 
             if (args.PropertyName == nameof(AutostartEnabled))
             {
@@ -201,12 +224,22 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private void RefreshMicrophones()
     {
+        var selectedDevice = SelectedMicrophoneDevice;
         Microphones.Clear();
         Microphones.Add(new MicrophoneItem(null, Loc.Instance["Microphone.Default"]));
-        foreach (var (number, name) in AudioRecordingService.GetAvailableDevices())
+        var availableDevices = _audio.GetAvailableInputDevices();
+        foreach (var (number, name) in availableDevices)
         {
             Microphones.Add(new MicrophoneItem(number, name));
         }
+
+        if (selectedDevice is int selectedDeviceNumber
+            && availableDevices.All(device => device.DeviceNumber != selectedDeviceNumber))
+        {
+            Microphones.Add(new MicrophoneItem(selectedDeviceNumber, Loc.Instance["Microphone.Disconnected"]));
+        }
+
+        SyncSelectedMicrophoneItem();
     }
 
     [RelayCommand]
@@ -500,6 +533,44 @@ public partial class SettingsViewModel : ObservableObject
             RefreshSpokenFeedbackProviders();
             _isLoading = wasLoading;
         });
+    }
+
+    private void OnAudioDevicesChanged(object? sender, EventArgs e)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is not null && !dispatcher.CheckAccess())
+        {
+            dispatcher.InvokeAsync(HandleAudioDevicesChanged);
+            return;
+        }
+
+        HandleAudioDevicesChanged();
+    }
+
+    private void HandleAudioDevicesChanged()
+    {
+        var wasPreviewing = _audio.IsPreviewing;
+        StopMicrophonePreview();
+        RefreshMicrophones();
+        _audio.SetMicrophoneDevice(SelectedMicrophoneDevice);
+        if (wasPreviewing)
+            StartMicrophonePreview();
+    }
+
+    private void SyncSelectedMicrophoneItem()
+    {
+        var selectedItem = Microphones.FirstOrDefault(m => m.DeviceNumber == SelectedMicrophoneDevice)
+            ?? Microphones.FirstOrDefault(m => m.DeviceNumber is null);
+
+        _isSyncingMicrophoneSelection = true;
+        try
+        {
+            SelectedMicrophoneItem = selectedItem;
+        }
+        finally
+        {
+            _isSyncingMicrophoneSelection = false;
+        }
     }
 
     private void RefreshSpokenFeedbackProviders()

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -406,7 +406,7 @@ public partial class WelcomeViewModel : ObservableObject
     {
         Microphones.Clear();
         Microphones.Add(new MicrophoneItem(null, Loc.Instance["Microphone.Default"]));
-        foreach (var (number, name) in AudioRecordingService.GetAvailableDevices())
+        foreach (var (number, name) in _audio.GetAvailableInputDevices())
             Microphones.Add(new MicrophoneItem(number, name));
     }
 

--- a/src/TypeWhisper.Windows/Views/Sections/AudioSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/AudioSection.xaml
@@ -199,8 +199,7 @@
                                           Style="{StaticResource SettingsAlignedComboBoxStyle}"
                                           ItemsSource="{Binding Settings.Microphones}"
                                           DisplayMemberPath="Name"
-                                          SelectedValuePath="DeviceNumber"
-                                          SelectedValue="{Binding Settings.SelectedMicrophoneDevice}"/>
+                                          SelectedItem="{Binding Settings.SelectedMicrophoneItem, Mode=TwoWay}"/>
                             </Grid>
                         </Border>
 

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -1,0 +1,235 @@
+using Moq;
+using NAudio.Wave;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Localization;
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class AudioRecordingServiceDeviceChangeTests
+{
+    [Fact]
+    public void CheckForDeviceChanges_RaisesDevicesChanged_WhenDeviceNamesChangeWithSameCount()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        Assert.True(sut.WarmUp());
+
+        var changes = 0;
+        sut.DevicesChanged += (_, _) => changes++;
+
+        devices.SetDevices("Built-in Microphone");
+        sut.CheckForDeviceChanges();
+
+        Assert.Equal(1, changes);
+    }
+
+    [Fact]
+    public void CheckForDeviceChanges_FallsBackWithoutClearingConfiguredSelection_WhenSelectedDeviceDisappears()
+    {
+        var devices = new FakeAudioInputDeviceProvider("Built-in Microphone", "USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        sut.SetMicrophoneDevice(1);
+        Assert.True(sut.WarmUp());
+
+        devices.SetDevices("Built-in Microphone");
+        sut.CheckForDeviceChanges();
+
+        Assert.Equal([1, 0], captures.Created.Select(c => c.DeviceNumber));
+    }
+
+    [Fact]
+    public void CheckForDeviceChanges_ReactivatesRememberedDeviceName_WhenSelectedDeviceReconnectsAtDifferentIndex()
+    {
+        var devices = new FakeAudioInputDeviceProvider("Built-in Microphone", "USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        sut.SetMicrophoneDevice(1);
+        Assert.True(sut.WarmUp());
+        devices.SetDevices("Built-in Microphone");
+        sut.CheckForDeviceChanges();
+
+        var available = 0;
+        sut.DeviceAvailable += (_, _) => available++;
+        devices.SetDevices("USB Microphone", "Built-in Microphone");
+        sut.CheckForDeviceChanges();
+
+        Assert.Equal(1, available);
+        Assert.Equal(0, captures.Created.Last().DeviceNumber);
+    }
+
+    [Fact]
+    public void RecordingStopped_ResetsWarmupAndRaisesDeviceLost_WhenCaptureStopsUnexpectedly()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        Assert.True(sut.WarmUp());
+
+        var lost = 0;
+        sut.DeviceLost += (_, _) => lost++;
+        captures.Created.Single().RaiseStopped();
+
+        Assert.Equal(1, lost);
+        Assert.False(sut.IsRecording);
+
+        Assert.True(sut.WarmUp());
+        Assert.Equal(2, captures.Created.Count);
+    }
+
+    [Fact]
+    public void CheckForDeviceChanges_ClearsRecordingState_WhenActiveDeviceDisappearsDuringRecording()
+    {
+        var devices = new FakeAudioInputDeviceProvider("Built-in Microphone", "USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        sut.SetMicrophoneDevice(1);
+        Assert.True(sut.WarmUp());
+        sut.StartRecording();
+
+        devices.SetDevices("Built-in Microphone");
+        sut.CheckForDeviceChanges();
+
+        Assert.False(sut.IsRecording);
+    }
+
+    private static AudioRecordingService CreateService(
+        FakeAudioInputDeviceProvider devices,
+        FakeAudioInputCaptureFactory captures) =>
+        new(devices, captures, Timeout.InfiniteTimeSpan);
+}
+
+public sealed class SettingsViewModelMicrophoneDeviceTests
+{
+    [Fact]
+    public void Constructor_SelectsDefaultMicrophoneItem_WhenNoDeviceIsConfigured()
+    {
+        Loc.Instance.Initialize();
+        Loc.Instance.CurrentLanguage = "en";
+
+        var devices = new FakeAudioInputDeviceProvider();
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        var settings = new FakeSettingsService(AppSettings.Default with { SelectedMicrophoneDevice = null });
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        using var speech = new SpeechFeedbackService(settings, pluginManager, new FakeTtsProvider("windows-sapi", "System Voice"));
+
+        var sut = CreateSettingsViewModel(settings, audio, speech);
+
+        Assert.Null(sut.SelectedMicrophoneDevice);
+        Assert.NotNull(sut.SelectedMicrophoneItem);
+        Assert.Null(sut.SelectedMicrophoneItem!.DeviceNumber);
+        Assert.Equal("Default", sut.SelectedMicrophoneItem.Name);
+    }
+
+    [Fact]
+    public void DevicesChanged_RefreshesMicrophonesAndKeepsMissingSelectedDevice()
+    {
+        Loc.Instance.Initialize();
+        Loc.Instance.CurrentLanguage = "en";
+
+        var devices = new FakeAudioInputDeviceProvider("Built-in Microphone", "USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        var settings = new FakeSettingsService(AppSettings.Default with { SelectedMicrophoneDevice = 1 });
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        using var speech = new SpeechFeedbackService(settings, pluginManager, new FakeTtsProvider("windows-sapi", "System Voice"));
+        var sut = CreateSettingsViewModel(settings, audio, speech);
+
+        devices.SetDevices("Built-in Microphone");
+        audio.CheckForDeviceChanges();
+
+        Assert.Equal(1, sut.SelectedMicrophoneDevice);
+        var placeholder = Assert.Single(sut.Microphones, m => m.DeviceNumber == 1);
+        Assert.Contains("disconnected", placeholder.Name, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(placeholder, sut.SelectedMicrophoneItem);
+    }
+
+    [Fact]
+    public void SelectingDefaultMicrophoneItem_PersistsNullDeviceSelection()
+    {
+        Loc.Instance.Initialize();
+        Loc.Instance.CurrentLanguage = "en";
+
+        var devices = new FakeAudioInputDeviceProvider("Built-in Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        var settings = new FakeSettingsService(AppSettings.Default with { SelectedMicrophoneDevice = 0 });
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        using var speech = new SpeechFeedbackService(settings, pluginManager, new FakeTtsProvider("windows-sapi", "System Voice"));
+        var sut = CreateSettingsViewModel(settings, audio, speech);
+
+        sut.SelectedMicrophoneItem = Assert.Single(sut.Microphones, m => m.DeviceNumber is null);
+
+        Assert.Null(sut.SelectedMicrophoneDevice);
+        Assert.Null(settings.Current.SelectedMicrophoneDevice);
+    }
+
+    private static SettingsViewModel CreateSettingsViewModel(
+        FakeSettingsService settings,
+        AudioRecordingService audio,
+        SpeechFeedbackService speech)
+    {
+        var api = new ApiServerController(Mock.Of<ILocalApiServer>(), settings);
+        var cli = new CliInstallService();
+        return new SettingsViewModel(settings, audio, api, cli, speech);
+    }
+}
+
+internal sealed class FakeAudioInputDeviceProvider : IAudioInputDeviceProvider
+{
+    private readonly List<string> _deviceNames;
+
+    public FakeAudioInputDeviceProvider(params string[] deviceNames)
+    {
+        _deviceNames = [.. deviceNames];
+    }
+
+    public int DeviceCount => _deviceNames.Count;
+
+    public string GetDeviceName(int deviceNumber) => _deviceNames[deviceNumber];
+
+    public void SetDevices(params string[] deviceNames)
+    {
+        _deviceNames.Clear();
+        _deviceNames.AddRange(deviceNames);
+    }
+}
+
+internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
+{
+    public List<FakeAudioInputCapture> Created { get; } = [];
+
+    public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
+    {
+        var capture = new FakeAudioInputCapture(deviceNumber);
+        Created.Add(capture);
+        return capture;
+    }
+}
+
+internal sealed class FakeAudioInputCapture(int deviceNumber) : IAudioInputCapture
+{
+    public int DeviceNumber { get; } = deviceNumber;
+    public bool Started { get; private set; }
+    public bool Stopped { get; private set; }
+    public bool Disposed { get; private set; }
+
+    public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
+    public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+
+    public void StartRecording() => Started = true;
+
+    public void StopRecording() => Stopped = true;
+
+    public void RaiseStopped() => RecordingStopped?.Invoke(this, new AudioInputRecordingStoppedEventArgs());
+
+    public void Dispose() => Disposed = true;
+
+    public void RaiseData(byte[] buffer, int bytesRecorded) =>
+        DataAvailable?.Invoke(this, new AudioInputDataAvailableEventArgs(buffer, bytesRecorded));
+}


### PR DESCRIPTION
## Summary
- Detect microphone device changes by device signature instead of only device count.
- Keep the configured microphone preference across disconnects and reselect the remembered device after reconnects, including index changes.
- Refresh the settings microphone picker on device changes and display the default/disconnected selection correctly.

## Root Cause
The audio service only compared `WaveInEvent.DeviceCount`, cleared the configured microphone on loss, and ignored unexpected capture stops. The settings combo box also bound a nullable selected value, which left the default microphone selection visually blank.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore`
- `git diff --check`