### PR TITLE
Add Smallest AI plugin release mapping

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -63,6 +63,7 @@ jobs:
             'google-cloud-stt'   = 'TypeWhisper.Plugin.GoogleCloudStt'
             'qwen3-stt'          = 'TypeWhisper.Plugin.Qwen3Stt'
             'voxtral'            = 'TypeWhisper.Plugin.Voxtral'
+            'smallest-ai'        = 'TypeWhisper.Plugin.SmallestAi'
             'supertonic-tts'     = 'TypeWhisper.Plugin.SupertonicTts'
             'whisper-cpp'        = 'TypeWhisper.Plugin.WhisperCpp'
             'file-memory'        = 'TypeWhisper.Plugin.FileMemory'


### PR DESCRIPTION
## Summary
- Add the Smallest AI plugin key to the plugin release workflow mapping.

## Test Plan
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated build and release process for the smallest-ai plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->