### PR TITLE
Fix online live transcription behavior

### DIFF
--- a/src/TypeWhisper.Core/Models/AppSettings.cs
+++ b/src/TypeWhisper.Core/Models/AppSettings.cs
@@ -49,6 +49,7 @@ public record AppSettings
 
     // Live transcription (streaming preview while recording)
     public bool LiveTranscriptionEnabled { get; init; } = true;
+    public bool OnlineAsrBatchLiveTranscriptionEnabled { get; init; }
     public double LiveTranscriptionFontSize { get; init; } = DefaultLiveTranscriptionFontSize;
 
     // Silence detection

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -434,6 +434,8 @@
   "Appearance.StyleCompactBadgeHint": "Kleines zentriertes Statuslicht, ohne Widgets oder Live-Text-Erweiterung.",
   "Appearance.LivePreview": "Live-Transkriptionsvorschau",
   "Appearance.LivePreviewHint": "Zeigt Teiltext in Island und Edge Dock, wenn kein externes Live-Preview-Plugin aktiv ist.",
+  "Appearance.OnlineAsrBatchLivePreview": "Online-Batch-Livevorschau",
+  "Appearance.OnlineAsrBatchLivePreviewHint": "Führt bei Providern ohne echtes Echtzeit-Streaming während der Aufnahme wiederholte Online-Transkriptionsaufrufe aus.",
   "Appearance.LiveTextSize": "Live-Textgroesse",
   "Appearance.LiveTextSizeFormat": "{0:0.#} pt",
   "Appearance.LeftContent": "Linker Inhalt",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -434,6 +434,8 @@
   "Appearance.StyleCompactBadgeHint": "Small centered status light, without widgets or live text expansion.",
   "Appearance.LivePreview": "Live transcription preview",
   "Appearance.LivePreviewHint": "Shows partial text in Island and Edge Dock when no external live preview plugin is active.",
+  "Appearance.OnlineAsrBatchLivePreview": "Online batch live preview",
+  "Appearance.OnlineAsrBatchLivePreviewHint": "Also run repeated online transcription calls while recording for providers without real-time streaming.",
   "Appearance.LiveTextSize": "Live text size",
   "Appearance.LiveTextSizeFormat": "{0:0.#} pt",
   "Appearance.LeftContent": "Left content",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -421,6 +421,8 @@
   "Appearance.StyleCompactBadgeHint": "ウィジェットやライブテキスト展開のない、小さな中央ステータスライトです。",
   "Appearance.LivePreview": "ライブ文字起こしプレビュー",
   "Appearance.LivePreviewHint": "外部ライブプレビュープラグインが無効なとき、Island と Edge Dock に途中テキストを表示します。",
+  "Appearance.OnlineAsrBatchLivePreview": "オンラインバッチのライブプレビュー",
+  "Appearance.OnlineAsrBatchLivePreviewHint": "リアルタイムストリーミング非対応のプロバイダーで、録音中にオンライン文字起こしを繰り返し実行します。",
   "Appearance.LiveTextSize": "ライブテキストサイズ",
   "Appearance.LiveTextSizeFormat": "{0:0.#} pt",
   "Appearance.LeftContent": "左コンテンツ",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -423,6 +423,8 @@
   "Appearance.StyleCompactBadgeHint": "Небольшой центральный индикатор без виджетов и расширения живого текста.",
   "Appearance.LivePreview": "Предпросмотр живой транскрипции",
   "Appearance.LivePreviewHint": "Показывает частичный текст в режимах «Островок» и «Боковая панель», если нет внешнего плагина предпросмотра.",
+  "Appearance.OnlineAsrBatchLivePreview": "Онлайн-предпросмотр пакетной ASR",
+  "Appearance.OnlineAsrBatchLivePreviewHint": "Во время записи выполняет повторные онлайн-запросы транскрипции для провайдеров без потоковой передачи в реальном времени.",
   "Appearance.LiveTextSize": "Размер живого текста",
   "Appearance.LiveTextSizeFormat": "{0:0.#} pt",
   "Appearance.LeftContent": "Содержимое слева",

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
 using System.Threading.Channels;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.PluginSDK;
@@ -134,7 +136,7 @@ public sealed class StreamingHandler : IDisposable
             {
                 SingleReader = true,
                 SingleWriter = false,
-                FullMode = BoundedChannelFullMode.Wait
+                FullMode = BoundedChannelFullMode.DropOldest
             });
 
             lock (_streamingAudioLock)
@@ -170,20 +172,27 @@ public sealed class StreamingHandler : IDisposable
         if (audioWriter is null)
             return;
 
-        SendStreamingAudio(audioWriter, pcm16, cts);
+        SendStreamingAudio(audioWriter, pcm16);
     }
 
-    private void SendStreamingAudio(ChannelWriter<byte[]> audioWriter, byte[] pcm16, CancellationTokenSource cts)
+    private void SendStreamingAudio(ChannelWriter<byte[]> audioWriter, byte[] pcm16)
     {
         try
         {
-            audioWriter.WriteAsync(pcm16, cts.Token).AsTask().GetAwaiter().GetResult();
+            if (!audioWriter.TryWrite(pcm16))
+                Debug.WriteLine("Streaming audio queue rejected a chunk.");
         }
-        catch (OperationCanceledException) { }
-        catch (ChannelClosedException) { }
-        catch (Exception ex)
+        catch (ChannelClosedException ex)
         {
-            Debug.WriteLine($"Queue streaming audio error: {ex.Message}");
+            Debug.WriteLine($"Streaming audio queue closed: {ex.Message}");
+        }
+        catch (ObjectDisposedException ex)
+        {
+            Debug.WriteLine($"Streaming audio queue disposed: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            Debug.WriteLine($"Streaming audio queue unavailable: {ex.Message}");
         }
     }
 
@@ -261,12 +270,21 @@ public sealed class StreamingHandler : IDisposable
                 await session.SendAudioAsync(pcm16, ct);
             }
         }
-        catch (OperationCanceledException) { }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
         {
-            Debug.WriteLine($"SendAudio error: {ex.Message}");
-            CleanupStreamingSessionAfterFailure(session);
+            Debug.WriteLine($"Streaming audio sender canceled: {ex.Message}");
         }
+        catch (ChannelClosedException ex) { HandleStreamingAudioSenderFailure(session, ex); }
+        catch (ObjectDisposedException ex) { HandleStreamingAudioSenderFailure(session, ex); }
+        catch (InvalidOperationException ex) { HandleStreamingAudioSenderFailure(session, ex); }
+        catch (IOException ex) { HandleStreamingAudioSenderFailure(session, ex); }
+        catch (WebSocketException ex) { HandleStreamingAudioSenderFailure(session, ex); }
+    }
+
+    private void HandleStreamingAudioSenderFailure(IStreamingSession session, Exception ex)
+    {
+        Debug.WriteLine($"SendAudio error: {ex.Message}");
+        CleanupStreamingSessionAfterFailure(session);
     }
 
     private void CleanupStreamingSessionAfterFailure(IStreamingSession? failedSession = null)

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading.Channels;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.PluginSDK;
 
@@ -19,12 +20,15 @@ public sealed class StreamingHandler : IDisposable
 
     private CancellationTokenSource? _cts;
     private Task? _streamingTask;
+    private Task? _streamingAudioSenderTask;
     private IStreamingSession? _session;
+    private ChannelWriter<byte[]>? _streamingAudioWriter;
     private Action<StreamingTranscriptEvent>? _transcriptHandler;
     private int _pendingStreamingAudioBytes;
     private bool _isFlushingPendingStreamingAudio;
 
     private const int MaxPendingStreamingAudioBytes = 1024 * 1024;
+    private const int StreamingAudioChannelCapacity = 128;
 
     public Action<string>? OnPartialTextUpdate { get; set; }
 
@@ -70,10 +74,21 @@ public sealed class StreamingHandler : IDisposable
 
         var finalText = _transcriptState.StopSession();
 
-        var session = _session;
-        var transcriptHandler = _transcriptHandler;
-        _session = null;
-        _transcriptHandler = null;
+        IStreamingSession? session;
+        ChannelWriter<byte[]>? audioWriter;
+        Action<StreamingTranscriptEvent>? transcriptHandler;
+        lock (_streamingAudioLock)
+        {
+            session = _session;
+            audioWriter = _streamingAudioWriter;
+            transcriptHandler = _transcriptHandler;
+            _session = null;
+            _streamingAudioWriter = null;
+            _streamingAudioSenderTask = null;
+            _transcriptHandler = null;
+            ClearPendingStreamingAudioCore();
+        }
+        audioWriter?.TryComplete();
 
         if (session is not null && transcriptHandler is not null)
             session.TranscriptReceived -= transcriptHandler;
@@ -87,7 +102,6 @@ public sealed class StreamingHandler : IDisposable
         _cts?.Dispose();
         _cts = null;
         _streamingTask = null;
-        ClearPendingStreamingAudio();
 
         return finalText;
     }
@@ -116,15 +130,24 @@ public sealed class StreamingHandler : IDisposable
                 return;
             }
 
+            var audioChannel = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(StreamingAudioChannelCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
             lock (_streamingAudioLock)
             {
                 _session = session;
+                _streamingAudioWriter = audioChannel.Writer;
                 _isFlushingPendingStreamingAudio = true;
             }
 
             _transcriptHandler = evt => OnTranscriptReceived(evt, sessionVersion);
             session.TranscriptReceived += _transcriptHandler;
-            await FlushPendingStreamingAudioAsync(session, ct);
+            _streamingAudioSenderTask = RunStreamingAudioSenderAsync(session, audioChannel.Reader, ct);
+            await FlushPendingStreamingAudioAsync(audioChannel.Writer, ct);
 
             // Keep alive until cancelled
             await Task.Delay(Timeout.Infinite, ct);
@@ -133,6 +156,7 @@ public sealed class StreamingHandler : IDisposable
         catch (Exception ex)
         {
             Debug.WriteLine($"WebSocket streaming error: {ex.Message}");
+            CleanupStreamingSessionAfterFailure();
         }
     }
 
@@ -142,34 +166,38 @@ public sealed class StreamingHandler : IDisposable
         if (cts is null || cts.IsCancellationRequested) return;
 
         var pcm16 = FloatToPcm16(e.Samples);
-        var session = GetSessionOrBufferStreamingAudio(pcm16);
-        if (session is null)
+        var audioWriter = GetStreamingAudioWriterOrBuffer(pcm16);
+        if (audioWriter is null)
             return;
 
-        SendStreamingAudio(session, pcm16, cts);
+        SendStreamingAudio(audioWriter, pcm16, cts);
     }
 
-    private void SendStreamingAudio(IStreamingSession session, byte[] pcm16, CancellationTokenSource cts)
+    private void SendStreamingAudio(ChannelWriter<byte[]> audioWriter, byte[] pcm16, CancellationTokenSource cts)
     {
-        _ = Task.Run(async () =>
+        try
         {
-            try { await session.SendAudioAsync(pcm16, cts.Token); }
-            catch (OperationCanceledException) { }
-            catch (Exception ex) { Debug.WriteLine($"SendAudio error: {ex.Message}"); }
-        });
+            audioWriter.WriteAsync(pcm16, cts.Token).AsTask().GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) { }
+        catch (ChannelClosedException) { }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Queue streaming audio error: {ex.Message}");
+        }
     }
 
-    private IStreamingSession? GetSessionOrBufferStreamingAudio(byte[] pcm16)
+    private ChannelWriter<byte[]>? GetStreamingAudioWriterOrBuffer(byte[] pcm16)
     {
         lock (_streamingAudioLock)
         {
-            if (_session is null || _isFlushingPendingStreamingAudio)
+            if (_streamingAudioWriter is null || _isFlushingPendingStreamingAudio)
             {
                 EnqueuePendingStreamingAudioCore(pcm16);
                 return null;
             }
 
-            return _session;
+            return _streamingAudioWriter;
         }
     }
 
@@ -185,7 +213,7 @@ public sealed class StreamingHandler : IDisposable
         }
     }
 
-    private async Task FlushPendingStreamingAudioAsync(IStreamingSession session, CancellationToken ct)
+    private async Task FlushPendingStreamingAudioAsync(ChannelWriter<byte[]> audioWriter, CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
@@ -202,7 +230,7 @@ public sealed class StreamingHandler : IDisposable
                 _pendingStreamingAudioBytes -= next.Length;
             }
 
-            await session.SendAudioAsync(next, ct);
+            await audioWriter.WriteAsync(next, ct);
         }
     }
 
@@ -210,10 +238,66 @@ public sealed class StreamingHandler : IDisposable
     {
         lock (_streamingAudioLock)
         {
-            _pendingStreamingAudio.Clear();
-            _pendingStreamingAudioBytes = 0;
-            _isFlushingPendingStreamingAudio = false;
+            ClearPendingStreamingAudioCore();
         }
+    }
+
+    private void ClearPendingStreamingAudioCore()
+    {
+        _pendingStreamingAudio.Clear();
+        _pendingStreamingAudioBytes = 0;
+        _isFlushingPendingStreamingAudio = false;
+    }
+
+    private async Task RunStreamingAudioSenderAsync(
+        IStreamingSession session,
+        ChannelReader<byte[]> audioReader,
+        CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var pcm16 in audioReader.ReadAllAsync(ct))
+            {
+                await session.SendAudioAsync(pcm16, ct);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"SendAudio error: {ex.Message}");
+            CleanupStreamingSessionAfterFailure(session);
+        }
+    }
+
+    private void CleanupStreamingSessionAfterFailure(IStreamingSession? failedSession = null)
+    {
+        IStreamingSession? sessionToCleanup;
+        ChannelWriter<byte[]>? audioWriter;
+        Action<StreamingTranscriptEvent>? transcriptHandler;
+
+        lock (_streamingAudioLock)
+        {
+            if (failedSession is not null && !ReferenceEquals(_session, failedSession))
+                return;
+
+            sessionToCleanup = _session;
+            audioWriter = _streamingAudioWriter;
+            transcriptHandler = _transcriptHandler;
+            _session = null;
+            _streamingAudioWriter = null;
+            _streamingAudioSenderTask = null;
+            _transcriptHandler = null;
+            ClearPendingStreamingAudioCore();
+        }
+
+        _audio.SamplesAvailable -= OnStreamingSamplesAvailable;
+        audioWriter?.TryComplete();
+
+        if (sessionToCleanup is not null && transcriptHandler is not null)
+            sessionToCleanup.TranscriptReceived -= transcriptHandler;
+
+        if (sessionToCleanup is not null)
+            _ = CleanupSessionAsync(sessionToCleanup);
     }
 
     private void OnTranscriptReceived(StreamingTranscriptEvent evt, int sessionVersion)

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -14,11 +14,17 @@ public sealed class StreamingHandler : IDisposable
     private readonly AudioRecordingService _audio;
     private readonly IDictionaryService _dictionary;
     private readonly StreamingTranscriptState _transcriptState = new();
+    private readonly object _streamingAudioLock = new();
+    private readonly Queue<byte[]> _pendingStreamingAudio = new();
 
     private CancellationTokenSource? _cts;
     private Task? _streamingTask;
     private IStreamingSession? _session;
     private Action<StreamingTranscriptEvent>? _transcriptHandler;
+    private int _pendingStreamingAudioBytes;
+    private bool _isFlushingPendingStreamingAudio;
+
+    private const int MaxPendingStreamingAudioBytes = 1024 * 1024;
 
     public Action<string>? OnPartialTextUpdate { get; set; }
 
@@ -38,6 +44,7 @@ public sealed class StreamingHandler : IDisposable
         Func<bool> isStillRecording)
     {
         Stop();
+        ClearPendingStreamingAudio();
 
         var sessionVersion = _transcriptState.StartSession();
         _cts = new CancellationTokenSource();
@@ -46,9 +53,14 @@ public sealed class StreamingHandler : IDisposable
         var plugin = _modelManager.ActiveTranscriptionPlugin;
 
         if (plugin is not null && plugin.SupportsStreaming)
+        {
+            _audio.SamplesAvailable += OnStreamingSamplesAvailable;
             _streamingTask = RunWebSocketStreamingAsync(plugin, language, sessionVersion, ct);
+        }
         else
+        {
             _streamingTask = RunPollingFallbackAsync(language, task, isStillRecording, sessionVersion, ct);
+        }
     }
 
     public string Stop()
@@ -75,6 +87,7 @@ public sealed class StreamingHandler : IDisposable
         _cts?.Dispose();
         _cts = null;
         _streamingTask = null;
+        ClearPendingStreamingAudio();
 
         return finalText;
     }
@@ -103,10 +116,15 @@ public sealed class StreamingHandler : IDisposable
                 return;
             }
 
-            _session = session;
+            lock (_streamingAudioLock)
+            {
+                _session = session;
+                _isFlushingPendingStreamingAudio = true;
+            }
+
             _transcriptHandler = evt => OnTranscriptReceived(evt, sessionVersion);
             session.TranscriptReceived += _transcriptHandler;
-            _audio.SamplesAvailable += OnStreamingSamplesAvailable;
+            await FlushPendingStreamingAudioAsync(session, ct);
 
             // Keep alive until cancelled
             await Task.Delay(Timeout.Infinite, ct);
@@ -120,17 +138,82 @@ public sealed class StreamingHandler : IDisposable
 
     private void OnStreamingSamplesAvailable(object? sender, SamplesAvailableEventArgs e)
     {
-        var session = _session;
         var cts = _cts;
-        if (session is null || cts is null || cts.IsCancellationRequested) return;
+        if (cts is null || cts.IsCancellationRequested) return;
 
         var pcm16 = FloatToPcm16(e.Samples);
+        var session = GetSessionOrBufferStreamingAudio(pcm16);
+        if (session is null)
+            return;
+
+        SendStreamingAudio(session, pcm16, cts);
+    }
+
+    private void SendStreamingAudio(IStreamingSession session, byte[] pcm16, CancellationTokenSource cts)
+    {
         _ = Task.Run(async () =>
         {
             try { await session.SendAudioAsync(pcm16, cts.Token); }
             catch (OperationCanceledException) { }
             catch (Exception ex) { Debug.WriteLine($"SendAudio error: {ex.Message}"); }
         });
+    }
+
+    private IStreamingSession? GetSessionOrBufferStreamingAudio(byte[] pcm16)
+    {
+        lock (_streamingAudioLock)
+        {
+            if (_session is null || _isFlushingPendingStreamingAudio)
+            {
+                EnqueuePendingStreamingAudioCore(pcm16);
+                return null;
+            }
+
+            return _session;
+        }
+    }
+
+    private void EnqueuePendingStreamingAudioCore(byte[] pcm16)
+    {
+        _pendingStreamingAudio.Enqueue(pcm16);
+        _pendingStreamingAudioBytes += pcm16.Length;
+
+        while (_pendingStreamingAudioBytes > MaxPendingStreamingAudioBytes
+            && _pendingStreamingAudio.Count > 0)
+        {
+            _pendingStreamingAudioBytes -= _pendingStreamingAudio.Dequeue().Length;
+        }
+    }
+
+    private async Task FlushPendingStreamingAudioAsync(IStreamingSession session, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            byte[]? next;
+            lock (_streamingAudioLock)
+            {
+                if (_pendingStreamingAudio.Count == 0)
+                {
+                    _isFlushingPendingStreamingAudio = false;
+                    return;
+                }
+
+                next = _pendingStreamingAudio.Dequeue();
+                _pendingStreamingAudioBytes -= next.Length;
+            }
+
+            await session.SendAudioAsync(next, ct);
+        }
+    }
+
+    private void ClearPendingStreamingAudio()
+    {
+        lock (_streamingAudioLock)
+        {
+            _pendingStreamingAudio.Clear();
+            _pendingStreamingAudioBytes = 0;
+            _isFlushingPendingStreamingAudio = false;
+        }
     }
 
     private void OnTranscriptReceived(StreamingTranscriptEvent evt, int sessionVersion)

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -726,11 +726,17 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         var isPluginModel = _modelManager.ActiveModelId is not null
             && ModelManagerService.IsPluginModel(_modelManager.ActiveModelId);
 
-        if (_settings.Current.LiveTranscriptionEnabled && isPluginModel)
+        var liveTranscriptionMode = LiveTranscriptionStartupPolicy.Select(
+            _settings.Current,
+            isPluginModel,
+            _modelManager.ActiveTranscriptionPlugin);
+
+        if (liveTranscriptionMode is LiveTranscriptionStartupMode.PluginStreaming
+            or LiveTranscriptionStartupMode.PluginPollingFallback)
         {
             _streamingHandler.Start(EffectiveLanguage, EffectiveTask, () => _isRecording);
         }
-        else if (_settings.Current.LiveTranscriptionEnabled && !isPluginModel)
+        else if (liveTranscriptionMode == LiveTranscriptionStartupMode.LegacyVad)
         {
             // VAD fallback for non-plugin models
             _vad = CreateVoiceActivityDetector();

--- a/src/TypeWhisper.Windows/ViewModels/LiveTranscriptionStartupPolicy.cs
+++ b/src/TypeWhisper.Windows/ViewModels/LiveTranscriptionStartupPolicy.cs
@@ -1,0 +1,38 @@
+using TypeWhisper.Core.Models;
+using TypeWhisper.PluginSDK;
+
+namespace TypeWhisper.Windows.ViewModels;
+
+internal enum LiveTranscriptionStartupMode
+{
+    None,
+    PluginStreaming,
+    PluginPollingFallback,
+    LegacyVad
+}
+
+internal static class LiveTranscriptionStartupPolicy
+{
+    public static LiveTranscriptionStartupMode Select(
+        AppSettings settings,
+        bool isPluginModel,
+        ITranscriptionEnginePlugin? plugin)
+    {
+        if (!settings.LiveTranscriptionEnabled)
+            return LiveTranscriptionStartupMode.None;
+
+        if (!isPluginModel)
+            return LiveTranscriptionStartupMode.LegacyVad;
+
+        if (plugin is null)
+            return LiveTranscriptionStartupMode.None;
+
+        if (plugin.SupportsStreaming)
+            return LiveTranscriptionStartupMode.PluginStreaming;
+
+        if (plugin.SupportsModelDownload || settings.OnlineAsrBatchLiveTranscriptionEnabled)
+            return LiveTranscriptionStartupMode.PluginPollingFallback;
+
+        return LiveTranscriptionStartupMode.None;
+    }
+}

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -38,6 +38,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _transcribeShortQuietClipsAggressively;
     [ObservableProperty] private IndicatorStyle _indicatorStyle = IndicatorStyle.StatusIsland;
     [ObservableProperty] private bool _liveTranscriptionEnabled = true;
+    [ObservableProperty] private bool _onlineAsrBatchLiveTranscriptionEnabled;
     [ObservableProperty] private double _liveTranscriptionFontSize = AppSettings.DefaultLiveTranscriptionFontSize;
     [ObservableProperty] private OverlayPosition _overlayPosition = OverlayPosition.Bottom;
     [ObservableProperty] private double _previewBubbleAutoHideSeconds = AppSettings.DefaultPreviewBubbleAutoHideMilliseconds / 1000d;
@@ -328,6 +329,7 @@ public partial class SettingsViewModel : ObservableObject
             TranscribeShortQuietClipsAggressively = TranscribeShortQuietClipsAggressively,
             IndicatorStyle = IndicatorStyle,
             LiveTranscriptionEnabled = LiveTranscriptionEnabled,
+            OnlineAsrBatchLiveTranscriptionEnabled = OnlineAsrBatchLiveTranscriptionEnabled,
             LiveTranscriptionFontSize = AppSettings.NormalizeLiveTranscriptionFontSize(LiveTranscriptionFontSize),
             OverlayPosition = OverlayPosition,
             PreviewBubbleAutoHideMilliseconds = AppSettings.NormalizePreviewBubbleAutoHideMilliseconds(
@@ -413,6 +415,7 @@ public partial class SettingsViewModel : ObservableObject
         TranscribeShortQuietClipsAggressively = s.TranscribeShortQuietClipsAggressively;
         IndicatorStyle = s.IndicatorStyle;
         LiveTranscriptionEnabled = s.LiveTranscriptionEnabled;
+        OnlineAsrBatchLiveTranscriptionEnabled = s.OnlineAsrBatchLiveTranscriptionEnabled;
         LiveTranscriptionFontSize = AppSettings.NormalizeLiveTranscriptionFontSize(s.LiveTranscriptionFontSize);
         OverlayPosition = s.OverlayPosition;
         PreviewBubbleAutoHideSeconds = AppSettings.NormalizePreviewBubbleAutoHideMilliseconds(

--- a/src/TypeWhisper.Windows/Views/Sections/AppearanceSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/AppearanceSection.xaml
@@ -304,6 +304,28 @@
                                             Margin="0,10,0,0"/>
                                 </Grid>
 
+                                <Grid x:Name="OnlineAsrBatchLivePreviewSettingsRow"
+                                      Margin="0,16,0,0"
+                                      IsEnabled="{Binding Settings.LiveTranscriptionEnabled}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel>
+                                        <TextBlock Text="{loc:Str Appearance.OnlineAsrBatchLivePreview}"
+                                                   Style="{StaticResource SettingsRowLabelStyle}"/>
+                                        <TextBlock Text="{loc:Str Appearance.OnlineAsrBatchLivePreviewHint}"
+                                                   Style="{StaticResource HintStyle}"
+                                                   Margin="0,5,0,0"
+                                                   TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                    <ui:ToggleSwitch Grid.Column="1"
+                                                     IsChecked="{Binding Settings.OnlineAsrBatchLiveTranscriptionEnabled}"
+                                                     OnContent=""
+                                                     OffContent=""
+                                                     VerticalAlignment="Center"/>
+                                </Grid>
+
                                 <Grid Margin="0,16,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>

--- a/tests/TypeWhisper.Core.Tests/Models/AppSettingsTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Models/AppSettingsTests.cs
@@ -23,6 +23,12 @@ public class AppSettingsTests
     }
 
     [Fact]
+    public void DefaultOnlineAsrBatchLiveTranscriptionEnabled_IsFalse()
+    {
+        Assert.False(AppSettings.Default.OnlineAsrBatchLiveTranscriptionEnabled);
+    }
+
+    [Fact]
     public void DefaultLocalModelAcceleration_IsAuto()
     {
         Assert.Equal(AppSettings.LocalModelAccelerationAuto, AppSettings.Default.LocalModelAcceleration);

--- a/tests/TypeWhisper.Core.Tests/Services/SettingsServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/SettingsServiceTests.cs
@@ -56,6 +56,7 @@ public class SettingsServiceTests : IDisposable
             TranscribeShortQuietClipsAggressively = true,
             IndicatorStyle = IndicatorStyle.EdgeDock,
             LiveTranscriptionEnabled = false,
+            OnlineAsrBatchLiveTranscriptionEnabled = true,
             LiveTranscriptionFontSize = 15.5,
             PreviewBubbleAutoHideMilliseconds = 3750,
             SelectedIndustryPresetId = "architecture"
@@ -84,6 +85,7 @@ public class SettingsServiceTests : IDisposable
         Assert.True(sut2.Current.TranscribeShortQuietClipsAggressively);
         Assert.Equal(IndicatorStyle.EdgeDock, sut2.Current.IndicatorStyle);
         Assert.False(sut2.Current.LiveTranscriptionEnabled);
+        Assert.True(sut2.Current.OnlineAsrBatchLiveTranscriptionEnabled);
         Assert.Equal(15.5, sut2.Current.LiveTranscriptionFontSize);
         Assert.Equal(3750, sut2.Current.PreviewBubbleAutoHideMilliseconds);
         Assert.Equal("architecture", sut2.Current.SelectedIndustryPresetId);
@@ -146,6 +148,20 @@ public class SettingsServiceTests : IDisposable
         var sut = new SettingsService(_filePath);
 
         Assert.Equal(AppSettings.Default.LiveTranscriptionFontSize, sut.Current.LiveTranscriptionFontSize);
+    }
+
+    [Fact]
+    public void Load_LegacySettings_DisablesOnlineAsrBatchLiveTranscriptionByDefault()
+    {
+        File.WriteAllText(_filePath, """
+        {
+          "language": "en"
+        }
+        """);
+
+        var sut = new SettingsService(_filePath);
+
+        Assert.False(sut.Current.OnlineAsrBatchLiveTranscriptionEnabled);
     }
 
     [Theory]

--- a/tests/TypeWhisper.PluginSystem.Tests/AppLocalizationResourcesTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppLocalizationResourcesTests.cs
@@ -38,6 +38,22 @@ public class AppLocalizationResourcesTests
             option => option.Code == "ru" && option.DisplayName == "Русский");
     }
 
+    [Theory]
+    [InlineData("en")]
+    [InlineData("de")]
+    [InlineData("ja")]
+    [InlineData("ru")]
+    public void AppearanceOnlineAsrBatchLivePreviewLocalizationKeys_ArePresent(string language)
+    {
+        var localizationDir = Path.Join(AppContext.BaseDirectory, "Resources", "Localization");
+        var localization = LoadLocalization(localizationDir, language);
+
+        Assert.Contains("Appearance.OnlineAsrBatchLivePreview", localization.Keys);
+        Assert.Contains("Appearance.OnlineAsrBatchLivePreviewHint", localization.Keys);
+        Assert.False(string.IsNullOrWhiteSpace(localization["Appearance.OnlineAsrBatchLivePreview"]));
+        Assert.False(string.IsNullOrWhiteSpace(localization["Appearance.OnlineAsrBatchLivePreviewHint"]));
+    }
+
     private static Dictionary<string, string> LoadLocalization(string localizationDir, string language)
     {
         var languageFileName = Path.GetFileName($"{language}.json");

--- a/tests/TypeWhisper.PluginSystem.Tests/AppearanceSectionLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppearanceSectionLayoutTests.cs
@@ -92,6 +92,22 @@ public sealed class AppearanceSectionLayoutTests
         AssertWidgetSettingCollapsesForCompactBadge(liveTextSize);
     }
 
+    [Fact]
+    public void AppearanceSection_OffersOnlineAsrBatchLivePreviewOptIn()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "AppearanceSection.xaml");
+
+        Assert.Contains("x:Name=\"OnlineAsrBatchLivePreviewSettingsRow\"", xaml);
+        Assert.Contains("Appearance.OnlineAsrBatchLivePreview", xaml);
+        Assert.Contains("Appearance.OnlineAsrBatchLivePreviewHint", xaml);
+        Assert.Contains("Settings.OnlineAsrBatchLiveTranscriptionEnabled", xaml);
+    }
+
     private static void AssertWidgetSettingCollapsesForCompactBadge(string xamlBlock)
     {
         Assert.Contains("Settings.IndicatorStyle", xamlBlock);

--- a/tests/TypeWhisper.PluginSystem.Tests/AppearanceSectionLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppearanceSectionLayoutTests.cs
@@ -106,6 +106,9 @@ public sealed class AppearanceSectionLayoutTests
         Assert.Contains("Appearance.OnlineAsrBatchLivePreview", xaml);
         Assert.Contains("Appearance.OnlineAsrBatchLivePreviewHint", xaml);
         Assert.Contains("Settings.OnlineAsrBatchLiveTranscriptionEnabled", xaml);
+
+        var row = TestFile.ExtractBlock(xaml, "x:Name=\"OnlineAsrBatchLivePreviewSettingsRow\"");
+        Assert.Contains("IsEnabled=\"{Binding Settings.LiveTranscriptionEnabled}\"", row);
     }
 
     private static void AssertWidgetSettingCollapsesForCompactBadge(string xamlBlock)

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelIndicatorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelIndicatorTests.cs
@@ -15,12 +15,14 @@ public class SettingsViewModelIndicatorTests
         {
             IndicatorStyle = IndicatorStyle.EdgeDock,
             LiveTranscriptionEnabled = false,
+            OnlineAsrBatchLiveTranscriptionEnabled = true,
             LiveTranscriptionFontSize = 15
         });
         var sut = CreateSettingsViewModel(settings);
 
         Assert.Equal(IndicatorStyle.EdgeDock, sut.IndicatorStyle);
         Assert.False(sut.LiveTranscriptionEnabled);
+        Assert.True(sut.OnlineAsrBatchLiveTranscriptionEnabled);
         Assert.Equal(15, sut.LiveTranscriptionFontSize);
     }
 
@@ -32,10 +34,12 @@ public class SettingsViewModelIndicatorTests
 
         sut.IndicatorStyle = IndicatorStyle.CompactBadge;
         sut.LiveTranscriptionEnabled = false;
+        sut.OnlineAsrBatchLiveTranscriptionEnabled = true;
         sut.LiveTranscriptionFontSize = 16.5;
 
         Assert.Equal(IndicatorStyle.CompactBadge, settings.Current.IndicatorStyle);
         Assert.False(settings.Current.LiveTranscriptionEnabled);
+        Assert.True(settings.Current.OnlineAsrBatchLiveTranscriptionEnabled);
         Assert.Equal(16.5, settings.Current.LiveTranscriptionFontSize);
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -1,7 +1,12 @@
 using Moq;
+using NAudio.Wave;
+using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.ViewModels;
 
 namespace TypeWhisper.PluginSystem.Tests;
 
@@ -98,6 +103,229 @@ public class StreamingTranscriptionTests
 
         Assert.Equal("Streamed text", result.Text);
         Assert.Equal("de", result.DetectedLanguage);
+    }
+
+    [Fact]
+    public async Task StreamingHandler_BuffersAudioCapturedBeforeRealtimeSessionConnects()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+
+        handler.Start("en", TranscriptionTask.Transcribe, () => audio.IsRecording);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        capture.RaiseData([0, 0, 0, 0], 4);
+        var session = new CapturingStreamingSession();
+        plugin.CompleteStart(session);
+
+        await WaitUntilAsync(() => session.SentAudio.Count == 1);
+
+        Assert.Equal(4, session.SentAudio.Single().Length);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        while (!condition())
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            await Task.Delay(20, timeout.Token);
+        }
+    }
+
+    private sealed class DelayedStreamingPlugin : ITranscriptionEnginePlugin
+    {
+        private readonly TaskCompletionSource<IStreamingSession> _startCompletion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string PluginId => "com.test.delayed-streaming";
+        public string PluginName => "Delayed Streaming";
+        public string PluginVersion => "1.0.0";
+        public string ProviderId => "delayed-streaming";
+        public string ProviderDisplayName => "Delayed Streaming";
+        public bool IsConfigured => true;
+        public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
+            [new PluginModelInfo("stream", "Stream")];
+        public string? SelectedModelId { get; private set; }
+        public bool SupportsTranslation => false;
+        public bool SupportsStreaming => true;
+
+        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
+        public Task DeactivateAsync() => Task.CompletedTask;
+        public System.Windows.Controls.UserControl? CreateSettingsView() => null;
+        public void Dispose() { }
+        public void SelectModel(string modelId) => SelectedModelId = modelId;
+        public Task<IStreamingSession> StartStreamingAsync(string? language, CancellationToken ct) =>
+            _startCompletion.Task.WaitAsync(ct);
+        public void CompleteStart(IStreamingSession session) => _startCompletion.SetResult(session);
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(
+            byte[] wavAudio,
+            string? language,
+            bool translate,
+            string? prompt,
+            CancellationToken ct) =>
+            Task.FromResult(new PluginTranscriptionResult("", language ?? "en", 0));
+    }
+
+    private sealed class CapturingStreamingSession : IStreamingSession
+    {
+        public List<byte[]> SentAudio { get; } = [];
+        public event Action<StreamingTranscriptEvent>? TranscriptReceived;
+        public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
+        {
+            SentAudio.Add(pcm16Audio.ToArray());
+            return Task.CompletedTask;
+        }
+
+        public Task FinalizeAsync(CancellationToken ct) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void RaiseTranscript(StreamingTranscriptEvent evt) => TranscriptReceived?.Invoke(evt);
+    }
+
+    private sealed class PassthroughDictionaryService : IDictionaryService
+    {
+        public IReadOnlyList<DictionaryEntry> Entries => [];
+        public event Action? EntriesChanged { add { } remove { } }
+        public void AddEntry(DictionaryEntry entry) { }
+        public void AddEntries(IEnumerable<DictionaryEntry> entries) { }
+        public void UpdateEntry(DictionaryEntry entry) { }
+        public void DeleteEntry(string id) { }
+        public void DeleteEntries(IEnumerable<string> ids) { }
+        public string ApplyCorrections(string text) => text;
+        public string? GetTermsForPrompt() => null;
+        public void LearnCorrection(string original, string replacement) { }
+        public void ActivatePack(TermPack pack) { }
+        public void DeactivatePack(string packId) { }
+    }
+}
+
+public class LiveTranscriptionStartupPolicyTests
+{
+    [Fact]
+    public void GlobalLiveTranscriptionDisabled_SuppressesAllLiveModes()
+    {
+        var plugin = new FakePolicyTranscriptionPlugin(supportsStreaming: true, supportsModelDownload: true);
+
+        var mode = LiveTranscriptionStartupPolicy.Select(
+            AppSettings.Default with { LiveTranscriptionEnabled = false },
+            isPluginModel: true,
+            plugin);
+
+        Assert.Equal(LiveTranscriptionStartupMode.None, mode);
+    }
+
+    [Fact]
+    public void StreamingPlugin_UsesRealtimeStreaming()
+    {
+        var plugin = new FakePolicyTranscriptionPlugin(supportsStreaming: true, supportsModelDownload: false);
+
+        var mode = LiveTranscriptionStartupPolicy.Select(
+            AppSettings.Default,
+            isPluginModel: true,
+            plugin);
+
+        Assert.Equal(LiveTranscriptionStartupMode.PluginStreaming, mode);
+    }
+
+    [Fact]
+    public void DownloadablePlugin_UsesPollingFallback()
+    {
+        var plugin = new FakePolicyTranscriptionPlugin(supportsStreaming: false, supportsModelDownload: true);
+
+        var mode = LiveTranscriptionStartupPolicy.Select(
+            AppSettings.Default,
+            isPluginModel: true,
+            plugin);
+
+        Assert.Equal(LiveTranscriptionStartupMode.PluginPollingFallback, mode);
+    }
+
+    [Fact]
+    public void OnlineBatchProvider_DefaultsToNoLiveTranscription()
+    {
+        var plugin = new FakePolicyTranscriptionPlugin(supportsStreaming: false, supportsModelDownload: false);
+
+        var mode = LiveTranscriptionStartupPolicy.Select(
+            AppSettings.Default,
+            isPluginModel: true,
+            plugin);
+
+        Assert.Equal(LiveTranscriptionStartupMode.None, mode);
+    }
+
+    [Fact]
+    public void OnlineBatchProvider_UsesPollingFallbackWhenOptedIn()
+    {
+        var plugin = new FakePolicyTranscriptionPlugin(supportsStreaming: false, supportsModelDownload: false);
+
+        var mode = LiveTranscriptionStartupPolicy.Select(
+            AppSettings.Default with { OnlineAsrBatchLiveTranscriptionEnabled = true },
+            isPluginModel: true,
+            plugin);
+
+        Assert.Equal(LiveTranscriptionStartupMode.PluginPollingFallback, mode);
+    }
+
+    [Fact]
+    public void NonPluginModel_UsesLegacyVad()
+    {
+        var mode = LiveTranscriptionStartupPolicy.Select(
+            AppSettings.Default,
+            isPluginModel: false,
+            plugin: null);
+
+        Assert.Equal(LiveTranscriptionStartupMode.LegacyVad, mode);
+    }
+
+    private sealed class FakePolicyTranscriptionPlugin : ITranscriptionEnginePlugin
+    {
+        public FakePolicyTranscriptionPlugin(bool supportsStreaming, bool supportsModelDownload)
+        {
+            SupportsStreaming = supportsStreaming;
+            SupportsModelDownload = supportsModelDownload;
+        }
+
+        public string PluginId => "com.test.policy";
+        public string PluginName => "Policy Test";
+        public string PluginVersion => "1.0.0";
+        public string ProviderId => "policy";
+        public string ProviderDisplayName => "Policy";
+        public bool IsConfigured => true;
+        public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
+            [new PluginModelInfo("model", "Model")];
+        public string? SelectedModelId => "model";
+        public bool SupportsTranslation => false;
+        public bool SupportsStreaming { get; }
+        public bool SupportsModelDownload { get; }
+
+        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
+        public Task DeactivateAsync() => Task.CompletedTask;
+        public System.Windows.Controls.UserControl? CreateSettingsView() => null;
+        public void Dispose() { }
+        public void SelectModel(string modelId) { }
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(
+            byte[] wavAudio,
+            string? language,
+            bool translate,
+            string? prompt,
+            CancellationToken ct) =>
+            Task.FromResult(new PluginTranscriptionResult("", language ?? "en", 0));
     }
 }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -179,6 +179,48 @@ public class StreamingTranscriptionTests
     }
 
     [Fact]
+    public async Task StreamingHandler_DoesNotBlockAudioCallbackWhenSenderFallsBehind()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        var session = new BlockingStreamingSession();
+        plugin.CompleteStart(session);
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+
+        handler.Start("en", TranscriptionTask.Transcribe, () => audio.IsRecording);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        capture.RaiseData([0, 0, 0, 0], 4);
+        await session.FirstSendEntered;
+
+        var raiseManyChunks = Task.Run(() =>
+        {
+            for (var i = 0; i < 200; i++)
+                capture.RaiseData([1, 0, 1, 0], 4);
+        });
+
+        var completedWithoutBlocking = await CompletesWithinAsync(raiseManyChunks, TimeSpan.FromMilliseconds(500));
+
+        session.ReleaseFirstSend();
+        await raiseManyChunks.WaitAsync(TimeSpan.FromSeconds(3));
+
+        Assert.True(completedWithoutBlocking);
+    }
+
+    [Fact]
     public async Task StreamingHandler_CleansUpStreamingStateWhenInitialFlushFails()
     {
         var settings = new FakeSettingsService(AppSettings.Default);

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Moq;
 using NAudio.Wave;
 using TypeWhisper.Core.Interfaces;
@@ -137,6 +138,87 @@ public class StreamingTranscriptionTests
         Assert.Equal(4, session.SentAudio.Single().Length);
     }
 
+    [Fact]
+    public async Task StreamingHandler_SerializesRealtimeAudioWrites()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        var session = new BlockingStreamingSession();
+        plugin.CompleteStart(session);
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+
+        handler.Start("en", TranscriptionTask.Transcribe, () => audio.IsRecording);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        capture.RaiseData([0, 0, 0, 0], 4);
+        await session.FirstSendEntered;
+
+        capture.RaiseData([1, 0, 1, 0], 4);
+
+        var overlapped = await CompletesWithinAsync(session.ConcurrentSendObserved, TimeSpan.FromMilliseconds(500));
+        Assert.False(overlapped);
+
+        session.ReleaseFirstSend();
+        await WaitUntilAsync(() => session.SendAttemptCount == 2);
+
+        Assert.Equal(1, session.MaxConcurrentSendCount);
+        Assert.Equal(2, session.SentAudioCount);
+    }
+
+    [Fact]
+    public async Task StreamingHandler_CleansUpStreamingStateWhenInitialFlushFails()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+
+        handler.Start("en", TranscriptionTask.Transcribe, () => audio.IsRecording);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        capture.RaiseData([0, 0, 0, 0], 4);
+
+        var session = new FailingStreamingSession();
+        plugin.CompleteStart(session);
+        await WaitUntilAsync(() => session.SendAttemptCount == 1);
+        await Task.Delay(100);
+
+        Assert.Null(GetPrivateField(handler, "_session"));
+        Assert.False((bool)GetPrivateField(handler, "_isFlushingPendingStreamingAudio")!);
+        Assert.Equal(0, (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")!);
+
+        capture.RaiseData([1, 0, 1, 0], 4);
+        await Task.Delay(50);
+
+        Assert.Equal(1, session.SendAttemptCount);
+        Assert.Equal(0, (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")!);
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
@@ -145,6 +227,19 @@ public class StreamingTranscriptionTests
             timeout.Token.ThrowIfCancellationRequested();
             await Task.Delay(20, timeout.Token);
         }
+    }
+
+    private static async Task<bool> CompletesWithinAsync(Task task, TimeSpan timeout)
+    {
+        var delay = Task.Delay(timeout);
+        return await Task.WhenAny(task, delay) == task;
+    }
+
+    private static object? GetPrivateField(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return field.GetValue(target);
     }
 
     private sealed class DelayedStreamingPlugin : ITranscriptionEnginePlugin
@@ -190,6 +285,99 @@ public class StreamingTranscriptionTests
         {
             SentAudio.Add(pcm16Audio.ToArray());
             return Task.CompletedTask;
+        }
+
+        public Task FinalizeAsync(CancellationToken ct) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void RaiseTranscript(StreamingTranscriptEvent evt) => TranscriptReceived?.Invoke(evt);
+    }
+
+    private sealed class BlockingStreamingSession : IStreamingSession
+    {
+        private readonly TaskCompletionSource _firstSendEntered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstSend =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _concurrentSendObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly List<byte[]> _sentAudio = [];
+
+        private int _inFlightSendCount;
+        private int _maxConcurrentSendCount;
+        private int _sendAttemptCount;
+
+        public Task FirstSendEntered => _firstSendEntered.Task;
+        public Task ConcurrentSendObserved => _concurrentSendObserved.Task;
+        public int MaxConcurrentSendCount => Volatile.Read(ref _maxConcurrentSendCount);
+        public int SendAttemptCount => Volatile.Read(ref _sendAttemptCount);
+        public int SentAudioCount
+        {
+            get
+            {
+                lock (_sentAudio) return _sentAudio.Count;
+            }
+        }
+
+        public event Action<StreamingTranscriptEvent>? TranscriptReceived;
+
+        public async Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
+        {
+            var inFlight = Interlocked.Increment(ref _inFlightSendCount);
+            TrackMaxConcurrentSendCount(inFlight);
+            if (inFlight > 1)
+                _concurrentSendObserved.TrySetResult();
+
+            var attempt = Interlocked.Increment(ref _sendAttemptCount);
+
+            try
+            {
+                if (attempt == 1)
+                {
+                    _firstSendEntered.TrySetResult();
+                    await _releaseFirstSend.Task.WaitAsync(ct);
+                }
+
+                lock (_sentAudio)
+                {
+                    _sentAudio.Add(pcm16Audio.ToArray());
+                }
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _inFlightSendCount);
+            }
+        }
+
+        public void ReleaseFirstSend() => _releaseFirstSend.TrySetResult();
+        public Task FinalizeAsync(CancellationToken ct) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void RaiseTranscript(StreamingTranscriptEvent evt) => TranscriptReceived?.Invoke(evt);
+
+        private void TrackMaxConcurrentSendCount(int count)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref _maxConcurrentSendCount);
+                if (count <= current)
+                    return;
+
+                if (Interlocked.CompareExchange(ref _maxConcurrentSendCount, count, current) == current)
+                    return;
+            }
+        }
+    }
+
+    private sealed class FailingStreamingSession : IStreamingSession
+    {
+        private int _sendAttemptCount;
+
+        public int SendAttemptCount => Volatile.Read(ref _sendAttemptCount);
+        public event Action<StreamingTranscriptEvent>? TranscriptReceived;
+
+        public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _sendAttemptCount);
+            throw new InvalidOperationException("Simulated streaming send failure.");
         }
 
         public Task FinalizeAsync(CancellationToken ct) => Task.CompletedTask;


### PR DESCRIPTION
## Summary
- Disable live batch polling by default for online ASR providers that do not support real-time streaming.
- Keep local live previews and true streaming providers active, with an opt-in setting for online batch live preview.
- Buffer early audio while streaming WebSocket sessions connect so providers such as Smallest AI do not miss the beginning of dictation.

## Root Cause
Online ASR providers without real-time streaming were still using repeated batch transcription during recording, which could contend with final transcription. Separately, true streaming sessions subscribed to audio only after the WebSocket connected, so early audio chunks could be dropped during connection setup.

## Test Plan
- `dotnet test -p:EnableWindowsTargeting=true`

Fixes #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Online batch live preview" toggle in Appearance to opt into repeated online transcription calls for non‑streaming providers; row enabled only when live transcription is on.
  * Improved live-transcription startup to select appropriate mode and ensure captured audio is buffered and flushed when streaming becomes available.

* **Tests**
  * Added tests for the new setting, localization keys, streaming buffering/cleanup, and startup-policy behavior.

* **Documentation**
  * Added translations for the new UI text (en, de, ja, ru).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->