### PR TITLE
Align Windows HTTP API with Mac contract

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -150,7 +150,34 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts/security
-          pip-audit -r plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt --progress-spinner off | tee artifacts/security/granite-speech-pip-audit.txt
+          # These torch/transformers advisories currently have no fixed versions
+          # in the vulnerability feed; keep the audit active for all other IDs.
+          ignored_vulns=(
+            PYSEC-2025-189
+            PYSEC-2025-190
+            PYSEC-2025-191
+            PYSEC-2025-192
+            PYSEC-2025-193
+            PYSEC-2025-194
+            PYSEC-2025-195
+            PYSEC-2025-196
+            PYSEC-2025-197
+            PYSEC-2025-210
+            PYSEC-2025-211
+            PYSEC-2025-212
+            PYSEC-2025-213
+            PYSEC-2025-214
+            PYSEC-2025-215
+            PYSEC-2025-216
+            PYSEC-2025-217
+            PYSEC-2025-218
+            PYSEC-2026-139
+          )
+          ignore_args=()
+          for vuln in "${ignored_vulns[@]}"; do
+            ignore_args+=(--ignore-vuln "$vuln")
+          done
+          pip-audit -r plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt --progress-spinner off "${ignore_args[@]}" | tee artifacts/security/granite-speech-pip-audit.txt
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -173,6 +173,13 @@ jobs:
             PYSEC-2025-218
             PYSEC-2026-139
           )
+          for vuln in "${ignored_vulns[@]}"; do
+            fixed_versions="$(curl -fsS "https://api.osv.dev/v1/vulns/${vuln}" | jq -r '[.affected[]?.ranges[]?.events[]?|select(has("fixed"))|.fixed] | unique | join(",")')"
+            if [[ -n "${fixed_versions}" ]]; then
+              echo "Ignored advisory ${vuln} now has fix(es): ${fixed_versions}. Remove it from ignored_vulns."
+              exit 1
+            fi
+          done
           ignore_args=()
           for vuln in "${ignored_vulns[@]}"; do
             ignore_args+=(--ignore-vuln "$vuln")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TypeWhisper for Windows includes system-wide dictation, file transcription, work
 - **Workflows:** Prompt actions and matching rules live in one workflow surface with templates for cleanup, translation, email replies, meeting notes, checklists, JSON extraction, summaries, and custom prompts.
 - **Expanded engines:** Local SherpaOnnx, whisper.cpp, Granite Speech, and compatible server-based engines sit alongside cloud transcription providers.
 - **Streaming preview:** The recording overlay can show partial results while speech is still being captured.
-- **Automation refresh:** The local HTTP API and CLI support per-request engine/model overrides, language hints, translation targets, and dictionary term management.
+- **Automation refresh:** The local HTTP API and CLI support tokenized discovery, local-file transcription, workflow/rule listing, per-request engine/model overrides, language hints, translation targets, and dictionary term/correction management.
 - **Plugin marketplace:** Browse, install, upgrade, and remove bundled or external plugins from Settings.
 - **Release channels:** Velopack powers stable, release-candidate, and daily build delivery.
 
@@ -58,7 +58,7 @@ TypeWhisper for Windows includes system-wide dictation, file transcription, work
 - **Plugin system:** Extend TypeWhisper with custom transcription engines, LLM providers, post-processors, memory providers, TTS providers, event observers, and action plugins.
 - **Plugin marketplace:** Browse, install, upgrade, and remove plugins directly from Settings. Recommended extensions can be installed automatically on first run.
 - **Action plugins:** Linear, Obsidian, Script, Webhook, and LiveTranscript can turn transcriptions into issues, notes, scripts, notifications, or live windows.
-- **HTTP API:** Local REST server for status, models, transcription, history, dictionary terms, and dictation control.
+- **HTTP API:** Local REST server for status, models, transcription, workflows/rules, history, dictionary terms and corrections, and dictation control.
 - **CLI tool:** Shell-friendly transcription via the bundled `typewhisper` command.
 
 ### General
@@ -134,22 +134,32 @@ The app appears in the system tray, and the welcome wizard guides you through ex
 
 ## HTTP API
 
-The HTTP API is an advanced local automation surface. It binds to `localhost` and `127.0.0.1`, is configurable in Settings, and uses port `8978` by default.
+The HTTP API is an advanced local automation surface. It binds to `localhost` and `127.0.0.1`, is configurable in Settings, and uses port `8978` by default. When the server starts it writes discovery files to `%LOCALAPPDATA%\TypeWhisper`: legacy `api-port` and `api-discovery.json` with `{ "version": 1, "port": 8978, "token": "..." }`.
+
+Authentication is off by default for local compatibility. If Settings > Advanced > API Server > Require API Token is enabled, `/v1/status` remains public and all other routes require either `Authorization: Bearer <token>` or `X-TypeWhisper-API-Token: <token>`. `OPTIONS` requests return `204 No Content`.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/v1/status` | GET | App status, active engine, active model, API version, and capability flags |
 | `/v1/models` | GET | List all available local and cloud models |
 | `/v1/transcribe` | POST | Transcribe multipart or raw audio |
+| `/v1/transcribe/local-file` | POST | Transcribe a file path already on this Windows machine |
 | `/v1/history` | GET | Search history with pagination |
 | `/v1/history` | DELETE | Delete a history entry by ID |
+| `/v1/rules` | GET | List workflow-backed rules |
+| `/v1/profiles` | GET | List workflow-backed profiles |
+| `/v1/rules/toggle` | PUT | Toggle a rule by `id` |
+| `/v1/profiles/toggle` | PUT | Toggle a profile by `id` |
 | `/v1/dictation/start` | POST | Start recording |
 | `/v1/dictation/stop` | POST | Stop recording |
 | `/v1/dictation/status` | GET | Check current dictation state |
 | `/v1/dictation/transcription` | GET | Poll dictation result by session ID |
 | `/v1/dictionary/terms` | GET | List enabled dictionary terms |
 | `/v1/dictionary/terms` | PUT | Replace or append dictionary terms |
-| `/v1/dictionary/terms` | DELETE | Clear dictionary terms |
+| `/v1/dictionary/terms` | DELETE | Delete one dictionary term |
+| `/v1/dictionary/corrections` | GET | List enabled dictionary corrections |
+| `/v1/dictionary/corrections` | PUT | Upsert a correction |
+| `/v1/dictionary/corrections` | DELETE | Delete a correction |
 
 `/v1/transcribe` accepts `multipart/form-data` with a `file` part or a raw audio request body. Multipart fields are:
 
@@ -162,6 +172,20 @@ The HTTP API is an advanced local automation surface. It binds to `localhost` an
 - `engine` and `model`: per-request overrides using IDs from `/v1/models`
 
 Raw audio requests can pass the same options with headers: `X-Language`, `X-Language-Hints`, `X-Task`, `X-Target-Language`, `X-Response-Format`, `X-Prompt`, `X-Engine`, and `X-Model`. Add `?await_download=1` to wait for a local model download or restore when supported.
+
+`/v1/transcribe/local-file` accepts JSON. This is what the CLI uses for normal file paths, so large local files are not uploaded through the API process:
+
+```json
+{
+  "path": "C:\\Audio\\recording.wav",
+  "language_hints": ["de", "en"],
+  "task": "transcribe",
+  "engine": "mock",
+  "model": "tiny"
+}
+```
+
+Dictionary terms use `PUT /v1/dictionary/terms` with `{ "terms": ["TypeWhisper"], "replace": false }` and `DELETE /v1/dictionary/terms` with `{ "term": "TypeWhisper" }`. Corrections use `{ "original": "teh", "replacement": "the", "caseSensitive": false }`.
 
 ```bash
 curl -X POST http://localhost:8978/v1/transcribe \
@@ -177,7 +201,7 @@ curl "http://localhost:8978/v1/dictation/transcription?id=<session-id>"
 
 ## CLI Tool
 
-The optional `typewhisper` CLI talks to the local HTTP API and is intended for scripts, terminals, and batch workflows.
+The optional `typewhisper` CLI talks to the local HTTP API and is intended for scripts, terminals, Raycast commands, and batch workflows. It reads `%LOCALAPPDATA%\TypeWhisper\api-discovery.json` before the legacy `api-port` file. Tokens can also be supplied with `TYPEWHISPER_API_TOKEN` or `--api-token`.
 
 ### Commands
 
@@ -194,7 +218,8 @@ typewhisper transcribe - < audio.wav
 
 | Option | Description |
 |--------|-------------|
-| `--port <N>` | Server port (default: `8978`) |
+| `--port <N>` | Server port (default: auto-discover, fallback `8978`) |
+| `--api-token <token>` | API token override |
 | `--json` | Output as JSON |
 | `--language <code>` | Source language, such as `en` or `de` |
 | `--language-hint <code>` | Repeatable language hint for restricted auto-detection |

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -43,47 +43,81 @@
 
 ## Phase 2: HTTP API
 
-### 2.1 Basis-Status
-```bash
-curl http://localhost:8978/v1/status
+> **Hinweis:** API Server muss in Einstellungen → Erweitert → API Server aktiviert sein. Standardmäßig ist Auth aus. Wenn "API-Token verlangen" aktiv ist, bleibt `/v1/status` öffentlich; alle anderen Routen brauchen `Authorization: Bearer <token>` oder `X-TypeWhisper-API-Token`.
+
+### 2.1 Discovery + Auth
+```powershell
+$discovery = Get-Content "$env:LOCALAPPDATA\TypeWhisper\api-discovery.json" | ConvertFrom-Json
+$token = $discovery.token
+curl http://localhost:$($discovery.port)/v1/status
+curl -H "Authorization: Bearer $token" http://localhost:$($discovery.port)/v1/models
+curl -i -X OPTIONS http://localhost:$($discovery.port)/v1/models
 ```
-→ JSON mit `version`, `is_recording`, `supports_streaming`, `supports_translation`
+→ `api-discovery.json` enthält `version`, `port`, `token`; `api-port` existiert weiter. `OPTIONS` antwortet mit `204` ohne JSON-Body.
 
 ### 2.2 History
 ```bash
-# Alle Einträge
 curl "http://localhost:8978/v1/history?limit=5"
-# Suche
 curl "http://localhost:8978/v1/history?q=test"
-# Löschen (mit echter ID)
 curl -X DELETE "http://localhost:8978/v1/history?id=SOME_ID"
 ```
 
-### 2.3 Profile
+### 2.3 Workflows / Rules / Profiles
 ```bash
-# Alle Profile
+curl http://localhost:8978/v1/rules
 curl http://localhost:8978/v1/profiles
+curl -X PUT "http://localhost:8978/v1/rules/toggle?id=SOME_WORKFLOW_ID"
+curl -X PUT "http://localhost:8978/v1/profiles/toggle?id=SOME_WORKFLOW_ID"
+```
+→ Windows liefert im Feld `bundle_identifiers` die vorhandenen Prozessnamen.
+
+### 2.4 Dictionary Terms + Corrections
+```bash
+curl http://localhost:8978/v1/dictionary/terms
+curl -X PUT http://localhost:8978/v1/dictionary/terms ^
+  -H "Content-Type: application/json" ^
+  -d "{\"terms\":[\"TypeWhisper\",\"Raycast\"],\"replace\":false}"
+curl -X DELETE http://localhost:8978/v1/dictionary/terms ^
+  -H "Content-Type: application/json" ^
+  -d "{\"term\":\"Raycast\"}"
+
+curl http://localhost:8978/v1/dictionary/corrections
+curl -X PUT http://localhost:8978/v1/dictionary/corrections ^
+  -H "Content-Type: application/json" ^
+  -d "{\"original\":\"teh\",\"replacement\":\"the\",\"caseSensitive\":false}"
+curl -X DELETE http://localhost:8978/v1/dictionary/corrections ^
+  -H "Content-Type: application/json" ^
+  -d "{\"original\":\"teh\"}"
 ```
 
-### 2.4 Dictation Control
+### 2.5 Dictation Control
 ```bash
-# Status prüfen
 curl http://localhost:8978/v1/dictation/status
-# Starten
 curl -X POST http://localhost:8978/v1/dictation/start
-# Stoppen
 curl -X POST http://localhost:8978/v1/dictation/stop
 ```
 
-### 2.5 Transcribe
+### 2.6 Transcribe
 ```bash
-# Audio-Datei senden
+# Multipart oder raw audio
 curl -X POST http://localhost:8978/v1/transcribe \
   -F "file=@test.wav" \
   -F "language=de"
+
+# Mac-kompatible Local-File-Route ohne Byte-Upload
+curl -X POST "http://localhost:8978/v1/transcribe/local-file?await_download=1" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"path\":\"C:\\Audio\\test.wav\",\"language_hints\":[\"de\",\"en\"],\"task\":\"transcribe\"}"
 ```
 
-> **Hinweis:** API Server muss in Einstellungen → Allgemein aktiviert sein.
+### 2.7 CLI / Raycast-Pfad
+```powershell
+$env:TYPEWHISPER_API_TOKEN = $token
+typewhisper status
+typewhisper models
+typewhisper transcribe C:\Audio\test.wav --language de --json
+typewhisper transcribe C:\Audio\test.wav --api-token $token --await-download
+```
 
 ---
 

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -49,70 +49,63 @@
 ```powershell
 $discovery = Get-Content "$env:LOCALAPPDATA\TypeWhisper\api-discovery.json" | ConvertFrom-Json
 $token = $discovery.token
-curl http://localhost:$($discovery.port)/v1/status
-curl -H "Authorization: Bearer $token" http://localhost:$($discovery.port)/v1/models
-curl -i -X OPTIONS http://localhost:$($discovery.port)/v1/models
+$base = "http://localhost:$($discovery.port)"
+$env:TYPEWHISPER_API_TOKEN = $token
+$auth = "Authorization: Bearer $env:TYPEWHISPER_API_TOKEN"
+$json = "Content-Type: application/json"
+curl.exe "$base/v1/status"
+curl.exe -H $auth "$base/v1/models"
+curl.exe -i -X OPTIONS "$base/v1/models"
 ```
 → `api-discovery.json` enthält `version`, `port`, `token`; `api-port` existiert weiter. `OPTIONS` antwortet mit `204` ohne JSON-Body.
 
 ### 2.2 History
-```bash
-curl "http://localhost:8978/v1/history?limit=5"
-curl "http://localhost:8978/v1/history?q=test"
-curl -X DELETE "http://localhost:8978/v1/history?id=SOME_ID"
+```powershell
+curl.exe -H $auth "$base/v1/history?limit=5"
+curl.exe -H $auth "$base/v1/history?q=test"
+curl.exe -X DELETE -H $auth "$base/v1/history?id=SOME_ID"
 ```
 
 ### 2.3 Workflows / Rules / Profiles
-```bash
-curl http://localhost:8978/v1/rules
-curl http://localhost:8978/v1/profiles
-curl -X PUT "http://localhost:8978/v1/rules/toggle?id=SOME_WORKFLOW_ID"
-curl -X PUT "http://localhost:8978/v1/profiles/toggle?id=SOME_WORKFLOW_ID"
+```powershell
+curl.exe -H $auth "$base/v1/rules"
+curl.exe -H $auth "$base/v1/profiles"
+curl.exe -X PUT -H $auth "$base/v1/rules/toggle?id=SOME_WORKFLOW_ID"
+curl.exe -X PUT -H $auth "$base/v1/profiles/toggle?id=SOME_WORKFLOW_ID"
 ```
 → Windows liefert im Feld `bundle_identifiers` die vorhandenen Prozessnamen.
 
 ### 2.4 Dictionary Terms + Corrections
-```bash
-curl http://localhost:8978/v1/dictionary/terms
-curl -X PUT http://localhost:8978/v1/dictionary/terms ^
-  -H "Content-Type: application/json" ^
-  -d "{\"terms\":[\"TypeWhisper\",\"Raycast\"],\"replace\":false}"
-curl -X DELETE http://localhost:8978/v1/dictionary/terms ^
-  -H "Content-Type: application/json" ^
-  -d "{\"term\":\"Raycast\"}"
+```powershell
+curl.exe -H $auth "$base/v1/dictionary/terms"
+curl.exe -X PUT -H $auth -H $json -d '{"terms":["TypeWhisper","Raycast"],"replace":false}' "$base/v1/dictionary/terms"
+curl.exe -X DELETE -H $auth -H $json -d '{"term":"Raycast"}' "$base/v1/dictionary/terms"
 
-curl http://localhost:8978/v1/dictionary/corrections
-curl -X PUT http://localhost:8978/v1/dictionary/corrections ^
-  -H "Content-Type: application/json" ^
-  -d "{\"original\":\"teh\",\"replacement\":\"the\",\"caseSensitive\":false}"
-curl -X DELETE http://localhost:8978/v1/dictionary/corrections ^
-  -H "Content-Type: application/json" ^
-  -d "{\"original\":\"teh\"}"
+curl.exe -H $auth "$base/v1/dictionary/corrections"
+curl.exe -X PUT -H $auth -H $json -d '{"original":"teh","replacement":"the","caseSensitive":false}' "$base/v1/dictionary/corrections"
+curl.exe -X DELETE -H $auth -H $json -d '{"original":"teh"}' "$base/v1/dictionary/corrections"
 ```
 
 ### 2.5 Dictation Control
-```bash
-curl http://localhost:8978/v1/dictation/status
-curl -X POST http://localhost:8978/v1/dictation/start
-curl -X POST http://localhost:8978/v1/dictation/stop
+```powershell
+curl.exe -H $auth "$base/v1/dictation/status"
+curl.exe -X POST -H $auth "$base/v1/dictation/start"
+curl.exe -X POST -H $auth "$base/v1/dictation/stop"
 ```
 
 ### 2.6 Transcribe
-```bash
+```powershell
 # Multipart oder raw audio
-curl -X POST http://localhost:8978/v1/transcribe \
-  -F "file=@test.wav" \
+curl.exe -X POST -H $auth "$base/v1/transcribe" `
+  -F "file=@test.wav" `
   -F "language=de"
 
 # Mac-kompatible Local-File-Route ohne Byte-Upload
-curl -X POST "http://localhost:8978/v1/transcribe/local-file?await_download=1" ^
-  -H "Content-Type: application/json" ^
-  -d "{\"path\":\"C:\\Audio\\test.wav\",\"language_hints\":[\"de\",\"en\"],\"task\":\"transcribe\"}"
+curl.exe -X POST -H $auth -H $json -d '{"path":"C:\\Audio\\test.wav","language_hints":["de","en"],"task":"transcribe"}' "$base/v1/transcribe/local-file?await_download=1"
 ```
 
 ### 2.7 CLI / Raycast-Pfad
 ```powershell
-$env:TYPEWHISPER_API_TOKEN = $token
 typewhisper status
 typewhisper models
 typewhisper transcribe C:\Audio\test.wav --language de --json

--- a/src/TypeWhisper.Cli/CliSupport.cs
+++ b/src/TypeWhisper.Cli/CliSupport.cs
@@ -28,15 +28,15 @@ public static class CliConnectionResolver
 
     public static CliConnection Resolve(CliConnectionOptions options)
     {
-        var appDirectory = Path.Combine(
+        var appDirectory = Path.Join(
             options.ApplicationDataRoot
                 ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "TypeWhisper");
 
-        var discovery = ReadDiscovery(Path.Combine(appDirectory, "api-discovery.json"));
+        var discovery = ReadDiscovery(Path.Join(appDirectory, "api-discovery.json"));
         var port = ValidatePort(options.PortOverride)
             ?? ValidatePort(discovery?.Port)
-            ?? ValidatePort(ReadLegacyPort(Path.Combine(appDirectory, "api-port")))
+            ?? ValidatePort(ReadLegacyPort(Path.Join(appDirectory, "api-port")))
             ?? DefaultPort;
         var token = FirstNonBlank(
             options.ApiTokenOverride,
@@ -61,7 +61,7 @@ public static class CliConnectionResolver
 
             return discovery;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
         {
             return null;
         }
@@ -74,7 +74,12 @@ public static class CliConnectionResolver
             if (File.Exists(path) && int.TryParse(File.ReadAllText(path).Trim(), out var port))
                 return port;
         }
-        catch { }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or System.Security.SecurityException)
+        {
+        }
 
         return null;
     }
@@ -135,6 +140,30 @@ public static class CliRequestBuilder
     {
         if (!string.IsNullOrWhiteSpace(apiToken))
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken.Trim());
+    }
+
+    public static string BuildStdinFileName(ReadOnlySpan<byte> audioBytes)
+    {
+        if (audioBytes.Length >= 12
+            && audioBytes[..4].SequenceEqual("RIFF"u8)
+            && audioBytes[8..12].SequenceEqual("WAVE"u8))
+        {
+            return "stdin.wav";
+        }
+
+        if (audioBytes.StartsWith("fLaC"u8))
+            return "stdin.flac";
+
+        if (audioBytes.StartsWith("OggS"u8))
+            return "stdin.ogg";
+
+        if (audioBytes.StartsWith("ID3"u8)
+            || (audioBytes.Length >= 2 && audioBytes[0] == 0xFF && (audioBytes[1] & 0xE0) == 0xE0))
+        {
+            return "stdin.mp3";
+        }
+
+        return "stdin.wav";
     }
 
     private static Uri BuildUri(string baseUrl, string path) =>

--- a/src/TypeWhisper.Cli/CliSupport.cs
+++ b/src/TypeWhisper.Cli/CliSupport.cs
@@ -157,13 +157,32 @@ public static class CliRequestBuilder
         if (audioBytes.StartsWith("OggS"u8))
             return "stdin.ogg";
 
-        if (audioBytes.StartsWith("ID3"u8)
-            || (audioBytes.Length >= 2 && audioBytes[0] == 0xFF && (audioBytes[1] & 0xE0) == 0xE0))
+        if (LooksLikeAdtsAac(audioBytes))
+            return "stdin.aac";
+
+        if (audioBytes.StartsWith("ID3"u8) || LooksLikeMp3Frame(audioBytes))
         {
             return "stdin.mp3";
         }
 
         return "stdin.wav";
+    }
+
+    private static bool LooksLikeAdtsAac(ReadOnlySpan<byte> audioBytes) =>
+        audioBytes.Length >= 2
+        && audioBytes[0] == 0xFF
+        && (audioBytes[1] & 0xF0) == 0xF0
+        && (audioBytes[1] & 0x06) == 0x00;
+
+    private static bool LooksLikeMp3Frame(ReadOnlySpan<byte> audioBytes)
+    {
+        if (audioBytes.Length < 4 || audioBytes[0] != 0xFF || (audioBytes[1] & 0xE0) != 0xE0)
+            return false;
+
+        var version = (audioBytes[1] >> 3) & 0b11;
+        var layer = (audioBytes[1] >> 1) & 0b11;
+
+        return version != 0b01 && layer == 0b01;
     }
 
     private static Uri BuildUri(string baseUrl, string path) =>

--- a/src/TypeWhisper.Cli/CliSupport.cs
+++ b/src/TypeWhisper.Cli/CliSupport.cs
@@ -34,9 +34,9 @@ public static class CliConnectionResolver
             "TypeWhisper");
 
         var discovery = ReadDiscovery(Path.Combine(appDirectory, "api-discovery.json"));
-        var port = options.PortOverride
-            ?? discovery?.Port
-            ?? ReadLegacyPort(Path.Combine(appDirectory, "api-port"))
+        var port = ValidatePort(options.PortOverride)
+            ?? ValidatePort(discovery?.Port)
+            ?? ValidatePort(ReadLegacyPort(Path.Combine(appDirectory, "api-port")))
             ?? DefaultPort;
         var token = FirstNonBlank(
             options.ApiTokenOverride,
@@ -45,6 +45,8 @@ public static class CliConnectionResolver
 
         return new CliConnection(port, token);
     }
+
+    public static bool IsPortInRange(int port) => port is >= 1 and <= 65535;
 
     private static ApiDiscovery? ReadDiscovery(string path)
     {
@@ -57,7 +59,7 @@ public static class CliConnectionResolver
                 File.ReadAllText(path),
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-            return discovery?.Port > 0 ? discovery : null;
+            return discovery;
         }
         catch
         {
@@ -79,6 +81,9 @@ public static class CliConnectionResolver
 
     private static string? FirstNonBlank(params string?[] values) =>
         values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private static int? ValidatePort(int? port) =>
+        port is int value && IsPortInRange(value) ? value : null;
 
     private sealed record ApiDiscovery
     {

--- a/src/TypeWhisper.Cli/CliSupport.cs
+++ b/src/TypeWhisper.Cli/CliSupport.cs
@@ -1,0 +1,137 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace TypeWhisper.Cli;
+
+public sealed record CliConnectionOptions(
+    string? ApplicationDataRoot = null,
+    int? PortOverride = null,
+    string? ApiTokenOverride = null,
+    string? EnvironmentApiToken = null);
+
+public sealed record CliConnection(int Port, string? ApiToken);
+
+public sealed record CliTranscribeRequest(
+    string FilePath,
+    string? Language,
+    IReadOnlyList<string> LanguageHints,
+    string Task,
+    string? TargetLanguage,
+    string? Engine,
+    string? Model,
+    bool AwaitDownload);
+
+public static class CliConnectionResolver
+{
+    private const int DefaultPort = 8978;
+
+    public static CliConnection Resolve(CliConnectionOptions options)
+    {
+        var appDirectory = Path.Combine(
+            options.ApplicationDataRoot
+                ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TypeWhisper");
+
+        var discovery = ReadDiscovery(Path.Combine(appDirectory, "api-discovery.json"));
+        var port = options.PortOverride
+            ?? discovery?.Port
+            ?? ReadLegacyPort(Path.Combine(appDirectory, "api-port"))
+            ?? DefaultPort;
+        var token = FirstNonBlank(
+            options.ApiTokenOverride,
+            options.EnvironmentApiToken,
+            discovery?.Token);
+
+        return new CliConnection(port, token);
+    }
+
+    private static ApiDiscovery? ReadDiscovery(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+
+            var discovery = JsonSerializer.Deserialize<ApiDiscovery>(
+                File.ReadAllText(path),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return discovery?.Port > 0 ? discovery : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static int? ReadLegacyPort(string path)
+    {
+        try
+        {
+            if (File.Exists(path) && int.TryParse(File.ReadAllText(path).Trim(), out var port))
+                return port;
+        }
+        catch { }
+
+        return null;
+    }
+
+    private static string? FirstNonBlank(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private sealed record ApiDiscovery
+    {
+        public int Version { get; init; }
+        public int Port { get; init; }
+        public string? Token { get; init; }
+    }
+}
+
+public static class CliRequestBuilder
+{
+    public static HttpRequestMessage BuildGet(string baseUrl, string path, string? apiToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, BuildUri(baseUrl, path));
+        ApplyApiToken(request, apiToken);
+        return request;
+    }
+
+    public static HttpRequestMessage BuildTranscribeLocalFile(
+        string baseUrl,
+        CliTranscribeRequest request,
+        string? apiToken)
+    {
+        var path = request.AwaitDownload
+            ? "/v1/transcribe/local-file?await_download=1"
+            : "/v1/transcribe/local-file";
+        var message = new HttpRequestMessage(HttpMethod.Post, BuildUri(baseUrl, path));
+        ApplyApiToken(message, apiToken);
+
+        var body = new Dictionary<string, object?>
+        {
+            ["path"] = request.FilePath,
+            ["language"] = request.Language,
+            ["language_hints"] = request.LanguageHints,
+            ["task"] = request.Task,
+            ["target_language"] = request.TargetLanguage,
+            ["engine"] = request.Engine,
+            ["model"] = request.Model
+        }
+        .Where(pair => pair.Value is not null)
+        .ToDictionary(pair => pair.Key, pair => pair.Value);
+
+        var json = JsonSerializer.Serialize(body);
+        message.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        return message;
+    }
+
+    public static void ApplyApiToken(HttpRequestMessage request, string? apiToken)
+    {
+        if (!string.IsNullOrWhiteSpace(apiToken))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken.Trim());
+    }
+
+    private static Uri BuildUri(string baseUrl, string path) =>
+        new(new Uri(baseUrl.TrimEnd('/')), path);
+}

--- a/src/TypeWhisper.Cli/CliSupport.cs
+++ b/src/TypeWhisper.Cli/CliSupport.cs
@@ -79,6 +79,7 @@ public static class CliConnectionResolver
             or NotSupportedException
             or System.Security.SecurityException)
         {
+            return null;
         }
 
         return null;

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -147,7 +147,7 @@ static class Program
                 using var content = new MultipartFormDataContent();
                 var fileContent = new ByteArrayContent(audioBytes);
                 fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-                content.Add(fileContent, "file", "stdin.wav");
+                content.Add(fileContent, "file", CliRequestBuilder.BuildStdinFileName(audioBytes));
 
                 AddString(content, "language", options.Language);
                 foreach (var hint in options.LanguageHints)
@@ -387,7 +387,7 @@ static class Program
                         port = parsedPort;
                         break;
                     case "--api-token":
-                        if (!TryReadValue(args, ref i, out apiToken))
+                        if (!TryReadValue(args, ref i, out apiToken) || LooksLikeOption(apiToken))
                             return options with { Error = "--api-token requires a value." };
                         break;
                     case "--language":
@@ -455,5 +455,8 @@ static class Program
             value = args[++index];
             return true;
         }
+
+        private static bool LooksLikeOption(string value) =>
+            value.StartsWith("--", StringComparison.Ordinal);
     }
 }

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -387,7 +387,7 @@ static class Program
                         port = parsedPort;
                         break;
                     case "--api-token":
-                        if (!TryReadValue(args, ref i, out apiToken) || LooksLikeOption(apiToken))
+                        if (!TryReadValue(args, ref i, out apiToken))
                             return options with { Error = "--api-token requires a value." };
                         break;
                     case "--language":
@@ -446,7 +446,7 @@ static class Program
 
         private static bool TryReadValue(string[] args, ref int index, out string value)
         {
-            if (index + 1 >= args.Length)
+            if (index + 1 >= args.Length || LooksLikeOption(args[index + 1]))
             {
                 value = "";
                 return false;
@@ -457,6 +457,6 @@ static class Program
         }
 
         private static bool LooksLikeOption(string value) =>
-            value.StartsWith("--", StringComparison.Ordinal);
+            value.Length > 0 && value[0] == '-' && value != "-";
     }
 }

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -9,7 +9,6 @@ namespace TypeWhisper.Cli;
 /// </summary>
 static class Program
 {
-    private const int DefaultPort = 8978;
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromMinutes(5) };
 
     static async Task<int> Main(string[] args)
@@ -36,25 +35,34 @@ static class Program
             return 1;
         }
 
-        var baseUrl = $"http://localhost:{options.Port}";
+        var connection = CliConnectionResolver.Resolve(new CliConnectionOptions(
+            PortOverride: options.Port,
+            ApiTokenOverride: options.ApiToken,
+            EnvironmentApiToken: Environment.GetEnvironmentVariable("TYPEWHISPER_API_TOKEN")));
+        var baseUrl = $"http://127.0.0.1:{connection.Port}";
 
         return options.Command switch
         {
-            "status" => await StatusAsync(baseUrl, options.Json),
-            "models" => await ModelsAsync(baseUrl, options.Json),
-            "transcribe" => await TranscribeAsync(baseUrl, options),
+            "status" => await StatusAsync(baseUrl, options.Json, connection.ApiToken),
+            "models" => await ModelsAsync(baseUrl, options.Json, connection.ApiToken),
+            "transcribe" => await TranscribeAsync(baseUrl, options, connection.ApiToken),
             _ => Error($"Unknown command: {options.Command}")
         };
     }
 
-    static async Task<int> StatusAsync(string baseUrl, bool json)
+    static async Task<int> StatusAsync(string baseUrl, bool json, string? apiToken)
     {
         try
         {
-            var response = await Http.GetStringAsync($"{baseUrl}/v1/status");
-            if (json) { Console.WriteLine(PrettyJson(response)); return 0; }
+            using var request = CliRequestBuilder.BuildGet(baseUrl, "/v1/status", apiToken);
+            var response = await Http.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+                return Error($"Status request failed ({(int)response.StatusCode}): {ExtractErrorMessage(body)}");
 
-            using var doc = JsonDocument.Parse(response);
+            if (json) { Console.WriteLine(PrettyJson(body)); return 0; }
+
+            using var doc = JsonDocument.Parse(body);
             var root = doc.RootElement;
             var status = Prop(root, "status") == "ready" ? "Ready" : "No model loaded";
             var engine = Prop(root, "engine");
@@ -70,14 +78,19 @@ static class Program
         }
     }
 
-    static async Task<int> ModelsAsync(string baseUrl, bool json)
+    static async Task<int> ModelsAsync(string baseUrl, bool json, string? apiToken)
     {
         try
         {
-            var response = await Http.GetStringAsync($"{baseUrl}/v1/models");
-            if (json) { Console.WriteLine(PrettyJson(response)); return 0; }
+            using var request = CliRequestBuilder.BuildGet(baseUrl, "/v1/models", apiToken);
+            var response = await Http.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+                return Error($"Models request failed ({(int)response.StatusCode}): {ExtractErrorMessage(body)}");
 
-            using var doc = JsonDocument.Parse(response);
+            if (json) { Console.WriteLine(PrettyJson(body)); return 0; }
+
+            using var doc = JsonDocument.Parse(body);
             if (!doc.RootElement.TryGetProperty("models", out var models))
                 return 0;
 
@@ -110,7 +123,7 @@ static class Program
         }
     }
 
-    static async Task<int> TranscribeAsync(string baseUrl, CliOptions options)
+    static async Task<int> TranscribeAsync(string baseUrl, CliOptions options, string? apiToken)
     {
         if (!string.IsNullOrEmpty(options.Language) && options.LanguageHints.Count > 0)
             return Error("--language and --language-hint cannot be used together.");
@@ -119,44 +132,70 @@ static class Program
         if (string.IsNullOrWhiteSpace(file))
             return Error("Usage: typewhisper transcribe <file|->");
 
-        byte[] audioBytes;
-        var fileName = "audio.wav";
-
         if (file == "-")
         {
+            byte[] audioBytes;
             await using var stdin = Console.OpenStandardInput();
             using var buffer = new MemoryStream();
             await stdin.CopyToAsync(buffer);
             audioBytes = buffer.ToArray();
             if (audioBytes.Length == 0)
                 return Error("No data received from stdin.");
-        }
-        else
-        {
-            if (!File.Exists(file))
-                return Error($"File not found: {file}");
 
-            audioBytes = await File.ReadAllBytesAsync(file);
-            fileName = Path.GetFileName(file);
+            try
+            {
+                using var content = new MultipartFormDataContent();
+                var fileContent = new ByteArrayContent(audioBytes);
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                content.Add(fileContent, "file", "stdin.wav");
+
+                AddString(content, "language", options.Language);
+                foreach (var hint in options.LanguageHints)
+                    AddString(content, "language_hint", hint);
+                AddString(content, "task", options.Task);
+                AddString(content, "target_language", options.TranslateTo);
+                AddString(content, "engine", options.Engine);
+                AddString(content, "model", options.Model);
+
+                var path = options.AwaitDownload ? "/v1/transcribe?await_download=1" : "/v1/transcribe";
+                using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{path}") { Content = content };
+                CliRequestBuilder.ApplyApiToken(request, apiToken);
+                var response = await Http.SendAsync(request);
+                var body = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                    return Error($"Transcription failed ({(int)response.StatusCode}): {ExtractErrorMessage(body)}");
+
+                if (options.Json) { Console.WriteLine(PrettyJson(body)); return 0; }
+
+                using var doc = JsonDocument.Parse(body);
+                Console.WriteLine(Prop(doc.RootElement, "text"));
+                return 0;
+            }
+            catch (HttpRequestException)
+            {
+                return Error("TypeWhisper is not running or API server is disabled.");
+            }
         }
+
+        if (!File.Exists(file))
+            return Error($"File not found: {file}");
 
         try
         {
-            using var content = new MultipartFormDataContent();
-            var fileContent = new ByteArrayContent(audioBytes);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-            content.Add(fileContent, "file", fileName);
-
-            AddString(content, "language", options.Language);
-            foreach (var hint in options.LanguageHints)
-                AddString(content, "language_hint", hint);
-            AddString(content, "task", options.Task);
-            AddString(content, "target_language", options.TranslateTo);
-            AddString(content, "engine", options.Engine);
-            AddString(content, "model", options.Model);
-
-            var path = options.AwaitDownload ? "/v1/transcribe?await_download=1" : "/v1/transcribe";
-            var response = await Http.PostAsync($"{baseUrl}{path}", content);
+            using var request = CliRequestBuilder.BuildTranscribeLocalFile(
+                baseUrl,
+                new CliTranscribeRequest(
+                    Path.GetFullPath(file),
+                    options.Language,
+                    options.LanguageHints,
+                    options.Task,
+                    options.TranslateTo,
+                    options.Engine,
+                    options.Model,
+                    options.AwaitDownload),
+                apiToken);
+            var response = await Http.SendAsync(request);
             var body = await response.Content.ReadAsStringAsync();
 
             if (!response.IsSuccessStatusCode)
@@ -187,7 +226,8 @@ static class Program
               transcribe <file|->       Transcribe an audio file, or - for stdin
 
             Global options:
-              --port <N>                API server port (default: 8978)
+              --port <N>                API server port (default: auto-discover, fallback 8978)
+              --api-token <token>       API token (overrides TYPEWHISPER_API_TOKEN and discovery)
               --json                    Output as JSON
               --version                 Show version
               --help, -h                Show this help
@@ -293,7 +333,8 @@ static class Program
     {
         public string? Command { get; private init; }
         public List<string> Positionals { get; private init; } = [];
-        public int Port { get; private init; } = DefaultPort;
+        public int? Port { get; private init; }
+        public string? ApiToken { get; private init; }
         public bool Json { get; private init; }
         public bool ShowHelp { get; private init; }
         public bool ShowVersion { get; private init; }
@@ -317,7 +358,8 @@ static class Program
             string? translateTo = null;
             string? engine = null;
             string? model = null;
-            var port = DefaultPort;
+            int? port = null;
+            string? apiToken = null;
             var json = false;
             var awaitDownload = false;
 
@@ -338,8 +380,13 @@ static class Program
                         awaitDownload = true;
                         break;
                     case "--port":
-                        if (!TryReadValue(args, ref i, out var portValue) || !int.TryParse(portValue, out port))
+                        if (!TryReadValue(args, ref i, out var portValue) || !int.TryParse(portValue, out var parsedPort))
                             return options with { Error = "--port requires a number." };
+                        port = parsedPort;
+                        break;
+                    case "--api-token":
+                        if (!TryReadValue(args, ref i, out apiToken))
+                            return options with { Error = "--api-token requires a value." };
                         break;
                     case "--language":
                         if (!TryReadValue(args, ref i, out language))
@@ -383,6 +430,7 @@ static class Program
                 Command = command,
                 Positionals = positionals,
                 Port = port,
+                ApiToken = apiToken,
                 Json = json,
                 Language = language,
                 LanguageHints = languageHints,

--- a/src/TypeWhisper.Cli/Program.cs
+++ b/src/TypeWhisper.Cli/Program.cs
@@ -382,6 +382,8 @@ static class Program
                     case "--port":
                         if (!TryReadValue(args, ref i, out var portValue) || !int.TryParse(portValue, out var parsedPort))
                             return options with { Error = "--port requires a number." };
+                        if (!CliConnectionResolver.IsPortInRange(parsedPort))
+                            return options with { Error = "--port requires a TCP port between 1 and 65535." };
                         port = parsedPort;
                         break;
                     case "--api-token":

--- a/src/TypeWhisper.Cli/TypeWhisper.Cli.csproj
+++ b/src/TypeWhisper.Cli/TypeWhisper.Cli.csproj
@@ -6,6 +6,18 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>TypeWhisper.Cli</RootNamespace>
-    <AssemblyName>typewhisper</AssemblyName>
+    <AssemblyName>TypeWhisper.Cli</AssemblyName>
   </PropertyGroup>
+
+  <Target Name="CopyCommandShim" AfterTargets="Build" Condition="Exists('$(TargetDir)$(AssemblyName).exe')">
+    <Copy SourceFiles="$(TargetDir)$(AssemblyName).exe"
+          DestinationFiles="$(TargetDir)typewhisper.exe"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyPublishedCommandShim" AfterTargets="Publish" Condition="Exists('$(PublishDir)$(AssemblyName).exe')">
+    <Copy SourceFiles="$(PublishDir)$(AssemblyName).exe"
+          DestinationFiles="$(PublishDir)typewhisper.exe"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/src/TypeWhisper.Core/Interfaces/IDictionaryService.cs
+++ b/src/TypeWhisper.Core/Interfaces/IDictionaryService.cs
@@ -19,11 +19,23 @@ public interface IDictionaryService
         .Where(e => e.IsEnabled && e.EntryType == DictionaryEntryType.Term)
         .Select(e => e.Original)
         .ToList();
+    IReadOnlyList<DictionaryEntry> GetEnabledCorrections() => Entries
+        .Where(e => e.IsEnabled && e.EntryType == DictionaryEntryType.Correction)
+        .ToList();
 
     void SetTerms(IEnumerable<string> terms, bool replaceExisting) =>
         throw new NotSupportedException();
 
     void RemoveAllTerms() =>
+        throw new NotSupportedException();
+
+    bool DeleteTerm(string term) =>
+        throw new NotSupportedException();
+
+    void UpsertCorrection(string original, string replacement, bool caseSensitive) =>
+        throw new NotSupportedException();
+
+    bool DeleteCorrection(string original) =>
         throw new NotSupportedException();
 
     void LearnCorrection(string original, string replacement);

--- a/src/TypeWhisper.Core/Models/AppSettings.cs
+++ b/src/TypeWhisper.Core/Models/AppSettings.cs
@@ -83,6 +83,7 @@ public record AppSettings
     // API Server
     public bool ApiServerEnabled { get; init; }
     public int ApiServerPort { get; init; } = 8978;
+    public bool ApiServerRequiresAuthentication { get; init; }
 
     // Dictionary
     public string[] EnabledPackIds { get; init; } = [];

--- a/src/TypeWhisper.Core/Services/DictionaryService.cs
+++ b/src/TypeWhisper.Core/Services/DictionaryService.cs
@@ -155,18 +155,16 @@ public sealed class DictionaryService : IDictionaryService
         }
 
         var existingKeys = existingTerms.Select(e => TermKey(e.Original)).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var addedTerms = new List<DictionaryEntry>();
-        foreach (var term in normalized.Where(term => !existingKeys.Contains(TermKey(term))))
-        {
-            var entry = new DictionaryEntry
+        var addedTerms = normalized
+            .Where(term => !existingKeys.Contains(TermKey(term)))
+            .Select(term => new DictionaryEntry
             {
                 Id = Guid.NewGuid().ToString(),
                 EntryType = DictionaryEntryType.Term,
                 Original = term
-            };
-            _cache.Add(entry);
-            addedTerms.Add(entry);
-        }
+            })
+            .ToList();
+        _cache.AddRange(addedTerms);
 
         if (replaceExisting)
         {

--- a/src/TypeWhisper.Core/Services/DictionaryService.cs
+++ b/src/TypeWhisper.Core/Services/DictionaryService.cs
@@ -112,6 +112,15 @@ public sealed class DictionaryService : IDictionaryService
             .Select(e => e.Original));
     }
 
+    public IReadOnlyList<DictionaryEntry> GetEnabledCorrections()
+    {
+        EnsureCacheLoaded();
+        return _cache
+            .Where(e => e.IsEnabled && e.EntryType == DictionaryEntryType.Correction)
+            .OrderBy(e => e.Original, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     public void SetTerms(IEnumerable<string> terms, bool replaceExisting)
     {
         EnsureCacheLoaded();
@@ -119,6 +128,8 @@ public sealed class DictionaryService : IDictionaryService
         var normalized = NormalizeTerms(terms);
         var desiredByKey = normalized.ToDictionary(TermKey, term => term);
         var existingTerms = _cache.Where(e => e.EntryType == DictionaryEntryType.Term).ToList();
+        var touchedTerms = new List<DictionaryEntry>();
+        var untouchedTerms = new List<DictionaryEntry>();
 
         foreach (var entry in existingTerms)
         {
@@ -127,23 +138,48 @@ public sealed class DictionaryService : IDictionaryService
             {
                 var idx = _cache.FindIndex(e => e.Id == entry.Id);
                 if (idx >= 0)
-                    _cache[idx] = entry with { Original = desiredTerm, IsEnabled = true };
+                {
+                    var updated = entry with { Original = desiredTerm, IsEnabled = true };
+                    _cache[idx] = updated;
+                    touchedTerms.Add(updated);
+                }
             }
             else if (replaceExisting)
             {
                 _cache.Remove(entry);
             }
+            else
+            {
+                untouchedTerms.Add(entry);
+            }
         }
 
         var existingKeys = existingTerms.Select(e => TermKey(e.Original)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var addedTerms = new List<DictionaryEntry>();
         foreach (var term in normalized.Where(term => !existingKeys.Contains(TermKey(term))))
         {
-            _cache.Add(new DictionaryEntry
+            var entry = new DictionaryEntry
             {
                 Id = Guid.NewGuid().ToString(),
                 EntryType = DictionaryEntryType.Term,
                 Original = term
-            });
+            };
+            _cache.Add(entry);
+            addedTerms.Add(entry);
+        }
+
+        if (replaceExisting)
+        {
+            ReorderTerms(
+                normalized
+                    .Select(term => _cache.First(e =>
+                        e.EntryType == DictionaryEntryType.Term &&
+                        TermKey(e.Original) == TermKey(term)))
+                    .ToList());
+        }
+        else if (touchedTerms.Count > 0)
+        {
+            ReorderTerms([.. touchedTerms, .. addedTerms, .. untouchedTerms]);
         }
 
         SaveToDisk();
@@ -156,6 +192,74 @@ public sealed class DictionaryService : IDictionaryService
         _cache.RemoveAll(e => e.EntryType == DictionaryEntryType.Term);
         SaveToDisk();
         EntriesChanged?.Invoke();
+    }
+
+    public bool DeleteTerm(string term)
+    {
+        EnsureCacheLoaded();
+        var key = TermKey(term);
+        var removed = _cache.RemoveAll(e =>
+            e.EntryType == DictionaryEntryType.Term &&
+            TermKey(e.Original) == key);
+
+        if (removed == 0)
+            return false;
+
+        SaveToDisk();
+        EntriesChanged?.Invoke();
+        return true;
+    }
+
+    public void UpsertCorrection(string original, string replacement, bool caseSensitive)
+    {
+        EnsureCacheLoaded();
+        var existing = _cache.FirstOrDefault(e =>
+            e.EntryType == DictionaryEntryType.Correction &&
+            e.Original.Equals(original, StringComparison.OrdinalIgnoreCase));
+
+        if (existing is not null)
+        {
+            var idx = _cache.FindIndex(e => e.Id == existing.Id);
+            if (idx >= 0)
+            {
+                _cache[idx] = existing with
+                {
+                    Original = original,
+                    Replacement = replacement,
+                    CaseSensitive = caseSensitive,
+                    IsEnabled = true
+                };
+            }
+        }
+        else
+        {
+            _cache.Add(new DictionaryEntry
+            {
+                Id = Guid.NewGuid().ToString(),
+                EntryType = DictionaryEntryType.Correction,
+                Original = original,
+                Replacement = replacement,
+                CaseSensitive = caseSensitive
+            });
+        }
+
+        SaveToDisk();
+        EntriesChanged?.Invoke();
+    }
+
+    public bool DeleteCorrection(string original)
+    {
+        EnsureCacheLoaded();
+        var removed = _cache.RemoveAll(e =>
+            e.EntryType == DictionaryEntryType.Correction &&
+            e.Original.Equals(original, StringComparison.OrdinalIgnoreCase));
+
+        if (removed == 0)
+            return false;
+
+        SaveToDisk();
+        EntriesChanged?.Invoke();
+        return true;
     }
 
     public void LearnCorrection(string original, string replacement)
@@ -265,6 +369,17 @@ public sealed class DictionaryService : IDictionaryService
             File.WriteAllText(_filePath, json);
         }
         catch { }
+    }
+
+    private void ReorderTerms(IReadOnlyList<DictionaryEntry> orderedTerms)
+    {
+        var orderedIds = orderedTerms.Select(e => e.Id).ToHashSet(StringComparer.Ordinal);
+        var nonTerms = _cache.Where(e => e.EntryType != DictionaryEntryType.Term).ToList();
+        var remainingTerms = _cache
+            .Where(e => e.EntryType == DictionaryEntryType.Term && !orderedIds.Contains(e.Id))
+            .ToList();
+
+        _cache = [.. nonTerms, .. orderedTerms, .. remainingTerms];
     }
 
     private static IReadOnlyList<string> NormalizeTerms(IEnumerable<string> terms)

--- a/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
+++ b/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
@@ -4,22 +4,22 @@ public static class TypeWhisperEnvironment
 {
     public const string GithubRepoUrl = "https://github.com/TypeWhisper/typewhisper-win";
 
-    private static readonly string _basePath = Path.Combine(
+    private static readonly string _basePath = Path.Join(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "TypeWhisper");
 
     public static string BasePath => _basePath;
-    public static string ModelsPath => Path.Combine(_basePath, "Models");
-    public static string DataPath => Path.Combine(_basePath, "Data");
-    public static string LogsPath => Path.Combine(_basePath, "Logs");
-    public static string PluginsPath => Path.Combine(_basePath, "Plugins");
-    public static string AudioPath => Path.Combine(_basePath, "Audio");
-    public static string PluginDataPath => Path.Combine(_basePath, "PluginData");
-    public static string ApiPortFilePath => Path.Combine(_basePath, "api-port");
-    public static string ApiDiscoveryFilePath => Path.Combine(_basePath, "api-discovery.json");
-    public static string ApiTokenFilePath => Path.Combine(_basePath, "api-token");
-    public static string SettingsFilePath => Path.Combine(_basePath, "settings.json");
-    public static string DatabasePath => Path.Combine(DataPath, "typewhisper.db");
+    public static string ModelsPath => Path.Join(_basePath, "Models");
+    public static string DataPath => Path.Join(_basePath, "Data");
+    public static string LogsPath => Path.Join(_basePath, "Logs");
+    public static string PluginsPath => Path.Join(_basePath, "Plugins");
+    public static string AudioPath => Path.Join(_basePath, "Audio");
+    public static string PluginDataPath => Path.Join(_basePath, "PluginData");
+    public static string ApiPortFilePath => Path.Join(_basePath, "api-port");
+    public static string ApiDiscoveryFilePath => Path.Join(_basePath, "api-discovery.json");
+    public static string ApiTokenFilePath => Path.Join(_basePath, "api-token");
+    public static string SettingsFilePath => Path.Join(_basePath, "settings.json");
+    public static string DatabasePath => Path.Join(DataPath, "typewhisper.db");
 
     public static void EnsureDirectories()
     {

--- a/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
+++ b/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
@@ -16,6 +16,8 @@ public static class TypeWhisperEnvironment
     public static string AudioPath => Path.Combine(_basePath, "Audio");
     public static string PluginDataPath => Path.Combine(_basePath, "PluginData");
     public static string ApiPortFilePath => Path.Combine(_basePath, "api-port");
+    public static string ApiDiscoveryFilePath => Path.Combine(_basePath, "api-discovery.json");
+    public static string ApiTokenFilePath => Path.Combine(_basePath, "api-token");
     public static string SettingsFilePath => Path.Combine(_basePath, "settings.json");
     public static string DatabasePath => Path.Combine(DataPath, "typewhisper.db");
 

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -476,6 +476,8 @@
   "Advanced.ApiSection": "API-Server",
   "Advanced.ApiEnable": "Lokale API aktivieren",
   "Advanced.ApiPort": "Port",
+  "Advanced.ApiRequireToken": "API-Token verlangen",
+  "Advanced.ApiRequireTokenHint": "Lokale API-Anfragen mit dem Token aus api-discovery.json schützen.",
   "Advanced.ApiDisabled": "API-Server deaktiviert",
   "Advanced.ApiNotRunning": "API-Server aktiviert, aber nicht gestartet",
   "Advanced.ApiRunningFormat": "API-Server läuft auf Port {0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -476,6 +476,8 @@
   "Advanced.ApiSection": "API Server",
   "Advanced.ApiEnable": "Enable local API",
   "Advanced.ApiPort": "Port",
+  "Advanced.ApiRequireToken": "Require API Token",
+  "Advanced.ApiRequireTokenHint": "Protect local API requests with the token published in api-discovery.json.",
   "Advanced.ApiDisabled": "API server disabled",
   "Advanced.ApiNotRunning": "API server enabled, but not running",
   "Advanced.ApiRunningFormat": "API server running on port {0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -463,6 +463,8 @@
   "Advanced.ApiSection": "APIサーバー",
   "Advanced.ApiEnable": "ローカルAPIを有効化",
   "Advanced.ApiPort": "ポート",
+  "Advanced.ApiRequireToken": "APIトークンを必須にする",
+  "Advanced.ApiRequireTokenHint": "api-discovery.jsonに公開されるトークンでローカルAPIリクエストを保護します。",
   "Advanced.ApiDisabled": "APIサーバー無効",
   "Advanced.ApiNotRunning": "APIサーバーは有効ですが、実行されていません",
   "Advanced.ApiRunningFormat": "APIサーバーがポート{0}で実行中",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -465,6 +465,8 @@
   "Advanced.ApiSection": "Сервер API",
   "Advanced.ApiEnable": "Включить локальный API",
   "Advanced.ApiPort": "Порт",
+  "Advanced.ApiRequireToken": "Требовать API-токен",
+  "Advanced.ApiRequireTokenHint": "Защищать локальные API-запросы токеном из api-discovery.json.",
   "Advanced.ApiDisabled": "Сервер API выключен",
   "Advanced.ApiNotRunning": "API включён, но сервер не запущен",
   "Advanced.ApiRunningFormat": "Сервер API на порту {0}",

--- a/src/TypeWhisper.Windows/Services/CliInstallService.cs
+++ b/src/TypeWhisper.Windows/Services/CliInstallService.cs
@@ -67,8 +67,8 @@ public sealed class CliInstallService
             ?? throw new InvalidOperationException("Missing CLI install directory.");
 
         Directory.CreateDirectory(installDirectory);
-        foreach (var file in Directory.EnumerateFiles(Path.GetDirectoryName(state.BundledPath)!, "typewhisper.*")
-            .Where(file => Path.GetFileName(file).StartsWith("typewhisper.", StringComparison.Ordinal)))
+        foreach (var file in Directory.EnumerateFiles(Path.GetDirectoryName(state.BundledPath)!)
+            .Where(IsBundledCliRuntimeFile))
         {
             File.Copy(file, Path.Combine(installDirectory, Path.GetFileName(file)), overwrite: true);
         }
@@ -128,6 +128,14 @@ public sealed class CliInstallService
 
     private static bool IsCliAppHost(string path) =>
         FileExistsWithExactName(path);
+
+    private static bool IsBundledCliRuntimeFile(string path)
+    {
+        var name = Path.GetFileName(path);
+        return string.Equals(name, CliFileName, StringComparison.Ordinal)
+            || name.StartsWith("typewhisper.", StringComparison.Ordinal)
+            || name.StartsWith("TypeWhisper.Cli.", StringComparison.Ordinal);
+    }
 
     private static bool FileExistsWithExactName(string path)
     {

--- a/src/TypeWhisper.Windows/Services/HttpApiRequestParser.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiRequestParser.cs
@@ -210,6 +210,9 @@ internal static class HttpApiRequestParser
         if (payload is null || string.IsNullOrWhiteSpace(payload.Path))
             throw new HttpApiRequestException(400, "Invalid JSON body");
 
+        if (payload.LanguageHints is null)
+            throw new HttpApiRequestException(400, "'language_hints' must be an array or omitted");
+
         if (!string.IsNullOrWhiteSpace(payload.Language) && payload.LanguageHints.Count > 0)
             throw new HttpApiRequestException(400, "Use either 'language' or 'language_hint', not both");
 
@@ -442,7 +445,7 @@ internal static class HttpApiRequestParser
     {
         public string? Path { get; init; }
         public string? Language { get; init; }
-        public IReadOnlyList<string> LanguageHints { get; init; } = [];
+        public IReadOnlyList<string>? LanguageHints { get; init; } = [];
         public string? Task { get; init; }
         public string? TargetLanguage { get; init; }
         public string? ResponseFormat { get; init; }

--- a/src/TypeWhisper.Windows/Services/HttpApiRequestParser.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiRequestParser.cs
@@ -2,6 +2,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 
@@ -41,7 +42,25 @@ internal sealed record HttpApiRequest(
     }
 }
 
-internal sealed record HttpApiResponse(int StatusCode, string Body, string ContentType = "application/json");
+internal sealed record HttpApiResponse
+{
+    public int StatusCode { get; }
+    public string Body { get; }
+    public string ContentType { get; }
+    public IReadOnlyDictionary<string, string> Headers { get; }
+
+    public HttpApiResponse(
+        int statusCode,
+        string body,
+        string contentType = "application/json",
+        IReadOnlyDictionary<string, string>? headers = null)
+    {
+        StatusCode = statusCode;
+        Body = body;
+        ContentType = contentType;
+        Headers = headers ?? new Dictionary<string, string>();
+    }
+}
 
 internal sealed class HttpApiRequestException : Exception
 {
@@ -67,6 +86,18 @@ internal sealed record TranscribeApiRequest(
     string? Model,
     bool AwaitDownload);
 
+internal sealed record LocalFileTranscribeApiRequest(
+    string Path,
+    string? Language,
+    IReadOnlyList<string> LanguageHints,
+    TranscriptionTask Task,
+    string? TargetLanguage,
+    string ResponseFormat,
+    string? Prompt,
+    string? Engine,
+    string? Model,
+    bool AwaitDownload);
+
 internal sealed record MultipartPart(
     string Name,
     string? FileName,
@@ -75,6 +106,12 @@ internal sealed record MultipartPart(
 
 internal static class HttpApiRequestParser
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true
+    };
+
     public static TranscribeApiRequest ParseTranscribe(HttpApiRequest request)
     {
         var contentType = Header(request.Headers, "content-type") ?? "";
@@ -153,6 +190,47 @@ internal static class HttpApiRequestParser
             engine,
             model,
             awaitDownload);
+    }
+
+    public static LocalFileTranscribeApiRequest ParseTranscribeLocalFile(HttpApiRequest request)
+    {
+        if (request.Body.Length == 0)
+            throw new HttpApiRequestException(400, "Missing JSON body");
+
+        LocalFileTranscribePayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<LocalFileTranscribePayload>(request.Body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            throw new HttpApiRequestException(400, "Invalid JSON body");
+        }
+
+        if (payload is null || string.IsNullOrWhiteSpace(payload.Path))
+            throw new HttpApiRequestException(400, "Invalid JSON body");
+
+        if (!string.IsNullOrWhiteSpace(payload.Language) && payload.LanguageHints.Count > 0)
+            throw new HttpApiRequestException(400, "Use either 'language' or 'language_hint', not both");
+
+        var awaitDownload = string.Equals(request.QueryString["await_download"], "1", StringComparison.Ordinal)
+            || string.Equals(request.QueryString["await_download"], "true", StringComparison.OrdinalIgnoreCase);
+
+        return new LocalFileTranscribeApiRequest(
+            payload.Path.Trim(),
+            Clean(payload.Language),
+            payload.LanguageHints
+                .Select(Clean)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v!)
+                .ToList(),
+            ParseTask(payload.Task),
+            Clean(payload.TargetLanguage),
+            Clean(payload.ResponseFormat) ?? "json",
+            Clean(payload.Prompt),
+            Clean(payload.Engine),
+            Clean(payload.Model),
+            awaitDownload || payload.AwaitDownload);
     }
 
     public static IReadOnlyList<MultipartPart> ParseMultipart(byte[] body, string boundary)
@@ -358,5 +436,19 @@ internal static class HttpApiRequestParser
         }
 
         return -1;
+    }
+
+    private sealed record LocalFileTranscribePayload
+    {
+        public string? Path { get; init; }
+        public string? Language { get; init; }
+        public IReadOnlyList<string> LanguageHints { get; init; } = [];
+        public string? Task { get; init; }
+        public string? TargetLanguage { get; init; }
+        public string? ResponseFormat { get; init; }
+        public string? Prompt { get; init; }
+        public string? Engine { get; init; }
+        public string? Model { get; init; }
+        public bool AwaitDownload { get; init; }
     }
 }

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -329,12 +329,15 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         finally
         {
             try { File.Delete(tempPath); }
-            catch (IOException) { }
-            catch (UnauthorizedAccessException) { }
-            catch (NotSupportedException) { }
-            catch (System.Security.SecurityException) { }
+            catch (IOException ex) { LogTempDeleteFailure(tempPath, ex); }
+            catch (UnauthorizedAccessException ex) { LogTempDeleteFailure(tempPath, ex); }
+            catch (NotSupportedException ex) { LogTempDeleteFailure(tempPath, ex); }
+            catch (System.Security.SecurityException ex) { LogTempDeleteFailure(tempPath, ex); }
         }
     }
+
+    private static void LogTempDeleteFailure(string path, Exception ex) =>
+        System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to delete temporary audio file {path}: {ex.Message}");
 
     private async Task<HttpApiResponse> HandleTranscribeLocalFile(HttpApiRequest request, CancellationToken ct)
     {

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -115,10 +115,10 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             }, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(TypeWhisperEnvironment.ApiDiscoveryFilePath, discovery);
         }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to write API discovery files: {ex.Message}");
-        }
+        catch (IOException ex) { LogDiscoveryWriteFailure(ex); }
+        catch (UnauthorizedAccessException ex) { LogDiscoveryWriteFailure(ex); }
+        catch (NotSupportedException ex) { LogDiscoveryWriteFailure(ex); }
+        catch (System.Security.SecurityException ex) { LogDiscoveryWriteFailure(ex); }
     }
 
     private static void DeleteDiscoveryFiles()
@@ -134,11 +134,17 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             if (File.Exists(path))
                 File.Delete(path);
         }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to delete {path}: {ex.Message}");
-        }
+        catch (IOException ex) { LogDeleteFailure(path, ex); }
+        catch (UnauthorizedAccessException ex) { LogDeleteFailure(path, ex); }
+        catch (NotSupportedException ex) { LogDeleteFailure(path, ex); }
+        catch (System.Security.SecurityException ex) { LogDeleteFailure(path, ex); }
     }
+
+    private static void LogDiscoveryWriteFailure(Exception ex) =>
+        System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to write API discovery files: {ex.Message}");
+
+    private static void LogDeleteFailure(string path, Exception ex) =>
+        System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to delete {path}: {ex.Message}");
 
     private async Task ListenLoop(CancellationToken ct)
     {
@@ -310,7 +316,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     {
         var transcribeRequest = HttpApiRequestParser.ParseTranscribe(request);
 
-        var tempPath = Path.Combine(
+        var tempPath = Path.Join(
             Path.GetTempPath(),
             $"tw_api_{Guid.NewGuid():N}.{SanitizeExtension(transcribeRequest.FileExtension)}");
 
@@ -322,7 +328,11 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         }
         finally
         {
-            try { File.Delete(tempPath); } catch { }
+            try { File.Delete(tempPath); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+            catch (NotSupportedException) { }
+            catch (System.Security.SecurityException) { }
         }
     }
 
@@ -878,10 +888,11 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                     return token;
             }
         }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to read API token: {ex.Message}");
-        }
+        catch (IOException ex) { LogTokenReadFailure(ex); }
+        catch (UnauthorizedAccessException ex) { LogTokenReadFailure(ex); }
+        catch (NotSupportedException ex) { LogTokenReadFailure(ex); }
+        catch (CryptographicException ex) { LogTokenReadFailure(ex); }
+        catch (System.Security.SecurityException ex) { LogTokenReadFailure(ex); }
 
         var generated = GenerateApiToken();
         try
@@ -889,13 +900,20 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             Directory.CreateDirectory(TypeWhisperEnvironment.BasePath);
             File.WriteAllText(TypeWhisperEnvironment.ApiTokenFilePath, ApiKeyProtection.Encrypt(generated));
         }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to persist API token: {ex.Message}");
-        }
+        catch (IOException ex) { LogTokenPersistFailure(ex); }
+        catch (UnauthorizedAccessException ex) { LogTokenPersistFailure(ex); }
+        catch (NotSupportedException ex) { LogTokenPersistFailure(ex); }
+        catch (CryptographicException ex) { LogTokenPersistFailure(ex); }
+        catch (System.Security.SecurityException ex) { LogTokenPersistFailure(ex); }
 
         return generated;
     }
+
+    private static void LogTokenReadFailure(Exception ex) =>
+        System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to read API token: {ex.Message}");
+
+    private static void LogTokenPersistFailure(Exception ex) =>
+        System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to persist API token: {ex.Message}");
 
     private static string GenerateApiToken()
     {

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using System.Globalization;
 using System.Net;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Windows;
 using TypeWhisper.Core;
 using TypeWhisper.Core.Interfaces;
@@ -23,6 +25,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     private readonly IPostProcessingPipeline _pipeline;
     private readonly ITranslationService _translation;
     private readonly DictationViewModel _dictation;
+    private readonly IWorkflowService _workflows;
+    private readonly Func<string> _apiTokenProvider;
 
     private HttpListener? _listener;
     private CancellationTokenSource? _cts;
@@ -48,7 +52,9 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         IVocabularyBoostingService vocabularyBoosting,
         IPostProcessingPipeline pipeline,
         ITranslationService translation,
-        DictationViewModel dictation)
+        DictationViewModel dictation,
+        IWorkflowService workflows,
+        Func<string>? apiTokenProvider = null)
     {
         _modelManager = modelManager;
         _settings = settings;
@@ -59,6 +65,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         _pipeline = pipeline;
         _translation = translation;
         _dictation = dictation;
+        _workflows = workflows;
+        _apiTokenProvider = apiTokenProvider ?? LoadOrCreateApiToken;
     }
 
     public void Start(int port)
@@ -72,7 +80,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
         _listener.Start();
         _runningPort = port;
-        WriteApiPortFile(port);
+        WriteDiscoveryFiles(port, _apiTokenProvider());
 
         _listenTask = Task.Run(() => ListenLoop(_cts.Token));
     }
@@ -88,9 +96,10 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         _listenTask = null;
         _runningPort = null;
         cts?.Dispose();
+        DeleteDiscoveryFiles();
     }
 
-    private static void WriteApiPortFile(int port)
+    private static void WriteDiscoveryFiles(int port, string token)
     {
         try
         {
@@ -98,10 +107,36 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             File.WriteAllText(
                 TypeWhisperEnvironment.ApiPortFilePath,
                 port.ToString(CultureInfo.InvariantCulture));
+            var discovery = JsonSerializer.Serialize(new
+            {
+                version = 1,
+                port,
+                token
+            }, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(TypeWhisperEnvironment.ApiDiscoveryFilePath, discovery);
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to write API port file: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to write API discovery files: {ex.Message}");
+        }
+    }
+
+    private static void DeleteDiscoveryFiles()
+    {
+        TryDelete(TypeWhisperEnvironment.ApiPortFilePath);
+        TryDelete(TypeWhisperEnvironment.ApiDiscoveryFilePath);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to delete {path}: {ex.Message}");
         }
     }
 
@@ -131,13 +166,13 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
 
             response.StatusCode = apiResponse.StatusCode;
             response.ContentType = apiResponse.ContentType;
-            response.Headers["Access-Control-Allow-Origin"] = "*";
-            response.Headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS";
-            response.Headers["Access-Control-Allow-Headers"] = "Content-Type, X-Language, X-Language-Hints, X-Task, X-Target-Language, X-Response-Format, X-Prompt, X-Engine, X-Model";
+            foreach (var (name, value) in apiResponse.Headers)
+                response.Headers[name] = value;
 
             var bytes = Encoding.UTF8.GetBytes(apiResponse.Body);
             response.ContentLength64 = bytes.Length;
-            await response.OutputStream.WriteAsync(bytes, ct);
+            if (bytes.Length > 0)
+                await response.OutputStream.WriteAsync(bytes, ct);
         }
         catch (Exception ex)
         {
@@ -157,7 +192,16 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     internal async Task<HttpApiResponse> HandleRequestAsync(HttpApiRequest request, CancellationToken ct)
     {
         if (request.Method == "OPTIONS")
-            return Json(new { ok = true });
+            return new HttpApiResponse(204, "", "text/plain");
+
+        if (!IsKnownRoute(request.Path, request.Method))
+            return Error(404, "Not found");
+
+        if (RequiresAuthentication(request) && !HasValidApiToken(request))
+            return Error(
+                401,
+                "Missing or invalid API token",
+                new Dictionary<string, string> { ["WWW-Authenticate"] = "Bearer" });
 
         try
         {
@@ -166,15 +210,23 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                 ("/v1/status", "GET") => HandleStatus(),
                 ("/v1/models", "GET") => HandleModels(),
                 ("/v1/transcribe", "POST") => await HandleTranscribe(request, ct),
+                ("/v1/transcribe/local-file", "POST") => await HandleTranscribeLocalFile(request, ct),
                 ("/v1/history", "GET") => HandleHistorySearch(request),
                 ("/v1/history", "DELETE") => HandleHistoryDelete(request),
                 ("/v1/dictation/start", "POST") => await HandleDictationStart(),
                 ("/v1/dictation/stop", "POST") => await HandleDictationStop(),
                 ("/v1/dictation/status", "GET") => HandleDictationStatus(),
                 ("/v1/dictation/transcription", "GET") => HandleDictationTranscription(request),
+                ("/v1/rules", "GET") => HandleGetRules(),
+                ("/v1/profiles", "GET") => HandleGetProfiles(),
+                ("/v1/rules/toggle", "PUT") => HandleToggleRule(request),
+                ("/v1/profiles/toggle", "PUT") => HandleToggleRule(request),
                 ("/v1/dictionary/terms", "GET") => HandleGetDictionaryTerms(),
                 ("/v1/dictionary/terms", "PUT") => await HandlePutDictionaryTerms(request),
-                ("/v1/dictionary/terms", "DELETE") => await HandleDeleteDictionaryTerms(),
+                ("/v1/dictionary/terms", "DELETE") => await HandleDeleteDictionaryTerms(request),
+                ("/v1/dictionary/corrections", "GET") => HandleGetDictionaryCorrections(),
+                ("/v1/dictionary/corrections", "PUT") => await HandlePutDictionaryCorrection(request),
+                ("/v1/dictionary/corrections", "DELETE") => await HandleDeleteDictionaryCorrection(request),
                 _ => Error(404, "Not found")
             };
         }
@@ -258,12 +310,6 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     {
         var transcribeRequest = HttpApiRequestParser.ParseTranscribe(request);
 
-        await using var modelScope = await _modelManager.BeginTranscriptionRequestAsync(
-            transcribeRequest.Engine,
-            transcribeRequest.Model,
-            transcribeRequest.AwaitDownload,
-            ct);
-
         var tempPath = Path.Combine(
             Path.GetTempPath(),
             $"tw_api_{Guid.NewGuid():N}.{SanitizeExtension(transcribeRequest.FileExtension)}");
@@ -272,70 +318,85 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         {
             await File.WriteAllBytesAsync(tempPath, transcribeRequest.AudioData, ct);
             var samples = await _audioFile.LoadAudioAsync(tempPath, ct);
+            return await TranscribeSamplesAsync(samples, TranscribeOptions.From(transcribeRequest), ct);
+        }
+        finally
+        {
+            try { File.Delete(tempPath); } catch { }
+        }
+    }
 
-            var prompt = MergePrompt(
-                transcribeRequest.Prompt,
-                BuildLanguageHintsPrompt(transcribeRequest.LanguageHints),
-                _dictionary.GetTermsForPrompt());
+    private async Task<HttpApiResponse> HandleTranscribeLocalFile(HttpApiRequest request, CancellationToken ct)
+    {
+        var transcribeRequest = HttpApiRequestParser.ParseTranscribeLocalFile(request);
 
-            var activeResult = await _modelManager.TranscribeActiveAsync(
-                samples,
-                transcribeRequest.Language,
-                transcribeRequest.Task,
-                prompt,
-                ct);
+        if (!File.Exists(transcribeRequest.Path))
+            return Error(400, "File not found");
 
-            var result = activeResult.Result;
-            var pipelineResult = await _pipeline.ProcessAsync(result.Text, new PipelineOptions
+        if (!AudioFileService.IsSupported(transcribeRequest.Path))
+            return Error(400, "Unsupported audio format");
+
+        var samples = await _audioFile.LoadAudioAsync(transcribeRequest.Path, ct);
+        return await TranscribeSamplesAsync(samples, TranscribeOptions.From(transcribeRequest), ct);
+    }
+
+    private async Task<HttpApiResponse> TranscribeSamplesAsync(
+        float[] samples,
+        TranscribeOptions transcribeRequest,
+        CancellationToken ct)
+    {
+        await using var modelScope = await _modelManager.BeginTranscriptionRequestAsync(
+            transcribeRequest.Engine,
+            transcribeRequest.Model,
+            transcribeRequest.AwaitDownload,
+            ct);
+
+        var prompt = MergePrompt(
+            transcribeRequest.Prompt,
+            BuildLanguageHintsPrompt(transcribeRequest.LanguageHints),
+            _dictionary.GetTermsForPrompt());
+
+        var activeResult = await _modelManager.TranscribeActiveAsync(
+            samples,
+            transcribeRequest.Language,
+            transcribeRequest.Task,
+            prompt,
+            ct);
+
+        var result = activeResult.Result;
+        var pipelineResult = await _pipeline.ProcessAsync(result.Text, new PipelineOptions
+        {
+            VocabularyBooster = GetVocabularyBooster(),
+            DictionaryCorrector = _dictionary.ApplyCorrections
+        }, ct);
+
+        var finalText = pipelineResult.Text;
+        if (!string.IsNullOrWhiteSpace(transcribeRequest.TargetLanguage))
+        {
+            var sourceLanguage = result.DetectedLanguage
+                ?? transcribeRequest.Language
+                ?? "en";
+
+            try
             {
-                VocabularyBooster = GetVocabularyBooster(),
-                DictionaryCorrector = _dictionary.ApplyCorrections
-            }, ct);
-
-            var finalText = pipelineResult.Text;
-            if (!string.IsNullOrWhiteSpace(transcribeRequest.TargetLanguage))
-            {
-                var sourceLanguage = result.DetectedLanguage
-                    ?? transcribeRequest.Language
-                    ?? "en";
-
-                try
-                {
-                    finalText = await _translation.TranslateAsync(
-                        finalText,
-                        sourceLanguage,
-                        transcribeRequest.TargetLanguage,
-                        ct);
-                }
-                catch (NotSupportedException ex)
-                {
-                    return Error(501, ex.Message);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    return Error(501, ex.Message);
-                }
+                finalText = await _translation.TranslateAsync(
+                    finalText,
+                    sourceLanguage,
+                    transcribeRequest.TargetLanguage,
+                    ct);
             }
-
-            if (transcribeRequest.ResponseFormat.Equals("verbose_json", StringComparison.OrdinalIgnoreCase))
+            catch (NotSupportedException ex)
             {
-                return Json(new
-                {
-                    text = finalText,
-                    language = result.DetectedLanguage,
-                    duration = result.Duration,
-                    processing_time = result.ProcessingTime,
-                    engine = activeResult.EngineId,
-                    model = activeResult.ModelId,
-                    segments = result.Segments.Select(seg => new
-                    {
-                        text = seg.Text,
-                        start = seg.Start,
-                        end = seg.End
-                    })
-                });
+                return Error(501, ex.Message);
             }
+            catch (InvalidOperationException ex)
+            {
+                return Error(501, ex.Message);
+            }
+        }
 
+        if (transcribeRequest.ResponseFormat.Equals("verbose_json", StringComparison.OrdinalIgnoreCase))
+        {
             return Json(new
             {
                 text = finalText,
@@ -343,13 +404,25 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                 duration = result.Duration,
                 processing_time = result.ProcessingTime,
                 engine = activeResult.EngineId,
-                model = activeResult.ModelId
+                model = activeResult.ModelId,
+                segments = result.Segments.Select(seg => new
+                {
+                    text = seg.Text,
+                    start = seg.Start,
+                    end = seg.End
+                })
             });
         }
-        finally
+
+        return Json(new
         {
-            try { File.Delete(tempPath); } catch { }
-        }
+            text = finalText,
+            language = result.DetectedLanguage,
+            duration = result.Duration,
+            processing_time = result.ProcessingTime,
+            engine = activeResult.EngineId,
+            model = activeResult.ModelId
+        });
     }
 
     private HttpApiResponse HandleHistorySearch(HttpApiRequest request)
@@ -475,6 +548,43 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         });
     }
 
+    private HttpApiResponse HandleGetRules()
+    {
+        var rules = _workflows.Workflows
+            .OrderBy(workflow => workflow.SortOrder)
+            .Select(RuleFromWorkflow)
+            .ToList();
+
+        return Json(new { rules, count = rules.Count });
+    }
+
+    private HttpApiResponse HandleGetProfiles()
+    {
+        var profiles = _workflows.Workflows
+            .OrderBy(workflow => workflow.SortOrder)
+            .Select(RuleFromWorkflow)
+            .ToList();
+
+        return Json(new { profiles, count = profiles.Count });
+    }
+
+    private HttpApiResponse HandleToggleRule(HttpApiRequest request)
+    {
+        var id = request.QueryString["id"];
+        if (string.IsNullOrWhiteSpace(id))
+            return Error(400, "Missing or invalid 'id' query parameter");
+
+        var workflow = _workflows.GetWorkflow(id)
+            ?? _workflows.Workflows.FirstOrDefault(w => string.Equals(w.Id, id, StringComparison.Ordinal));
+        if (workflow is null)
+            return Error(404, "Rule not found");
+
+        _workflows.ToggleWorkflow(id);
+        var toggled = _workflows.GetWorkflow(id) ?? workflow with { IsEnabled = !workflow.IsEnabled };
+        var response = RuleFromWorkflow(toggled);
+        return Json(response);
+    }
+
     private HttpApiResponse HandleGetDictionaryTerms()
     {
         var terms = _dictionary.GetEnabledTerms();
@@ -508,15 +618,78 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         return Json(new { terms, count = terms.Count });
     }
 
-    private async Task<HttpApiResponse> HandleDeleteDictionaryTerms()
+    private async Task<HttpApiResponse> HandleDeleteDictionaryTerms(HttpApiRequest request)
     {
-        await InvokeOnDispatcherAsync(() =>
+        if (request.Body.Length == 0)
+            return Error(400, "Missing JSON body");
+
+        DictionaryTermDeleteRequest? payload;
+        try
         {
-            _dictionary.RemoveAllTerms();
-            return Task.FromResult(true);
+            payload = JsonSerializer.Deserialize<DictionaryTermDeleteRequest>(request.Body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return Error(400, "Invalid JSON body");
+        }
+
+        if (payload is null || string.IsNullOrWhiteSpace(payload.Term))
+            return Error(400, "Missing or empty 'term'");
+
+        var result = await InvokeOnDispatcherAsync(() =>
+        {
+            var deleted = _dictionary.DeleteTerm(payload.Term);
+            var terms = _dictionary.GetEnabledTerms();
+            return Task.FromResult((deleted, terms.Count));
         });
 
-        return Json(new { deleted = true, count = 0 });
+        return Json(new { deleted = result.deleted, count = result.Count });
+    }
+
+    private HttpApiResponse HandleGetDictionaryCorrections()
+    {
+        var corrections = CorrectionDtos(_dictionary.GetEnabledCorrections());
+        return Json(new { corrections, count = corrections.Count });
+    }
+
+    private async Task<HttpApiResponse> HandlePutDictionaryCorrection(HttpApiRequest request)
+    {
+        var payload = ParseDictionaryCorrectionMutation(request);
+        if (payload is null)
+            return Error(400, "Invalid JSON body");
+
+        if (string.IsNullOrWhiteSpace(payload.Original))
+            return Error(400, "Missing or empty 'original'");
+
+        if (payload.Replacement is null)
+            return Error(400, "Missing 'replacement'");
+
+        var corrections = await InvokeOnDispatcherAsync(() =>
+        {
+            _dictionary.UpsertCorrection(payload.Original, payload.Replacement, payload.CaseSensitive);
+            return Task.FromResult(CorrectionDtos(_dictionary.GetEnabledCorrections()));
+        });
+
+        return Json(new { corrections, count = corrections.Count });
+    }
+
+    private async Task<HttpApiResponse> HandleDeleteDictionaryCorrection(HttpApiRequest request)
+    {
+        var payload = ParseDictionaryCorrectionMutation(request);
+        if (payload is null)
+            return Error(400, "Invalid JSON body");
+
+        if (string.IsNullOrWhiteSpace(payload.Original))
+            return Error(400, "Missing or empty 'original'");
+
+        var result = await InvokeOnDispatcherAsync(() =>
+        {
+            var deleted = _dictionary.DeleteCorrection(payload.Original);
+            var corrections = CorrectionDtos(_dictionary.GetEnabledCorrections());
+            return Task.FromResult((deleted, corrections));
+        });
+
+        return Json(new { deleted = result.deleted, corrections = result.corrections, count = result.corrections.Count });
     }
 
     public void Dispose()
@@ -531,22 +704,306 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     private Func<string, string>? GetVocabularyBooster() =>
         _settings.Current.VocabularyBoostingEnabled ? _vocabularyBoosting.Apply : null;
 
+    private static bool IsKnownRoute(string path, string method) =>
+        (path, method) switch
+        {
+            ("/v1/status", "GET") => true,
+            ("/v1/models", "GET") => true,
+            ("/v1/transcribe", "POST") => true,
+            ("/v1/transcribe/local-file", "POST") => true,
+            ("/v1/history", "GET") => true,
+            ("/v1/history", "DELETE") => true,
+            ("/v1/dictation/start", "POST") => true,
+            ("/v1/dictation/stop", "POST") => true,
+            ("/v1/dictation/status", "GET") => true,
+            ("/v1/dictation/transcription", "GET") => true,
+            ("/v1/rules", "GET") => true,
+            ("/v1/profiles", "GET") => true,
+            ("/v1/rules/toggle", "PUT") => true,
+            ("/v1/profiles/toggle", "PUT") => true,
+            ("/v1/dictionary/terms", "GET") => true,
+            ("/v1/dictionary/terms", "PUT") => true,
+            ("/v1/dictionary/terms", "DELETE") => true,
+            ("/v1/dictionary/corrections", "GET") => true,
+            ("/v1/dictionary/corrections", "PUT") => true,
+            ("/v1/dictionary/corrections", "DELETE") => true,
+            _ => false
+        };
+
+    private bool RequiresAuthentication(HttpApiRequest request) =>
+        _settings.Current.ApiServerRequiresAuthentication &&
+        !string.Equals(request.Path, "/v1/status", StringComparison.Ordinal);
+
+    private bool HasValidApiToken(HttpApiRequest request)
+    {
+        var expected = _apiTokenProvider();
+        if (string.IsNullOrWhiteSpace(expected))
+            return false;
+
+        return TokenMatches(ExtractBearerToken(request.Headers), expected)
+            || TokenMatches(Header(request.Headers, "x-typewhisper-api-token"), expected);
+    }
+
+    private static string? ExtractBearerToken(IReadOnlyDictionary<string, string> headers)
+    {
+        var authorization = Header(headers, "authorization");
+        if (string.IsNullOrWhiteSpace(authorization))
+            return null;
+
+        const string bearerPrefix = "Bearer ";
+        if (!authorization.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var token = authorization[bearerPrefix.Length..].Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private static bool TokenMatches(string? candidate, string expected)
+    {
+        if (string.IsNullOrEmpty(candidate))
+            return false;
+
+        var candidateBytes = Encoding.UTF8.GetBytes(candidate);
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        return candidateBytes.Length == expectedBytes.Length
+            && CryptographicOperations.FixedTimeEquals(candidateBytes, expectedBytes);
+    }
+
+    private static string? Header(IReadOnlyDictionary<string, string> headers, string name) =>
+        headers.TryGetValue(name, out var value) ? value : null;
+
+    private static IReadOnlyList<DictionaryCorrectionDto> CorrectionDtos(IReadOnlyList<DictionaryEntry> entries) =>
+        entries
+            .Select(entry => new DictionaryCorrectionDto(
+                entry.Original,
+                entry.Replacement ?? "",
+                entry.CaseSensitive))
+            .ToList();
+
+    private DictionaryCorrectionMutationRequest? ParseDictionaryCorrectionMutation(HttpApiRequest request)
+    {
+        if (request.Body.Length == 0)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<DictionaryCorrectionMutationRequest>(request.Body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private RuleDto RuleFromWorkflow(Workflow workflow)
+    {
+        var language = ResolveWorkflowLanguage(workflow);
+        var translationTarget = FirstNonBlank(
+            workflow.Behavior.TranslationTarget,
+            WorkflowSetting(workflow, "targetLanguage"),
+            WorkflowSetting(workflow, "target"));
+
+        return new RuleDto(
+            workflow.Id,
+            workflow.Name,
+            workflow.Name,
+            workflow.Name,
+            workflow.IsEnabled,
+            workflow.SortOrder,
+            workflow.Trigger.ProcessNames.ToList(),
+            workflow.Trigger.WebsitePatterns.ToList(),
+            language.InputLanguage,
+            language.Mode,
+            language.Hints,
+            translationTarget);
+    }
+
+    private static WorkflowLanguageDto ResolveWorkflowLanguage(Workflow workflow)
+    {
+        var configured = FirstNonBlank(
+            workflow.Behavior.InputLanguage,
+            WorkflowSetting(workflow, "inputLanguage"),
+            WorkflowSetting(workflow, "language"));
+
+        if (string.IsNullOrWhiteSpace(configured))
+            return new WorkflowLanguageDto("inherit_global", null, []);
+
+        var trimmed = configured.Trim();
+        if (trimmed.StartsWith("[", StringComparison.Ordinal))
+        {
+            try
+            {
+                var hints = JsonSerializer.Deserialize<IReadOnlyList<string>>(trimmed) ?? [];
+                var normalized = hints
+                    .Select(value => value.Trim())
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .ToList();
+
+                if (normalized.Count > 0)
+                    return new WorkflowLanguageDto("multiple", null, normalized);
+            }
+            catch (JsonException)
+            {
+                // Fall through and expose the raw setting as an exact language.
+            }
+        }
+
+        if (trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase))
+            return new WorkflowLanguageDto("auto", "auto", []);
+
+        if (trimmed.Equals("global", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("inherit_global", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkflowLanguageDto("inherit_global", null, []);
+        }
+
+        return new WorkflowLanguageDto("exact", trimmed, []);
+    }
+
+    private static string? WorkflowSetting(Workflow workflow, string key) =>
+        workflow.Behavior.Settings.TryGetValue(key, out var value) ? value : null;
+
+    private static string? FirstNonBlank(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private static string LoadOrCreateApiToken()
+    {
+        try
+        {
+            if (File.Exists(TypeWhisperEnvironment.ApiTokenFilePath))
+            {
+                var encrypted = File.ReadAllText(TypeWhisperEnvironment.ApiTokenFilePath).Trim();
+                var token = ApiKeyProtection.Decrypt(encrypted);
+                if (!string.IsNullOrWhiteSpace(token))
+                    return token;
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to read API token: {ex.Message}");
+        }
+
+        var generated = GenerateApiToken();
+        try
+        {
+            Directory.CreateDirectory(TypeWhisperEnvironment.BasePath);
+            File.WriteAllText(TypeWhisperEnvironment.ApiTokenFilePath, ApiKeyProtection.Encrypt(generated));
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[HttpApi] Failed to persist API token: {ex.Message}");
+        }
+
+        return generated;
+    }
+
+    private static string GenerateApiToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
     private static HttpApiResponse Json<T>(T value, int statusCode = 200) =>
         new(statusCode, JsonSerializer.Serialize(value, JsonOptions));
 
-    private static HttpApiResponse Error(int statusCode, string message) =>
-        Json(new
-        {
-            error = new
+    private static HttpApiResponse Error(
+        int statusCode,
+        string message,
+        IReadOnlyDictionary<string, string>? headers = null) =>
+        new(
+            statusCode,
+            JsonSerializer.Serialize(new
             {
-                code = ErrorCode(statusCode),
-                message
-            }
-        }, statusCode);
+                error = new
+                {
+                    code = ErrorCode(statusCode),
+                    message
+                }
+            }, JsonOptions),
+            "application/json",
+            headers);
+
+    private sealed record TranscribeOptions(
+        string? Language,
+        IReadOnlyList<string> LanguageHints,
+        TranscriptionTask Task,
+        string? TargetLanguage,
+        string ResponseFormat,
+        string? Prompt,
+        string? Engine,
+        string? Model,
+        bool AwaitDownload)
+    {
+        public static TranscribeOptions From(TranscribeApiRequest request) =>
+            new(
+                request.Language,
+                request.LanguageHints,
+                request.Task,
+                request.TargetLanguage,
+                request.ResponseFormat,
+                request.Prompt,
+                request.Engine,
+                request.Model,
+                request.AwaitDownload);
+
+        public static TranscribeOptions From(LocalFileTranscribeApiRequest request) =>
+            new(
+                request.Language,
+                request.LanguageHints,
+                request.Task,
+                request.TargetLanguage,
+                request.ResponseFormat,
+                request.Prompt,
+                request.Engine,
+                request.Model,
+                request.AwaitDownload);
+    }
+
+    private sealed record RuleDto(
+        string Id,
+        string Name,
+        string RuleName,
+        string ProfileName,
+        bool IsEnabled,
+        int Priority,
+        IReadOnlyList<string> BundleIdentifiers,
+        IReadOnlyList<string> UrlPatterns,
+        string? InputLanguage,
+        string LanguageMode,
+        IReadOnlyList<string> LanguageHints,
+        string? TranslationTargetLanguage);
+
+    private sealed record WorkflowLanguageDto(
+        string Mode,
+        string? InputLanguage,
+        IReadOnlyList<string> Hints);
+
+    private sealed record DictionaryCorrectionDto(
+        [property: JsonPropertyName("original")] string Original,
+        [property: JsonPropertyName("replacement")] string Replacement,
+        [property: JsonPropertyName("caseSensitive")] bool CaseSensitive);
+
+    private sealed record DictionaryCorrectionMutationRequest
+    {
+        public string? Original { get; init; }
+        public string? Replacement { get; init; }
+
+        [JsonPropertyName("caseSensitive")]
+        public bool CaseSensitive { get; init; }
+    }
+
+    private sealed record DictionaryTermDeleteRequest
+    {
+        public string? Term { get; init; }
+    }
 
     private static string ErrorCode(int statusCode) => statusCode switch
     {
         400 => "bad_request",
+        401 => "unauthorized",
         404 => "not_found",
         409 => "conflict",
         413 => "payload_too_large",
@@ -587,11 +1044,27 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     private static async Task<T> InvokeOnDispatcherAsync<T>(Func<Task<T>> action)
     {
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null || dispatcher.CheckAccess())
+        if (dispatcher is null
+            || dispatcher.CheckAccess()
+            || dispatcher.HasShutdownStarted
+            || dispatcher.HasShutdownFinished)
+        {
             return await action();
+        }
 
-        var operation = dispatcher.InvokeAsync(action);
-        return await await operation.Task;
+        try
+        {
+            var operation = dispatcher.InvokeAsync(action);
+            return await await operation.Task;
+        }
+        catch (TaskCanceledException)
+        {
+            return await action();
+        }
+        catch (InvalidOperationException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+        {
+            return await action();
+        }
     }
 
     private sealed record DictionaryTermsRequest

--- a/src/TypeWhisper.Windows/TypeWhisper.Windows.csproj
+++ b/src/TypeWhisper.Windows/TypeWhisper.Windows.csproj
@@ -25,7 +25,8 @@
              Targets="Restore;Build"
              Properties="Configuration=$(Configuration);Version=$(Version)" />
     <ItemGroup>
-      <BundledCliBinary Include="..\TypeWhisper.Cli\bin\$(Configuration)\net10.0\typewhisper.*" />
+      <BundledCliBinary Include="..\TypeWhisper.Cli\bin\$(Configuration)\net10.0\typewhisper.exe" />
+      <BundledCliBinary Include="..\TypeWhisper.Cli\bin\$(Configuration)\net10.0\TypeWhisper.Cli.*" />
     </ItemGroup>
     <Copy SourceFiles="@(BundledCliBinary)"
           DestinationFolder="$(OutputPath)Cli\"
@@ -38,7 +39,8 @@
              Targets="Restore;Publish"
              Properties="Configuration=$(Configuration);Version=$(Version);PublishDir=$(MSBuildThisFileDirectory)..\TypeWhisper.Cli\obj\bundled-cli\$(Configuration)\;SelfContained=false" />
     <ItemGroup>
-      <PublishedCliBinary Include="$(MSBuildThisFileDirectory)..\TypeWhisper.Cli\obj\bundled-cli\$(Configuration)\typewhisper.*" />
+      <PublishedCliBinary Include="$(MSBuildThisFileDirectory)..\TypeWhisper.Cli\obj\bundled-cli\$(Configuration)\typewhisper.exe" />
+      <PublishedCliBinary Include="$(MSBuildThisFileDirectory)..\TypeWhisper.Cli\obj\bundled-cli\$(Configuration)\TypeWhisper.Cli.*" />
     </ItemGroup>
     <Copy SourceFiles="@(PublishedCliBinary)"
           DestinationFolder="$(PublishDir)Cli\"

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -53,6 +53,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string? _translationTargetLanguage;
     [ObservableProperty] private bool _apiServerEnabled;
     [ObservableProperty] private int _apiServerPort = 8978;
+    [ObservableProperty] private bool _apiServerRequiresAuthentication;
     [ObservableProperty] private OverlayWidget _overlayLeftWidget = OverlayWidget.Waveform;
     [ObservableProperty] private OverlayWidget _overlayRightWidget = OverlayWidget.Timer;
     [ObservableProperty] private string? _uiLanguage;
@@ -339,6 +340,7 @@ public partial class SettingsViewModel : ObservableObject
             TranslationTargetLanguage = TranslationTargetLanguage,
             ApiServerEnabled = ApiServerEnabled,
             ApiServerPort = ApiServerPort,
+            ApiServerRequiresAuthentication = ApiServerRequiresAuthentication,
             ToggleOnlyHotkey = HotkeyParser.Normalize(ToggleOnlyHotkey),
             HoldOnlyHotkey = HotkeyParser.Normalize(HoldOnlyHotkey),
             RecentTranscriptionsHotkey = HotkeyParser.Normalize(RecentTranscriptionsHotkey),
@@ -423,6 +425,7 @@ public partial class SettingsViewModel : ObservableObject
         TranslationTargetLanguage = s.TranslationTargetLanguage;
         ApiServerEnabled = s.ApiServerEnabled;
         ApiServerPort = s.ApiServerPort;
+        ApiServerRequiresAuthentication = s.ApiServerRequiresAuthentication;
         ToggleOnlyHotkey = HotkeyParser.Normalize(s.ToggleOnlyHotkey);
         HoldOnlyHotkey = HotkeyParser.Normalize(s.HoldOnlyHotkey);
         RecentTranscriptionsHotkey = HotkeyParser.Normalize(s.RecentTranscriptionsHotkey);

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -19,6 +19,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly ApiServerController _apiServer;
     private readonly CliInstallService _cliInstall;
     private readonly SpeechFeedbackService _speechFeedback;
+    private readonly Action<Action> _dispatchToUi;
 
     [ObservableProperty] private string _toggleHotkey = "";
     [ObservableProperty] private string _pushToTalkHotkey = "";
@@ -172,13 +173,15 @@ public partial class SettingsViewModel : ObservableObject
         AudioRecordingService audio,
         ApiServerController apiServer,
         CliInstallService cliInstall,
-        SpeechFeedbackService speechFeedback)
+        SpeechFeedbackService speechFeedback,
+        Action<Action>? dispatchToUi = null)
     {
         _settings = settings;
         _audio = audio;
         _apiServer = apiServer;
         _cliInstall = cliInstall;
         _speechFeedback = speechFeedback;
+        _dispatchToUi = dispatchToUi ?? DispatchToUi;
         Loc.Instance.LanguageChanged += OnLanguageChanged;
         _apiServer.StateChanged += OnApiServerStateChanged;
         _speechFeedback.ProvidersChanged += OnTtsProvidersChanged;
@@ -454,7 +457,7 @@ public partial class SettingsViewModel : ObservableObject
         if (_isSavingSettings)
             return;
 
-        DispatchToUi(() =>
+        _dispatchToUi(() =>
         {
             _isLoading = true;
             LoadFromSettings(updatedSettings);
@@ -467,7 +470,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnApiServerStateChanged()
     {
-        DispatchToUi(RefreshApiServerStatus);
+        _dispatchToUi(RefreshApiServerStatus);
     }
 
     private void RefreshApiServerStatus()
@@ -505,7 +508,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
-        DispatchToUi(() =>
+        _dispatchToUi(() =>
         {
             _isLoading = true;
             RefreshLocalizedCollections();
@@ -529,7 +532,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnTtsProvidersChanged(object? sender, EventArgs e)
     {
-        DispatchToUi(() =>
+        _dispatchToUi(() =>
         {
             var wasLoading = _isLoading;
             _isLoading = true;
@@ -540,7 +543,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnAudioDevicesChanged(object? sender, EventArgs e)
     {
-        DispatchToUi(HandleAudioDevicesChanged);
+        _dispatchToUi(HandleAudioDevicesChanged);
     }
 
     private static void DispatchToUi(Action action)

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -546,26 +546,26 @@ public partial class SettingsViewModel : ObservableObject
     private static void DispatchToUi(Action action)
     {
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null
-            || dispatcher.CheckAccess()
-            || dispatcher.HasShutdownStarted
-            || dispatcher.HasShutdownFinished)
+        if (dispatcher is null || dispatcher.CheckAccess())
         {
             action();
             return;
         }
 
+        if (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+            return;
+
         try
         {
             dispatcher.Invoke(action);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
         {
-            action();
+            return;
         }
         catch (InvalidOperationException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
         {
-            action();
+            return;
         }
     }
 

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -454,7 +454,7 @@ public partial class SettingsViewModel : ObservableObject
         if (_isSavingSettings)
             return;
 
-        System.Windows.Application.Current?.Dispatcher.Invoke(() =>
+        DispatchToUi(() =>
         {
             _isLoading = true;
             LoadFromSettings(updatedSettings);
@@ -467,7 +467,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnApiServerStateChanged()
     {
-        Application.Current?.Dispatcher.InvokeAsync(RefreshApiServerStatus);
+        DispatchToUi(RefreshApiServerStatus);
     }
 
     private void RefreshApiServerStatus()
@@ -505,7 +505,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
-        Application.Current?.Dispatcher.Invoke(() =>
+        DispatchToUi(() =>
         {
             _isLoading = true;
             RefreshLocalizedCollections();
@@ -529,7 +529,7 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnTtsProvidersChanged(object? sender, EventArgs e)
     {
-        Application.Current?.Dispatcher.Invoke(() =>
+        DispatchToUi(() =>
         {
             var wasLoading = _isLoading;
             _isLoading = true;
@@ -540,14 +540,33 @@ public partial class SettingsViewModel : ObservableObject
 
     private void OnAudioDevicesChanged(object? sender, EventArgs e)
     {
+        DispatchToUi(HandleAudioDevicesChanged);
+    }
+
+    private static void DispatchToUi(Action action)
+    {
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is not null && !dispatcher.CheckAccess())
+        if (dispatcher is null
+            || dispatcher.CheckAccess()
+            || dispatcher.HasShutdownStarted
+            || dispatcher.HasShutdownFinished)
         {
-            dispatcher.Invoke(HandleAudioDevicesChanged);
+            action();
             return;
         }
 
-        HandleAudioDevicesChanged();
+        try
+        {
+            dispatcher.Invoke(action);
+        }
+        catch (TaskCanceledException)
+        {
+            action();
+        }
+        catch (InvalidOperationException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+        {
+            action();
+        }
     }
 
     private void HandleAudioDevicesChanged()

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -616,26 +616,26 @@ public partial class WelcomeViewModel : ObservableObject
     private static void DispatchToUi(Action action)
     {
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null
-            || dispatcher.CheckAccess()
-            || dispatcher.HasShutdownStarted
-            || dispatcher.HasShutdownFinished)
+        if (dispatcher is null || dispatcher.CheckAccess())
         {
             action();
             return;
         }
 
+        if (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+            return;
+
         try
         {
             dispatcher.Invoke(action);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
         {
-            action();
+            return;
         }
         catch (InvalidOperationException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
         {
-            action();
+            return;
         }
     }
 

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -616,13 +616,27 @@ public partial class WelcomeViewModel : ObservableObject
     private static void DispatchToUi(Action action)
     {
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null || dispatcher.CheckAccess())
+        if (dispatcher is null
+            || dispatcher.CheckAccess()
+            || dispatcher.HasShutdownStarted
+            || dispatcher.HasShutdownFinished)
         {
             action();
             return;
         }
 
-        dispatcher.Invoke(action);
+        try
+        {
+            dispatcher.Invoke(action);
+        }
+        catch (TaskCanceledException)
+        {
+            action();
+        }
+        catch (InvalidOperationException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+        {
+            action();
+        }
     }
 
     private string GetLocalRecommendationStatus()

--- a/src/TypeWhisper.Windows/Views/Sections/AdvancedSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/AdvancedSection.xaml
@@ -65,6 +65,14 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="1"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="1"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="1"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="1"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="1"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
                         <Border Grid.Row="0" Style="{StaticResource SettingsRowBorderStyle}">
@@ -228,6 +236,8 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="1"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="1"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
                         <Border Grid.Row="0" Style="{StaticResource SettingsRowBorderStyle}">
@@ -262,6 +272,28 @@
                         <Border Grid.Row="3" Background="#18FFFFFF"/>
 
                         <Border Grid.Row="4" Style="{StaticResource SettingsRowBorderStyle}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="{loc:Str Advanced.ApiRequireToken}" Style="{StaticResource SettingsRowLabelStyle}"/>
+                                    <TextBlock Text="{loc:Str Advanced.ApiRequireTokenHint}"
+                                               Style="{StaticResource HintStyle}"
+                                               FontSize="12"
+                                               Margin="0,4,16,0"/>
+                                </StackPanel>
+                                <ui:ToggleSwitch Grid.Column="1"
+                                                 IsChecked="{Binding Settings.ApiServerRequiresAuthentication, Mode=TwoWay}"
+                                                 OnContent=""
+                                                 OffContent=""/>
+                            </Grid>
+                        </Border>
+
+                        <Border Grid.Row="5" Background="#18FFFFFF"/>
+
+                        <Border Grid.Row="6" Style="{StaticResource SettingsRowBorderStyle}">
                             <StackPanel>
                                 <TextBlock Text="{Binding Settings.ApiServerStatusText}"
                                            Style="{StaticResource SettingsRowLabelStyle}"/>
@@ -273,18 +305,18 @@
                             </StackPanel>
                         </Border>
 
-                        <Border Grid.Row="5" Background="#18FFFFFF"/>
+                        <Border Grid.Row="7" Background="#18FFFFFF"/>
 
-                        <Border Grid.Row="6" Style="{StaticResource SettingsRowBorderStyle}">
+                        <Border Grid.Row="8" Style="{StaticResource SettingsRowBorderStyle}">
                             <TextBlock Text="{loc:Str Advanced.ApiHint}"
                                        Style="{StaticResource HintStyle}"
                                        FontSize="12"
                                        Margin="0"/>
                         </Border>
 
-                        <Border Grid.Row="7" Background="#18FFFFFF"/>
+                        <Border Grid.Row="9" Background="#18FFFFFF"/>
 
-                        <Border Grid.Row="8" Style="{StaticResource SettingsRowBorderStyle}">
+                        <Border Grid.Row="10" Style="{StaticResource SettingsRowBorderStyle}">
                             <StackPanel>
                                 <TextBlock Text="{loc:Str Advanced.CurlExamples}" Style="{StaticResource SettingsRowLabelStyle}"/>
                                 <ItemsControl ItemsSource="{Binding Settings.CurlExamples}" Margin="0,8,0,0">

--- a/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
@@ -174,6 +174,43 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void DeleteTerm_RemovesSingleTermCaseInsensitively()
+    {
+        _sut.SetTerms(["TypeWhisper", "WhisperKit", "Raycast"], replaceExisting: true);
+
+        var deleted = _sut.DeleteTerm("typewhisper");
+
+        Assert.True(deleted);
+        Assert.Equal(["WhisperKit", "Raycast"], _sut.GetEnabledTerms());
+    }
+
+    [Fact]
+    public void UpsertCorrection_UpdatesExistingCaseInsensitivelyAndEnablesIt()
+    {
+        _sut.UpsertCorrection("teh", "the", caseSensitive: false);
+        _sut.UpsertCorrection("TEH", "The", caseSensitive: true);
+
+        var correction = Assert.Single(_sut.GetEnabledCorrections());
+        Assert.Equal("TEH", correction.Original);
+        Assert.Equal("The", correction.Replacement);
+        Assert.True(correction.CaseSensitive);
+        Assert.True(correction.IsEnabled);
+    }
+
+    [Fact]
+    public void DeleteCorrection_RemovesSingleCorrectionCaseInsensitively()
+    {
+        _sut.UpsertCorrection("teh", "the", caseSensitive: false);
+        _sut.UpsertCorrection("um", "", caseSensitive: false);
+
+        var deleted = _sut.DeleteCorrection("TEH");
+
+        Assert.True(deleted);
+        var remaining = Assert.Single(_sut.GetEnabledCorrections());
+        Assert.Equal("um", remaining.Original);
+    }
+
+    [Fact]
     public void LearnCorrection_AddsNewCorrection()
     {
         _sut.LearnCorrection("kubernets", "Kubernetes");

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -176,7 +176,7 @@ public sealed class SettingsViewModelMicrophoneDeviceTests
     {
         var api = new ApiServerController(Mock.Of<ILocalApiServer>(), settings);
         var cli = new CliInstallService();
-        return new SettingsViewModel(settings, audio, api, cli, speech);
+        return new SettingsViewModel(settings, audio, api, cli, speech, dispatchToUi: action => action());
     }
 }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
@@ -9,15 +9,15 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class CliSupportTests : IDisposable
 {
-    private readonly string _root = Path.Combine(Path.GetTempPath(), "typewhisper-cli-support-" + Guid.NewGuid().ToString("N"));
+    private readonly string _root = Path.Join(Path.GetTempPath(), "typewhisper-cli-support-" + Guid.NewGuid().ToString("N"));
 
     [Fact]
     public void ConnectionResolver_UsesTokenizedDiscoveryFileBeforeLegacyPortFile()
     {
-        var appDirectory = Path.Combine(_root, "TypeWhisper");
+        var appDirectory = Path.Join(_root, "TypeWhisper");
         Directory.CreateDirectory(appDirectory);
-        File.WriteAllText(Path.Combine(appDirectory, "api-port"), "9911");
-        File.WriteAllText(Path.Combine(appDirectory, "api-discovery.json"), """
+        File.WriteAllText(Path.Join(appDirectory, "api-port"), "9911");
+        File.WriteAllText(Path.Join(appDirectory, "api-discovery.json"), """
             {
               "version": 1,
               "port": 9922,
@@ -34,9 +34,9 @@ public sealed class CliSupportTests : IDisposable
     [Fact]
     public void ConnectionResolver_UsesExplicitAndEnvironmentOverrides()
     {
-        var appDirectory = Path.Combine(_root, "TypeWhisper");
+        var appDirectory = Path.Join(_root, "TypeWhisper");
         Directory.CreateDirectory(appDirectory);
-        File.WriteAllText(Path.Combine(appDirectory, "api-discovery.json"), """
+        File.WriteAllText(Path.Join(appDirectory, "api-discovery.json"), """
             {
               "version": 1,
               "port": 9922,
@@ -62,10 +62,10 @@ public sealed class CliSupportTests : IDisposable
     [Fact]
     public void ConnectionResolver_SkipsInvalidPorts()
     {
-        var appDirectory = Path.Combine(_root, "TypeWhisper");
+        var appDirectory = Path.Join(_root, "TypeWhisper");
         Directory.CreateDirectory(appDirectory);
-        File.WriteAllText(Path.Combine(appDirectory, "api-port"), "9911");
-        File.WriteAllText(Path.Combine(appDirectory, "api-discovery.json"), """
+        File.WriteAllText(Path.Join(appDirectory, "api-port"), "9911");
+        File.WriteAllText(Path.Join(appDirectory, "api-discovery.json"), """
             {
               "version": 1,
               "port": 70000,
@@ -76,7 +76,7 @@ public sealed class CliSupportTests : IDisposable
         var legacyFallback = CliConnectionResolver.Resolve(new CliConnectionOptions(
             ApplicationDataRoot: _root));
 
-        File.WriteAllText(Path.Combine(appDirectory, "api-port"), "0");
+        File.WriteAllText(Path.Join(appDirectory, "api-port"), "0");
         var defaultFallback = CliConnectionResolver.Resolve(new CliConnectionOptions(
             ApplicationDataRoot: _root,
             PortOverride: -1));
@@ -99,7 +99,7 @@ public sealed class CliSupportTests : IDisposable
     [Fact]
     public async Task RequestBuilder_UsesLocalFileEndpointWithoutUploadingBytes()
     {
-        var filePath = Path.Combine(_root, "large.wav");
+        var filePath = Path.Join(_root, "large.wav");
         Directory.CreateDirectory(_root);
         await File.WriteAllTextAsync(filePath, "distinctive-audio-bytes");
 
@@ -136,8 +136,10 @@ public sealed class CliSupportTests : IDisposable
     [InlineData(new byte[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F', 0, 0, 0, 0, (byte)'W', (byte)'A', (byte)'V', (byte)'E' }, "stdin.wav")]
     [InlineData(new byte[] { (byte)'f', (byte)'L', (byte)'a', (byte)'C' }, "stdin.flac")]
     [InlineData(new byte[] { (byte)'O', (byte)'g', (byte)'g', (byte)'S' }, "stdin.ogg")]
+    [InlineData(new byte[] { 0xFF, 0xF1 }, "stdin.aac")]
+    [InlineData(new byte[] { 0xFF, 0xF9 }, "stdin.aac")]
     [InlineData(new byte[] { (byte)'I', (byte)'D', (byte)'3' }, "stdin.mp3")]
-    [InlineData(new byte[] { 0xFF, 0xFB }, "stdin.mp3")]
+    [InlineData(new byte[] { 0xFF, 0xFB, 0x90, 0x64 }, "stdin.mp3")]
     public void RequestBuilder_DetectsStdinFileNameFromAudioHeader(byte[] audioBytes, string expectedFileName)
     {
         Assert.Equal(expectedFileName, CliRequestBuilder.BuildStdinFileName(audioBytes));
@@ -149,6 +151,14 @@ public sealed class CliSupportTests : IDisposable
         var options = ParseCliOptions("status", "--api-token", "--json");
 
         Assert.Equal("--api-token requires a value.", GetOptionValue<string>(options, "Error"));
+    }
+
+    [Fact]
+    public void CliOptions_RejectsSwitchLikeValueForSharedOptionParser()
+    {
+        var options = ParseCliOptions("transcribe", "file.wav", "--language", "--json");
+
+        Assert.Equal("--language requires a value.", GetOptionValue<string>(options, "Error"));
     }
 
     public void Dispose()

--- a/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
@@ -1,0 +1,112 @@
+using System.Net.Http.Headers;
+using System.Net.Http;
+using System.IO;
+using System.Text.Json;
+using TypeWhisper.Cli;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class CliSupportTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "typewhisper-cli-support-" + Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ConnectionResolver_UsesTokenizedDiscoveryFileBeforeLegacyPortFile()
+    {
+        var appDirectory = Path.Combine(_root, "TypeWhisper");
+        Directory.CreateDirectory(appDirectory);
+        File.WriteAllText(Path.Combine(appDirectory, "api-port"), "9911");
+        File.WriteAllText(Path.Combine(appDirectory, "api-discovery.json"), """
+            {
+              "version": 1,
+              "port": 9922,
+              "token": "token-from-discovery"
+            }
+            """);
+
+        var connection = CliConnectionResolver.Resolve(new CliConnectionOptions(ApplicationDataRoot: _root));
+
+        Assert.Equal(9922, connection.Port);
+        Assert.Equal("token-from-discovery", connection.ApiToken);
+    }
+
+    [Fact]
+    public void ConnectionResolver_UsesExplicitAndEnvironmentOverrides()
+    {
+        var appDirectory = Path.Combine(_root, "TypeWhisper");
+        Directory.CreateDirectory(appDirectory);
+        File.WriteAllText(Path.Combine(appDirectory, "api-discovery.json"), """
+            {
+              "version": 1,
+              "port": 9922,
+              "token": "token-from-discovery"
+            }
+            """);
+
+        var envOverride = CliConnectionResolver.Resolve(new CliConnectionOptions(
+            ApplicationDataRoot: _root,
+            EnvironmentApiToken: "token-from-env"));
+        var explicitOverride = CliConnectionResolver.Resolve(new CliConnectionOptions(
+            ApplicationDataRoot: _root,
+            PortOverride: 9933,
+            ApiTokenOverride: "token-from-flag",
+            EnvironmentApiToken: "token-from-env"));
+
+        Assert.Equal(9922, envOverride.Port);
+        Assert.Equal("token-from-env", envOverride.ApiToken);
+        Assert.Equal(9933, explicitOverride.Port);
+        Assert.Equal("token-from-flag", explicitOverride.ApiToken);
+    }
+
+    [Fact]
+    public void RequestBuilder_AddsBearerTokenToRequests()
+    {
+        using var request = CliRequestBuilder.BuildGet("http://127.0.0.1:8978", "/v1/models", "cli-token");
+
+        Assert.Equal(new Uri("http://127.0.0.1:8978/v1/models"), request.RequestUri);
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal(new AuthenticationHeaderValue("Bearer", "cli-token"), request.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task RequestBuilder_UsesLocalFileEndpointWithoutUploadingBytes()
+    {
+        var filePath = Path.Combine(_root, "large.wav");
+        Directory.CreateDirectory(_root);
+        await File.WriteAllTextAsync(filePath, "distinctive-audio-bytes");
+
+        using var request = CliRequestBuilder.BuildTranscribeLocalFile(
+            "http://127.0.0.1:8978",
+            new CliTranscribeRequest(
+                FilePath: filePath,
+                Language: null,
+                LanguageHints: ["de", "en"],
+                Task: "transcribe",
+                TargetLanguage: null,
+                Engine: "mock",
+                Model: "tiny",
+                AwaitDownload: true),
+            apiToken: "cli-token");
+
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(new Uri("http://127.0.0.1:8978/v1/transcribe/local-file?await_download=1"), request.RequestUri);
+        Assert.Equal(new AuthenticationHeaderValue("Bearer", "cli-token"), request.Headers.Authorization);
+        Assert.Equal("application/json", request.Content?.Headers.ContentType?.MediaType);
+
+        var body = await request.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        Assert.Equal(filePath, root.GetProperty("path").GetString());
+        Assert.Equal(["de", "en"], root.GetProperty("language_hints").EnumerateArray().Select(e => e.GetString() ?? "").ToArray());
+        Assert.Equal("transcribe", root.GetProperty("task").GetString());
+        Assert.Equal("mock", root.GetProperty("engine").GetString());
+        Assert.Equal("tiny", root.GetProperty("model").GetString());
+        Assert.DoesNotContain("distinctive-audio-bytes", body);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
@@ -59,6 +59,33 @@ public sealed class CliSupportTests : IDisposable
     }
 
     [Fact]
+    public void ConnectionResolver_SkipsInvalidPorts()
+    {
+        var appDirectory = Path.Combine(_root, "TypeWhisper");
+        Directory.CreateDirectory(appDirectory);
+        File.WriteAllText(Path.Combine(appDirectory, "api-port"), "9911");
+        File.WriteAllText(Path.Combine(appDirectory, "api-discovery.json"), """
+            {
+              "version": 1,
+              "port": 70000,
+              "token": "token-from-discovery"
+            }
+            """);
+
+        var legacyFallback = CliConnectionResolver.Resolve(new CliConnectionOptions(
+            ApplicationDataRoot: _root));
+
+        File.WriteAllText(Path.Combine(appDirectory, "api-port"), "0");
+        var defaultFallback = CliConnectionResolver.Resolve(new CliConnectionOptions(
+            ApplicationDataRoot: _root,
+            PortOverride: -1));
+
+        Assert.Equal(9911, legacyFallback.Port);
+        Assert.Equal(8978, defaultFallback.Port);
+    }
+
+
+    [Fact]
     public void RequestBuilder_AddsBearerTokenToRequests()
     {
         using var request = CliRequestBuilder.BuildGet("http://127.0.0.1:8978", "/v1/models", "cli-token");

--- a/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CliSupportTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http;
 using System.IO;
+using System.Reflection;
 using System.Text.Json;
 using TypeWhisper.Cli;
 
@@ -131,9 +132,40 @@ public sealed class CliSupportTests : IDisposable
         Assert.DoesNotContain("distinctive-audio-bytes", body);
     }
 
+    [Theory]
+    [InlineData(new byte[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F', 0, 0, 0, 0, (byte)'W', (byte)'A', (byte)'V', (byte)'E' }, "stdin.wav")]
+    [InlineData(new byte[] { (byte)'f', (byte)'L', (byte)'a', (byte)'C' }, "stdin.flac")]
+    [InlineData(new byte[] { (byte)'O', (byte)'g', (byte)'g', (byte)'S' }, "stdin.ogg")]
+    [InlineData(new byte[] { (byte)'I', (byte)'D', (byte)'3' }, "stdin.mp3")]
+    [InlineData(new byte[] { 0xFF, 0xFB }, "stdin.mp3")]
+    public void RequestBuilder_DetectsStdinFileNameFromAudioHeader(byte[] audioBytes, string expectedFileName)
+    {
+        Assert.Equal(expectedFileName, CliRequestBuilder.BuildStdinFileName(audioBytes));
+    }
+
+    [Fact]
+    public void CliOptions_RejectsApiTokenWhenNextArgumentIsSwitch()
+    {
+        var options = ParseCliOptions("status", "--api-token", "--json");
+
+        Assert.Equal("--api-token requires a value.", GetOptionValue<string>(options, "Error"));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root))
             Directory.Delete(_root, recursive: true);
     }
+
+    private static object ParseCliOptions(params string[] args)
+    {
+        var type = typeof(CliRequestBuilder).Assembly.GetType("TypeWhisper.Cli.Program+CliOptions", throwOnError: true)!;
+        var parse = type.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static)!;
+        return parse.Invoke(null, [args])!;
+    }
+
+    private static T? GetOptionValue<T>(object options, string propertyName) =>
+        (T?)options.GetType()
+            .GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(options);
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiRequestParserTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiRequestParserTests.cs
@@ -145,6 +145,22 @@ public class HttpApiRequestParserTests
         Assert.Contains("file", ex.Message);
     }
 
+    [Fact]
+    public void ParseTranscribeLocalFile_RejectsNullLanguageHints()
+    {
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/transcribe/local-file",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["content-type"] = "application/json" },
+            Encoding.UTF8.GetBytes("""{"path":"C:\\Audio\\test.wav","language_hints":null}"""));
+
+        var ex = Assert.Throws<HttpApiRequestException>(() => HttpApiRequestParser.ParseTranscribeLocalFile(request));
+
+        Assert.Equal(400, ex.StatusCode);
+        Assert.Contains("language_hints", ex.Message);
+    }
+
     private static byte[] Multipart(
         string boundary,
         params (string Name, string? FileName, string? ContentType, byte[] Data)[] parts)

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -418,11 +418,14 @@ public class HttpApiServiceTests : IDisposable
     public async Task TranscribeLocalFileEndpoint_RejectsMissingAndUnsupportedFiles()
     {
         var service = CreateService();
+        var missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"typewhisper-missing-{Guid.NewGuid():N}.wav");
 
         var missing = await service.HandleRequestAsync(JsonRequest(
             "POST",
             "/v1/transcribe/local-file",
-            """{"path":"C:\\definitely-missing\\audio.wav"}"""), CancellationToken.None);
+            JsonSerializer.Serialize(new { path = missingPath })), CancellationToken.None);
 
         var tempTextFile = Path.GetTempFileName();
         try

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -418,7 +418,7 @@ public class HttpApiServiceTests : IDisposable
     public async Task TranscribeLocalFileEndpoint_RejectsMissingAndUnsupportedFiles()
     {
         var service = CreateService();
-        var missingPath = Path.Combine(
+        var missingPath = Path.Join(
             Path.GetTempPath(),
             $"typewhisper-missing-{Guid.NewGuid():N}.wav");
 

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -33,23 +33,89 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task DictionaryTermsEndpoints_SetAppendAndDeleteTerms()
+    public async Task Options_ReturnsNoContentWithoutJsonBody()
+    {
+        var service = CreateService();
+
+        var response = await service.HandleRequestAsync(new HttpApiRequest(
+            "OPTIONS",
+            "/v1/models",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+
+        Assert.Equal(204, response.StatusCode);
+        Assert.Equal("", response.Body);
+        Assert.Equal("text/plain", response.ContentType);
+    }
+
+    [Fact]
+    public async Task Authentication_ProtectsNonStatusRoutesWhenEnabled()
+    {
+        var service = CreateService(settings: new AppSettings
+        {
+            ApiServerRequiresAuthentication = true,
+            SaveToHistoryEnabled = true
+        });
+
+        var status = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/status",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+        var missingToken = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/models",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+        var badToken = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/models",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["authorization"] = "Bearer wrong-token" },
+            []), CancellationToken.None);
+        var goodBearer = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/models",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["authorization"] = "Bearer test-token" },
+            []), CancellationToken.None);
+        var goodHeader = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/models",
+            new NameValueCollection(),
+            new Dictionary<string, string> { ["x-typewhisper-api-token"] = "test-token" },
+            []), CancellationToken.None);
+
+        Assert.Equal(200, status.StatusCode);
+        Assert.Equal(401, missingToken.StatusCode);
+        Assert.Equal("Bearer", missingToken.Headers["WWW-Authenticate"]);
+        Assert.Equal(401, badToken.StatusCode);
+        Assert.Equal(200, goodBearer.StatusCode);
+        Assert.Equal(200, goodHeader.StatusCode);
+    }
+
+    [Fact]
+    public async Task DictionaryTermsEndpoints_ReplaceMergeAndDeleteSingleTerm()
     {
         var service = CreateService();
 
         var put = await service.HandleRequestAsync(JsonRequest(
             "PUT",
             "/v1/dictionary/terms",
-            """{"terms":[" TypeWhisper ","WhisperKit","typewhisper"],"replace":true}"""), CancellationToken.None);
+            """{"terms":[" TypeWhisper ","WhisperKit","typewhisper","Qwen3 "],"replace":true}"""), CancellationToken.None);
         var putJson = JsonObject(put);
 
         Assert.Equal(200, put.StatusCode);
-        Assert.Equal(2, putJson["count"].GetInt32());
+        Assert.Equal(3, putJson["count"].GetInt32());
+        Assert.Equal(["TypeWhisper", "WhisperKit", "Qwen3"], Terms(putJson));
 
         await service.HandleRequestAsync(JsonRequest(
             "PUT",
             "/v1/dictionary/terms",
-            """{"terms":["Kubernetes"],"replace":false}"""), CancellationToken.None);
+            """{"terms":["Raycast","qwen3"],"replace":false}"""), CancellationToken.None);
 
         var get = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
             "GET",
@@ -58,18 +124,99 @@ public class HttpApiServiceTests : IDisposable
             new Dictionary<string, string>(),
             []), CancellationToken.None));
 
-        var terms = get["terms"].EnumerateArray().Select(e => e.GetString()).ToList();
-        Assert.Equal(["TypeWhisper", "WhisperKit", "Kubernetes"], terms);
+        Assert.Equal(["qwen3", "Raycast", "TypeWhisper", "WhisperKit"], Terms(get));
 
-        var delete = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+        var delete = JsonObject(await service.HandleRequestAsync(JsonRequest(
             "DELETE",
+            "/v1/dictionary/terms",
+            """{"term":"typewhisper"}"""), CancellationToken.None));
+
+        Assert.True(delete["deleted"].GetBoolean());
+        Assert.Equal(3, delete["count"].GetInt32());
+
+        var finalGet = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
             "/v1/dictionary/terms",
             new NameValueCollection(),
             new Dictionary<string, string>(),
             []), CancellationToken.None));
 
+        Assert.Equal(["qwen3", "Raycast", "WhisperKit"], Terms(finalGet));
+    }
+
+    [Fact]
+    public async Task DictionaryCorrectionsEndpoints_ListUpsertDeleteAndValidateInput()
+    {
+        var service = CreateService();
+
+        var initial = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/dictionary/corrections",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+
+        Assert.Equal(0, initial["count"].GetInt32());
+        Assert.Empty(initial["corrections"].EnumerateArray());
+
+        var put = JsonObject(await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/corrections",
+            """{"original":"teh","replacement":"the","caseSensitive":false}"""), CancellationToken.None));
+
+        Assert.Equal(1, put["count"].GetInt32());
+        var correction = Assert.Single(put["corrections"].EnumerateArray());
+        Assert.Equal("teh", correction.GetProperty("original").GetString());
+        Assert.Equal("the", correction.GetProperty("replacement").GetString());
+        Assert.False(correction.GetProperty("caseSensitive").GetBoolean());
+
+        var upsert = JsonObject(await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/corrections",
+            """{"original":"TEH","replacement":"The","caseSensitive":true}"""), CancellationToken.None));
+
+        Assert.Equal(1, upsert["count"].GetInt32());
+        correction = Assert.Single(upsert["corrections"].EnumerateArray());
+        Assert.Equal("TEH", correction.GetProperty("original").GetString());
+        Assert.Equal("The", correction.GetProperty("replacement").GetString());
+        Assert.True(correction.GetProperty("caseSensitive").GetBoolean());
+
+        var emptyReplacement = JsonObject(await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/corrections",
+            """{"original":"um","replacement":"","caseSensitive":false}"""), CancellationToken.None));
+        Assert.Equal(2, emptyReplacement["count"].GetInt32());
+
+        var delete = JsonObject(await service.HandleRequestAsync(JsonRequest(
+            "DELETE",
+            "/v1/dictionary/corrections",
+            """{"original":"teh"}"""), CancellationToken.None));
         Assert.True(delete["deleted"].GetBoolean());
-        Assert.Equal(0, delete["count"].GetInt32());
+        Assert.Equal(1, delete["count"].GetInt32());
+
+        var missingDelete = JsonObject(await service.HandleRequestAsync(JsonRequest(
+            "DELETE",
+            "/v1/dictionary/corrections",
+            """{"original":"missing"}"""), CancellationToken.None));
+        Assert.False(missingDelete["deleted"].GetBoolean());
+        Assert.Equal(1, missingDelete["count"].GetInt32());
+
+        var missingOriginalPut = await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/corrections",
+            """{"replacement":"value"}"""), CancellationToken.None);
+        var missingReplacementPut = await service.HandleRequestAsync(JsonRequest(
+            "PUT",
+            "/v1/dictionary/corrections",
+            """{"original":"value"}"""), CancellationToken.None);
+        var missingOriginalDelete = await service.HandleRequestAsync(JsonRequest(
+            "DELETE",
+            "/v1/dictionary/corrections",
+            "{}"), CancellationToken.None);
+
+        Assert.Equal(400, missingOriginalPut.StatusCode);
+        Assert.Equal(400, missingReplacementPut.StatusCode);
+        Assert.Equal(400, missingOriginalDelete.StatusCode);
     }
 
     [Fact]
@@ -207,34 +354,122 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ProfilesList_ReturnsNotFoundAfterWorkflowMigration()
+    public async Task RulesAndProfilesEndpoints_ListWorkflowBackedRulesAndToggle()
     {
+        var workflow = new Workflow
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Docs",
+            SortOrder = 7,
+            Template = WorkflowTemplate.Summary,
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.App,
+                ProcessNames = ["chrome.exe"],
+                WebsitePatterns = ["docs.github.com"]
+            },
+            Behavior = new WorkflowBehavior
+            {
+                InputLanguage = null,
+                Settings = new Dictionary<string, string> { ["inputLanguage"] = """["de","en"]""" },
+                TranslationTarget = "fr"
+            }
+        };
+        _workflows.Setup(w => w.Workflows).Returns([workflow]);
+
         var service = CreateService();
-        var response = await service.HandleRequestAsync(new HttpApiRequest(
+        var rules = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/rules",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+        var profiles = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
             "GET",
             "/v1/profiles",
             new NameValueCollection(),
             new Dictionary<string, string>(),
-            []), CancellationToken.None);
+            []), CancellationToken.None));
+        var rule = Assert.Single(rules["rules"].EnumerateArray());
+        var profile = Assert.Single(profiles["profiles"].EnumerateArray());
 
-        Assert.Equal(404, response.StatusCode);
+        Assert.Equal("Docs", rule.GetProperty("name").GetString());
+        Assert.Equal("multiple", rule.GetProperty("language_mode").GetString());
+        Assert.Equal(["de", "en"], rule.GetProperty("language_hints").EnumerateArray().Select(e => e.GetString() ?? "").ToArray());
+        Assert.Equal(JsonValueKind.Null, rule.GetProperty("input_language").ValueKind);
+        Assert.Equal("fr", rule.GetProperty("translation_target_language").GetString());
+        Assert.Equal("Docs", profile.GetProperty("name").GetString());
+
+        var toggle = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "PUT",
+            "/v1/rules/toggle",
+            new NameValueCollection { ["id"] = workflow.Id },
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+
+        Assert.Equal(workflow.Id, toggle["id"].GetString());
+        Assert.Equal("Docs", toggle["name"].GetString());
+        Assert.Equal("Docs", toggle["rule_name"].GetString());
+        Assert.Equal("Docs", toggle["profile_name"].GetString());
+        _workflows.Verify(w => w.ToggleWorkflow(workflow.Id), Times.Once);
     }
 
-    private HttpApiService CreateService(params ITranscriptionEnginePlugin[] plugins)
+    [Fact]
+    public async Task TranscribeLocalFileEndpoint_RejectsMissingAndUnsupportedFiles()
+    {
+        var service = CreateService();
+
+        var missing = await service.HandleRequestAsync(JsonRequest(
+            "POST",
+            "/v1/transcribe/local-file",
+            """{"path":"C:\\definitely-missing\\audio.wav"}"""), CancellationToken.None);
+
+        var tempTextFile = Path.GetTempFileName();
+        try
+        {
+            var unsupported = await service.HandleRequestAsync(JsonRequest(
+                "POST",
+                "/v1/transcribe/local-file",
+                JsonSerializer.Serialize(new { path = tempTextFile })), CancellationToken.None);
+
+            Assert.Equal(400, missing.StatusCode);
+            Assert.Equal("File not found", ErrorMessage(missing));
+            Assert.Equal(400, unsupported.StatusCode);
+            Assert.Equal("Unsupported audio format", ErrorMessage(unsupported));
+        }
+        finally
+        {
+            File.Delete(tempTextFile);
+        }
+    }
+
+    private HttpApiService CreateService(params ITranscriptionEnginePlugin[] plugins) =>
+        CreateService(null, null, plugins);
+
+    private HttpApiService CreateService(
+        AppSettings? settings = null,
+        Func<string>? apiTokenProvider = null,
+        params ITranscriptionEnginePlugin[] plugins)
     {
         var selectedModel = plugins.Length > 0
             ? ModelManagerService.GetPluginModelId(plugins[0].PluginId, plugins[0].TranscriptionModels[0].Id)
             : null;
 
-        return CreateServiceWithModelManager(new AppSettings
+        return CreateServiceWithModelManager(settings ?? new AppSettings
         {
             SelectedModelId = selectedModel,
             SaveToHistoryEnabled = true
-        }, plugins).Service;
+        }, apiTokenProvider, plugins).Service;
     }
 
     private (HttpApiService Service, ModelManagerService ModelManager) CreateServiceWithModelManager(
         AppSettings settings,
+        params ITranscriptionEnginePlugin[] plugins)
+        => CreateServiceWithModelManager(settings, null, plugins);
+
+    private (HttpApiService Service, ModelManagerService ModelManager) CreateServiceWithModelManager(
+        AppSettings settings,
+        Func<string>? apiTokenProvider,
         params ITranscriptionEnginePlugin[] plugins)
     {
         _settings.Setup(s => s.Current).Returns(settings);
@@ -265,7 +500,9 @@ public class HttpApiServiceTests : IDisposable
             vocabulary.Object,
             new PostProcessingPipeline(),
             translation.Object,
-            null!);
+            null!,
+            _workflows.Object,
+            apiTokenProvider ?? (() => "test-token"));
 
         return (service, modelManager);
     }
@@ -313,6 +550,9 @@ public class HttpApiServiceTests : IDisposable
         return doc.RootElement.EnumerateObject()
             .ToDictionary(p => p.Name, p => p.Value.Clone());
     }
+
+    private static string[] Terms(Dictionary<string, JsonElement> json) =>
+        json["terms"].EnumerateArray().Select(e => e.GetString() ?? "").ToArray();
 
     private static string ErrorMessage(HttpApiResponse response)
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelIndicatorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelIndicatorTests.cs
@@ -39,6 +39,22 @@ public class SettingsViewModelIndicatorTests
         Assert.Equal(16.5, settings.Current.LiveTranscriptionFontSize);
     }
 
+    [Fact]
+    public void LoadsAndPersistsApiAuthenticationSetting()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default with
+        {
+            ApiServerRequiresAuthentication = true
+        });
+        var sut = CreateSettingsViewModel(settings);
+
+        Assert.True(sut.ApiServerRequiresAuthentication);
+
+        sut.ApiServerRequiresAuthentication = false;
+
+        Assert.False(settings.Current.ApiServerRequiresAuthentication);
+    }
+
     private static SettingsViewModel CreateSettingsViewModel(FakeSettingsService settings)
     {
         var pluginManager = TestPluginManagerFactory.Create(settings);

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelIndicatorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelIndicatorTests.cs
@@ -64,6 +64,6 @@ public class SettingsViewModelIndicatorTests
         var api = new ApiServerController(Mock.Of<ILocalApiServer>(), settings);
         var cli = new CliInstallService();
 
-        return new SettingsViewModel(settings, audio, api, cli, speech);
+        return new SettingsViewModel(settings, audio, api, cli, speech, dispatchToUi: action => action());
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/TtsSupportTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TtsSupportTests.cs
@@ -328,7 +328,7 @@ public class SettingsViewModelTtsTests
     {
         var api = new ApiServerController(Mock.Of<ILocalApiServer>(), settings);
         var cli = new CliInstallService();
-        return new SettingsViewModel(settings, audio, api, cli, speech);
+        return new SettingsViewModel(settings, audio, api, cli, speech, dispatchToUi: action => action());
     }
 }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SmallestAi\TypeWhisper.Plugin.SmallestAi.csproj" />
+    <ProjectReference Include="..\..\src\TypeWhisper.Cli\TypeWhisper.Cli.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Windows\TypeWhisper.Windows.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Add Mac-compatible local API discovery with `api-discovery.json`, persisted token generation, and optional token enforcement.
- Add Windows HTTP API parity for local-file transcription, rules/profiles listing and toggles, dictionary term delete-one, and dictionary corrections.
- Update the CLI to resolve discovery before the legacy port file, send Bearer tokens, and use the local-file transcription endpoint for normal file paths.
- Document the updated API contract and add regression coverage for auth, discovery, CLI token headers, dictionary mutations, rules/profiles, and local-file transcription.

## Validation

- `dotnet test F:\typewhisper\typewhisper-win\TypeWhisper.slnx --no-restore`

## Notes

- Authentication stays off by default for local compatibility.
- `GET /v1/status` remains public when token enforcement is enabled so local integrations can discover server readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local-file transcription endpoint with await-download and expanded transcription options
  * API token authentication for the local HTTP API and a persisted UI toggle (with localization)
  * Dictionary corrections CRUD and single-term deletion; workflow-backed rules/profiles listing & toggle
  * CLI auto-discovery of server port, plus --api-token and environment token support

* **Documentation**
  * README and testing guide expanded with discovery, auth, endpoints, request formats, and CLI usage

* **Tests**
  * Added/expanded tests for API auth, dictionary corrections/terms, CLI behavior, and local-file transcribe validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->