### PR TITLE
Harden plugin registry categories

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -226,7 +226,7 @@ jobs:
               for ($j = 0; $j -lt $registry.Count; $j++) {
                 if ($registry[$j].id -eq $env:PLUGIN_ID) {
                   $category = Get-RegistryCategory $manifest $registry[$j].category
-                  $categories = Get-RegistryCategories $manifest $category
+                  $categories = [string[]]@(Get-RegistryCategories $manifest $category)
 
                   Set-RegistryProperty $registry[$j] 'name' $manifest.name
                   Set-RegistryProperty $registry[$j] 'version' $env:PLUGIN_VERSION
@@ -248,7 +248,7 @@ jobs:
 
               if (-not $updated) {
                 $category = Get-RegistryCategory $manifest ''
-                $categories = Get-RegistryCategories $manifest $category
+                $categories = [string[]]@(Get-RegistryCategories $manifest $category)
 
                 $registry += [pscustomobject]@{
                   id = $manifest.id

--- a/src/TypeWhisper.Windows/Services/Plugins/RegistryPlugin.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/RegistryPlugin.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace TypeWhisper.Windows.Services.Plugins;
@@ -14,12 +15,62 @@ public sealed record RegistryPlugin
     public string Author { get; init; } = "";
     public string Description { get; init; } = "";
     public string? Category { get; init; }
+    [JsonConverter(typeof(RegistryCategoriesJsonConverter))]
     public IReadOnlyList<string>? Categories { get; init; }
     public long Size { get; init; }
     public string DownloadUrl { get; init; } = "";
     public string? IconSystemName { get; init; }
     public bool RequiresApiKey { get; init; }
     public Dictionary<string, string>? Descriptions { get; init; }
+}
+
+internal sealed class RegistryCategoriesJsonConverter : JsonConverter<IReadOnlyList<string>?>
+{
+    public override IReadOnlyList<string>? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+
+        if (reader.TokenType == JsonTokenType.String)
+            return [reader.GetString() ?? string.Empty];
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException("Registry plugin categories must be a string or an array of strings.");
+
+        var categories = new List<string>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                return categories;
+
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException("Registry plugin categories must only contain strings.");
+
+            categories.Add(reader.GetString() ?? string.Empty);
+        }
+
+        throw new JsonException("Registry plugin categories array was not closed.");
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        IReadOnlyList<string>? value,
+        JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStartArray();
+        foreach (var category in value)
+            writer.WriteStringValue(category);
+        writer.WriteEndArray();
+    }
 }
 
 /// <summary>

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -112,6 +112,37 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FetchRegistryAsync_DeserializesSingleCategoryString()
+    {
+        const string json = """
+        [
+            {
+                "id": "com.test.utility",
+                "name": "Utility",
+                "version": "1.0.0",
+                "author": "Tester",
+                "description": "A utility plugin",
+                "category": "utility",
+                "categories": "utility",
+                "size": 1024,
+                "downloadUrl": "https://example.com/plugin.zip",
+                "requiresApiKey": false
+            }
+        ]
+        """;
+
+        var httpClient = CreateMockHttpClient(json);
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, httpClient);
+
+        var result = await service.FetchRegistryAsync();
+
+        Assert.Single(result);
+        Assert.Equal("utility", result[0].Category);
+        Assert.Equal(["utility"], result[0].Categories);
+    }
+
+    [Fact]
     public async Task FetchRegistryAsync_PreservesLegacyCategoryWhenCategoriesMissing()
     {
         var plugins = new[]


### PR DESCRIPTION
## Summary
- keep plugin registry categories as JSON arrays in the plugin publishing workflow
- tolerate a legacy single-string `categories` value when reading registry entries
- add regression coverage for single-string registry categories

## Testing
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter PluginRegistryServiceTests`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`