### PR TITLE
Fix local GPU acceleration reload

### DIFF
--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -212,6 +212,9 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                     _accelerationPreference == TranscriptionAccelerationPreference.Auto
                     && string.Equals(activeProvider, "cuda", StringComparison.OrdinalIgnoreCase))
                 {
+                    _host?.Log(
+                        PluginLogLevel.Warning,
+                        $"CUDA provider failed for {modelId}; falling back to CPU: {ex.Message}");
                     activeProvider = "cpu";
                     _recognizer = CreateRecognizer(model, dir, activeProvider);
                     accelerationStatus = new TranscriptionAccelerationStatus(
@@ -228,6 +231,9 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                 _canaryTgtLang = "en";
                 _accelerationStatus = accelerationStatus;
 
+                _host?.Log(
+                    PluginLogLevel.Info,
+                    $"Loaded model {modelId} using provider {activeProvider} ({_accelerationStatus.DisplayText})");
                 Debug.WriteLine($"[SherpaOnnx] Model {modelId} loaded from {dir} using {activeProvider}");
             }
         }, ct);

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -187,13 +187,16 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                 throw CreateNativeLoadFailureException(ex);
             }
 
+            var loadedLibrary = RuntimeOptions.LoadedLibrary;
             _accelerationStatus = CreateLoadedAccelerationStatus(
-                RuntimeOptions.LoadedLibrary,
+                loadedLibrary,
                 _accelerationPreference);
             _loadedModelId = modelId;
             _selectedModelId = modelId;
             _host?.SetSetting("selectedModel", modelId);
-            _host?.Log(PluginLogLevel.Info, $"Loaded model {modelId} ({_accelerationStatus.DisplayText})");
+            _host?.Log(
+                PluginLogLevel.Info,
+                $"Loaded model {modelId} using runtime {loadedLibrary?.ToString() ?? "unknown"} ({_accelerationStatus.DisplayText})");
         }
         finally
         {

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using TypeWhisper.Core;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
+using TypeWhisper.PluginSDK.Models;
 using TypeWhisper.Windows.ViewModels;
 
 namespace TypeWhisper.Windows.Services;
@@ -197,6 +198,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         var activeModel = _modelManager.ActiveModelId is { } activeModelId && ModelManagerService.IsPluginModel(activeModelId)
             ? ModelManagerService.ParsePluginModelId(activeModelId).ModelId
             : activePlugin?.SelectedModelId;
+        var accelerationStatus = activePlugin?.AccelerationStatus;
 
         return Json(new
         {
@@ -206,7 +208,17 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             active_model = _modelManager.ActiveModelId,
             api_version = "1.0",
             supports_streaming = activePlugin?.SupportsStreaming ?? false,
-            supports_translation = activePlugin?.SupportsTranslation ?? false
+            supports_translation = activePlugin?.SupportsTranslation ?? false,
+            acceleration = activePlugin is null || accelerationStatus is null
+                ? null
+                : new
+                {
+                    preference = AppSettings.NormalizeLocalModelAcceleration(_settings.Current.LocalModelAcceleration),
+                    active_backend = FormatAccelerationBackend(accelerationStatus.ActiveBackend),
+                    display_text = accelerationStatus.DisplayText,
+                    detail = accelerationStatus.Detail,
+                    requires_restart = accelerationStatus.RequiresRestart
+                }
         });
     }
 
@@ -542,6 +554,13 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         503 => "service_unavailable",
         _ => "error"
     };
+
+    private static string FormatAccelerationBackend(TranscriptionAccelerationBackend backend) =>
+        backend switch
+        {
+            TranscriptionAccelerationBackend.NvidiaCuda => AppSettings.LocalModelAccelerationNvidiaCuda,
+            _ => AppSettings.LocalModelAccelerationCpu
+        };
 
     private static int ParseInt(string? value, int fallback) =>
         int.TryParse(value, out var parsed) ? parsed : fallback;

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -34,6 +34,7 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
     private readonly ISettingsService _settings;
     private readonly Dictionary<string, ModelStatus> _modelStatuses = new();
     private string? _activeModelId;
+    private TranscriptionAccelerationPreference? _activeModelAccelerationPreference;
     private System.Timers.Timer? _autoUnloadTimer;
     private bool _disposed;
 
@@ -191,7 +192,8 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         SetStatus(modelId, ModelStatus.LoadingModel);
         try
         {
-            plugin.SetAccelerationPreference(GetAccelerationPreference(_settings.Current.LocalModelAcceleration));
+            var accelerationPreference = GetAccelerationPreference(_settings.Current.LocalModelAcceleration);
+            plugin.SetAccelerationPreference(accelerationPreference);
 
             if (plugin.SupportsModelDownload)
                 await plugin.LoadModelAsync(pluginModelId, cancellationToken);
@@ -199,6 +201,7 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
             plugin.SelectModel(pluginModelId);
             SetStatus(modelId, ModelStatus.Ready);
             ActiveModelId = modelId;
+            _activeModelAccelerationPreference = accelerationPreference;
         }
         catch (Exception ex)
         {
@@ -228,6 +231,7 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
             });
             SetStatus(ActiveModelId, ModelStatus.NotDownloaded);
             ActiveModelId = null;
+            _activeModelAccelerationPreference = null;
         }
     }
 
@@ -274,9 +278,17 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         if (string.IsNullOrWhiteSpace(targetModelId))
             return false;
 
-        if (ActiveModelId == targetModelId)
+        var targetAccelerationPreference = GetAccelerationPreference(_settings.Current.LocalModelAcceleration);
+        if (ActiveModelId == targetModelId
+            && _activeModelAccelerationPreference == targetAccelerationPreference)
         {
             CancelAutoUnload();
+            return true;
+        }
+
+        if (ActiveModelId == targetModelId)
+        {
+            await LoadModelAsync(targetModelId, cancellationToken);
             return true;
         }
 
@@ -444,6 +456,7 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         if (previousActiveModelId is null)
         {
             ActiveModelId = null;
+            _activeModelAccelerationPreference = null;
             return Task.CompletedTask;
         }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -126,6 +126,45 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Status_IncludesActiveAccelerationDetails()
+    {
+        var plugin = new FakeTranscriptionPlugin
+        {
+            AccelerationStatusOverride = new TranscriptionAccelerationStatus(
+                TranscriptionAccelerationBackend.NvidiaCuda,
+                "Using CUDA",
+                "Loaded provider cuda.",
+                RequiresRestart: true)
+        };
+        var (service, modelManager) = CreateServiceWithModelManager(
+            new AppSettings
+            {
+                SelectedModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "tiny"),
+                LocalModelAcceleration = AppSettings.LocalModelAccelerationNvidiaCuda,
+                SaveToHistoryEnabled = true
+            },
+            plugin);
+
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "tiny"));
+
+        var response = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/status",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+        var json = JsonObject(response);
+        var acceleration = json["acceleration"];
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal(AppSettings.LocalModelAccelerationNvidiaCuda, acceleration.GetProperty("preference").GetString());
+        Assert.Equal(AppSettings.LocalModelAccelerationNvidiaCuda, acceleration.GetProperty("active_backend").GetString());
+        Assert.Equal("Using CUDA", acceleration.GetProperty("display_text").GetString());
+        Assert.Equal("Loaded provider cuda.", acceleration.GetProperty("detail").GetString());
+        Assert.True(acceleration.GetProperty("requires_restart").GetBoolean());
+    }
+
+    [Fact]
     public async Task HistorySearch_IncludesRaycastCompatibleAliases()
     {
         var record = new TranscriptionRecord
@@ -187,11 +226,18 @@ public class HttpApiServiceTests : IDisposable
             ? ModelManagerService.GetPluginModelId(plugins[0].PluginId, plugins[0].TranscriptionModels[0].Id)
             : null;
 
-        _settings.Setup(s => s.Current).Returns(new AppSettings
+        return CreateServiceWithModelManager(new AppSettings
         {
             SelectedModelId = selectedModel,
             SaveToHistoryEnabled = true
-        });
+        }, plugins).Service;
+    }
+
+    private (HttpApiService Service, ModelManagerService ModelManager) CreateServiceWithModelManager(
+        AppSettings settings,
+        params ITranscriptionEnginePlugin[] plugins)
+    {
+        _settings.Setup(s => s.Current).Returns(settings);
 
         var pluginManager = new PluginManager(
             _loader,
@@ -210,7 +256,7 @@ public class HttpApiServiceTests : IDisposable
         translation.Setup(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string text, string _, string _, CancellationToken _) => text);
 
-        return new HttpApiService(
+        var service = new HttpApiService(
             modelManager,
             _settings.Object,
             new AudioFileService(),
@@ -220,6 +266,8 @@ public class HttpApiServiceTests : IDisposable
             new PostProcessingPipeline(),
             translation.Object,
             null!);
+
+        return (service, modelManager);
     }
 
     private static HttpApiRequest JsonRequest(string method, string path, string json) =>
@@ -307,11 +355,18 @@ public class HttpApiServiceTests : IDisposable
         public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } = [new("tiny", "Tiny")];
         public string? SelectedModelId { get; private set; } = "tiny";
         public bool SupportsTranslation => true;
+        public TranscriptionAccelerationPreference AccelerationPreference { get; private set; } =
+            TranscriptionAccelerationPreference.Auto;
+        public TranscriptionAccelerationStatus? AccelerationStatusOverride { get; init; }
+        public TranscriptionAccelerationStatus AccelerationStatus => AccelerationStatusOverride
+            ?? new TranscriptionAccelerationStatus(TranscriptionAccelerationBackend.Cpu, "Using CPU");
 
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
         public Task DeactivateAsync() => Task.CompletedTask;
         public System.Windows.Controls.UserControl? CreateSettingsView() => null;
         public void SelectModel(string modelId) => SelectedModelId = modelId;
+        public void SetAccelerationPreference(TranscriptionAccelerationPreference preference) =>
+            AccelerationPreference = preference;
 
         public Task<PluginTranscriptionResult> TranscribeAsync(
             byte[] wavAudio,

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
@@ -69,6 +69,74 @@ public class ModelManagerServiceTests
         Assert.True(sut.Engine.IsModelLoaded);
     }
 
+    [Fact]
+    public async Task EnsureModelLoadedAsync_ReloadsActiveModel_WhenAccelerationPreferenceChanges()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var currentSettings = new AppSettings
+        {
+            SelectedModelId = fullModelId,
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationCpu
+        };
+
+        _settings.Setup(s => s.Current).Returns(() => currentSettings);
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true);
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        await sut.EnsureModelLoadedAsync();
+        currentSettings = currentSettings with
+        {
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationNvidiaCuda
+        };
+
+        var loaded = await sut.EnsureModelLoadedAsync();
+
+        Assert.True(loaded);
+        Assert.Equal(2, plugin.LoadCallCount);
+        Assert.Equal(
+            [TranscriptionAccelerationPreference.Cpu, TranscriptionAccelerationPreference.NvidiaCuda],
+            plugin.AccelerationPreferencesAtLoad);
+    }
+
+    [Fact]
+    public async Task EnsureModelLoadedAsync_DoesNotReloadActiveModel_WhenAccelerationPreferenceIsUnchanged()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            SelectedModelId = fullModelId,
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationNvidiaCuda
+        });
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true);
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        await sut.EnsureModelLoadedAsync();
+        var loaded = await sut.EnsureModelLoadedAsync();
+
+        Assert.True(loaded);
+        Assert.Equal(1, plugin.LoadCallCount);
+        Assert.Equal(
+            [TranscriptionAccelerationPreference.NvidiaCuda],
+            plugin.AccelerationPreferencesAtLoad);
+    }
+
     [Theory]
     [InlineData(AppSettings.LocalModelAccelerationAuto, TranscriptionAccelerationPreference.Auto)]
     [InlineData(AppSettings.LocalModelAccelerationCpu, TranscriptionAccelerationPreference.Cpu)]
@@ -149,6 +217,8 @@ public class ModelManagerServiceTests
         public string? SelectedModelId { get; private set; }
         public bool SupportsTranslation => false;
         public string? LastLoadedModelId { get; private set; }
+        public int LoadCallCount { get; private set; }
+        public List<TranscriptionAccelerationPreference> AccelerationPreferencesAtLoad { get; } = [];
         public TranscriptionAccelerationPreference LastAccelerationPreference { get; private set; } =
             TranscriptionAccelerationPreference.Auto;
         public TranscriptionAccelerationPreference? AccelerationPreferenceAtLoad { get; private set; }
@@ -162,7 +232,9 @@ public class ModelManagerServiceTests
 
         public Task LoadModelAsync(string modelId, CancellationToken ct)
         {
+            LoadCallCount++;
             AccelerationPreferenceAtLoad = LastAccelerationPreference;
+            AccelerationPreferencesAtLoad.Add(LastAccelerationPreference);
             LastLoadedModelId = modelId;
             SelectedModelId = modelId;
             return Task.CompletedTask;


### PR DESCRIPTION
## Summary
- Reload the active local transcription model when the saved acceleration preference changes, so CPU -> NVIDIA CUDA changes are applied before the next transcription.
- Add acceleration details to `/v1/status` for clearer diagnostics.
- Improve Sherpa/Whisper local runtime logs so the loaded provider/runtime is visible.

## Root Cause
The active model cache only checked the selected model id. If the user changed local acceleration while the same model stayed active, the next transcription could keep using the previously loaded backend until the model was reloaded or the app restarted.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj` (608 passed)
- `dotnet build TypeWhisper.slnx -c Release` (0 warnings, 0 errors)
- Local GPU comparison with Parakeet/Sherpa: CPU run had no GPU engine activity and took ~18.2s; CUDA run reported `active_backend: nvidia-cuda`, showed CUDA engine activity, and took ~9.5s.

Fixes #125
