### PR TITLE
Fix onboarding completion for unready transcription engines

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -173,10 +173,15 @@ public partial class App : Application
         if (!settings.Current.HasCompletedOnboarding && !Program.StartMinimized)
         {
             _welcomeWindow = _serviceProvider.GetRequiredService<WelcomeWindow>();
-            _welcomeWindow.Closed += (_, _) =>
+            _welcomeWindow.Closed += (sender, _) =>
             {
+                var completionRequest = (sender as WelcomeWindow)?.DataContext is WelcomeViewModel viewModel
+                    ? viewModel.CompletionRequest
+                    : WelcomeCompletionRequest.None;
                 settings.Save(settings.Current with { HasCompletedOnboarding = true });
                 _welcomeWindow = null;
+                if (completionRequest.SettingsRoute is { } route)
+                    ShowSettingsWindow(route, focusPluginId: completionRequest.PluginIdToConfigure);
             };
             _welcomeWindow.Show();
         }
@@ -264,23 +269,21 @@ public partial class App : Application
         ShowSettingsWindow(SettingsRoute.License);
     }
 
-    private void ShowSettingsWindow(SettingsRoute? route = null, bool presentFileImporter = false)
+    private void ShowSettingsWindow(
+        SettingsRoute? route = null,
+        bool presentFileImporter = false,
+        string? focusPluginId = null)
     {
         if (!Dispatcher.CheckAccess())
         {
-            Dispatcher.Invoke(() => ShowSettingsWindow(route, presentFileImporter));
+            Dispatcher.Invoke(() => ShowSettingsWindow(route, presentFileImporter, focusPluginId));
             return;
         }
 
         if (_settingsWindow is { IsLoaded: true })
         {
             if (_settingsWindow.DataContext is SettingsWindowViewModel existingViewModel)
-            {
-                if (presentFileImporter)
-                    existingViewModel.OpenFileImporterCommand.Execute(null);
-                else if (route.HasValue)
-                    existingViewModel.Open(route.Value);
-            }
+                ApplySettingsWindowRequest(existingViewModel, route, presentFileImporter, focusPluginId);
             _settingsWindow.Activate();
             return;
         }
@@ -290,12 +293,22 @@ public partial class App : Application
         _settingsWindow.Show();
 
         if (_settingsWindow.DataContext is SettingsWindowViewModel viewModel)
-        {
-            if (presentFileImporter)
-                viewModel.OpenFileImporterCommand.Execute(null);
-            else if (route.HasValue)
-                viewModel.Open(route.Value);
-        }
+            ApplySettingsWindowRequest(viewModel, route, presentFileImporter, focusPluginId);
+    }
+
+    private static void ApplySettingsWindowRequest(
+        SettingsWindowViewModel viewModel,
+        SettingsRoute? route,
+        bool presentFileImporter,
+        string? focusPluginId)
+    {
+        if (presentFileImporter)
+            viewModel.OpenFileImporterCommand.Execute(null);
+        else if (route.HasValue)
+            viewModel.Open(route.Value);
+
+        if (!string.IsNullOrWhiteSpace(focusPluginId))
+            viewModel.FocusInstalledPlugin(focusPluginId);
     }
 
     private void ShowFileTranscriptionWindow()

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -731,6 +731,7 @@
   "Models.StatusReady": "Bereit",
   "Models.StatusErrorFormat": "Fehler: {0}",
   "Models.StatusDownloaded": "Heruntergeladen",
+  "Models.StatusApiKeyRequired": "API-Key erforderlich",
   "Models.LoadingModel": "Lade Modell...",
 
   "Welcome.DownloadProgress": "Herunterladen...",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -731,6 +731,7 @@
   "Models.StatusReady": "Ready",
   "Models.StatusErrorFormat": "Error: {0}",
   "Models.StatusDownloaded": "Downloaded",
+  "Models.StatusApiKeyRequired": "API key required",
   "Models.LoadingModel": "Loading model...",
 
   "Welcome.DownloadProgress": "Downloading...",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -694,6 +694,7 @@
   "Models.StatusReady": "準備完了",
   "Models.StatusErrorFormat": "エラー: {0}",
   "Models.StatusDownloaded": "ダウンロード済み",
+  "Models.StatusApiKeyRequired": "APIキーが必要です",
   "Models.LoadingModel": "モデルを読み込み中...",
   "Welcome.DownloadProgress": "ダウンロード中...",
   "Welcome.LoadingModel": "モデルを読み込み中...",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -704,6 +704,7 @@
   "Models.StatusReady": "Готово",
   "Models.StatusErrorFormat": "Ошибка: {0}",
   "Models.StatusDownloaded": "Скачано",
+  "Models.StatusApiKeyRequired": "Требуется API-ключ",
   "Models.LoadingModel": "Загрузка модели…",
   "Welcome.DownloadProgress": "Загрузка…",
   "Welcome.LoadingModel": "Загрузка модели…",

--- a/src/TypeWhisper.Windows/ViewModels/ModelManagerViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/ModelManagerViewModel.cs
@@ -28,6 +28,7 @@ public partial class ModelManagerViewModel : ObservableObject
     [ObservableProperty] private string _activeModelStatusText = "";
     private string _accelerationStatusText = "";
     [ObservableProperty] private bool _isActiveModelReady;
+    [ObservableProperty] private bool _isActiveModelBusy;
     [ObservableProperty] private bool _isAccelerationSectionVisible;
 
     public string SelectedAccelerationOptionValue
@@ -140,6 +141,8 @@ public partial class ModelManagerViewModel : ObservableObject
             foreach (var m in providerVm.Models)
                 m.IsAvailable = isConfigured;
         }
+
+        RefreshAllModels();
     }
 
     private void RefreshAllModels()
@@ -151,7 +154,8 @@ public partial class ModelManagerViewModel : ObservableObject
                 m.IsDownloaded = _modelManager.IsDownloaded(m.FullId);
                 var status = _modelManager.GetStatus(m.FullId);
                 m.IsReady = status.Type == ModelStatusType.Ready;
-                m.StatusText = FormatStatus(status, m.IsDownloaded);
+                m.IsBusy = IsBusyStatus(status);
+                m.StatusText = FormatStatus(status, m.IsDownloaded, m.IsAvailable, m.SupportsDownload);
             }
 
         SyncSelectedModelOption();
@@ -195,14 +199,22 @@ public partial class ModelManagerViewModel : ObservableObject
         RefreshAccelerationStatus();
     }
 
-    internal static string FormatStatus(ModelStatus status, bool isDownloaded) => status.Type switch
+    internal static string FormatStatus(
+        ModelStatus status,
+        bool isDownloaded,
+        bool isConfigured,
+        bool supportsDownload) => status.Type switch
     {
         ModelStatusType.Downloading => $"Download {status.Progress:P0}",
         ModelStatusType.Loading => Loc.Instance["Models.StatusLoading"],
         ModelStatusType.Ready => Loc.Instance["Models.StatusReady"],
         ModelStatusType.Error => Loc.Instance.GetString("Models.StatusErrorFormat", status.ErrorMessage ?? ""),
+        _ when !supportsDownload && !isConfigured => Loc.Instance["Models.StatusApiKeyRequired"],
         _ => isDownloaded ? Loc.Instance["Models.StatusDownloaded"] : ""
     };
+
+    internal static bool IsBusyStatus(ModelStatus status) =>
+        status.Type is ModelStatusType.Downloading or ModelStatusType.Loading;
 
     [RelayCommand]
     private async Task ActivateModel(string fullModelId)
@@ -287,6 +299,7 @@ public partial class ModelManagerViewModel : ObservableObject
             ActiveModelDisplayName = "No model selected";
             ActiveModelStatusText = "";
             IsActiveModelReady = false;
+            IsActiveModelBusy = false;
             RefreshAccelerationStatus();
             return;
         }
@@ -295,6 +308,7 @@ public partial class ModelManagerViewModel : ObservableObject
         ActiveModelDisplayName = activeModel.Model.DisplayName;
         ActiveModelStatusText = activeModel.Model.StatusText;
         IsActiveModelReady = activeModel.Model.IsReady;
+        IsActiveModelBusy = activeModel.Model.IsBusy;
         RefreshAccelerationStatus();
     }
 
@@ -382,6 +396,7 @@ public partial class ModelItemViewModel : ObservableObject
     [ObservableProperty] private bool _isAvailable;
     [ObservableProperty] private bool _isDownloaded;
     [ObservableProperty] private bool _isReady;
+    [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private string _statusText = "";
 
     public ModelItemViewModel(string fullId, PluginModelInfo model, bool isAvailable,
@@ -399,7 +414,8 @@ public partial class ModelItemViewModel : ObservableObject
         _isActive = isActive;
         _isDownloaded = isDownloaded;
         _isReady = status.Type == ModelStatusType.Ready;
-        _statusText = ModelManagerViewModel.FormatStatus(status, isDownloaded);
+        _isBusy = ModelManagerViewModel.IsBusyStatus(status);
+        _statusText = ModelManagerViewModel.FormatStatus(status, isDownloaded, isAvailable, supportsDownload);
     }
 }
 

--- a/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
@@ -151,6 +151,19 @@ public partial class PluginsViewModel : ObservableObject
         OnPropertyChanged(nameof(HasActiveMarketplaceCapabilityFilters));
     }
 
+    internal bool FocusInstalledPlugin(string pluginId)
+    {
+        var selected = Plugins.FirstOrDefault(plugin =>
+            string.Equals(plugin.Id, pluginId, StringComparison.OrdinalIgnoreCase));
+        if (selected is null)
+            return false;
+
+        IsMarketplaceSelected = false;
+        foreach (var plugin in Plugins)
+            plugin.IsExpanded = ReferenceEquals(plugin, selected);
+        return true;
+    }
+
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
         Application.Current?.Dispatcher.Invoke(() =>

--- a/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
@@ -283,6 +283,15 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
             ModelManager.RefreshPluginAvailability();
     }
 
+    internal bool FocusInstalledPlugin(string pluginId)
+    {
+        if (string.IsNullOrWhiteSpace(pluginId))
+            return false;
+
+        Open(SettingsRoute.Integrations);
+        return Plugins.FocusInstalledPlugin(pluginId);
+    }
+
     public bool TryConsumePendingFileImporterRequest()
     {
         if (PendingFileImporterRequestId == 0)

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -16,6 +16,11 @@ namespace TypeWhisper.Windows.ViewModels;
 
 public record WelcomeModelItem(string FullModelId, string DisplayName, string? SizeDescription, bool IsRecommended);
 
+public sealed record WelcomeCompletionRequest(SettingsRoute? SettingsRoute, string? PluginIdToConfigure)
+{
+    public static WelcomeCompletionRequest None { get; } = new(null, null);
+}
+
 public partial class WelcomeViewModel : ObservableObject
 {
     private const string LocalPluginId = "com.typewhisper.sherpa-onnx";
@@ -53,6 +58,7 @@ public partial class WelcomeViewModel : ObservableObject
     public ObservableCollection<WelcomeModelItem> AvailableModels { get; } = [];
     public ObservableCollection<IndustryPreset> IndustryPresets => _dictionary.IndustryPresets;
     public ObservableCollection<MicrophoneItem> Microphones { get; } = [];
+    public WelcomeCompletionRequest CompletionRequest { get; private set; } = WelcomeCompletionRequest.None;
     public event EventHandler? Completed;
 
     public WelcomeViewModel(
@@ -383,7 +389,7 @@ public partial class WelcomeViewModel : ObservableObject
     {
         if (CurrentStep == 3)
         {
-            Finish();
+            Finish(openSettingsWhenEngineNotReady: true);
             return;
         }
 
@@ -461,13 +467,28 @@ public partial class WelcomeViewModel : ObservableObject
             Microphones.Add(new MicrophoneItem(number, name));
     }
 
-    private void Finish()
+    private void Finish(bool openSettingsWhenEngineNotReady = false)
     {
+        CompletionRequest = openSettingsWhenEngineNotReady
+            ? BuildCompletionRequest()
+            : WelcomeCompletionRequest.None;
+        OnPropertyChanged(nameof(CompletionRequest));
+
         StopMicTest();
         PersistMainDictationHotkey(MainDictationHotkey);
         _dictionary.ApplyIndustryPreset(SelectedIndustryPresetId);
 
         Completed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private WelcomeCompletionRequest BuildCompletionRequest()
+    {
+        if (HasReadyEngine)
+            return WelcomeCompletionRequest.None;
+
+        return GetSelectedConfigurationPlugin() is { } plugin
+            ? new WelcomeCompletionRequest(SettingsRoute.Integrations, plugin.PluginId)
+            : new WelcomeCompletionRequest(SettingsRoute.Dictation, null);
     }
 
     public void Cleanup()

--- a/src/TypeWhisper.Windows/Views/Sections/AudioSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/AudioSection.xaml
@@ -145,18 +145,8 @@
                                                      Margin="0,0,8,0"
                                                      VerticalAlignment="Center"
                                                      IsIndeterminate="True"
-                                                     Foreground="{StaticResource AccentBrush}">
-                                            <ProgressBar.Style>
-                                                <Style TargetType="ProgressBar">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding ModelManager.IsActiveModelReady}" Value="True">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </ProgressBar.Style>
-                                        </ProgressBar>
+                                                     Foreground="{StaticResource AccentBrush}"
+                                                     Visibility="{Binding ModelManager.IsActiveModelBusy, Converter={StaticResource BoolToVis}}"/>
 
                                         <TextBlock Grid.Column="1"
                                                    Text="{Binding ModelManager.ActiveModelStatusText}">

--- a/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml.cs
@@ -57,7 +57,7 @@ public partial class PluginsSection : UserControl
     private void OnPluginsPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(PluginsViewModel.IsMarketplaceSelected))
-            ApplyTabSelection(_pluginsViewModel?.IsMarketplaceSelected == true);
+            ApplyTabSelection(_pluginsViewModel?.IsMarketplaceSelected ?? false);
     }
 
     private void OnInstalledTabClick(object sender, RoutedEventArgs e)

--- a/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml.cs
@@ -8,10 +8,13 @@ namespace TypeWhisper.Windows.Views.Sections;
 
 public partial class PluginsSection : UserControl
 {
+    private PluginsViewModel? _pluginsViewModel;
+
     public PluginsSection()
     {
         InitializeComponent();
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -19,7 +22,15 @@ public partial class PluginsSection : UserControl
         var vm = (DataContext as SettingsWindowViewModel)?.Plugins;
         if (vm is not null)
         {
-            vm.IsMarketplaceSelected = false;
+            if (!ReferenceEquals(_pluginsViewModel, vm))
+            {
+                if (_pluginsViewModel is not null)
+                    _pluginsViewModel.PropertyChanged -= OnPluginsPropertyChanged;
+                _pluginsViewModel = vm;
+                _pluginsViewModel.PropertyChanged += OnPluginsPropertyChanged;
+            }
+
+            ApplyTabSelection(vm.IsMarketplaceSelected);
             EmptyState.Visibility = vm.Plugins.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
 
             // Setup grouping by Category
@@ -34,26 +45,43 @@ public partial class PluginsSection : UserControl
         }
     }
 
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_pluginsViewModel is null)
+            return;
+
+        _pluginsViewModel.PropertyChanged -= OnPluginsPropertyChanged;
+        _pluginsViewModel = null;
+    }
+
+    private void OnPluginsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(PluginsViewModel.IsMarketplaceSelected))
+            ApplyTabSelection(_pluginsViewModel?.IsMarketplaceSelected == true);
+    }
+
     private void OnInstalledTabClick(object sender, RoutedEventArgs e)
     {
         if (DataContext is SettingsWindowViewModel vm)
             vm.Plugins.IsMarketplaceSelected = false;
-
-        TabInstalled.Style = (Style)Resources["ActiveTabButtonStyle"];
-        TabMarketplace.Style = (Style)Resources["TabButtonStyle"];
-        InstalledPanel.Visibility = Visibility.Visible;
-        MarketplacePanel.Visibility = Visibility.Collapsed;
+        else
+            ApplyTabSelection(false);
     }
 
     private void OnMarketplaceTabClick(object sender, RoutedEventArgs e)
     {
         if (DataContext is SettingsWindowViewModel vm)
             vm.Plugins.IsMarketplaceSelected = true;
+        else
+            ApplyTabSelection(true);
+    }
 
-        TabInstalled.Style = (Style)Resources["TabButtonStyle"];
-        TabMarketplace.Style = (Style)Resources["ActiveTabButtonStyle"];
-        InstalledPanel.Visibility = Visibility.Collapsed;
-        MarketplacePanel.Visibility = Visibility.Visible;
+    private void ApplyTabSelection(bool marketplaceSelected)
+    {
+        TabInstalled.Style = (Style)Resources[marketplaceSelected ? "TabButtonStyle" : "ActiveTabButtonStyle"];
+        TabMarketplace.Style = (Style)Resources[marketplaceSelected ? "ActiveTabButtonStyle" : "TabButtonStyle"];
+        InstalledPanel.Visibility = marketplaceSelected ? Visibility.Collapsed : Visibility.Visible;
+        MarketplacePanel.Visibility = marketplaceSelected ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void OnMarketplacePanelPreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelAccelerationLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelAccelerationLayoutTests.cs
@@ -23,4 +23,17 @@ public sealed class ModelAccelerationLayoutTests
             "Audio settings should hide the acceleration row and its separator for cloud engines.");
         Assert.Contains("Visibility=\"{Binding ModelManager.IsAccelerationSectionVisible", modelsXaml);
     }
+
+    [Fact]
+    public void AudioSection_BindsModelStatusProgressToBusyState()
+    {
+        var audioXaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "AudioSection.xaml");
+
+        Assert.Contains("ModelManager.IsActiveModelBusy", audioXaml);
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -5,6 +5,7 @@ using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
 using TypeWhisper.Windows.ViewModels;
 
@@ -218,6 +219,54 @@ public class ModelManagerViewModelTests
         Assert.Equal("Whisper Large V3", sut.ActiveModelDisplayName);
     }
 
+    [Fact]
+    public void Constructor_ShowsApiKeyRequiredWithoutBusy_ForUnconfiguredCloudSelection()
+    {
+        const string pluginId = "com.typewhisper.groq";
+        const string modelId = "whisper-large-v3";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            SelectedModelId = fullModelId
+        });
+
+        var pluginManager = CreatePluginManager(settings,
+            new FakeTranscriptionPlugin(pluginId, "Groq", modelId, "Whisper Large V3", configured: false));
+        var modelManager = new ModelManagerService(pluginManager, settings);
+
+        var sut = new ModelManagerViewModel(modelManager, settings);
+
+        Assert.Equal(fullModelId, sut.SelectedModelOptionId);
+        Assert.Equal("Groq", sut.ActiveProviderDisplayName);
+        Assert.Equal("Whisper Large V3", sut.ActiveModelDisplayName);
+        Assert.Equal(Loc.Instance["Models.StatusApiKeyRequired"], sut.ActiveModelStatusText);
+        Assert.False(sut.IsActiveModelReady);
+        Assert.False(sut.IsActiveModelBusy);
+    }
+
+    [Fact]
+    public void RefreshPluginAvailability_MarksConfiguredCloudSelectionReadyWithoutBusy()
+    {
+        const string pluginId = "com.typewhisper.groq";
+        const string modelId = "whisper-large-v3";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            SelectedModelId = fullModelId
+        });
+        var plugin = new FakeTranscriptionPlugin(pluginId, "Groq", modelId, "Whisper Large V3", configured: false);
+        var pluginManager = CreatePluginManager(settings, plugin);
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var sut = new ModelManagerViewModel(modelManager, settings);
+
+        plugin.IsConfigured = true;
+        sut.RefreshPluginAvailability();
+
+        Assert.Equal(Loc.Instance["Models.StatusReady"], sut.ActiveModelStatusText);
+        Assert.True(sut.IsActiveModelReady);
+        Assert.False(sut.IsActiveModelBusy);
+    }
+
     private PluginManager CreatePluginManager(ISettingsService settings, params ITranscriptionEnginePlugin[] transcriptionEngines)
     {
         var pluginManager = new PluginManager(
@@ -281,7 +330,7 @@ public class ModelManagerViewModelTests
         public string PluginVersion => "1.0.0";
         public string ProviderId => PluginId;
         public string ProviderDisplayName { get; }
-        public bool IsConfigured { get; }
+        public bool IsConfigured { get; set; }
         public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; }
         public string? SelectedModelId { get; private set; }
         public bool SupportsTranslation => false;

--- a/tests/TypeWhisper.PluginSystem.Tests/WelcomeViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WelcomeViewModelTests.cs
@@ -78,6 +78,75 @@ public sealed class WelcomeViewModelTests
         });
     }
 
+    [Fact]
+    public void FinalGetStarted_WithUnconfiguredCloudModel_RequestsPluginSettings()
+    {
+        RunOnStaThread(() =>
+        {
+            var plugin = new FakeTranscriptionPlugin(
+                "com.typewhisper.groq",
+                "Groq",
+                configured: false,
+                supportsModelDownload: false);
+            var sut = CreateViewModel(plugin);
+            sut.SelectedModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "whisper-large-v3-turbo");
+            sut.CurrentStep = 3;
+            var completed = false;
+            sut.Completed += (_, _) => completed = true;
+
+            sut.NextStepCommand.Execute(null);
+
+            Assert.True(completed);
+            Assert.Equal(SettingsRoute.Integrations, sut.CompletionRequest.SettingsRoute);
+            Assert.Equal(plugin.PluginId, sut.CompletionRequest.PluginIdToConfigure);
+        });
+    }
+
+    [Fact]
+    public void FinalGetStarted_WithMissingDownloadableModel_RequestsDictationSettings()
+    {
+        RunOnStaThread(() =>
+        {
+            var plugin = new FakeTranscriptionPlugin(
+                "com.typewhisper.sherpa-onnx",
+                "Parakeet",
+                configured: true,
+                supportsModelDownload: true,
+                isModelDownloaded: false);
+            var sut = CreateViewModel(plugin);
+            sut.SelectedModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "whisper-large-v3-turbo");
+            sut.CurrentStep = 3;
+            var completed = false;
+            sut.Completed += (_, _) => completed = true;
+
+            sut.NextStepCommand.Execute(null);
+
+            Assert.True(completed);
+            Assert.Equal(SettingsRoute.Dictation, sut.CompletionRequest.SettingsRoute);
+            Assert.Null(sut.CompletionRequest.PluginIdToConfigure);
+        });
+    }
+
+    [Fact]
+    public void Skip_DoesNotRequestSettings_WhenEngineIsNotReady()
+    {
+        RunOnStaThread(() =>
+        {
+            var plugin = new FakeTranscriptionPlugin(
+                "com.typewhisper.groq",
+                "Groq",
+                configured: false,
+                supportsModelDownload: false);
+            var sut = CreateViewModel(plugin);
+            sut.SelectedModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "whisper-large-v3-turbo");
+
+            sut.SkipCommand.Execute(null);
+
+            Assert.Null(sut.CompletionRequest.SettingsRoute);
+            Assert.Null(sut.CompletionRequest.PluginIdToConfigure);
+        });
+    }
+
     private static WelcomeViewModel CreateViewModel(FakeTranscriptionPlugin plugin) =>
         CreateViewModel(plugin, out _);
 
@@ -166,12 +235,14 @@ public sealed class WelcomeViewModelTests
             string pluginId,
             string providerDisplayName,
             bool configured,
-            bool supportsModelDownload)
+            bool supportsModelDownload,
+            bool isModelDownloaded = true)
         {
             PluginId = pluginId;
             ProviderDisplayName = providerDisplayName;
             IsConfigured = configured;
             SupportsModelDownload = supportsModelDownload;
+            ModelDownloaded = isModelDownloaded;
         }
 
         public string PluginId { get; }
@@ -181,6 +252,7 @@ public sealed class WelcomeViewModelTests
         public string ProviderDisplayName { get; }
         public bool IsConfigured { get; set; }
         public bool SupportsModelDownload { get; }
+        public bool ModelDownloaded { get; }
         public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
         [
             new("whisper-large-v3-turbo", "Whisper Large V3 Turbo")
@@ -198,6 +270,7 @@ public sealed class WelcomeViewModelTests
         }
 
         public void SelectModel(string modelId) => SelectedModelId = modelId;
+        public bool IsModelDownloaded(string modelId) => !SupportsModelDownload || ModelDownloaded;
 
         public Task<PluginTranscriptionResult> TranscribeAsync(
             byte[] wavAudio,


### PR DESCRIPTION
## Summary
- Route onboarding completion to Settings when no transcription engine is ready
- Expand the selected cloud provider settings for unconfigured providers such as Groq
- Show “API key required” instead of an empty status with an endless busy indicator

## Test Plan
- dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj
- git diff --check
- dotnet build src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release -p:OutputPath=C:\Users\marco\.codex\tmp\typewhisper-build\windows\

Note: the normal Release output path was locked by a running TypeWhisper process, so the build was verified with an alternate OutputPath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding can complete with a request that opens settings and optionally focuses a specific plugin

* **Improvements**
  * Settings window now accepts requests to open specific routes, present importer, and focus installed plugins
  * Model UI exposes and binds a busy state so progress indicators reflect active-model processing

* **Localization**
  * Added "API key required" message in English, German, Japanese, and Russian

* **Tests**
  * New unit and UI tests covering onboarding requests, model readiness, and busy-state bindings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->