### PR TITLE
Make Live Transcript window movable

### DIFF
--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -19,11 +19,15 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     private const int DefaultAutoHideMilliseconds = 3000;
     private const int MinAutoHideMilliseconds = 0;
     private const int MaxAutoHideMilliseconds = 10000;
+    private const int MaxTerminalRecordingIds = 64;
 
     private IPluginHostServices? _host;
     private LiveTranscriptWindow? _window;
     private readonly List<IDisposable> _subscriptions = [];
     private CancellationTokenSource? _autoHideCts;
+    private readonly object _terminalRecordingLock = new();
+    private readonly Queue<Guid> _terminalRecordingOrder = [];
+    private readonly HashSet<Guid> _terminalRecordingIds = [];
     private bool _disposed;
     // Set to the RecordingId of the active recording; all handlers reject events
     // whose RecordingId differs so stale Task.Run callbacks can never mutate state
@@ -125,6 +129,8 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnRecordingStarted(RecordingStartedEvent evt)
     {
+        if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
+
         _autoHideCts?.Cancel();
         _autoHideCts?.Dispose();
         _autoHideCts = null;
@@ -132,6 +138,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
+            if (IsTerminalRecording(evt.RecordingId)) return;
             if (_activeRecordingId != evt.RecordingId) return;
             EnsureWindow();
             _window!.SetSavedPosition(WindowLeft, WindowTop);
@@ -144,10 +151,12 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnRecordingStopped(RecordingStoppedEvent evt)
     {
+        if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
         // Keep window visible — it will be hidden after TranscriptionCompleted/Failed or timeout
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
+            if (IsTerminalRecording(evt.RecordingId)) return;
             if (evt.RecordingId != _activeRecordingId) return;
             if (_window is { IsVisible: true })
                 _window.UpdateText(_window.CurrentText + "\nProcessing...");
@@ -158,9 +167,11 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnPartialTranscriptionUpdate(PartialTranscriptionUpdateEvent evt)
     {
+        if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
+            if (IsTerminalRecording(evt.RecordingId)) return;
             if (evt.RecordingId != _activeRecordingId) return;
             EnsureWindow();
             _window!.UpdateText(evt.PartialText);
@@ -173,6 +184,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnTranscriptionCompleted(TranscriptionCompletedEvent evt)
     {
+        MarkTerminalRecording(evt.RecordingId);
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
 
         _autoHideCts?.Cancel();
@@ -215,6 +227,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnTranscriptionFailed(TranscriptionFailedEvent evt)
     {
+        MarkTerminalRecording(evt.RecordingId);
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
 
         _autoHideCts?.Cancel();
@@ -243,6 +256,32 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private static int NormalizeAutoHideMilliseconds(int milliseconds) =>
         Math.Clamp(milliseconds, MinAutoHideMilliseconds, MaxAutoHideMilliseconds);
+
+    private void MarkTerminalRecording(Guid? recordingId)
+    {
+        if (recordingId is not { } id) return;
+
+        lock (_terminalRecordingLock)
+        {
+            if (!_terminalRecordingIds.Add(id)) return;
+
+            _terminalRecordingOrder.Enqueue(id);
+            while (_terminalRecordingOrder.Count > MaxTerminalRecordingIds)
+            {
+                _terminalRecordingIds.Remove(_terminalRecordingOrder.Dequeue());
+            }
+        }
+    }
+
+    private bool IsTerminalRecording(Guid? recordingId)
+    {
+        if (recordingId is not { } id) return false;
+
+        lock (_terminalRecordingLock)
+        {
+            return _terminalRecordingIds.Contains(id);
+        }
+    }
 
     public void Dispose()
     {

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -11,6 +11,15 @@ namespace TypeWhisper.Plugin.LiveTranscript;
 /// </summary>
 public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 {
+    private const string FontSizeSettingName = "fontSize";
+    private const string OpacitySettingName = "opacity";
+    private const string AutoHideMillisecondsSettingName = "autoHideMilliseconds";
+    private const string WindowLeftSettingName = "windowLeft";
+    private const string WindowTopSettingName = "windowTop";
+    private const int DefaultAutoHideMilliseconds = 3000;
+    private const int MinAutoHideMilliseconds = 0;
+    private const int MaxAutoHideMilliseconds = 10000;
+
     private IPluginHostServices? _host;
     private LiveTranscriptWindow? _window;
     private readonly List<IDisposable> _subscriptions = [];
@@ -27,10 +36,10 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     public int FontSize
     {
-        get => _host?.GetSetting<int?>("fontSize") ?? 16;
+        get => _host?.GetSetting<int?>(FontSizeSettingName) ?? 16;
         set
         {
-            _host?.SetSetting("fontSize", value);
+            _host?.SetSetting(FontSizeSettingName, value);
             if (_window is not null)
                 Application.Current?.Dispatcher.InvokeAsync(() => _window.SetFontSize(value));
         }
@@ -38,13 +47,41 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     public double Opacity
     {
-        get => _host?.GetSetting<double?>("opacity") ?? 0.85;
+        get => _host?.GetSetting<double?>(OpacitySettingName) ?? 0.85;
         set
         {
-            _host?.SetSetting("opacity", value);
+            _host?.SetSetting(OpacitySettingName, value);
             if (_window is not null)
                 Application.Current?.Dispatcher.InvokeAsync(() => _window.SetWindowOpacity(value));
         }
+    }
+
+    public int AutoHideMilliseconds
+    {
+        get => NormalizeAutoHideMilliseconds(
+            _host?.GetSetting<int?>(AutoHideMillisecondsSettingName) ?? DefaultAutoHideMilliseconds);
+        set => _host?.SetSetting(AutoHideMillisecondsSettingName, NormalizeAutoHideMilliseconds(value));
+    }
+
+    private double? WindowLeft => _host?.GetSetting<double?>(WindowLeftSettingName);
+    private double? WindowTop => _host?.GetSetting<double?>(WindowTopSettingName);
+
+    public void SaveWindowPosition(double left, double top)
+    {
+        if (!double.IsFinite(left) || !double.IsFinite(top))
+            return;
+
+        _host?.SetSetting(WindowLeftSettingName, left);
+        _host?.SetSetting(WindowTopSettingName, top);
+    }
+
+    public void ResetWindowPosition()
+    {
+        _host?.SetSetting<double?>(WindowLeftSettingName, null);
+        _host?.SetSetting<double?>(WindowTopSettingName, null);
+
+        if (_window is not null)
+            Application.Current?.Dispatcher.InvokeAsync(_window.ResetToDefaultPosition);
     }
 
     public Task ActivateAsync(IPluginHostServices host)
@@ -97,6 +134,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         {
             if (_activeRecordingId != evt.RecordingId) return;
             EnsureWindow();
+            _window!.SetSavedPosition(WindowLeft, WindowTop);
             _window!.UpdateText("Listening...");
             _window.Show();
         });
@@ -139,8 +177,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
         _autoHideCts?.Cancel();
         _autoHideCts?.Dispose();
-        _autoHideCts = new CancellationTokenSource();
-        var token = _autoHideCts.Token;
+        _autoHideCts = null;
 
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
@@ -149,12 +186,18 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
                 _window.UpdateText(evt.Text);
         });
 
-        // Auto-hide after 3 seconds
+        var autoHideMilliseconds = AutoHideMilliseconds;
+        if (autoHideMilliseconds <= 0)
+            return Task.CompletedTask;
+
+        _autoHideCts = new CancellationTokenSource();
+        var token = _autoHideCts.Token;
+
         _ = Task.Run(async () =>
         {
             try
             {
-                await Task.Delay(3000, token);
+                await Task.Delay(autoHideMilliseconds, token);
                 Application.Current?.Dispatcher.InvokeAsync(() =>
                 {
                     if (evt.RecordingId == _activeRecordingId)
@@ -191,10 +234,15 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         if (_window is null || !_window.IsLoaded)
         {
             _window = new LiveTranscriptWindow();
+            _window.PositionChanged += SaveWindowPosition;
             _window.SetFontSize(FontSize);
             _window.SetWindowOpacity(Opacity);
+            _window.SetSavedPosition(WindowLeft, WindowTop);
         }
     }
+
+    private static int NormalizeAutoHideMilliseconds(int milliseconds) =>
+        Math.Clamp(milliseconds, MinAutoHideMilliseconds, MaxAutoHideMilliseconds);
 
     public void Dispose()
     {

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml
@@ -42,5 +42,34 @@
                     Value="0.85"
                     ValueChanged="OpacitySlider_ValueChanged" />
         </DockPanel>
+
+        <!-- Auto-hide -->
+        <TextBlock Text="Auto-hide Delay"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,4" />
+        <DockPanel Margin="0,0,0,12">
+            <TextBlock DockPanel.Dock="Right"
+                       Width="52"
+                       TextAlignment="Right"
+                       VerticalAlignment="Center"
+                       x:Name="AutoHideLabel"
+                       Text="3.0s" />
+            <Slider x:Name="AutoHideSlider"
+                    Minimum="0"
+                    Maximum="10"
+                    TickFrequency="0.25"
+                    IsSnapToTickEnabled="True"
+                    Value="3"
+                    ValueChanged="AutoHideSlider_ValueChanged" />
+        </DockPanel>
+
+        <!-- Position -->
+        <TextBlock Text="Window Position"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,4" />
+        <Button Content="Reset position"
+                HorizontalAlignment="Left"
+                Padding="12,6"
+                Click="ResetPositionButton_Click" />
     </StackPanel>
 </UserControl>

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml.cs
@@ -23,6 +23,9 @@ public partial class LiveTranscriptSettingsView : UserControl
         OpacitySlider.Value = plugin.Opacity;
         OpacityLabel.Text = $"{(int)(plugin.Opacity * 100)}%";
 
+        AutoHideSlider.Value = plugin.AutoHideMilliseconds / 1000d;
+        UpdateAutoHideLabel(AutoHideSlider.Value);
+
         _initialized = true;
     }
 
@@ -42,5 +45,25 @@ public partial class LiveTranscriptSettingsView : UserControl
         var opacity = e.NewValue;
         OpacityLabel.Text = $"{(int)(opacity * 100)}%";
         _plugin.Opacity = opacity;
+    }
+
+    private void AutoHideSlider_ValueChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (!_initialized) return;
+
+        UpdateAutoHideLabel(e.NewValue);
+        _plugin.AutoHideMilliseconds = (int)Math.Round(e.NewValue * 1000, MidpointRounding.AwayFromZero);
+    }
+
+    private void ResetPositionButton_Click(object sender, System.Windows.RoutedEventArgs e)
+    {
+        _plugin.ResetWindowPosition();
+    }
+
+    private void UpdateAutoHideLabel(double seconds)
+    {
+        AutoHideLabel.Text = seconds <= 0
+            ? "Off"
+            : $"{seconds:0.##}s";
     }
 }

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptWindow.xaml
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptWindow.xaml
@@ -23,16 +23,37 @@
                               Opacity="0.5"
                               Color="Black" />
         </Border.Effect>
-        <ScrollViewer x:Name="TranscriptScroller"
-                      VerticalScrollBarVisibility="Auto"
-                      MaxHeight="200"
-                      HorizontalScrollBarVisibility="Disabled">
-            <TextBlock x:Name="TranscriptText"
-                       Foreground="#CCDDDDDD"
-                       FontSize="16"
-                       TextWrapping="Wrap"
-                       FontFamily="Segoe UI"
-                       Text="Listening..." />
-        </ScrollViewer>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Grid x:Name="DragHandle"
+                  Height="12"
+                  Margin="0,0,0,6"
+                  Cursor="SizeAll"
+                  MouseLeftButtonDown="DragHandle_MouseLeftButtonDown">
+                <Border Width="34"
+                        Height="4"
+                        CornerRadius="2"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Background="#35FFFFFF" />
+            </Grid>
+
+            <ScrollViewer x:Name="TranscriptScroller"
+                          Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          MaxHeight="200"
+                          HorizontalScrollBarVisibility="Disabled">
+                <TextBlock x:Name="TranscriptText"
+                           Foreground="#CCDDDDDD"
+                           FontSize="16"
+                           TextWrapping="Wrap"
+                           FontFamily="Segoe UI"
+                           Text="Listening..." />
+            </ScrollViewer>
+        </Grid>
     </Border>
 </Window>

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptWindow.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Input;
 
 namespace TypeWhisper.Plugin.LiveTranscript;
 
@@ -8,10 +9,16 @@ namespace TypeWhisper.Plugin.LiveTranscript;
 /// </summary>
 public partial class LiveTranscriptWindow : Window
 {
+    private const double FallbackHeight = 80;
+    private double? _savedLeft;
+    private double? _savedTop;
+
     public LiveTranscriptWindow()
     {
         InitializeComponent();
     }
+
+    public event Action<double, double>? PositionChanged;
 
     /// <summary>Gets the current displayed text.</summary>
     public string CurrentText => TranscriptText.Text;
@@ -35,16 +42,89 @@ public partial class LiveTranscriptWindow : Window
         RootBorder.Opacity = opacity;
     }
 
+    public void SetSavedPosition(double? left, double? top)
+    {
+        _savedLeft = left;
+        _savedTop = top;
+
+        if (IsLoaded)
+            PositionWindow();
+    }
+
+    public void ResetToDefaultPosition()
+    {
+        _savedLeft = null;
+        _savedTop = null;
+
+        if (IsLoaded)
+            PositionAtBottomCenter();
+    }
+
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
+        PositionWindow();
+    }
+
+    private void PositionWindow()
+    {
+        if (_savedLeft is { } left && _savedTop is { } top)
+        {
+            PositionWithinWorkArea(left, top);
+            return;
+        }
+
         PositionAtBottomCenter();
     }
 
     private void PositionAtBottomCenter()
     {
         var workArea = SystemParameters.WorkArea;
-        Left = (workArea.Width - Width) / 2 + workArea.Left;
-        Top = workArea.Bottom - ActualHeight - 40;
+        var width = GetEffectiveWidth();
+        var height = GetEffectiveHeight();
+        Left = workArea.Left + (workArea.Width - width) / 2;
+        Top = workArea.Bottom - height - 40;
+    }
+
+    private void PositionWithinWorkArea(double left, double top)
+    {
+        var workArea = SystemParameters.WorkArea;
+        var width = GetEffectiveWidth();
+        var height = GetEffectiveHeight();
+
+        Left = Clamp(left, workArea.Left, workArea.Right - width);
+        Top = Clamp(top, workArea.Top, workArea.Bottom - height);
+    }
+
+    private double GetEffectiveWidth() =>
+        ActualWidth > 0 ? ActualWidth : Width;
+
+    private double GetEffectiveHeight() =>
+        ActualHeight > 0
+            ? ActualHeight
+            : !double.IsNaN(Height) && Height > 0
+                ? Height
+                : FallbackHeight;
+
+    private static double Clamp(double value, double min, double max) =>
+        Math.Clamp(value, min, Math.Max(min, max));
+
+    private void DragHandle_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ButtonState != MouseButtonState.Pressed)
+            return;
+
+        try
+        {
+            DragMove();
+            _savedLeft = Left;
+            _savedTop = Top;
+            PositionChanged?.Invoke(Left, Top);
+            e.Handled = true;
+        }
+        catch (InvalidOperationException)
+        {
+            // DragMove can throw if the mouse state changes before WPF starts dragging.
+        }
     }
 
     /// <summary>
@@ -54,6 +134,6 @@ public partial class LiveTranscriptWindow : Window
     {
         base.OnRenderSizeChanged(sizeInfo);
         if (IsLoaded)
-            PositionAtBottomCenter();
+            PositionWindow();
     }
 }

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
@@ -8,7 +8,7 @@ using TypeWhisper.Plugin.LiveTranscript;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 
-namespace TypeWhisper.PluginSystem.Tests;
+namespace TypeWhisper.Plugin.LiveTranscript.Tests;
 
 public sealed class LiveTranscriptPluginTests
 {
@@ -360,6 +360,26 @@ public sealed class LiveTranscriptPluginTests
             try
             {
                 plugin.ActivateAsync(host).GetAwaiter().GetResult();
+
+                var noSpeechRecordingId = Guid.NewGuid();
+                eventBus.Publish(new TranscriptionFailedEvent
+                {
+                    RecordingId = noSpeechRecordingId,
+                    ErrorMessage = "No speech detected"
+                });
+                PumpDispatcher();
+
+                Assert.False(GetWindow(plugin)?.IsVisible == true);
+
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = noSpeechRecordingId });
+                PumpDispatcher();
+
+                Assert.False(GetWindow(plugin)?.IsVisible == true);
+
+                eventBus.Publish(new RecordingStoppedEvent { RecordingId = noSpeechRecordingId });
+                PumpDispatcher();
+
+                Assert.False(GetWindow(plugin)?.IsVisible == true);
 
                 eventBus.Publish(new RecordingStartedEvent());
                 PumpDispatcher();

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/TypeWhisper.Plugin.LiveTranscript.csproj
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/TypeWhisper.Plugin.LiveTranscript.csproj
@@ -8,6 +8,9 @@
     <RootNamespace>TypeWhisper.Plugin.LiveTranscript</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Tests\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/TypeWhisper.PluginSystem.Tests/LiveTranscriptPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/LiveTranscriptPluginTests.cs
@@ -68,6 +68,13 @@ public sealed class LiveTranscriptPluginTests
     }
 
     [Fact]
+    public void AutoHideMilliseconds_DefaultsTo3000_WhenNoSettingStored()
+    {
+        var sut = CreatePlugin();
+        Assert.Equal(3000, sut.AutoHideMilliseconds);
+    }
+
+    [Fact]
     public async Task FontSize_PersistsToHostSettings()
     {
         var host = new TestPluginHostServices();
@@ -90,6 +97,43 @@ public sealed class LiveTranscriptPluginTests
     }
 
     [Fact]
+    public async Task AutoHideMilliseconds_PersistsToHostSettings()
+    {
+        var host = new TestPluginHostServices();
+        var sut = await ActivatedPlugin(host);
+
+        sut.AutoHideMilliseconds = 1250;
+
+        Assert.Equal(1250, host.GetSetting<int?>("autoHideMilliseconds"));
+    }
+
+    [Fact]
+    public async Task WindowPosition_PersistsToHostSettings()
+    {
+        var host = new TestPluginHostServices();
+        var sut = await ActivatedPlugin(host);
+
+        sut.SaveWindowPosition(123.5, 456.25);
+
+        Assert.Equal(123.5, host.GetSetting<double?>("windowLeft"));
+        Assert.Equal(456.25, host.GetSetting<double?>("windowTop"));
+    }
+
+    [Fact]
+    public async Task ResetWindowPosition_ClearsPersistedCoordinates()
+    {
+        var host = new TestPluginHostServices();
+        host.SetSetting("windowLeft", 123.5);
+        host.SetSetting("windowTop", 456.25);
+        var sut = await ActivatedPlugin(host);
+
+        sut.ResetWindowPosition();
+
+        Assert.Null(host.GetSetting<double?>("windowLeft"));
+        Assert.Null(host.GetSetting<double?>("windowTop"));
+    }
+
+    [Fact]
     public async Task FontSize_ReadsPersistedValueFromHost()
     {
         var host = new TestPluginHostServices();
@@ -107,6 +151,16 @@ public sealed class LiveTranscriptPluginTests
         var sut = await ActivatedPlugin(host);
 
         Assert.Equal(0.6, sut.Opacity, precision: 10);
+    }
+
+    [Fact]
+    public async Task AutoHideMilliseconds_ReadsPersistedValueFromHost()
+    {
+        var host = new TestPluginHostServices();
+        host.SetSetting("autoHideMilliseconds", 750);
+        var sut = await ActivatedPlugin(host);
+
+        Assert.Equal(750, sut.AutoHideMilliseconds);
     }
 
     [Fact]
@@ -295,6 +349,12 @@ public sealed class LiveTranscriptPluginTests
             var app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
             var eventBus = new TestPluginEventBus();
             var host = new WpfTestHostServices(eventBus);
+            var workArea = SystemParameters.WorkArea;
+            var expectedLeft = workArea.Left + 40;
+            var expectedTop = workArea.Top + 40;
+            host.SetSetting("windowLeft", expectedLeft);
+            host.SetSetting("windowTop", expectedTop);
+            host.SetSetting("autoHideMilliseconds", 0);
             var plugin = new LiveTranscriptPlugin();
 
             try
@@ -308,6 +368,8 @@ public sealed class LiveTranscriptPluginTests
                 Assert.NotNull(window);
                 Assert.True(window.IsVisible);
                 Assert.Equal("Listening...", window.CurrentText);
+                Assert.Equal(expectedLeft, window.Left, precision: 1);
+                Assert.Equal(expectedTop, window.Top, precision: 1);
 
                 eventBus.Publish(new RecordingStoppedEvent());
                 PumpDispatcher();
@@ -319,6 +381,24 @@ public sealed class LiveTranscriptPluginTests
                 PumpDispatcher();
 
                 Assert.False(window.IsVisible);
+
+                host.SetSetting("windowLeft", 100000d);
+                host.SetSetting("windowTop", 100000d);
+                eventBus.Publish(new RecordingStartedEvent());
+                PumpDispatcher();
+
+                var windowWidth = window.ActualWidth > 0 ? window.ActualWidth : window.Width;
+                var windowHeight = window.ActualHeight > 0 ? window.ActualHeight : window.Height;
+                Assert.InRange(window.Left, workArea.Left, workArea.Right - windowWidth + 1);
+                Assert.InRange(window.Top, workArea.Top, workArea.Bottom - windowHeight + 1);
+
+                eventBus.Publish(new TranscriptionCompletedEvent { Text = "Finished" });
+                PumpDispatcher();
+                Thread.Sleep(3300);
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Finished", window.CurrentText);
             }
             finally
             {

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\Tests\*.cs" LinkBase="LiveTranscript" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenAi\TypeWhisper.Plugin.OpenAi.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Xai\TypeWhisper.Plugin.Xai.csproj" />


### PR DESCRIPTION
## Summary
- Add a small drag handle to the Live Transcript plugin window and persist its window position.
- Clamp saved positions to the current work area so the window remains reachable after display changes.
- Add plugin-local auto-hide delay and reset-position controls without changing global app settings or the plugin SDK.
- Prevent out-of-order no-speech events from leaving the Live Transcript window stuck on processing.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter LiveTranscriptPluginTests`
- `dotnet build plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj -c Release`

Closes #139.
Closes #140.