### PR TITLE
Fix live transcript appearance settings

### DIFF
--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -1,5 +1,7 @@
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 
@@ -38,14 +40,21 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     public string PluginName => "Live Transcript";
     public string PluginVersion => "1.0.1";
 
-    public int FontSize
+    public bool UsesHostAppearance => _host is ILivePreviewAppearanceProvider;
+
+    public double FontSize
     {
-        get => _host?.GetSetting<int?>(FontSizeSettingName) ?? 16;
+        get => (_host as ILivePreviewAppearanceProvider)?.LiveTranscriptionFontSize
+            ?? _host?.GetSetting<double?>(FontSizeSettingName)
+            ?? 16d;
         set
         {
+            if (UsesHostAppearance)
+                return;
+
             _host?.SetSetting(FontSizeSettingName, value);
             if (_window is not null)
-                Application.Current?.Dispatcher.InvokeAsync(() => _window.SetFontSize(value));
+                DispatchToUi(() => _window.SetFontSize(FontSize));
         }
     }
 
@@ -56,15 +65,22 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         {
             _host?.SetSetting(OpacitySettingName, value);
             if (_window is not null)
-                Application.Current?.Dispatcher.InvokeAsync(() => _window.SetWindowOpacity(value));
+                DispatchToUi(() => _window.SetWindowOpacity(value));
         }
     }
 
     public int AutoHideMilliseconds
     {
-        get => NormalizeAutoHideMilliseconds(
-            _host?.GetSetting<int?>(AutoHideMillisecondsSettingName) ?? DefaultAutoHideMilliseconds);
-        set => _host?.SetSetting(AutoHideMillisecondsSettingName, NormalizeAutoHideMilliseconds(value));
+        get => (_host as ILivePreviewAppearanceProvider)?.PreviewBubbleAutoHideMilliseconds
+            ?? NormalizeAutoHideMilliseconds(
+                _host?.GetSetting<int?>(AutoHideMillisecondsSettingName) ?? DefaultAutoHideMilliseconds);
+        set
+        {
+            if (UsesHostAppearance)
+                return;
+
+            _host?.SetSetting(AutoHideMillisecondsSettingName, NormalizeAutoHideMilliseconds(value));
+        }
     }
 
     private double? WindowLeft => _host?.GetSetting<double?>(WindowLeftSettingName);
@@ -85,7 +101,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _host?.SetSetting<double?>(WindowTopSettingName, null);
 
         if (_window is not null)
-            Application.Current?.Dispatcher.InvokeAsync(_window.ResetToDefaultPosition);
+            DispatchToUi(_window.ResetToDefaultPosition);
     }
 
     public Task ActivateAsync(IPluginHostServices host)
@@ -97,6 +113,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _subscriptions.Add(host.EventBus.Subscribe<PartialTranscriptionUpdateEvent>(OnPartialTranscriptionUpdate));
         _subscriptions.Add(host.EventBus.Subscribe<TranscriptionCompletedEvent>(OnTranscriptionCompleted));
         _subscriptions.Add(host.EventBus.Subscribe<TranscriptionFailedEvent>(OnTranscriptionFailed));
+        _subscriptions.Add(host.EventBus.Subscribe<TextInsertedEvent>(OnTextInserted));
 
         host.Log(PluginLogLevel.Info, "Live Transcript plugin activated");
         return Task.CompletedTask;
@@ -114,7 +131,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
         if (_window is not null)
         {
-            Application.Current?.Dispatcher.InvokeAsync(() =>
+            DispatchToUi(() =>
             {
                 _window.Close();
                 _window = null;
@@ -136,7 +153,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _autoHideCts = null;
         _activeRecordingId = evt.RecordingId;
 
-        Application.Current?.Dispatcher.InvokeAsync(() =>
+        DispatchToUi(() =>
         {
             if (IsTerminalRecording(evt.RecordingId)) return;
             if (_activeRecordingId != evt.RecordingId) return;
@@ -153,8 +170,8 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     {
         if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
-        // Keep window visible — it will be hidden after TranscriptionCompleted/Failed or timeout
-        Application.Current?.Dispatcher.InvokeAsync(() =>
+        // Keep window visible while final processing and text insertion complete.
+        DispatchToUi(() =>
         {
             if (IsTerminalRecording(evt.RecordingId)) return;
             if (evt.RecordingId != _activeRecordingId) return;
@@ -169,7 +186,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     {
         if (IsTerminalRecording(evt.RecordingId)) return Task.CompletedTask;
         if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
-        Application.Current?.Dispatcher.InvokeAsync(() =>
+        DispatchToUi(() =>
         {
             if (IsTerminalRecording(evt.RecordingId)) return;
             if (evt.RecordingId != _activeRecordingId) return;
@@ -191,7 +208,25 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _autoHideCts?.Dispose();
         _autoHideCts = null;
 
-        Application.Current?.Dispatcher.InvokeAsync(() =>
+        DispatchToUi(() =>
+        {
+            if (evt.RecordingId != _activeRecordingId) return;
+            if (_window is not null)
+                _window.UpdateText(evt.Text);
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnTextInserted(TextInsertedEvent evt)
+    {
+        if (evt.RecordingId != _activeRecordingId) return Task.CompletedTask;
+
+        _autoHideCts?.Cancel();
+        _autoHideCts?.Dispose();
+        _autoHideCts = null;
+
+        DispatchToUi(() =>
         {
             if (evt.RecordingId != _activeRecordingId) return;
             if (_window is not null)
@@ -200,7 +235,18 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
 
         var autoHideMilliseconds = AutoHideMilliseconds;
         if (autoHideMilliseconds <= 0)
+        {
+            if (UsesHostAppearance)
+            {
+                DispatchToUi(() =>
+                {
+                    if (evt.RecordingId == _activeRecordingId)
+                        _window?.Hide();
+                });
+            }
+
             return Task.CompletedTask;
+        }
 
         _autoHideCts = new CancellationTokenSource();
         var token = _autoHideCts.Token;
@@ -210,7 +256,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
             try
             {
                 await Task.Delay(autoHideMilliseconds, token);
-                Application.Current?.Dispatcher.InvokeAsync(() =>
+                DispatchToUi(() =>
                 {
                     if (evt.RecordingId == _activeRecordingId)
                         _window?.Hide();
@@ -234,7 +280,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         _autoHideCts?.Dispose();
         _autoHideCts = null;
 
-        Application.Current?.Dispatcher.InvokeAsync(() =>
+        DispatchToUi(() =>
         {
             if (evt.RecordingId != _activeRecordingId) return;
             _window?.Hide();
@@ -248,14 +294,46 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
         {
             _window = new LiveTranscriptWindow();
             _window.PositionChanged += SaveWindowPosition;
-            _window.SetFontSize(FontSize);
-            _window.SetWindowOpacity(Opacity);
-            _window.SetSavedPosition(WindowLeft, WindowTop);
         }
+
+        _window.SetFontSize(FontSize);
+        _window.SetWindowOpacity(Opacity);
+        _window.SetSavedPosition(WindowLeft, WindowTop);
     }
 
     private static int NormalizeAutoHideMilliseconds(int milliseconds) =>
         Math.Clamp(milliseconds, MinAutoHideMilliseconds, MaxAutoHideMilliseconds);
+
+    private void DispatchToUi(Action action)
+    {
+        var dispatcher = ResolveDispatcher();
+        if (dispatcher is null)
+            return;
+
+        if (dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        dispatcher.InvokeAsync(action);
+    }
+
+    private Dispatcher? ResolveDispatcher()
+    {
+        if (_window?.Dispatcher is { } windowDispatcher && IsUsable(windowDispatcher))
+            return windowDispatcher;
+
+        if (Application.Current?.Dispatcher is { } appDispatcher && IsUsable(appDispatcher))
+            return appDispatcher;
+
+        return Thread.CurrentThread.GetApartmentState() == ApartmentState.STA
+            ? Dispatcher.CurrentDispatcher
+            : null;
+    }
+
+    private static bool IsUsable(Dispatcher dispatcher) =>
+        !dispatcher.HasShutdownStarted && !dispatcher.HasShutdownFinished;
 
     private void MarkTerminalRecording(Guid? recordingId)
     {
@@ -295,9 +373,9 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
             sub.Dispose();
         _subscriptions.Clear();
 
-        if (_window is not null && Application.Current is not null)
+        if (_window is not null)
         {
-            Application.Current.Dispatcher.InvokeAsync(() =>
+            DispatchToUi(() =>
             {
                 _window?.Close();
                 _window = null;

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml
@@ -3,25 +3,26 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Padding="8">
     <StackPanel>
-        <!-- Font Size -->
-        <TextBlock Text="Font Size"
-                   FontWeight="SemiBold"
-                   Margin="0,0,0,4" />
-        <DockPanel Margin="0,0,0,12">
-            <TextBlock DockPanel.Dock="Right"
-                       Width="30"
-                       TextAlignment="Right"
-                       VerticalAlignment="Center"
-                       x:Name="FontSizeLabel"
-                       Text="16" />
-            <Slider x:Name="FontSizeSlider"
-                    Minimum="12"
-                    Maximum="32"
-                    IsSnapToTickEnabled="True"
-                    TickFrequency="1"
-                    Value="16"
-                    ValueChanged="FontSizeSlider_ValueChanged" />
-        </DockPanel>
+        <StackPanel x:Name="FontSizePanel">
+            <TextBlock Text="Font Size"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4" />
+            <DockPanel Margin="0,0,0,12">
+                <TextBlock DockPanel.Dock="Right"
+                           Width="30"
+                           TextAlignment="Right"
+                           VerticalAlignment="Center"
+                           x:Name="FontSizeLabel"
+                           Text="16" />
+                <Slider x:Name="FontSizeSlider"
+                        Minimum="12"
+                        Maximum="32"
+                        IsSnapToTickEnabled="True"
+                        TickFrequency="1"
+                        Value="16"
+                        ValueChanged="FontSizeSlider_ValueChanged" />
+            </DockPanel>
+        </StackPanel>
 
         <!-- Opacity -->
         <TextBlock Text="Window Opacity"
@@ -43,25 +44,26 @@
                     ValueChanged="OpacitySlider_ValueChanged" />
         </DockPanel>
 
-        <!-- Auto-hide -->
-        <TextBlock Text="Auto-hide Delay"
-                   FontWeight="SemiBold"
-                   Margin="0,0,0,4" />
-        <DockPanel Margin="0,0,0,12">
-            <TextBlock DockPanel.Dock="Right"
-                       Width="52"
-                       TextAlignment="Right"
-                       VerticalAlignment="Center"
-                       x:Name="AutoHideLabel"
-                       Text="3.0s" />
-            <Slider x:Name="AutoHideSlider"
-                    Minimum="0"
-                    Maximum="10"
-                    TickFrequency="0.25"
-                    IsSnapToTickEnabled="True"
-                    Value="3"
-                    ValueChanged="AutoHideSlider_ValueChanged" />
-        </DockPanel>
+        <StackPanel x:Name="AutoHidePanel">
+            <TextBlock Text="Auto-hide Delay"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4" />
+            <DockPanel Margin="0,0,0,12">
+                <TextBlock DockPanel.Dock="Right"
+                           Width="52"
+                           TextAlignment="Right"
+                           VerticalAlignment="Center"
+                           x:Name="AutoHideLabel"
+                           Text="3.0s" />
+                <Slider x:Name="AutoHideSlider"
+                        Minimum="0"
+                        Maximum="10"
+                        TickFrequency="0.25"
+                        IsSnapToTickEnabled="True"
+                        Value="3"
+                        ValueChanged="AutoHideSlider_ValueChanged" />
+            </DockPanel>
+        </StackPanel>
 
         <!-- Position -->
         <TextBlock Text="Window Position"

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptSettingsView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace TypeWhisper.Plugin.LiveTranscript;
@@ -16,15 +17,22 @@ public partial class LiveTranscriptSettingsView : UserControl
         _plugin = plugin;
         InitializeComponent();
 
-        // Load current values from plugin settings
-        FontSizeSlider.Value = plugin.FontSize;
-        FontSizeLabel.Text = plugin.FontSize.ToString();
+        if (plugin.UsesHostAppearance)
+        {
+            FontSizePanel.Visibility = Visibility.Collapsed;
+            AutoHidePanel.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            FontSizeSlider.Value = plugin.FontSize;
+            FontSizeLabel.Text = plugin.FontSize.ToString("0.#");
+
+            AutoHideSlider.Value = plugin.AutoHideMilliseconds / 1000d;
+            UpdateAutoHideLabel(AutoHideSlider.Value);
+        }
 
         OpacitySlider.Value = plugin.Opacity;
         OpacityLabel.Text = $"{(int)(plugin.Opacity * 100)}%";
-
-        AutoHideSlider.Value = plugin.AutoHideMilliseconds / 1000d;
-        UpdateAutoHideLabel(AutoHideSlider.Value);
 
         _initialized = true;
     }
@@ -33,8 +41,8 @@ public partial class LiveTranscriptSettingsView : UserControl
     {
         if (!_initialized) return;
 
-        var size = (int)e.NewValue;
-        FontSizeLabel.Text = size.ToString();
+        var size = e.NewValue;
+        FontSizeLabel.Text = size.ToString("0.#");
         _plugin.FontSize = size;
     }
 

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptWindow.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptWindow.xaml.cs
@@ -31,7 +31,7 @@ public partial class LiveTranscriptWindow : Window
     }
 
     /// <summary>Sets the font size of the transcript text.</summary>
-    public void SetFontSize(int size)
+    public void SetFontSize(double size)
     {
         TranscriptText.FontSize = size;
     }

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/Tests/LiveTranscriptPluginTests.cs
@@ -57,7 +57,7 @@ public sealed class LiveTranscriptPluginTests
     public void FontSize_DefaultsTo16_WhenNoSettingStored()
     {
         var sut = CreatePlugin();
-        Assert.Equal(16, sut.FontSize);
+        Assert.Equal(16d, sut.FontSize);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public sealed class LiveTranscriptPluginTests
 
         sut.FontSize = 20;
 
-        Assert.Equal(20, host.GetSetting<int?>("fontSize"));
+        Assert.Equal(20d, host.GetSetting<double?>("fontSize"));
     }
 
     [Fact]
@@ -137,10 +137,36 @@ public sealed class LiveTranscriptPluginTests
     public async Task FontSize_ReadsPersistedValueFromHost()
     {
         var host = new TestPluginHostServices();
-        host.SetSetting("fontSize", 24);
+        host.SetSetting("fontSize", 24d);
         var sut = await ActivatedPlugin(host);
 
-        Assert.Equal(24, sut.FontSize);
+        Assert.Equal(24d, sut.FontSize);
+    }
+
+    [Fact]
+    public async Task FontSize_UsesHostAppearance_WhenAvailable()
+    {
+        var host = new AppearanceTestPluginHostServices
+        {
+            LiveTranscriptionFontSize = 10.5
+        };
+        host.SetSetting("fontSize", 24d);
+        var sut = await ActivatedPlugin(host);
+
+        Assert.Equal(10.5, sut.FontSize);
+    }
+
+    [Fact]
+    public async Task AutoHideMilliseconds_UsesHostAppearance_WhenAvailable()
+    {
+        var host = new AppearanceTestPluginHostServices
+        {
+            PreviewBubbleAutoHideMilliseconds = 0
+        };
+        host.SetSetting("autoHideMilliseconds", 3000);
+        var sut = await ActivatedPlugin(host);
+
+        Assert.Equal(0, sut.AutoHideMilliseconds);
     }
 
     [Fact]
@@ -188,13 +214,13 @@ public sealed class LiveTranscriptPluginTests
     }
 
     [Fact]
-    public async Task ActivateAsync_SubscribesToFiveEvents()
+    public async Task ActivateAsync_SubscribesToSixEvents()
     {
         var host = new TestPluginHostServices();
         var sut = CreatePlugin();
         await sut.ActivateAsync(host);
 
-        Assert.Equal(5, host.Bus.SubscriptionCount);
+        Assert.Equal(6, host.Bus.SubscriptionCount);
     }
 
     [Fact]
@@ -345,8 +371,6 @@ public sealed class LiveTranscriptPluginTests
     {
         RunOnStaThread(() =>
         {
-            var appCreated = Application.Current is null;
-            var app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
             var eventBus = new TestPluginEventBus();
             var host = new WpfTestHostServices(eventBus);
             var workArea = SystemParameters.WorkArea;
@@ -386,7 +410,7 @@ public sealed class LiveTranscriptPluginTests
 
                 var window = GetWindow(plugin);
                 Assert.NotNull(window);
-                Assert.True(window.IsVisible);
+                Assert.True(window.IsVisible, "Window should be visible after a fresh recording starts.");
                 Assert.Equal("Listening...", window.CurrentText);
                 Assert.Equal(expectedLeft, window.Left, precision: 1);
                 Assert.Equal(expectedTop, window.Top, precision: 1);
@@ -394,7 +418,7 @@ public sealed class LiveTranscriptPluginTests
                 eventBus.Publish(new RecordingStoppedEvent());
                 PumpDispatcher();
 
-                Assert.True(window.IsVisible);
+                Assert.True(window.IsVisible, "Window should stay visible while the recording is processing.");
                 Assert.Equal("Listening...\nProcessing...", window.CurrentText);
 
                 eventBus.Publish(new TranscriptionFailedEvent { ErrorMessage = "No speech detected" });
@@ -417,15 +441,163 @@ public sealed class LiveTranscriptPluginTests
                 Thread.Sleep(3300);
                 PumpDispatcher();
 
-                Assert.True(window.IsVisible);
+                Assert.True(window.IsVisible, "Fallback auto-hide setting of 0 should keep the window visible after completion.");
                 Assert.Equal("Finished", window.CurrentText);
             }
             finally
             {
                 plugin.DeactivateAsync().GetAwaiter().GetResult();
                 PumpDispatcher();
-                if (appCreated)
-                    app.Shutdown();
+            }
+        });
+    }
+
+    [Fact]
+    public void TextInsertedEvent_StartsAppearanceAutoHideForMatchingRecording()
+    {
+        RunOnStaThread(() =>
+        {
+            var eventBus = new TestPluginEventBus();
+            var host = new AppearanceWpfTestHostServices(eventBus)
+            {
+                LiveTranscriptionFontSize = 15,
+                PreviewBubbleAutoHideMilliseconds = 25
+            };
+            host.SetSetting("autoHideMilliseconds", 0);
+            var plugin = new LiveTranscriptPlugin();
+
+            try
+            {
+                plugin.ActivateAsync(host).GetAwaiter().GetResult();
+
+                var recordingId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = recordingId });
+                PumpDispatcher();
+
+                var window = GetWindow(plugin);
+                Assert.NotNull(window);
+                Assert.True(window.IsVisible, "Window should be visible after a fresh recording starts.");
+
+                eventBus.Publish(new TranscriptionCompletedEvent
+                {
+                    RecordingId = recordingId,
+                    Text = "Finished"
+                });
+                PumpDispatcher();
+                Thread.Sleep(80);
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible, "Completion alone should not start the Appearance auto-hide timer.");
+                Assert.Equal("Finished", window.CurrentText);
+
+                eventBus.Publish(new TextInsertedEvent
+                {
+                    RecordingId = Guid.NewGuid(),
+                    Text = "Other"
+                });
+                PumpDispatcher();
+                Thread.Sleep(80);
+                PumpDispatcher();
+
+                Assert.True(window.IsVisible, "A TextInsertedEvent for another recording must not hide the active window.");
+
+                eventBus.Publish(new TextInsertedEvent
+                {
+                    RecordingId = recordingId,
+                    Text = "Finished"
+                });
+                PumpDispatcher();
+                Thread.Sleep(80);
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+            }
+            finally
+            {
+                plugin.DeactivateAsync().GetAwaiter().GetResult();
+                PumpDispatcher();
+            }
+        });
+    }
+
+    [Fact]
+    public void TextInsertedEvent_WithZeroAppearanceAutoHide_HidesImmediately()
+    {
+        RunOnStaThread(() =>
+        {
+            var eventBus = new TestPluginEventBus();
+            var host = new AppearanceWpfTestHostServices(eventBus)
+            {
+                LiveTranscriptionFontSize = 15,
+                PreviewBubbleAutoHideMilliseconds = 0
+            };
+            host.SetSetting("autoHideMilliseconds", 3000);
+            var plugin = new LiveTranscriptPlugin();
+
+            try
+            {
+                plugin.ActivateAsync(host).GetAwaiter().GetResult();
+
+                var recordingId = Guid.NewGuid();
+                eventBus.Publish(new RecordingStartedEvent { RecordingId = recordingId });
+                PumpDispatcher();
+
+                var window = GetWindow(plugin);
+                Assert.NotNull(window);
+                Assert.True(window.IsVisible, "Window should be visible after a fresh recording starts.");
+
+                eventBus.Publish(new TranscriptionCompletedEvent
+                {
+                    RecordingId = recordingId,
+                    Text = "Finished"
+                });
+                PumpDispatcher();
+                Assert.True(window.IsVisible, "Completion alone should not hide when global auto-hide is 0.");
+
+                eventBus.Publish(new TextInsertedEvent
+                {
+                    RecordingId = recordingId,
+                    Text = "Finished"
+                });
+                PumpDispatcher();
+
+                Assert.False(window.IsVisible);
+            }
+            finally
+            {
+                plugin.DeactivateAsync().GetAwaiter().GetResult();
+                PumpDispatcher();
+            }
+        });
+    }
+
+    [Fact]
+    public void SettingsView_HidesDuplicateAppearanceControls_WhenHostProvidesAppearance()
+    {
+        RunOnStaThread(() =>
+        {
+            var host = new AppearanceTestPluginHostServices
+            {
+                LiveTranscriptionFontSize = 14,
+                PreviewBubbleAutoHideMilliseconds = 1500
+            };
+            var plugin = new LiveTranscriptPlugin();
+
+            try
+            {
+                plugin.ActivateAsync(host).GetAwaiter().GetResult();
+
+                var view = Assert.IsType<LiveTranscriptSettingsView>(plugin.CreateSettingsView());
+                var fontSizePanel = Assert.IsAssignableFrom<FrameworkElement>(view.FindName("FontSizePanel"));
+                var autoHidePanel = Assert.IsAssignableFrom<FrameworkElement>(view.FindName("AutoHidePanel"));
+
+                Assert.Equal(Visibility.Collapsed, fontSizePanel.Visibility);
+                Assert.Equal(Visibility.Collapsed, autoHidePanel.Visibility);
+            }
+            finally
+            {
+                plugin.DeactivateAsync().GetAwaiter().GetResult();
+                PumpDispatcher();
             }
         });
     }
@@ -483,7 +655,7 @@ public sealed class LiveTranscriptPluginTests
         Dispatcher.PushFrame(frame);
     }
 
-    private sealed class TestPluginHostServices : IPluginHostServices
+    private class TestPluginHostServices : IPluginHostServices
     {
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
@@ -516,7 +688,13 @@ public sealed class LiveTranscriptPluginTests
         public Task DeleteSecretAsync(string key) => Task.CompletedTask;
     }
 
-    private sealed class WpfTestHostServices(IPluginEventBus eventBus) : IPluginHostServices
+    private sealed class AppearanceTestPluginHostServices : TestPluginHostServices, ILivePreviewAppearanceProvider
+    {
+        public double LiveTranscriptionFontSize { get; init; }
+        public int PreviewBubbleAutoHideMilliseconds { get; init; }
+    }
+
+    private class WpfTestHostServices(IPluginEventBus eventBus) : IPluginHostServices
     {
         private readonly Dictionary<string, JsonElement> _settings = [];
 
@@ -540,6 +718,13 @@ public sealed class LiveTranscriptPluginTests
         public void Log(PluginLogLevel level, string message) { }
         public void NotifyCapabilitiesChanged() { }
         public IPluginLocalization Localization { get; } = new NoOpLocalization();
+    }
+
+    private sealed class AppearanceWpfTestHostServices(IPluginEventBus eventBus)
+        : WpfTestHostServices(eventBus), ILivePreviewAppearanceProvider
+    {
+        public double LiveTranscriptionFontSize { get; init; }
+        public int PreviewBubbleAutoHideMilliseconds { get; init; }
     }
 
     private sealed class TrackingPluginEventBus : IPluginEventBus

--- a/src/TypeWhisper.PluginSDK/IPluginHostServices.cs
+++ b/src/TypeWhisper.PluginSDK/IPluginHostServices.cs
@@ -58,3 +58,13 @@ public interface IPluginHostServices
     /// </summary>
     void SetStreamingDisplayActive(bool active) { }
 }
+
+/// <summary>
+/// Optional host-provided appearance values for plugins that render live preview text.
+/// Values are already normalized by the host.
+/// </summary>
+public interface ILivePreviewAppearanceProvider
+{
+    double LiveTranscriptionFontSize { get; }
+    int PreviewBubbleAutoHideMilliseconds { get; }
+}

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginHostServices.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginHostServices.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 using AppLocalization = TypeWhisper.Windows.Services.Localization;
@@ -12,7 +13,7 @@ namespace TypeWhisper.Windows.Services.Plugins;
 /// Per-plugin host services implementation. Each plugin gets its own instance
 /// with isolated settings storage and secret management scoped to its plugin ID.
 /// </summary>
-public sealed class PluginHostServices : IPluginHostServices
+public sealed class PluginHostServices : IPluginHostServices, ILivePreviewAppearanceProvider
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -27,6 +28,7 @@ public sealed class PluginHostServices : IPluginHostServices
     private readonly IPluginEventBus _eventBus;
     private readonly IWorkflowService _workflows;
     private readonly Action? _onCapabilitiesChanged;
+    private readonly ISettingsService? _settings;
     private readonly PluginLocalization _localization;
     private readonly string _settingsFilePath;
     private readonly string _pluginDataDirectory;
@@ -40,13 +42,15 @@ public sealed class PluginHostServices : IPluginHostServices
         IActiveWindowService activeWindow,
         IPluginEventBus eventBus,
         IWorkflowService workflows,
-        Action? onCapabilitiesChanged = null)
+        Action? onCapabilitiesChanged = null,
+        ISettingsService? settings = null)
     {
         _pluginId = pluginId;
         _activeWindow = activeWindow;
         _eventBus = eventBus;
         _workflows = workflows;
         _onCapabilitiesChanged = onCapabilitiesChanged;
+        _settings = settings;
         _localization = new PluginLocalization(pluginDirectory, AppLocalization.Loc.Instance.CurrentLanguage);
         _pluginDataDirectory = Path.Combine(Core.TypeWhisperEnvironment.PluginDataPath, pluginId);
         _settingsFilePath = Path.Combine(_pluginDataDirectory, "settings.json");
@@ -70,6 +74,14 @@ public sealed class PluginHostServices : IPluginHostServices
 
     public IReadOnlyList<string> AvailableProfileNames =>
         _workflows.Workflows.Select(w => w.Name).ToList();
+
+    public double LiveTranscriptionFontSize =>
+        AppSettings.NormalizeLiveTranscriptionFontSize(
+            (_settings?.Current ?? AppSettings.Default).LiveTranscriptionFontSize);
+
+    public int PreviewBubbleAutoHideMilliseconds =>
+        AppSettings.NormalizePreviewBubbleAutoHideMilliseconds(
+            (_settings?.Current ?? AppSettings.Default).PreviewBubbleAutoHideMilliseconds);
 
     public void Log(PluginLogLevel level, string message)
     {

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
@@ -216,7 +216,8 @@ public sealed class PluginManager : IDisposable
                 {
                     RebuildCapabilityIndices();
                     PluginStateChanged?.Invoke(this, EventArgs.Empty);
-                });
+                },
+                settings: _settings);
 
             await plugin.Instance.ActivateAsync(hostServices);
 

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1271,7 +1271,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             _eventBus.Publish(new TextInsertedEvent
             {
                 Text = finalText,
-                TargetApp = job.CapturedProcessName
+                TargetApp = job.CapturedProcessName,
+                RecordingId = job.RecordingId
             });
 
             // Restore global model if workflow override was active

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginHostServicesTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginHostServicesTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Moq;
 using TypeWhisper.Core.Interfaces;
+using TypeWhisper.Core.Models;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.Windows.Services.Plugins;
 
@@ -20,9 +21,11 @@ public class PluginHostServicesTests : IDisposable
         Directory.CreateDirectory(_tempDir);
     }
 
-    private PluginHostServices CreateServices(Action? onCapabilitiesChanged = null) =>
+    private PluginHostServices CreateServices(
+        Action? onCapabilitiesChanged = null,
+        ISettingsService? settings = null) =>
         new("test-plugin", _tempDir, _activeWindow.Object, _eventBus.Object,
-            _workflows.Object, onCapabilitiesChanged);
+            _workflows.Object, onCapabilitiesChanged, settings);
 
     [Fact]
     public void NotifyCapabilitiesChanged_InvokesCallback()
@@ -33,6 +36,23 @@ public class PluginHostServicesTests : IDisposable
         services.NotifyCapabilitiesChanged();
 
         Assert.True(callbackInvoked);
+    }
+
+    [Fact]
+    public void LivePreviewAppearanceProvider_ReturnsNormalizedGlobalSettings()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            LiveTranscriptionFontSize = 99,
+            PreviewBubbleAutoHideMilliseconds = 9999
+        });
+        var services = CreateServices(settings: settings.Object);
+
+        var provider = Assert.IsAssignableFrom<ILivePreviewAppearanceProvider>(services);
+
+        Assert.Equal(AppSettings.MaxLiveTranscriptionFontSize, provider.LiveTranscriptionFontSize);
+        Assert.Equal(AppSettings.MaxPreviewBubbleAutoHideMilliseconds, provider.PreviewBubbleAutoHideMilliseconds);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add a host-provided live preview appearance interface so plugins can use normalized global Appearance values.
- Update the Live Transcript plugin to prefer host font size and auto-hide settings, hide duplicate controls, and keep plugin settings as fallback for older hosts.
- Publish recording IDs on text insertion so auto-hide only affects the active live transcript window.

## Root Cause
The visible live preview was often the Live Transcript plugin, which had separate font-size and auto-hide settings from the built-in overlay. Changing Appearance settings therefore did not affect the preview users were seeing.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "LiveTranscriptPluginTests|PluginHostServicesTests|SettingsViewModelIndicatorTests|DictationOverlayPresentationTests"`
- `git diff --check`

Fixes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-provided appearance support for live transcript font size and auto-hide intervals
  * Settings UI hides duplicate appearance controls when host appearance is available

* **Improvements**
  * Font size accepts decimal values for finer granularity
  * More reliable UI updates and refined auto-hide behavior when using host appearance

* **Tests**
  * Added tests covering host appearance overrides and related auto-hide/event scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->