### PR TITLE
Fix Live Transcript no-speech cleanup

### DIFF
--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -33,6 +33,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     // whose RecordingId differs so stale Task.Run callbacks can never mutate state
     // that belongs to a newer recording.
     private Guid? _activeRecordingId;
+    private Guid? _pendingTerminalRecordingId;
     private bool _activeRecordingEnded;
 
     public string PluginId => "com.typewhisper.live-transcript";
@@ -155,6 +156,8 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
         if (_activeRecordingEnded) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
+        _pendingTerminalRecordingId = evt.RecordingId;
+
         // Keep window visible — it will be hidden after TranscriptionCompleted/Failed or timeout
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
@@ -190,6 +193,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     private Task OnTranscriptionCompleted(TranscriptionCompletedEvent evt)
     {
         MarkTerminalRecording(evt.RecordingId);
+        ClearPendingTerminalRecording(evt.RecordingId);
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
         _activeRecordingEnded = true;
 
@@ -231,17 +235,26 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnTranscriptionFailed(TranscriptionFailedEvent evt)
     {
-        var terminalRecordingId = evt.RecordingId ?? _activeRecordingId;
+        var terminalRecordingId = evt.RecordingId ?? _pendingTerminalRecordingId;
         MarkTerminalRecording(terminalRecordingId);
-        if (evt.RecordingId is not null && evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
+        ClearPendingTerminalRecording(terminalRecordingId);
+
+        var appliesToActiveRecording = terminalRecordingId == _activeRecordingId
+            || (terminalRecordingId is null && _activeRecordingId is null);
+        if (!appliesToActiveRecording) return Task.CompletedTask;
+
         _activeRecordingEnded = true;
 
         CancelAutoHide();
 
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
-            if (evt.RecordingId is not null && evt.RecordingId != _activeRecordingId) return;
-            if (evt.RecordingId is null && terminalRecordingId is not null && terminalRecordingId != _activeRecordingId) return;
+            if (terminalRecordingId != _activeRecordingId
+                && !(terminalRecordingId is null && _activeRecordingId is null))
+            {
+                return;
+            }
+
             _window?.Hide();
         });
         return Task.CompletedTask;
@@ -267,6 +280,12 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _autoHideCts?.Cancel();
         _autoHideCts?.Dispose();
         _autoHideCts = null;
+    }
+
+    private void ClearPendingTerminalRecording(Guid? recordingId)
+    {
+        if (recordingId == _pendingTerminalRecordingId)
+            _pendingTerminalRecordingId = null;
     }
 
     private void MarkTerminalRecording(Guid? recordingId)

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -33,6 +33,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     // whose RecordingId differs so stale Task.Run callbacks can never mutate state
     // that belongs to a newer recording.
     private Guid? _activeRecordingId;
+    private bool _activeRecordingEnded;
 
     public string PluginId => "com.typewhisper.live-transcript";
     public string PluginName => "Live Transcript";
@@ -131,15 +132,15 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     {
         if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
 
-        _autoHideCts?.Cancel();
-        _autoHideCts?.Dispose();
-        _autoHideCts = null;
+        CancelAutoHide();
+        _activeRecordingEnded = false;
         _activeRecordingId = evt.RecordingId;
 
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
             if (IsTerminalRecording(evt.RecordingId)) return;
             if (_activeRecordingId != evt.RecordingId) return;
+            if (_activeRecordingEnded) return;
             EnsureWindow();
             _window!.SetSavedPosition(WindowLeft, WindowTop);
             _window!.UpdateText("Listening...");
@@ -152,11 +153,13 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     private Task OnRecordingStopped(RecordingStoppedEvent evt)
     {
         if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
+        if (_activeRecordingEnded) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
         // Keep window visible — it will be hidden after TranscriptionCompleted/Failed or timeout
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
             if (IsTerminalRecording(evt.RecordingId)) return;
+            if (_activeRecordingEnded) return;
             if (evt.RecordingId != _activeRecordingId) return;
             if (_window is { IsVisible: true })
                 _window.UpdateText(_window.CurrentText + "\nProcessing...");
@@ -168,10 +171,12 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     private Task OnPartialTranscriptionUpdate(PartialTranscriptionUpdateEvent evt)
     {
         if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
+        if (_activeRecordingEnded) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
             if (IsTerminalRecording(evt.RecordingId)) return;
+            if (_activeRecordingEnded) return;
             if (evt.RecordingId != _activeRecordingId) return;
             EnsureWindow();
             _window!.UpdateText(evt.PartialText);
@@ -186,10 +191,9 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     {
         MarkTerminalRecording(evt.RecordingId);
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
+        _activeRecordingEnded = true;
 
-        _autoHideCts?.Cancel();
-        _autoHideCts?.Dispose();
-        _autoHideCts = null;
+        CancelAutoHide();
 
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
@@ -227,16 +231,17 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private Task OnTranscriptionFailed(TranscriptionFailedEvent evt)
     {
-        MarkTerminalRecording(evt.RecordingId);
-        if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
+        var terminalRecordingId = evt.RecordingId ?? _activeRecordingId;
+        MarkTerminalRecording(terminalRecordingId);
+        if (evt.RecordingId is not null && evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
+        _activeRecordingEnded = true;
 
-        _autoHideCts?.Cancel();
-        _autoHideCts?.Dispose();
-        _autoHideCts = null;
+        CancelAutoHide();
 
         Application.Current?.Dispatcher.InvokeAsync(() =>
         {
-            if (evt.RecordingId != _activeRecordingId) return;
+            if (evt.RecordingId is not null && evt.RecordingId != _activeRecordingId) return;
+            if (evt.RecordingId is null && terminalRecordingId is not null && terminalRecordingId != _activeRecordingId) return;
             _window?.Hide();
         });
         return Task.CompletedTask;
@@ -256,6 +261,13 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
     private static int NormalizeAutoHideMilliseconds(int milliseconds) =>
         Math.Clamp(milliseconds, MinAutoHideMilliseconds, MaxAutoHideMilliseconds);
+
+    private void CancelAutoHide()
+    {
+        _autoHideCts?.Cancel();
+        _autoHideCts?.Dispose();
+        _autoHideCts = null;
+    }
 
     private void MarkTerminalRecording(Guid? recordingId)
     {

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
@@ -409,7 +409,43 @@ public sealed class LiveTranscriptPluginTests
                 Assert.True(window.IsVisible);
                 Assert.Equal("Listening...", window.CurrentText);
 
+                eventBus.Publish(new RecordingStoppedEvent { RecordingId = recordingIdWithoutFailureId });
                 eventBus.Publish(new TranscriptionFailedEvent { ErrorMessage = "No speech detected" });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+
+                var delayedNoIdFailureRecordingId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = delayedNoIdFailureRecordingId });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new RecordingStoppedEvent { RecordingId = delayedNoIdFailureRecordingId });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...\nProcessing...", window.CurrentText);
+
+                var newRecordingId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = newRecordingId });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new TranscriptionFailedEvent { ErrorMessage = "No speech detected" });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new TranscriptionFailedEvent
+                {
+                    RecordingId = newRecordingId,
+                    ErrorMessage = "No speech detected"
+                });
                 PumpDispatcher();
 
                 Assert.False(window.IsVisible);

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
@@ -402,6 +402,60 @@ public sealed class LiveTranscriptPluginTests
 
                 Assert.False(window.IsVisible);
 
+                var recordingIdWithoutFailureId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = recordingIdWithoutFailureId });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new TranscriptionFailedEvent { ErrorMessage = "No speech detected" });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+
+                var queuedStopRecordingId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = queuedStopRecordingId });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new RecordingStoppedEvent { RecordingId = queuedStopRecordingId });
+                eventBus.Publish(new TranscriptionFailedEvent { ErrorMessage = "No speech detected" });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+                Assert.NotEqual("Listening...\nProcessing...", window.CurrentText);
+
+                eventBus.Publish(new PartialTranscriptionUpdateEvent
+                {
+                    RecordingId = queuedStopRecordingId,
+                    PartialText = "stale partial"
+                });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+                Assert.NotEqual("stale partial", window.CurrentText);
+
+                var queuedStopWithFailureId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = queuedStopWithFailureId });
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible);
+                Assert.Equal("Listening...", window.CurrentText);
+
+                eventBus.Publish(new RecordingStoppedEvent { RecordingId = queuedStopWithFailureId });
+                eventBus.Publish(new TranscriptionFailedEvent
+                {
+                    RecordingId = queuedStopWithFailureId,
+                    ErrorMessage = "No speech detected"
+                });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+                Assert.NotEqual("Listening...\nProcessing...", window.CurrentText);
+
                 host.SetSetting("windowLeft", 100000d);
                 host.SetSetting("windowTop", 100000d);
                 eventBus.Publish(new RecordingStartedEvent());


### PR DESCRIPTION
## Summary
- Treat Live Transcript transcription failures without a recording id as terminal for the active recording.
- Prevent queued stop and partial-update callbacks from restoring stale `Listening...` / `Processing...` text after no speech is detected.
- Add regression coverage for no-speech cleanup and stale callback ordering.

## Root cause
The production plugin event bus dispatches handlers asynchronously, while the existing Live Transcript tests primarily exercised synchronous event delivery. A no-speech failure without a recording id could be ignored by the active Live Transcript window, leaving the processing preview visible.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- Manual check: installed the rebuilt Live Transcript plugin into `%LocalAppData%\TypeWhisper\Plugins`, launched the Release build, started/stopped dictation without speaking, and confirmed the Live Transcript window disappeared instead of leaving `Listening...` / `Processing...` visible.

Fixes #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live transcript window now maintains correct state across recording start/stop cycles.
  * Improved handling of transcription failures so the window hides only for the relevant recording and avoids incorrect re-shows.
  * Prevents stale partial transcripts from appearing after a recording ends and improves auto-hide reliability during active recordings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->