### PR TITLE
Fix Windows-key hotkey focus handling

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -70,6 +70,8 @@ public sealed class KeyboardHook : IDisposable
             var result = _stateMachine.ProcessKeyEvent(vkCode, isKeyDown, isKeyUp);
             if (IsEnabled)
             {
+                if (result.SyntheticKeyDownVk != 0)
+                    SendSyntheticKeyDown((ushort)result.SyntheticKeyDownVk);
                 if (result.SyntheticKeyTapVk != 0)
                     SendSyntheticKeyTap((ushort)result.SyntheticKeyTapVk);
                 if (result.SyntheticKeyUpVk != 0)
@@ -124,6 +126,24 @@ public sealed class KeyboardHook : IDisposable
         NativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<NativeMethods.INPUT>());
     }
 
+    private static void SendSyntheticKeyDown(ushort vk)
+    {
+        var input = new NativeMethods.INPUT
+        {
+            type = NativeMethods.INPUT_KEYBOARD,
+            u = new NativeMethods.INPUTUNION
+            {
+                ki = new NativeMethods.KEYBDINPUT
+                {
+                    wVk = vk,
+                    dwExtraInfo = NativeMethods.SelfInjectedInputMarker
+                }
+            }
+        };
+
+        NativeMethods.SendInput(1, [input], Marshal.SizeOf<NativeMethods.INPUT>());
+    }
+
     private static void SendSyntheticKeyUp(ushort vk)
     {
         var input = new NativeMethods.INPUT
@@ -158,6 +178,7 @@ internal readonly record struct HotkeyProcessResult(
     bool RaiseKeyDown,
     bool RaiseKeyUp,
     bool Swallow,
+    uint SyntheticKeyDownVk = 0,
     uint SyntheticKeyTapVk = 0,
     uint SyntheticKeyUpVk = 0);
 
@@ -167,9 +188,11 @@ internal sealed class HotkeyMatchStateMachine
     private readonly HashSet<uint> _pendingSuppressedKeyUps = [];
     private readonly HashSet<uint> _suppressedKeyDowns = [];
 
+    private uint _pendingSuppressedWinKey;
     private uint _targetModifiers;
     private uint _targetVk;
     private bool _isPressed;
+    private bool _winPassThroughActive;
 
     public bool HasHotkey => _targetVk != 0 || _targetModifiers != 0;
 
@@ -195,6 +218,9 @@ internal sealed class HotkeyMatchStateMachine
         var swallow = false;
         var raiseKeyDown = false;
         var raiseKeyUp = false;
+        uint syntheticKeyDownVk = 0;
+        uint syntheticKeyTapVk = 0;
+        uint syntheticKeyUpVk = 0;
 
         if (isKeyUp && _pendingSuppressedKeyUps.Remove(vkCode))
             swallow = true;
@@ -202,6 +228,13 @@ internal sealed class HotkeyMatchStateMachine
         if (isKeyDown)
         {
             var firstPress = _pressedKeys.Add(vkCode);
+
+            if (!_isPressed && firstPress && ShouldPreSuppressWinKeyDown(vkCode))
+            {
+                swallow = true;
+                _pendingSuppressedWinKey = vkCode;
+                _suppressedKeyDowns.Add(vkCode);
+            }
 
             if (!_isPressed)
             {
@@ -211,6 +244,7 @@ internal sealed class HotkeyMatchStateMachine
                     raiseKeyDown = true;
                     swallow = true;
                     _suppressedKeyDowns.Add(vkCode);
+                    _pendingSuppressedWinKey = 0;
                     CaptureWinKeyUpsForSuppression();
 
                     if ((_targetModifiers & NativeMethods.MOD_WIN) != 0
@@ -219,10 +253,22 @@ internal sealed class HotkeyMatchStateMachine
                     {
                         _pendingSuppressedKeyUps.Add(unsuppressedWinKey);
                         _suppressedKeyDowns.Add(unsuppressedWinKey);
+                        syntheticKeyUpVk = unsuppressedWinKey;
                     }
                 }
+                else if (!firstPress && _suppressedKeyDowns.Contains(vkCode))
+                {
+                    swallow = true;
+                }
+                else if (firstPress && ShouldReleasePendingSuppressedWinKey(vkCode, out var suppressedWinKey))
+                {
+                    syntheticKeyDownVk = suppressedWinKey;
+                    _suppressedKeyDowns.Remove(suppressedWinKey);
+                    _pendingSuppressedWinKey = 0;
+                    _winPassThroughActive = true;
+                }
             }
-            else if (!firstPress && ShouldSuppressWhilePressed(vkCode))
+            else if (!firstPress && (ShouldSuppressWhilePressed(vkCode) || _suppressedKeyDowns.Contains(vkCode)))
             {
                 swallow = true;
             }
@@ -232,6 +278,14 @@ internal sealed class HotkeyMatchStateMachine
         }
         else if (isKeyUp)
         {
+            if (!_isPressed && _pendingSuppressedWinKey == vkCode)
+            {
+                _pendingSuppressedWinKey = 0;
+                _pressedKeys.Remove(vkCode);
+                _suppressedKeyDowns.Remove(vkCode);
+                return new HotkeyProcessResult(raiseKeyDown, raiseKeyUp, true, SyntheticKeyTapVk: vkCode);
+            }
+
             if (_isPressed && ShouldRelease(vkCode))
             {
                 _isPressed = false;
@@ -243,9 +297,19 @@ internal sealed class HotkeyMatchStateMachine
 
             _pressedKeys.Remove(vkCode);
             _suppressedKeyDowns.Remove(vkCode);
+            if (_pendingSuppressedWinKey == vkCode)
+                _pendingSuppressedWinKey = 0;
+            if (HotkeyKeyClassifier.IsWinKey(vkCode))
+                _winPassThroughActive = false;
         }
 
-        return new HotkeyProcessResult(raiseKeyDown, raiseKeyUp, swallow);
+        return new HotkeyProcessResult(
+            raiseKeyDown,
+            raiseKeyUp,
+            swallow,
+            SyntheticKeyDownVk: syntheticKeyDownVk,
+            SyntheticKeyTapVk: syntheticKeyTapVk,
+            SyntheticKeyUpVk: syntheticKeyUpVk);
     }
 
     private void ResetRuntimeState()
@@ -253,11 +317,16 @@ internal sealed class HotkeyMatchStateMachine
         _pressedKeys.Clear();
         _pendingSuppressedKeyUps.Clear();
         _suppressedKeyDowns.Clear();
+        _pendingSuppressedWinKey = 0;
         _isPressed = false;
+        _winPassThroughActive = false;
     }
 
     private bool ShouldActivate(uint vkCode)
     {
+        if (_winPassThroughActive && (_targetModifiers & NativeMethods.MOD_WIN) != 0)
+            return false;
+
         if (_targetVk != 0)
             return vkCode == _targetVk && AreRequiredModifiersPressed();
 
@@ -325,6 +394,26 @@ internal sealed class HotkeyMatchStateMachine
     private bool ShouldSuppressWhilePressed(uint vkCode) =>
         vkCode == _targetVk
         || ((_targetModifiers & NativeMethods.MOD_WIN) != 0 && HotkeyKeyClassifier.IsWinKey(vkCode));
+
+    private bool ShouldPreSuppressWinKeyDown(uint vkCode)
+    {
+        if (!HotkeyKeyClassifier.IsWinKey(vkCode))
+            return false;
+
+        if ((_targetModifiers & NativeMethods.MOD_WIN) == 0)
+            return false;
+
+        return _targetVk != 0 || (_targetModifiers & ~NativeMethods.MOD_WIN) != 0;
+    }
+
+    private bool ShouldReleasePendingSuppressedWinKey(uint vkCode, out uint suppressedWinKey)
+    {
+        suppressedWinKey = _pendingSuppressedWinKey;
+        if (suppressedWinKey == 0 || vkCode == suppressedWinKey)
+            return false;
+
+        return !IsRequiredModifier(vkCode);
+    }
 
     private void CaptureWinKeyUpsForSuppression()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -70,7 +70,7 @@ public class HotkeyInputTests
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_ALT);
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.Equal(default, winDown);
+        Assert.True(winDown.Swallow);
 
         var altDown = sut.ProcessKeyEvent(NativeMethods.VK_LMENU, isKeyDown: true, isKeyUp: false);
         Assert.True(altDown.RaiseKeyDown);
@@ -126,12 +126,12 @@ public class HotkeyInputTests
     }
 
     [Fact]
-    public void ModifierOnly_CtrlWin_WhenWinIsPressedFirst_RequestsSyntheticWinRelease()
+    public void ModifierOnly_CtrlWin_WhenWinIsPressedFirst_SuppressesInitialWinKey()
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.Equal(default, winDown);
+        Assert.True(winDown.Swallow);
 
         var ctrlDown = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
         Assert.True(ctrlDown.RaiseKeyDown);
@@ -144,15 +144,39 @@ public class HotkeyInputTests
     }
 
     [Fact]
-    public void ModifierOnly_CtrlWin_WhenWinIsPressedAlone_AllowsStandaloneWinTap()
+    public void ModifierOnly_CtrlWin_WhenCtrlIsPressedFirst_SuppressesWinActivationKey()
+    {
+        var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
+
+        var ctrlDown = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
+        Assert.Equal(default, ctrlDown);
+
+        var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
+        Assert.True(winDown.RaiseKeyDown);
+        Assert.True(winDown.Swallow);
+        Assert.Equal(0u, winDown.SyntheticKeyUpVk);
+
+        var ctrlUp = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: false, isKeyUp: true);
+        Assert.True(ctrlUp.RaiseKeyUp);
+        Assert.False(ctrlUp.Swallow);
+
+        var winUp = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true);
+        Assert.True(winUp.Swallow);
+        Assert.False(winUp.RaiseKeyUp);
+    }
+
+    [Fact]
+    public void ModifierOnly_CtrlWin_WhenWinIsPressedAlone_ReplaysStandaloneWinTap()
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.Equal(default, winDown);
+        Assert.True(winDown.Swallow);
 
         var winUp = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true);
-        Assert.Equal(default, winUp);
+        Assert.True(winUp.Swallow);
+        Assert.Equal((uint)NativeMethods.VK_LWIN, winUp.SyntheticKeyTapVk);
+        Assert.False(winUp.RaiseKeyUp);
     }
 
     [Fact]
@@ -161,12 +185,13 @@ public class HotkeyInputTests
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL, (uint)'X');
 
         var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
-        Assert.Equal(default, winDown);
+        Assert.True(winDown.Swallow);
         _ = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
 
         var xDown = sut.ProcessKeyEvent((uint)'X', isKeyDown: true, isKeyUp: false);
         Assert.True(xDown.RaiseKeyDown);
         Assert.True(xDown.Swallow);
+        Assert.Equal(0u, xDown.SyntheticKeyUpVk);
 
         var xUp = sut.ProcessKeyEvent((uint)'X', isKeyDown: false, isKeyUp: true);
         Assert.True(xUp.RaiseKeyUp);
@@ -184,8 +209,13 @@ public class HotkeyInputTests
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
 
-        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false));
-        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false));
+        var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
+        Assert.True(winDown.Swallow);
+
+        var shiftDown = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false);
+        Assert.False(shiftDown.Swallow);
+        Assert.Equal((uint)NativeMethods.VK_LWIN, shiftDown.SyntheticKeyDownVk);
+
         Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: true, isKeyUp: false));
         Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: false, isKeyUp: true));
         Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true));
@@ -197,10 +227,34 @@ public class HotkeyInputTests
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN, (uint)'X');
 
-        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false));
-        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false));
+        var winDown = sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false);
+        Assert.True(winDown.Swallow);
+
+        var shiftDown = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false);
+        Assert.False(shiftDown.Swallow);
+        Assert.Equal((uint)NativeMethods.VK_LWIN, shiftDown.SyntheticKeyDownVk);
+
         Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: true, isKeyUp: false));
         Assert.Equal(default, sut.ProcessKeyEvent((uint)'S', isKeyDown: false, isKeyUp: true));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true));
+        Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true));
+    }
+
+    [Fact]
+    public void KeyedHotkey_WinX_DoesNotActivateAfterWinChordWasPassedThrough()
+    {
+        var sut = CreateStateMachine(NativeMethods.MOD_WIN, (uint)'X');
+
+        Assert.True(sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: true, isKeyUp: false).Swallow);
+
+        var shiftDown = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false);
+        Assert.False(shiftDown.Swallow);
+        Assert.Equal((uint)NativeMethods.VK_LWIN, shiftDown.SyntheticKeyDownVk);
+
+        var xDown = sut.ProcessKeyEvent((uint)'X', isKeyDown: true, isKeyUp: false);
+        Assert.Equal(default, xDown);
+
+        Assert.Equal(default, sut.ProcessKeyEvent((uint)'X', isKeyDown: false, isKeyUp: true));
         Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true));
         Assert.Equal(default, sut.ProcessKeyEvent(NativeMethods.VK_LWIN, isKeyDown: false, isKeyUp: true));
     }


### PR DESCRIPTION
## Summary
- Prevent Windows-key based TypeWhisper hotkeys from handing focus to Start/Search before dictation begins.
- Defer the initial Windows key press, replay it only for non-TypeWhisper Windows shortcuts, and keep standalone Windows key taps working.
- Add regression coverage for Windows-key modifier chords, keyed hotkeys, and pass-through Windows shortcuts.

## Root Cause
When the Windows key was pressed first, the hook allowed the physical keydown through until the full TypeWhisper hotkey was recognized. Windows could then activate Start/SearchHost before dictation captured the target app, so auto-paste later targeted the wrong window or fell back.

## Test Plan
- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -p:EnableWindowsTargeting=true

Manual verification: configured a Windows-key hotkey, pressed Windows first, then the second modifier; dictation no longer focused SearchHost and paste returned to the intended app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard hotkey processing with enhanced handling of Windows key behavior in modifier combinations.

* **Tests**
  * Updated and expanded test coverage for multi-key hotkey scenarios, including additional keystroke order combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->