### PR TITLE
Fix workflow post-processing fallbacks

### DIFF
--- a/src/TypeWhisper.Core/Interfaces/IPostProcessingPipeline.cs
+++ b/src/TypeWhisper.Core/Interfaces/IPostProcessingPipeline.cs
@@ -38,6 +38,9 @@ public sealed record PipelineOptions
     /// <summary>Runs LLM prompt processing on text. Returns processed text.</summary>
     public Func<string, CancellationToken, Task<string>>? LlmHandler { get; init; }
 
+    /// <summary>When true, LLM failures abort processing instead of falling back to the current text.</summary>
+    public bool RequireLlmSuccess { get; init; }
+
     /// <summary>Translates text. Params: text, sourceLang, targetLang. Returns translated text.</summary>
     public Func<string, string, string, CancellationToken, Task<string>>? TranslationHandler { get; init; }
 

--- a/src/TypeWhisper.Core/Services/PostProcessingPipeline.cs
+++ b/src/TypeWhisper.Core/Services/PostProcessingPipeline.cs
@@ -26,6 +26,9 @@ public sealed class PostProcessingPipeline : IPostProcessingPipeline
         PipelineOptions options,
         CancellationToken ct = default)
     {
+        if (options.RequireLlmSuccess && options.LlmHandler is null)
+            throw new InvalidOperationException("Required LLM post-processing is not configured.");
+
         var steps = BuildSteps(options);
         var text = rawText;
 
@@ -44,6 +47,9 @@ public sealed class PostProcessingPipeline : IPostProcessingPipeline
             {
                 System.Diagnostics.Debug.WriteLine(
                     $"PostProcessingPipeline: Step '{name}' failed: {ex.Message}");
+                if (name == "LLM" && options.RequireLlmSuccess)
+                    throw;
+
                 // Continue with current text — don't let one step break the pipeline
             }
         }

--- a/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
@@ -22,6 +22,37 @@ public static class OpenAiChatHelper
     /// <param name="userText">User message text.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The assistant's response content text.</returns>
+    public static Task<string> SendChatCompletionAsync(
+        HttpClient httpClient, string baseUrl, string apiKey,
+        string model, string systemPrompt, string userText, CancellationToken ct) =>
+        SendChatCompletionAsync(
+            httpClient,
+            baseUrl,
+            apiKey,
+            model,
+            systemPrompt,
+            userText,
+            ct,
+            maxOutputTokens: 2048,
+            maxOutputTokenParameter: "max_tokens",
+            reasoningEffort: null,
+            temperature: 0.1);
+
+    /// <summary>
+    /// Sends a chat completion request to an OpenAI-compatible API endpoint.
+    /// </summary>
+    /// <param name="httpClient">HTTP client to use for the request.</param>
+    /// <param name="baseUrl">API base URL (e.g. "https://api.openai.com").</param>
+    /// <param name="apiKey">Bearer token for authentication.</param>
+    /// <param name="model">Model identifier (e.g. "gpt-4o").</param>
+    /// <param name="systemPrompt">System prompt text.</param>
+    /// <param name="userText">User message text.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="maxOutputTokens">Optional response token cap.</param>
+    /// <param name="maxOutputTokenParameter">Provider-specific token cap parameter name.</param>
+    /// <param name="reasoningEffort">Optional reasoning effort value for providers that support it.</param>
+    /// <param name="temperature">Optional sampling temperature.</param>
+    /// <returns>The assistant's response content text.</returns>
     public static async Task<string> SendChatCompletionAsync(
         HttpClient httpClient, string baseUrl, string apiKey,
         string model, string systemPrompt, string userText, CancellationToken ct,

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1157,9 +1157,12 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 {
                     var errorMessage = Loc.Instance["Error.NoLlmProvider"];
                     llmHandler = (_, _) => throw new InvalidOperationException(errorMessage);
-                    FeedbackText = Loc.Instance["Error.NoLlmProvider"];
-                    FeedbackIsError = true;
-                    ShowFeedback = true;
+                    await Application.Current.Dispatcher.InvokeAsync(() =>
+                    {
+                        FeedbackText = errorMessage;
+                        FeedbackIsError = true;
+                        ShowFeedback = true;
+                    });
                 }
             }
 

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1136,11 +1136,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable
 
             // Build LLM handler if the active workflow has prompt behavior.
             Func<string, CancellationToken, Task<string>>? llmHandler = null;
+            var workflowRequiresLlm = false;
             if (job.ActiveWorkflow?.SystemPrompt(
                     fallbackTranslationTarget: job.ActiveWorkflow.Behavior.TranslationTarget,
                     detectedLanguage: detectedLanguage,
                     configuredLanguage: job.EffectiveLanguage == "auto" ? null : job.EffectiveLanguage) is { } systemPrompt)
             {
+                workflowRequiresLlm = true;
                 if (_workflowTextProcessor.IsAnyProviderAvailable)
                 {
                     var behavior = job.ActiveWorkflow.Behavior;
@@ -1153,6 +1155,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                 }
                 else
                 {
+                    var errorMessage = Loc.Instance["Error.NoLlmProvider"];
+                    llmHandler = (_, _) => throw new InvalidOperationException(errorMessage);
                     FeedbackText = Loc.Instance["Error.NoLlmProvider"];
                     FeedbackIsError = true;
                     ShowFeedback = true;
@@ -1183,6 +1187,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     return t;
                 }),
                 LlmHandler = llmHandler,
+                RequireLlmSuccess = workflowRequiresLlm,
                 TranslationHandler = !string.IsNullOrEmpty(translationTarget)
                     ? (text, src, tgt, token) => _translation.TranslateAsync(text, src, tgt, token)
                     : null,

--- a/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
@@ -51,6 +51,32 @@ public class PostProcessingPipelineTests
     }
 
     [Fact]
+    public async Task ProcessAsync_RequiredLlmHandlerFailure_Throws()
+    {
+        var options = new PipelineOptions
+        {
+            LlmHandler = (_, _) => throw new InvalidOperationException("LLM failed"),
+            RequireLlmSuccess = true
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.ProcessAsync("raw transcript", options));
+        Assert.Equal("LLM failed", ex.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RequiredLlmWithoutHandler_Throws()
+    {
+        var options = new PipelineOptions
+        {
+            RequireLlmSuccess = true
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.ProcessAsync("raw transcript", options));
+    }
+
+    [Fact]
     public async Task ProcessAsync_Translation_Applied()
     {
         var options = new PipelineOptions

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
@@ -1,0 +1,33 @@
+using System.Net.Http;
+using System.Reflection;
+using TypeWhisper.PluginSDK.Helpers;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class OpenAiChatHelperTests
+{
+    [Fact]
+    public void SendChatCompletionAsync_PreservesLegacySevenParameterOverload()
+    {
+        var parameterTypes = new[]
+        {
+            typeof(HttpClient),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(CancellationToken)
+        };
+
+        var method = typeof(OpenAiChatHelper).GetMethod(
+            nameof(OpenAiChatHelper.SendChatCompletionAsync),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: parameterTypes,
+            modifiers: null);
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(Task<string>), method!.ReturnType);
+    }
+}


### PR DESCRIPTION
## Summary
- Require workflow LLM post-processing to succeed before inserting dictated text
- Keep optional post-processing resilient for non-required steps
- Restore the legacy OpenAI chat helper overload for plugin binary compatibility

## Test Plan
- dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj --no-restore
- dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore

Fixes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable LLM failure handling: processing can either abort on LLM failures or fall back to current text.
  * Simplified OpenAI chat completion API with a shorter overload for common scenarios.

* **Bug Fixes**
  * Improved error handling when an LLM is required but not available or fails.

* **Tests**
  * Added unit tests validating required-LLM behavior and the new chat completion overload.

* **Documentation**
  * Updated method docs to describe optional parameters for chat completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->