### PR TITLE
Prepare v0.8.0 release notes

### DIFF
--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,31 @@
+# TypeWhisper v0.8.0
+
+TypeWhisper 0.8.0 is a major Windows release focused on faster local transcription, a broader plugin marketplace, richer speech and TTS provider support, and steadier everyday dictation behavior.
+
+## New Features
+
+- Added GPU acceleration for local transcription so supported local models can run faster on capable Windows systems.
+- Added multi-category plugin marketplace support, making discovery clearer as plugins expand across transcription, text generation, TTS, memory, and workflow integrations.
+- Added the Supertonic TTS provider plugin and a dedicated TTS marketplace category.
+- Added side-specific modifier hotkeys for workflows that need distinct left/right keyboard shortcuts.
+- Added Russian localization for the Windows app.
+- Added Windows indicator style variants for a more flexible recording status experience.
+- Added licensed industry term packs for specialized vocabulary workflows.
+- Expanded OpenAI and ChatGPT plugin capabilities.
+
+## Improvements
+
+- Improved plugin marketplace behavior and polish, including category handling and uninstall state feedback.
+- Improved whisper.cpp native runtime packaging so bundled local transcription dependencies are more reliable.
+- Improved touch scrolling across ScrollViewer controls.
+- Limited Supertonic TTS runtime packaging to keep bundled plugin output cleaner.
+
+## Fixes
+
+- Fixed microphone reconnect handling.
+- Reduced repeated short transcription phrases and improved dictation ellipsis cleanup.
+- Fixed plaintext insertion for email clients.
+- Fixed live preview font size updates.
+- Fixed live transcript no-speech handling.
+- Fixed dictionary usage count localization.
+- Fixed marketplace plugin uninstall state handling.


### PR DESCRIPTION
## Summary
- Add curated release notes for TypeWhisper v0.8.0.
- Capture the main feature, improvement, and fix highlights since v0.7.2.
- Prepare the stable release workflow to use `docs/releases/v0.8.0.md` when the `v0.8.0` tag is published.

## Test Plan
- `dotnet restore TypeWhisper.slnx`
- `dotnet build TypeWhisper.slnx -c Release -p:Version=0.8.0 --no-restore`
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-build`
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release --no-build`