### PR TITLE
Preserve long dictation preview fallback

### DIFF
--- a/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
@@ -20,8 +20,9 @@ internal sealed class StreamingTranscriptState
 
     public string StopSession()
     {
-        var hasUncommittedPreview = _lastDisplayedText != _confirmedText;
-        var finalText = hasUncommittedPreview ? "" : _confirmedText;
+        var finalText = !string.IsNullOrWhiteSpace(_lastDisplayedText)
+            ? _lastDisplayedText
+            : _confirmedText;
         InvalidateSession();
         _confirmedText = "";
         _lastDisplayedText = "";

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1274,11 +1274,15 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 try
                 {
                     audioFileName = $"{Guid.NewGuid():N}.wav";
-                    var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, audioFileName);
+                    var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, Path.GetFileName(audioFileName));
                     var wav = TypeWhisper.Core.Audio.WavEncoder.Encode(job.OriginalSamples);
                     await File.WriteAllBytesAsync(audioPath, wav, ct);
                 }
-                catch
+                catch (IOException)
+                {
+                    audioFileName = null;
+                }
+                catch (UnauthorizedAccessException)
                 {
                     audioFileName = null;
                 }
@@ -1412,7 +1416,11 @@ public partial class DictationViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
-            FailApiDictationSession(job.ApiSessionId, ex.Message);
+            var apiSessionAlreadyCompleted = job.ApiSessionId is Guid completedApiSessionId
+                && GetApiDictationSession(completedApiSessionId)?.Status == ApiDictationSessionStatus.Completed;
+            if (!apiSessionAlreadyCompleted)
+                FailApiDictationSession(job.ApiSessionId, ex.Message);
+
             _errorLog.AddEntry(ex.Message, ErrorCategory.Transcription);
             _eventBus.Publish(new TranscriptionFailedEvent
             {

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1003,7 +1003,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 StatusText = Loc.Instance["Status.Processing"];
             });
 
-            string rawText;
+            string rawText = "";
             string? detectedLanguage = null;
             double audioDuration = job.OriginalSamples.Length / 16000.0;
             var diagnosticsEnabled = _settings.Current.InternalParakeetTailDiagnosticsEnabled;
@@ -1021,27 +1021,59 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             var previewText = DictationFinalTextPolicy.JoinPreviewSegments(job.PartialSegments);
             var language = job.EffectiveLanguage == "auto" ? null : job.EffectiveLanguage;
             var decodeStartedAt = DateTime.UtcNow;
-            var result = await _modelManager.Engine.TranscribeAsync(
-                decodeSamples, language, job.EffectiveTask, ct);
-            fullDecodeDurationMs = (long)(DateTime.UtcNow - decodeStartedAt).TotalMilliseconds;
-            fullDecodeText = result.Text ?? "";
-            fullDecodeDetectedLanguage = result.DetectedLanguage;
-
-            if (isParakeetJob)
+            TranscriptionResult? result = null;
+            try
             {
-                var selection = ParakeetTailHelper.SelectResult(
-                    job.ActiveModelIdAtCapture,
-                    fullDecodeText,
-                    job.PartialSegments);
-                rawText = DictationFinalTextPolicy.SelectRawText(selection.Text);
-                detectedLanguage = fullDecodeDetectedLanguage;
+                result = await _modelManager.Engine.TranscribeAsync(
+                    decodeSamples, language, job.EffectiveTask, ct);
+                fullDecodeText = result.Text ?? "";
+                fullDecodeDetectedLanguage = result.DetectedLanguage;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (!string.IsNullOrWhiteSpace(previewText))
+            {
+                rawText = DictationFinalTextPolicy.SelectRawText(null, previewText);
+                detectedLanguage = language;
+                _errorLog.AddEntry(
+                    $"Final transcription failed; using live preview fallback: {ex.Message}",
+                    ErrorCategory.Transcription);
                 job = job with
                 {
                     Diagnostic = job.Diagnostic with
                     {
                         TailGuardApplied = tailGuardApplied,
                         TailSamplesAdded = tailSamplesAdded,
-                        FinalTextSource = selection.Source,
+                        FinalTextSource = "live_preview_fallback",
+                        FullDecodeTextLength = 0,
+                        PartialTextLength = previewText.Length
+                    }
+                };
+            }
+            finally
+            {
+                fullDecodeDurationMs = (long)(DateTime.UtcNow - decodeStartedAt).TotalMilliseconds;
+            }
+
+            if (result is not null && isParakeetJob)
+            {
+                var selection = ParakeetTailHelper.SelectResult(
+                    job.ActiveModelIdAtCapture,
+                    fullDecodeText,
+                    job.PartialSegments);
+                rawText = DictationFinalTextPolicy.SelectRawText(selection.Text, previewText);
+                detectedLanguage = fullDecodeDetectedLanguage;
+                var usedPreviewFallback = string.IsNullOrWhiteSpace(fullDecodeText)
+                    && !string.IsNullOrWhiteSpace(previewText);
+                job = job with
+                {
+                    Diagnostic = job.Diagnostic with
+                    {
+                        TailGuardApplied = tailGuardApplied,
+                        TailSamplesAdded = tailSamplesAdded,
+                        FinalTextSource = usedPreviewFallback ? "live_preview_fallback" : selection.Source,
                         FullDecodeTextLength = selection.FullDecodeTextLength,
                         PartialTextLength = selection.PartialTextLength,
                         DivergedFromPartials = selection.DivergedFromPartials,
@@ -1049,7 +1081,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     }
                 };
             }
-            else
+            else if (result is not null)
             {
                 if (DictationFinalTextPolicy.ShouldRejectAsNoSpeech(
                         result.Text,
@@ -1064,13 +1096,18 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     return;
                 }
 
-                rawText = DictationFinalTextPolicy.SelectRawText(result.Text);
+                rawText = DictationFinalTextPolicy.SelectRawText(result.Text, previewText);
                 detectedLanguage = result.DetectedLanguage;
+                var usedPreviewFallback = string.IsNullOrWhiteSpace(
+                    DictationFinalTextPolicy.SelectRawText(result.Text))
+                    && !string.IsNullOrWhiteSpace(rawText);
                 job = job with
                 {
                     Diagnostic = job.Diagnostic with
                     {
-                        FinalTextSource = string.IsNullOrWhiteSpace(fullDecodeText) ? "empty" : "full_decode",
+                        FinalTextSource = usedPreviewFallback
+                            ? "live_preview_fallback"
+                            : string.IsNullOrWhiteSpace(fullDecodeText) ? "empty" : "full_decode",
                         FullDecodeTextLength = fullDecodeText.Length,
                         PartialTextLength = previewText.Length,
                         FullDecodeDurationMs = fullDecodeDurationMs
@@ -1202,6 +1239,68 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             var pipelineResult = await _pipeline.ProcessAsync(rawText, pipelineOptions, ct);
             var finalText = pipelineResult.Text;
 
+            var timestamp = DateTime.UtcNow;
+            var engineUsed = ResolveEngineUsed(job.ActiveModelIdAtCapture);
+            var wordsCount = CountWords(finalText);
+            var recordId = job.ApiSessionId?.ToString() ?? Guid.NewGuid().ToString();
+            await Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                LastTranscribedText = finalText;
+                LastTranscriptionLanguage = detectedLanguage;
+            });
+            _recentTranscriptions.RecordTranscription(
+                recordId,
+                finalText,
+                timestamp,
+                job.CapturedWindowTitle,
+                job.CapturedProcessName);
+            CompleteApiDictationSession(job.ApiSessionId, new ApiDictationTranscription(
+                finalText,
+                rawText,
+                timestamp,
+                job.CapturedWindowTitle,
+                job.CapturedProcessName,
+                job.CapturedUrl,
+                audioDuration,
+                detectedLanguage,
+                engineUsed,
+                job.ActiveModelIdAtCapture,
+                wordsCount));
+
+            // Save to history before output delivery so paste/action failures do not lose text.
+            if (_settings.Current.SaveToHistoryEnabled)
+            {
+                string? audioFileName = null;
+                try
+                {
+                    audioFileName = $"{Guid.NewGuid():N}.wav";
+                    var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, audioFileName);
+                    var wav = TypeWhisper.Core.Audio.WavEncoder.Encode(job.OriginalSamples);
+                    await File.WriteAllBytesAsync(audioPath, wav, ct);
+                }
+                catch
+                {
+                    audioFileName = null;
+                }
+
+                _history.AddRecord(new TranscriptionRecord
+                {
+                    Id = recordId,
+                    Timestamp = timestamp,
+                    RawText = rawText,
+                    FinalText = finalText,
+                    AppName = job.CapturedWindowTitle,
+                    AppProcessName = job.CapturedProcessName,
+                    AppUrl = job.CapturedUrl,
+                    DurationSeconds = audioDuration,
+                    Language = detectedLanguage,
+                    ProfileName = job.ActiveWorkflow?.Name,
+                    EngineUsed = engineUsed,
+                    ModelUsed = job.ActiveModelIdAtCapture,
+                    AudioFileName = audioFileName
+                });
+            }
+
             // Route to action plugin if configured
             var targetActionPluginId = job.ActiveWorkflow?.Output.TargetActionPluginId;
 
@@ -1281,68 +1380,6 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 && _settings.Current.SelectedModelId is not null)
             {
                 await _modelManager.LoadModelAsync(_settings.Current.SelectedModelId);
-            }
-
-            var timestamp = DateTime.UtcNow;
-            var engineUsed = ResolveEngineUsed(job.ActiveModelIdAtCapture);
-            var wordsCount = CountWords(finalText);
-            var recordId = job.ApiSessionId?.ToString() ?? Guid.NewGuid().ToString();
-            await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                LastTranscribedText = finalText;
-                LastTranscriptionLanguage = detectedLanguage;
-            });
-            _recentTranscriptions.RecordTranscription(
-                recordId,
-                finalText,
-                timestamp,
-                job.CapturedWindowTitle,
-                job.CapturedProcessName);
-            CompleteApiDictationSession(job.ApiSessionId, new ApiDictationTranscription(
-                finalText,
-                rawText,
-                timestamp,
-                job.CapturedWindowTitle,
-                job.CapturedProcessName,
-                job.CapturedUrl,
-                audioDuration,
-                detectedLanguage,
-                engineUsed,
-                job.ActiveModelIdAtCapture,
-                wordsCount));
-
-            // Save to history (if enabled)
-            if (_settings.Current.SaveToHistoryEnabled)
-            {
-                string? audioFileName = null;
-                try
-                {
-                    audioFileName = $"{Guid.NewGuid():N}.wav";
-                    var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, audioFileName);
-                    var wav = TypeWhisper.Core.Audio.WavEncoder.Encode(job.OriginalSamples);
-                    await File.WriteAllBytesAsync(audioPath, wav, ct);
-                }
-                catch
-                {
-                    audioFileName = null;
-                }
-
-                _history.AddRecord(new TranscriptionRecord
-                {
-                    Id = recordId,
-                    Timestamp = timestamp,
-                    RawText = rawText,
-                    FinalText = finalText,
-                    AppName = job.CapturedWindowTitle,
-                    AppProcessName = job.CapturedProcessName,
-                    AppUrl = job.CapturedUrl,
-                    DurationSeconds = audioDuration,
-                    Language = detectedLanguage,
-                    ProfileName = job.ActiveWorkflow?.Name,
-                    EngineUsed = engineUsed,
-                    ModelUsed = job.ActiveModelIdAtCapture,
-                    AudioFileName = audioFileName
-                });
             }
 
             _sound.PlaySuccessSound();
@@ -1637,7 +1674,7 @@ internal static class DictationFinalTextPolicy
         bool transcribeShortQuietClipsAggressively)
     {
         if (string.IsNullOrWhiteSpace(finalText))
-            return true;
+            return !hasPreviewText;
 
         return noSpeechProbability is > NoSpeechProbabilityThreshold
             && !transcribeShortQuietClipsAggressively
@@ -1655,7 +1692,11 @@ internal static class DictationFinalTextPolicy
 
     public static string SelectRawText(string? finalText, string? trustedLiveText)
     {
-        return SelectRawText(finalText);
+        var normalizedFinalText = SelectRawText(finalText);
+        if (!string.IsNullOrWhiteSpace(normalizedFinalText))
+            return normalizedFinalText;
+
+        return SelectRawText(SelectTrustedLiveText(trustedLiveText));
     }
 
     private static string NormalizeDictationArtifacts(string text) =>

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1274,7 +1274,11 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 try
                 {
                     audioFileName = $"{Guid.NewGuid():N}.wav";
-                    var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, Path.GetFileName(audioFileName));
+                    var safeAudioFileName = Path.GetFileName(audioFileName);
+                    if (string.IsNullOrEmpty(safeAudioFileName))
+                        safeAudioFileName = $"{Guid.NewGuid():N}.wav";
+                    audioFileName = safeAudioFileName;
+                    var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, safeAudioFileName);
                     var wav = TypeWhisper.Core.Audio.WavEncoder.Encode(job.OriginalSamples);
                     await File.WriteAllBytesAsync(audioPath, wav, ct);
                 }

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1275,7 +1275,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 {
                     audioFileName = $"{Guid.NewGuid():N}.wav";
                     var safeAudioFileName = Path.GetFileName(audioFileName);
-                    if (string.IsNullOrEmpty(safeAudioFileName))
+                    if (string.IsNullOrEmpty(safeAudioFileName) || Path.IsPathRooted(safeAudioFileName))
                         safeAudioFileName = $"{Guid.NewGuid():N}.wav";
                     audioFileName = safeAudioFileName;
                     var audioPath = Path.Combine(TypeWhisperEnvironment.AudioPath, safeAudioFileName);

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
@@ -57,7 +57,9 @@ public sealed class DictationOutputPersistenceTests
         var processJob = ReadProcessSingleJobAsync();
 
         Assert.Contains("var safeAudioFileName = Path.GetFileName(audioFileName);", processJob);
-        Assert.Contains("if (string.IsNullOrEmpty(safeAudioFileName))", processJob);
+        Assert.Contains(
+            "if (string.IsNullOrEmpty(safeAudioFileName) || Path.IsPathRooted(safeAudioFileName))",
+            processJob);
         Assert.Contains("safeAudioFileName = $\"{Guid.NewGuid():N}.wav\";", processJob);
         Assert.Contains("Path.Combine(TypeWhisperEnvironment.AudioPath, safeAudioFileName)", processJob);
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
@@ -1,0 +1,29 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class DictationOutputPersistenceTests
+{
+    [Fact]
+    public void ProcessSingleJobAsync_PersistsCompletedTextBeforeOutputDelivery()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+        var processJob = TestFile.ExtractBlock(source, "private async Task ProcessSingleJobAsync", 18000);
+
+        var finalTextIndex = processJob.IndexOf("var finalText = pipelineResult.Text;", StringComparison.Ordinal);
+        var recentIndex = processJob.IndexOf("_recentTranscriptions.RecordTranscription(", StringComparison.Ordinal);
+        var historyIndex = processJob.IndexOf("_history.AddRecord(", StringComparison.Ordinal);
+        var actionOutputIndex = processJob.IndexOf("actionPlugin.ExecuteAsync(", StringComparison.Ordinal);
+        var pasteOutputIndex = processJob.IndexOf("_textInsertion.InsertTextAsync(", StringComparison.Ordinal);
+
+        Assert.True(finalTextIndex >= 0, "The job must finish post-processing before persisting output.");
+        Assert.True(recentIndex > finalTextIndex, "Recent transcription persistence should use the final post-processed text.");
+        Assert.True(historyIndex > finalTextIndex, "History persistence should use the final post-processed text.");
+        Assert.True(recentIndex < actionOutputIndex, "Recent transcription persistence must happen before action-plugin output.");
+        Assert.True(historyIndex < actionOutputIndex, "History persistence must happen before action-plugin output.");
+        Assert.True(recentIndex < pasteOutputIndex, "Recent transcription persistence must happen before paste/clipboard output.");
+        Assert.True(historyIndex < pasteOutputIndex, "History persistence must happen before paste/clipboard output.");
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
@@ -30,19 +30,23 @@ public sealed class DictationOutputPersistenceTests
         var completionIndex = processJob.IndexOf(
             "CompleteApiDictationSession(job.ApiSessionId,",
             StringComparison.Ordinal);
+        Assert.True(completionIndex >= 0, "API dictation sessions must be completed before output delivery.");
+
         var catchIndex = processJob.IndexOf("catch (Exception ex)", completionIndex, StringComparison.Ordinal);
+        Assert.True(catchIndex > completionIndex, "The output failure path should remain after session completion.");
+
         var completedGuardIndex = processJob.IndexOf(
             "GetApiDictationSession(completedApiSessionId)?.Status == ApiDictationSessionStatus.Completed",
             catchIndex,
             StringComparison.Ordinal);
+        Assert.True(completedGuardIndex > catchIndex, "Output failures must check for an already-completed API session.");
+
         var failIndex = processJob.IndexOf(
             "FailApiDictationSession(job.ApiSessionId, ex.Message);",
             catchIndex,
             StringComparison.Ordinal);
 
-        Assert.True(completionIndex >= 0, "API dictation sessions must be completed before output delivery.");
-        Assert.True(catchIndex > completionIndex, "The output failure path should remain after session completion.");
-        Assert.True(completedGuardIndex > catchIndex, "Output failures must check for an already-completed API session.");
+        Assert.True(failIndex > catchIndex, "The output failure path must still fail unfinished API sessions.");
         Assert.True(completedGuardIndex < failIndex, "The completed-session guard must run before marking a session failed.");
         Assert.Contains("if (!apiSessionAlreadyCompleted)", processJob);
     }
@@ -52,20 +56,24 @@ public sealed class DictationOutputPersistenceTests
     {
         var processJob = ReadProcessSingleJobAsync();
 
-        Assert.Contains(
-            "Path.Combine(TypeWhisperEnvironment.AudioPath, Path.GetFileName(audioFileName))",
-            processJob);
+        Assert.Contains("var safeAudioFileName = Path.GetFileName(audioFileName);", processJob);
+        Assert.Contains("if (string.IsNullOrEmpty(safeAudioFileName))", processJob);
+        Assert.Contains("safeAudioFileName = $\"{Guid.NewGuid():N}.wav\";", processJob);
+        Assert.Contains("Path.Combine(TypeWhisperEnvironment.AudioPath, safeAudioFileName)", processJob);
     }
 
     [Fact]
     public void ProcessSingleJobAsync_AudioHistorySaveOnlyCatchesExpectedIoFailures()
     {
         var processJob = ReadProcessSingleJobAsync();
+        var audioSaveBlock = TestFile.ExtractBlock(
+            processJob,
+            "audioFileName = $\"{Guid.NewGuid():N}.wav\";",
+            900);
 
-        Assert.Contains("catch (IOException)", processJob);
-        Assert.Contains("catch (UnauthorizedAccessException)", processJob);
-        Assert.DoesNotContain("catch\r\n                {", processJob);
-        Assert.DoesNotContain("catch\n                {", processJob);
+        Assert.Contains("catch (IOException)", audioSaveBlock);
+        Assert.Contains("catch (UnauthorizedAccessException)", audioSaveBlock);
+        Assert.DoesNotMatch(@"catch\s*\{", audioSaveBlock);
     }
 
     private static string ReadProcessSingleJobAsync()

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
@@ -5,12 +5,7 @@ public sealed class DictationOutputPersistenceTests
     [Fact]
     public void ProcessSingleJobAsync_PersistsCompletedTextBeforeOutputDelivery()
     {
-        var source = TestFile.ReadProjectFile(
-            "src",
-            "TypeWhisper.Windows",
-            "ViewModels",
-            "DictationViewModel.cs");
-        var processJob = TestFile.ExtractBlock(source, "private async Task ProcessSingleJobAsync", 18000);
+        var processJob = ReadProcessSingleJobAsync();
 
         var finalTextIndex = processJob.IndexOf("var finalText = pipelineResult.Text;", StringComparison.Ordinal);
         var recentIndex = processJob.IndexOf("_recentTranscriptions.RecordTranscription(", StringComparison.Ordinal);
@@ -25,5 +20,62 @@ public sealed class DictationOutputPersistenceTests
         Assert.True(historyIndex < actionOutputIndex, "History persistence must happen before action-plugin output.");
         Assert.True(recentIndex < pasteOutputIndex, "Recent transcription persistence must happen before paste/clipboard output.");
         Assert.True(historyIndex < pasteOutputIndex, "History persistence must happen before paste/clipboard output.");
+    }
+
+    [Fact]
+    public void ProcessSingleJobAsync_PreservesCompletedApiSessionWhenOutputDeliveryFails()
+    {
+        var processJob = ReadProcessSingleJobAsync();
+
+        var completionIndex = processJob.IndexOf(
+            "CompleteApiDictationSession(job.ApiSessionId,",
+            StringComparison.Ordinal);
+        var catchIndex = processJob.IndexOf("catch (Exception ex)", completionIndex, StringComparison.Ordinal);
+        var completedGuardIndex = processJob.IndexOf(
+            "GetApiDictationSession(completedApiSessionId)?.Status == ApiDictationSessionStatus.Completed",
+            catchIndex,
+            StringComparison.Ordinal);
+        var failIndex = processJob.IndexOf(
+            "FailApiDictationSession(job.ApiSessionId, ex.Message);",
+            catchIndex,
+            StringComparison.Ordinal);
+
+        Assert.True(completionIndex >= 0, "API dictation sessions must be completed before output delivery.");
+        Assert.True(catchIndex > completionIndex, "The output failure path should remain after session completion.");
+        Assert.True(completedGuardIndex > catchIndex, "Output failures must check for an already-completed API session.");
+        Assert.True(completedGuardIndex < failIndex, "The completed-session guard must run before marking a session failed.");
+        Assert.Contains("if (!apiSessionAlreadyCompleted)", processJob);
+    }
+
+    [Fact]
+    public void ProcessSingleJobAsync_ConstrainsAudioHistoryFileNameBeforeCombining()
+    {
+        var processJob = ReadProcessSingleJobAsync();
+
+        Assert.Contains(
+            "Path.Combine(TypeWhisperEnvironment.AudioPath, Path.GetFileName(audioFileName))",
+            processJob);
+    }
+
+    [Fact]
+    public void ProcessSingleJobAsync_AudioHistorySaveOnlyCatchesExpectedIoFailures()
+    {
+        var processJob = ReadProcessSingleJobAsync();
+
+        Assert.Contains("catch (IOException)", processJob);
+        Assert.Contains("catch (UnauthorizedAccessException)", processJob);
+        Assert.DoesNotContain("catch\r\n                {", processJob);
+        Assert.DoesNotContain("catch\n                {", processJob);
+    }
+
+    private static string ReadProcessSingleJobAsync()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+
+        return TestFile.ExtractBlock(source, "private async Task ProcessSingleJobAsync", 26000);
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
@@ -237,17 +237,17 @@ public class DictationFinalTextPolicyTests
     {
         var result = DictationFinalTextPolicy.SelectRawText(null, "  confirmed live transcript  ");
 
-        Assert.Equal("", result);
+        Assert.Equal("confirmed live transcript", result);
     }
 
     [Fact]
-    public void SelectRawText_WhitespaceFinalTextDoesNotUseTrustedLiveText()
+    public void SelectRawText_WhitespaceFinalTextUsesTrustedLiveText()
     {
         var result = DictationFinalTextPolicy.SelectRawText(
             "   ",
             "Please send the updated draft tomorrow morning. Please send the updated draft tomorrow morning.");
 
-        Assert.Equal("", result);
+        Assert.Equal("Please send the updated draft tomorrow morning.", result);
     }
 
     [Fact]
@@ -273,7 +273,7 @@ public class DictationFinalTextPolicyTests
             hasPreviewText: true,
             transcribeShortQuietClipsAggressively: false);
 
-        Assert.True(reject);
+        Assert.False(reject);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -634,7 +634,7 @@ public class StabilizeTextTests
 public class StreamingTranscriptStateTests
 {
     [Fact]
-    public void StopSession_UsesOnlyConfirmedRealtimeText()
+    public void StopSession_FallsBackToOnlyInterimRealtimeText()
     {
         var sut = new StreamingTranscriptState();
         var sessionVersion = sut.StartSession();
@@ -650,7 +650,7 @@ public class StreamingTranscriptStateTests
 
         var finalText = sut.StopSession();
 
-        Assert.Equal("", finalText);
+        Assert.Equal("Hello world", finalText);
     }
 
     [Fact]
@@ -702,7 +702,7 @@ public class StreamingTranscriptStateTests
             out var interimDisplay));
         Assert.Equal("Confirmed still changing", interimDisplay);
 
-        Assert.Equal("", sut.StopSession());
+        Assert.Equal("Confirmed still changing", sut.StopSession());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Use the latest trusted live preview text as a fallback when final transcription is empty or fails after a long dictation.
- Persist completed dictation text to recent transcriptions, API results, and history before attempting paste or action-plugin delivery.
- Update regression coverage for preview fallback, no-speech handling, and output persistence ordering.

## Root Cause
Long dictations could show text in the live preview, but the stop flow discarded unconfirmed preview text and saved history only after output delivery. If final decode failed or paste/action delivery failed, the visible transcription could be lost.

## Test Plan
- `dotnet test TypeWhisper.slnx`

Fixes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prefer the most-recent displayed preview as the final transcript when present.
  * Persist completed transcription and audio history before delivering output; avoid re-marking already-completed sessions as failed.
  * Fall back to live-preview text on decode failures; treat whitespace final text as non-empty when a preview exists.

* **Tests**
  * Added/updated tests for persistence ordering, audio-history save behavior, session-completion guards, and streaming fallback expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->