### PR TITLE
Add Reson8 transcription plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ TypeWhisper for Windows includes system-wide dictation, file transcription, work
 ### Transcription
 
 - **On-device models:** Parakeet TDT 0.6B, Canary 180M Flash, whisper.cpp models, and Granite Speech run locally through plugins. Recommended local models run on CPU, with no GPU required.
-- **Cloud transcription:** Groq Whisper, xAI/Grok STT, OpenAI Whisper, AssemblyAI, Deepgram, ElevenLabs, Gladia, Google Cloud STT, Soniox, Speechmatics, Cloudflare ASR, Voxtral, and any OpenAI-compatible server can be added through plugins.
+- **Cloud transcription:** Groq Whisper, xAI/Grok STT, OpenAI Whisper, AssemblyAI, Deepgram, ElevenLabs, Reson8, Gladia, Google Cloud STT, Soniox, Speechmatics, Cloudflare ASR, Voxtral, and any OpenAI-compatible server can be added through plugins.
 - **Streaming preview:** Silero VAD detects speech segments during recording and shows partial transcription results in the overlay before recording stops.
 - **Short-clip handling:** Brief utterances are padded and retained more reliably across local and cloud engines.
 - **File transcription:** Drag and drop audio/video files. Supports WAV, MP3, M4A, AAC, OGG, FLAC, WMA, MP4, MKV, AVI, MOV, and WebM.
@@ -266,7 +266,7 @@ Bundled plugin families include:
 | Type | Plugins |
 |------|---------|
 | Local transcription | SherpaOnnx, whisper.cpp, Granite Speech |
-| Cloud transcription | OpenAI, Groq, xAI/Grok, AssemblyAI, Deepgram, ElevenLabs, Gladia, Google Cloud STT, Soniox, Speechmatics, Cloudflare ASR, Voxtral, OpenAI Compatible |
+| Cloud transcription | OpenAI, Groq, xAI/Grok, AssemblyAI, Deepgram, ElevenLabs, Reson8, Gladia, Google Cloud STT, Soniox, Speechmatics, Cloudflare ASR, Voxtral, OpenAI Compatible |
 | Server-backed transcription | Qwen3 STT |
 | LLM providers | OpenAI, Groq, xAI/Grok, Gemini, Claude, Cerebras, Cohere, Fireworks, OpenRouter, OpenAI Compatible, Gemma Local |
 | TTS providers | OpenAI, xAI/Grok, Supertonic TTS |

--- a/plugins/TypeWhisper.Plugin.Reson8/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Reson8/Localization/de.json
@@ -1,0 +1,23 @@
+{
+  "Settings.ApiKeyLabel": "API-Schlüssel",
+  "Settings.Test": "Testen",
+  "Settings.Save": "Speichern",
+  "Settings.Remove": "Entfernen",
+  "Settings.Saved": "Gespeichert",
+  "Settings.EnterApiKey": "Bitte zuerst einen API-Schlüssel eingeben",
+  "Settings.ApiKeyHint": "Wird sicher gespeichert und für Reson8-Transkription verwendet.",
+  "Settings.Testing": "Teste...",
+  "Settings.ApiKeyValid": "API-Schlüssel gültig!",
+  "Settings.ApiKeyInvalid": "Ungültiger API-Schlüssel",
+  "Settings.Model": "Modell",
+  "Settings.Refresh": "Aktualisieren",
+  "Settings.Refreshing": "Aktualisiere...",
+  "Settings.ModelsFetched": "{0} eigene(s) Modell(e) geladen",
+  "Settings.ModelsRefreshFailed": "Eigene Modelle konnten nicht geladen werden",
+  "Settings.NoCustomModels": "Noch keine eigenen Modelle - Standardmodell wird verwendet",
+  "Settings.Advanced": "Erweitert",
+  "Settings.CustomBaseUrl": "Eigene Basis-URL",
+  "Settings.CustomAuthHeader": "Eigener Auth-Header",
+  "Settings.AdvancedHint": "Für ein LiveKit-Gateway oder einen eigenen Proxy.",
+  "Settings.Error": "Fehler: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Reson8/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Reson8/Localization/en.json
@@ -1,0 +1,23 @@
+{
+  "Settings.ApiKeyLabel": "API Key",
+  "Settings.Test": "Test",
+  "Settings.Save": "Save",
+  "Settings.Remove": "Remove",
+  "Settings.Saved": "Saved",
+  "Settings.EnterApiKey": "Please enter an API key first",
+  "Settings.ApiKeyHint": "Stored securely and used for Reson8 transcription.",
+  "Settings.Testing": "Testing...",
+  "Settings.ApiKeyValid": "API key valid!",
+  "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.Model": "Model",
+  "Settings.Refresh": "Refresh",
+  "Settings.Refreshing": "Refreshing...",
+  "Settings.ModelsFetched": "{0} custom model(s) loaded",
+  "Settings.ModelsRefreshFailed": "Could not load custom models",
+  "Settings.NoCustomModels": "No custom models yet - using the default model",
+  "Settings.Advanced": "Advanced",
+  "Settings.CustomBaseUrl": "Custom Base URL",
+  "Settings.CustomAuthHeader": "Custom Auth Header",
+  "Settings.AdvancedHint": "For a LiveKit gateway or custom proxy.",
+  "Settings.Error": "Error: {0}"
+}

--- a/plugins/TypeWhisper.Plugin.Reson8/Reson8CustomModel.cs
+++ b/plugins/TypeWhisper.Plugin.Reson8/Reson8CustomModel.cs
@@ -1,0 +1,7 @@
+namespace TypeWhisper.Plugin.Reson8;
+
+public sealed record Reson8CustomModel(
+    string Id,
+    string Name,
+    string? Description,
+    int? PhraseCount);

--- a/plugins/TypeWhisper.Plugin.Reson8/Reson8Plugin.cs
+++ b/plugins/TypeWhisper.Plugin.Reson8/Reson8Plugin.cs
@@ -1,0 +1,510 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Windows.Controls;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.Reson8;
+
+public sealed class Reson8Plugin : ITranscriptionEnginePlugin
+{
+    internal const string DefaultModelId = "__default__";
+    internal const string DefaultBaseUrl = "https://api.reson8.dev";
+    internal const string DefaultAuthHeader = "Authorization";
+
+    private const string ApiKeySecretName = "api-key";
+    private const string SelectedModelSettingName = "selectedModel";
+    private const string CustomBaseUrlSettingName = "customBaseURL";
+    private const string CustomAuthHeaderSettingName = "customAuthHeader";
+    private const string FetchedCustomModelsSettingName = "fetchedCustomModels";
+
+    private static readonly IReadOnlyList<string> Languages =
+    [
+        "nl", "en", "fr", "de", "it", "pl", "pt", "es", "sv"
+    ];
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly SemaphoreSlim _apiKeyWriteLock = new(1, 1);
+    private IPluginHostServices? _host;
+    private string? _apiKey;
+    private string _selectedModelId = DefaultModelId;
+    private string _customBaseUrl = DefaultBaseUrl;
+    private string _customAuthHeader = DefaultAuthHeader;
+    private IReadOnlyList<Reson8CustomModel> _fetchedCustomModels = [];
+
+    public Reson8Plugin()
+        : this(CreateHttpClient())
+    {
+    }
+
+    internal Reson8Plugin(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public string PluginId => "com.typewhisper.reson8";
+    public string PluginName => "Reson8";
+    public string PluginVersion => "1.0.0";
+
+    public async Task ActivateAsync(IPluginHostServices host)
+    {
+        _host = host;
+        _apiKey = NormalizeApiKey(await host.LoadSecretAsync(ApiKeySecretName));
+        _customBaseUrl = NormalizeBaseUrl(host.GetSetting<string>(CustomBaseUrlSettingName));
+        _customAuthHeader = NormalizeAuthHeader(host.GetSetting<string>(CustomAuthHeaderSettingName));
+        _fetchedCustomModels = host.GetSetting<List<Reson8CustomModel>>(FetchedCustomModelsSettingName) ?? [];
+        _selectedModelId = NormalizeModelId(host.GetSetting<string>(SelectedModelSettingName));
+        host.Log(PluginLogLevel.Info, $"Activated (configured={IsConfigured})");
+    }
+
+    public Task DeactivateAsync()
+    {
+        _host = null;
+        return Task.CompletedTask;
+    }
+
+    public UserControl? CreateSettingsView() => new Reson8SettingsView(this);
+
+    public string ProviderId => "reson8";
+    public string ProviderDisplayName => "Reson8";
+    public bool IsConfigured => !string.IsNullOrEmpty(_apiKey);
+    public IReadOnlyList<PluginModelInfo> TranscriptionModels =>
+        [new PluginModelInfo(DefaultModelId, "Default model"), .. _fetchedCustomModels.Select(m => new PluginModelInfo(m.Id, m.Name))];
+    public string? SelectedModelId => _selectedModelId;
+    public bool SupportsTranslation => false;
+    public bool SupportsStreaming => true;
+    public IReadOnlyList<string> SupportedLanguages => Languages;
+
+    internal string? ApiKey => _apiKey;
+    internal string CustomBaseUrl => _customBaseUrl;
+    internal string CustomAuthHeader => _customAuthHeader;
+    internal IReadOnlyList<Reson8CustomModel> FetchedCustomModels => _fetchedCustomModels;
+    internal IPluginLocalization? Loc => _host?.Localization;
+
+    public void SelectModel(string modelId)
+    {
+        var normalized = NormalizeModelId(modelId);
+        _selectedModelId = normalized;
+        _host?.SetSetting(SelectedModelSettingName, normalized);
+    }
+
+    public async Task<PluginTranscriptionResult> TranscribeAsync(
+        byte[] wavAudio,
+        string? language,
+        bool translate,
+        string? prompt,
+        CancellationToken ct)
+    {
+        if (translate)
+            throw new InvalidOperationException("Reson8 does not support translation.");
+
+        if (!IsConfigured)
+            throw new InvalidOperationException("Plugin not configured. API key required.");
+
+        var pcm16 = WavPcm16Extractor.ExtractPcm16(wavAudio);
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            BuildPrerecordedUri(_customBaseUrl, _selectedModelId, NormalizeLanguage(language)));
+        AddAuthHeader(request, _apiKey!, _customAuthHeader);
+        request.Content = new ByteArrayContent(pcm16);
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+
+        if (!response.IsSuccessStatusCode)
+            ThrowForApiError(response.StatusCode, json);
+
+        return ParseTranscriptionResponse(json, NormalizeLanguage(language), pcm16.Length);
+    }
+
+    public async Task<PluginTranscriptionResult> TranscribeStreamingAsync(
+        byte[] wavAudio,
+        string? language,
+        bool translate,
+        string? prompt,
+        Func<string, bool> onProgress,
+        CancellationToken ct)
+    {
+        if (translate)
+            throw new InvalidOperationException("Reson8 does not support translation.");
+
+        if (!IsConfigured)
+            throw new InvalidOperationException("Plugin not configured. API key required.");
+
+        try
+        {
+            var pcm16 = WavPcm16Extractor.ExtractPcm16(wavAudio);
+            await using var session = await StartStreamingAsync(language, ct);
+            var collector = new Reson8TranscriptCollector();
+            var transcriptReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            session.TranscriptReceived += evt =>
+            {
+                var text = collector.ApplyEvent(evt);
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    if (!onProgress(text))
+                        transcriptReceived.TrySetCanceled(ct);
+                }
+
+                if (evt.IsFinal)
+                    transcriptReceived.TrySetResult();
+            };
+
+            const int chunkSize = 8192;
+            for (var offset = 0; offset < pcm16.Length; offset += chunkSize)
+            {
+                var count = Math.Min(chunkSize, pcm16.Length - offset);
+                await session.SendAudioAsync(pcm16.AsMemory(offset, count), ct);
+            }
+
+            await session.FinalizeAsync(ct);
+
+            var text = collector.FinalText;
+            return string.IsNullOrWhiteSpace(text)
+                ? await TranscribeAsync(wavAudio, language, translate, prompt, ct)
+                : new PluginTranscriptionResult(text, NormalizeLanguage(language), PcmDurationSeconds(pcm16.Length), NoSpeechProbability: null);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            return await TranscribeAsync(wavAudio, language, translate, prompt, ct);
+        }
+    }
+
+    public async Task<IStreamingSession> StartStreamingAsync(string? language, CancellationToken ct)
+    {
+        if (!IsConfigured)
+            throw new InvalidOperationException("Plugin not configured. API key required.");
+
+        return await Reson8StreamingSession.ConnectAsync(
+            _apiKey!,
+            _customBaseUrl,
+            _customAuthHeader,
+            _selectedModelId,
+            NormalizeLanguage(language),
+            ct);
+    }
+
+    internal async Task SetApiKeyAsync(string apiKey)
+    {
+        var normalized = NormalizeApiKey(apiKey);
+        IPluginHostServices? hostToNotify = null;
+
+        await _apiKeyWriteLock.WaitAsync();
+        try
+        {
+            var wasConfigured = IsConfigured;
+            var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
+
+            _apiKey = normalized;
+            if (_host is not null)
+            {
+                if (normalized is null)
+                    await _host.DeleteSecretAsync(ApiKeySecretName);
+                else
+                    await _host.StoreSecretAsync(ApiKeySecretName, normalized);
+
+                if (changed && wasConfigured != IsConfigured)
+                    hostToNotify = _host;
+            }
+        }
+        finally
+        {
+            _apiKeyWriteLock.Release();
+        }
+
+        hostToNotify?.NotifyCapabilitiesChanged();
+    }
+
+    internal async Task<bool> ValidateApiKeyAsync(string apiKey, CancellationToken ct = default)
+    {
+        var normalized = NormalizeApiKey(apiKey);
+        if (normalized is null)
+            return false;
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            BuildPrerecordedUri(_customBaseUrl, DefaultModelId, language: null));
+        AddAuthHeader(request, normalized, _customAuthHeader);
+        request.Content = new ByteArrayContent([]);
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct);
+            return response.StatusCode != HttpStatusCode.Unauthorized;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return false;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    internal async Task<IReadOnlyList<Reson8CustomModel>> FetchCustomModelsAsync(CancellationToken ct = default)
+    {
+        if (!IsConfigured)
+            return [];
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{_customBaseUrl}/v1/custom-model");
+        AddAuthHeader(request, _apiKey!, _customAuthHeader);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                return [];
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            return JsonSerializer.Deserialize<List<Reson8CustomModel>>(json, JsonOptions) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+        catch (HttpRequestException)
+        {
+            return [];
+        }
+    }
+
+    internal void SetFetchedCustomModels(IReadOnlyList<Reson8CustomModel> models)
+    {
+        _fetchedCustomModels = models.ToArray();
+        _host?.SetSetting(FetchedCustomModelsSettingName, _fetchedCustomModels);
+
+        if (_selectedModelId != DefaultModelId && _fetchedCustomModels.All(m => m.Id != _selectedModelId))
+        {
+            _selectedModelId = DefaultModelId;
+            _host?.SetSetting(SelectedModelSettingName, _selectedModelId);
+        }
+
+        _host?.NotifyCapabilitiesChanged();
+    }
+
+    internal void SetCustomBaseUrl(string? url)
+    {
+        _customBaseUrl = NormalizeBaseUrl(url);
+        _host?.SetSetting(CustomBaseUrlSettingName, _customBaseUrl == DefaultBaseUrl ? null : _customBaseUrl);
+    }
+
+    internal void SetCustomAuthHeader(string? header)
+    {
+        _customAuthHeader = NormalizeAuthHeader(header);
+        _host?.SetSetting(CustomAuthHeaderSettingName, _customAuthHeader == DefaultAuthHeader ? null : _customAuthHeader);
+    }
+
+    internal static Uri BuildPrerecordedUri(string baseUrl, string? modelId, string? language)
+    {
+        var query = new List<string>
+        {
+            "encoding=pcm_s16le",
+            "sample_rate=16000",
+            "channels=1"
+        };
+
+        if (!string.IsNullOrWhiteSpace(language))
+            query.Add($"language={Uri.EscapeDataString(language)}");
+
+        if (!string.IsNullOrWhiteSpace(modelId)
+            && !string.Equals(modelId, DefaultModelId, StringComparison.Ordinal))
+        {
+            query.Add($"custom_model_id={Uri.EscapeDataString(modelId)}");
+        }
+
+        return new Uri($"{NormalizeBaseUrl(baseUrl)}/v1/speech-to-text/prerecorded?{string.Join("&", query)}");
+    }
+
+    internal static PluginTranscriptionResult ParseTranscriptionResponse(
+        string json,
+        string? fallbackLanguage,
+        int pcm16ByteLength)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var text = GetString(root, "text")?.Trim() ?? "";
+        var language = GetString(root, "language") ?? GetString(root, "detected_language") ?? fallbackLanguage;
+        return new PluginTranscriptionResult(text, language, PcmDurationSeconds(pcm16ByteLength), NoSpeechProbability: null);
+    }
+
+    internal static string ExtractApiError(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (GetString(root, "code") is { } code && GetString(root, "message") is { } codeMessage)
+                return $"{code}: {codeMessage}";
+
+            return GetString(root, "message")
+                ?? GetString(root, "error")
+                ?? GetString(root, "detail")
+                ?? "Unknown error";
+        }
+        catch (JsonException)
+        {
+            return string.IsNullOrWhiteSpace(json) ? "Unknown error" : json;
+        }
+    }
+
+    internal static string? NormalizeLanguage(string? language) =>
+        string.IsNullOrWhiteSpace(language) || language.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : language.Trim();
+
+    internal static void AddAuthHeader(HttpRequestMessage request, string apiKey, string authHeader)
+    {
+        var normalizedHeader = NormalizeAuthHeader(authHeader);
+        if (string.Equals(normalizedHeader, DefaultAuthHeader, StringComparison.OrdinalIgnoreCase))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("ApiKey", apiKey);
+            return;
+        }
+
+        request.Headers.TryAddWithoutValidation(normalizedHeader, apiKey);
+    }
+
+    internal static string AuthHeaderValue(string apiKey, string authHeader) =>
+        string.Equals(NormalizeAuthHeader(authHeader), DefaultAuthHeader, StringComparison.OrdinalIgnoreCase)
+            ? $"ApiKey {apiKey}"
+            : apiKey;
+
+    private static string NormalizeModelId(string? modelId) =>
+        string.IsNullOrWhiteSpace(modelId) ? DefaultModelId : modelId.Trim();
+
+    private static string? NormalizeApiKey(string? apiKey) =>
+        string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
+
+    private static string NormalizeBaseUrl(string? url)
+    {
+        var normalized = string.IsNullOrWhiteSpace(url) ? DefaultBaseUrl : url.Trim();
+        while (normalized.EndsWith("/", StringComparison.Ordinal))
+            normalized = normalized[..^1];
+
+        return string.IsNullOrWhiteSpace(normalized) ? DefaultBaseUrl : normalized;
+    }
+
+    private static string NormalizeAuthHeader(string? header) =>
+        string.IsNullOrWhiteSpace(header) ? DefaultAuthHeader : header.Trim();
+
+    private static string? GetString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static void ThrowForApiError(HttpStatusCode statusCode, string json)
+    {
+        var message = ExtractApiError(json);
+        switch (statusCode)
+        {
+            case HttpStatusCode.Unauthorized:
+                throw new UnauthorizedAccessException("Invalid Reson8 API key.");
+            case HttpStatusCode.NotFound:
+                throw new KeyNotFoundException($"Reson8 custom model not found: {message}");
+            case HttpStatusCode.RequestEntityTooLarge:
+                throw new InvalidOperationException($"Reson8 file too large: {message}");
+            case HttpStatusCode.TooManyRequests:
+                throw new HttpRequestException($"Reson8 rate limit exceeded: {message}");
+            case HttpStatusCode.InternalServerError:
+                throw new HttpRequestException($"Reson8 server error: {message}");
+            default:
+                throw new HttpRequestException($"Reson8 API error {(int)statusCode}: {message}");
+        }
+    }
+
+    private static double PcmDurationSeconds(int pcm16ByteLength) =>
+        pcm16ByteLength <= 0 ? 0 : pcm16ByteLength / 2.0 / 16000.0;
+
+    private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromSeconds(120) };
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+        _apiKeyWriteLock.Dispose();
+    }
+}
+
+internal static class WavPcm16Extractor
+{
+    public static byte[] ExtractPcm16(byte[] wavAudio)
+    {
+        if (wavAudio.Length < 44
+            || !HasAscii(wavAudio, 0, "RIFF")
+            || !HasAscii(wavAudio, 8, "WAVE"))
+        {
+            return wavAudio;
+        }
+
+        var offset = 12;
+        short audioFormat = 0;
+        short channels = 0;
+        int sampleRate = 0;
+        short bitsPerSample = 0;
+        byte[]? data = null;
+
+        while (offset + 8 <= wavAudio.Length)
+        {
+            var chunkId = Encoding.ASCII.GetString(wavAudio, offset, 4);
+            var chunkSize = BitConverter.ToInt32(wavAudio, offset + 4);
+            offset += 8;
+            if (chunkSize < 0 || offset + chunkSize > wavAudio.Length)
+                break;
+
+            if (chunkId == "fmt " && chunkSize >= 16)
+            {
+                audioFormat = BitConverter.ToInt16(wavAudio, offset);
+                channels = BitConverter.ToInt16(wavAudio, offset + 2);
+                sampleRate = BitConverter.ToInt32(wavAudio, offset + 4);
+                bitsPerSample = BitConverter.ToInt16(wavAudio, offset + 14);
+            }
+            else if (chunkId == "data")
+            {
+                data = wavAudio.Skip(offset).Take(chunkSize).ToArray();
+            }
+
+            offset += chunkSize + (chunkSize % 2);
+        }
+
+        if (data is null)
+            return wavAudio;
+
+        if (audioFormat == 1 && channels == 1 && sampleRate == 16000 && bitsPerSample == 16)
+            return data;
+
+        return data;
+    }
+
+    private static bool HasAscii(byte[] bytes, int offset, string value)
+    {
+        if (offset + value.Length > bytes.Length)
+            return false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (bytes[offset + i] != value[i])
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/plugins/TypeWhisper.Plugin.Reson8/Reson8SettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Reson8/Reson8SettingsView.xaml
@@ -1,0 +1,47 @@
+<UserControl x:Class="TypeWhisper.Plugin.Reson8.Reson8SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="0,4" MaxWidth="520">
+        <TextBlock x:Name="ApiKeyLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
+                    Click="OnTestClick" x:Name="TestButton" />
+            <Button Grid.Column="2" Margin="8,0,0,0" Padding="12,4"
+                    Click="OnRemoveClick" x:Name="RemoveButton" />
+        </Grid>
+        <TextBlock x:Name="ApiKeyHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        <TextBlock x:Name="StatusText" Margin="0,6,0,0" FontSize="12" />
+
+        <StackPanel x:Name="ModelsSection" Margin="0,16,0,0" Visibility="Collapsed">
+            <Grid Margin="0,0,0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="ModelLabel" FontWeight="SemiBold" VerticalAlignment="Center" />
+                <Button Grid.Column="1" x:Name="RefreshModelsButton" Padding="12,4"
+                        Click="OnRefreshModelsClick" />
+            </Grid>
+            <ComboBox x:Name="ModelPicker"
+                      DisplayMemberPath="DisplayName"
+                      SelectionChanged="OnModelChanged" />
+            <TextBlock x:Name="ModelHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Expander x:Name="AdvancedExpander" Margin="0,16,0,0">
+            <StackPanel Margin="0,8,0,0">
+                <TextBlock x:Name="CustomBaseUrlLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
+                <TextBox x:Name="CustomBaseUrlBox" TextChanged="OnCustomBaseUrlChanged" />
+                <TextBlock x:Name="CustomAuthHeaderLabel" FontWeight="SemiBold" Margin="0,10,0,4" />
+                <TextBox x:Name="CustomAuthHeaderBox" TextChanged="OnCustomAuthHeaderChanged" />
+                <TextBlock x:Name="AdvancedHintText" Margin="0,4,0,0" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+            </StackPanel>
+        </Expander>
+    </StackPanel>
+</UserControl>

--- a/plugins/TypeWhisper.Plugin.Reson8/Reson8SettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Reson8/Reson8SettingsView.xaml.cs
@@ -1,0 +1,183 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.Reson8;
+
+public partial class Reson8SettingsView : UserControl
+{
+    private readonly Reson8Plugin _plugin;
+    private bool _suppressChanges;
+
+    public Reson8SettingsView(Reson8Plugin plugin)
+    {
+        _plugin = plugin;
+        InitializeComponent();
+
+        ApiKeyLabel.Text = L("Settings.ApiKeyLabel");
+        TestButton.Content = L("Settings.Test");
+        RemoveButton.Content = L("Settings.Remove");
+        ApiKeyHintText.Text = L("Settings.ApiKeyHint");
+        ModelLabel.Text = L("Settings.Model");
+        RefreshModelsButton.Content = L("Settings.Refresh");
+        AdvancedExpander.Header = L("Settings.Advanced");
+        CustomBaseUrlLabel.Text = L("Settings.CustomBaseUrl");
+        CustomAuthHeaderLabel.Text = L("Settings.CustomAuthHeader");
+        AdvancedHintText.Text = L("Settings.AdvancedHint");
+
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _suppressChanges = true;
+        try
+        {
+            ApiKeyBox.Password = _plugin.ApiKey ?? "";
+            CustomBaseUrlBox.Text = _plugin.CustomBaseUrl == Reson8Plugin.DefaultBaseUrl ? "" : _plugin.CustomBaseUrl;
+            CustomAuthHeaderBox.Text = _plugin.CustomAuthHeader == Reson8Plugin.DefaultAuthHeader ? "" : _plugin.CustomAuthHeader;
+            AdvancedExpander.IsExpanded = !string.IsNullOrWhiteSpace(CustomBaseUrlBox.Text)
+                || !string.IsNullOrWhiteSpace(CustomAuthHeaderBox.Text);
+            PopulateModelPicker();
+            UpdateVisibility();
+        }
+        finally
+        {
+            _suppressChanges = false;
+        }
+    }
+
+    private async void OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (_suppressChanges)
+            return;
+
+        await _plugin.SetApiKeyAsync(ApiKeyBox.Password);
+        StatusText.Text = string.IsNullOrWhiteSpace(ApiKeyBox.Password) ? "" : L("Settings.Saved");
+        StatusText.Foreground = Brushes.Gray;
+        UpdateVisibility();
+    }
+
+    private async void OnTestClick(object sender, RoutedEventArgs e)
+    {
+        var key = ApiKeyBox.Password;
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            StatusText.Text = L("Settings.EnterApiKey");
+            StatusText.Foreground = Brushes.Orange;
+            return;
+        }
+
+        TestButton.IsEnabled = false;
+        StatusText.Text = L("Settings.Testing");
+        StatusText.Foreground = Brushes.Gray;
+
+        try
+        {
+            var valid = await _plugin.ValidateApiKeyAsync(key);
+            StatusText.Text = valid ? L("Settings.ApiKeyValid") : L("Settings.ApiKeyInvalid");
+            StatusText.Foreground = valid ? Brushes.Green : Brushes.Red;
+            if (valid)
+                await RefreshModelsAsync();
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = L("Settings.Error", ex.Message);
+            StatusText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            TestButton.IsEnabled = true;
+            UpdateVisibility();
+        }
+    }
+
+    private async void OnRemoveClick(object sender, RoutedEventArgs e)
+    {
+        ApiKeyBox.Password = "";
+        await _plugin.SetApiKeyAsync("");
+        _plugin.SetFetchedCustomModels([]);
+        StatusText.Text = "";
+        PopulateModelPicker();
+        UpdateVisibility();
+    }
+
+    private void OnModelChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressChanges)
+            return;
+
+        if (ModelPicker.SelectedItem is PluginModelInfo model)
+            _plugin.SelectModel(model.Id);
+    }
+
+    private async void OnRefreshModelsClick(object sender, RoutedEventArgs e)
+    {
+        await RefreshModelsAsync();
+    }
+
+    private void OnCustomBaseUrlChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_suppressChanges)
+            return;
+
+        _plugin.SetCustomBaseUrl(CustomBaseUrlBox.Text);
+    }
+
+    private void OnCustomAuthHeaderChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_suppressChanges)
+            return;
+
+        _plugin.SetCustomAuthHeader(CustomAuthHeaderBox.Text);
+    }
+
+    private async Task RefreshModelsAsync()
+    {
+        RefreshModelsButton.IsEnabled = false;
+        RefreshModelsButton.Content = L("Settings.Refreshing");
+        try
+        {
+            var models = await _plugin.FetchCustomModelsAsync();
+            _plugin.SetFetchedCustomModels(models);
+            PopulateModelPicker();
+            StatusText.Text = L("Settings.ModelsFetched", models.Count);
+            StatusText.Foreground = Brushes.Green;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = L("Settings.Error", ex.Message);
+            StatusText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            RefreshModelsButton.Content = L("Settings.Refresh");
+            RefreshModelsButton.IsEnabled = true;
+        }
+    }
+
+    private void PopulateModelPicker()
+    {
+        var models = _plugin.TranscriptionModels.ToList();
+        ModelPicker.ItemsSource = models;
+        ModelPicker.SelectedItem = models.FirstOrDefault(m => m.Id == _plugin.SelectedModelId)
+            ?? models.FirstOrDefault();
+        ModelHintText.Text = _plugin.FetchedCustomModels.Count == 0
+            ? L("Settings.NoCustomModels")
+            : L("Settings.ModelsFetched", _plugin.FetchedCustomModels.Count);
+    }
+
+    private void UpdateVisibility()
+    {
+        ModelsSection.Visibility = _plugin.IsConfigured ? Visibility.Visible : Visibility.Collapsed;
+        RemoveButton.Visibility = _plugin.IsConfigured ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    internal static string FormatFallbackText(string key, params object[] args) =>
+        args.Length == 0 ? key : string.Format(key, args);
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) =>
+        _plugin.Loc?.GetString(key, args) ?? FormatFallbackText(key, args);
+}

--- a/plugins/TypeWhisper.Plugin.Reson8/Reson8StreamingSession.cs
+++ b/plugins/TypeWhisper.Plugin.Reson8/Reson8StreamingSession.cs
@@ -1,0 +1,328 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.PluginSDK;
+
+namespace TypeWhisper.Plugin.Reson8;
+
+internal sealed class Reson8StreamingSession : IStreamingSession
+{
+    private readonly ClientWebSocket _ws;
+    private readonly Reson8TranscriptCollector _collector;
+    private readonly CancellationTokenSource _receiveCts = new();
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly TaskCompletionSource _flushConfirmed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Task? _receiveTask;
+    private bool _disposed;
+
+    private Reson8StreamingSession(ClientWebSocket ws, Reson8TranscriptCollector collector)
+    {
+        _ws = ws;
+        _collector = collector;
+    }
+
+    public event Action<StreamingTranscriptEvent>? TranscriptReceived;
+
+    public static async Task<Reson8StreamingSession> ConnectAsync(
+        string apiKey,
+        string baseUrl,
+        string authHeader,
+        string? modelId,
+        string? language,
+        CancellationToken ct)
+    {
+        var ws = new ClientWebSocket();
+        foreach (var header in CreateStreamingHeaders(apiKey, authHeader))
+            ws.Options.SetRequestHeader(header.Key, header.Value);
+
+        await ws.ConnectAsync(BuildRealtimeUri(baseUrl, modelId, language), ct);
+
+        var session = new Reson8StreamingSession(ws, new Reson8TranscriptCollector());
+        session._receiveTask = session.ReceiveLoopAsync(session._receiveCts.Token);
+        return session;
+    }
+
+    public static Uri BuildRealtimeUri(string baseUrl, string? modelId, string? language)
+    {
+        var normalizedBase = baseUrl.Trim().TrimEnd('/');
+        var baseUri = new Uri(normalizedBase);
+        var builder = new UriBuilder(baseUri)
+        {
+            Scheme = baseUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ? "ws" : "wss",
+            Path = "/v1/speech-to-text/realtime"
+        };
+
+        var query = new List<string>
+        {
+            "encoding=pcm_s16le",
+            "sample_rate=16000",
+            "channels=1",
+            "include_interim=true"
+        };
+
+        if (!string.IsNullOrWhiteSpace(language)
+            && !language.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            query.Add($"language={Uri.EscapeDataString(language.Trim())}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(modelId)
+            && !string.Equals(modelId, Reson8Plugin.DefaultModelId, StringComparison.Ordinal))
+        {
+            query.Add($"custom_model_id={Uri.EscapeDataString(modelId.Trim())}");
+        }
+
+        builder.Query = string.Join("&", query);
+        return builder.Uri;
+    }
+
+    public static IReadOnlyDictionary<string, string> CreateStreamingHeaders(string apiKey, string authHeader) =>
+        new Dictionary<string, string>
+        {
+            [string.IsNullOrWhiteSpace(authHeader) ? Reson8Plugin.DefaultAuthHeader : authHeader.Trim()] =
+                Reson8Plugin.AuthHeaderValue(apiKey, authHeader)
+        };
+
+    public async Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
+    {
+        if (_disposed || _ws.State != WebSocketState.Open || pcm16Audio.Length == 0)
+            return;
+
+        await _sendLock.WaitAsync(ct);
+        try
+        {
+            if (_ws.State == WebSocketState.Open)
+                await _ws.SendAsync(pcm16Audio, WebSocketMessageType.Binary, true, ct);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    public async Task FinalizeAsync(CancellationToken ct)
+    {
+        if (_disposed || _ws.State != WebSocketState.Open)
+            return;
+
+        var json = $$"""{"type":"flush_request","id":"{{Guid.NewGuid()}}"}""";
+        await _sendLock.WaitAsync(ct);
+        try
+        {
+            if (_ws.State == WebSocketState.Open)
+            {
+                var payload = Encoding.UTF8.GetBytes(json);
+                await _ws.SendAsync(payload, WebSocketMessageType.Text, true, ct);
+            }
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+
+        await _flushConfirmed.Task.WaitAsync(ct);
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        using var messageBuffer = new MemoryStream();
+
+        try
+        {
+            while (!ct.IsCancellationRequested && _ws.State == WebSocketState.Open)
+            {
+                messageBuffer.SetLength(0);
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await _ws.ReceiveAsync(buffer, ct);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        _flushConfirmed.TrySetResult();
+                        return;
+                    }
+
+                    messageBuffer.Write(buffer, 0, result.Count);
+                } while (!result.EndOfMessage);
+
+                if (result.MessageType != WebSocketMessageType.Text)
+                    continue;
+
+                var json = Encoding.UTF8.GetString(messageBuffer.GetBuffer(), 0, (int)messageBuffer.Length);
+                var transcriptEvent = _collector.ApplyEvent(json);
+                if (transcriptEvent is not null)
+                    TranscriptReceived?.Invoke(transcriptEvent);
+
+                if (_collector.IsFlushConfirmed)
+                    _flushConfirmed.TrySetResult();
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            Debug.WriteLine($"Reson8 receive loop canceled: {ex.Message}");
+        }
+        catch (WebSocketException ex)
+        {
+            Debug.WriteLine($"Reson8 WebSocket error: {ex.Message}");
+            _flushConfirmed.TrySetException(ex);
+        }
+        catch (JsonException ex)
+        {
+            Debug.WriteLine($"Reson8 parse error: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            Debug.WriteLine($"Reson8 stream error: {ex.Message}");
+            _flushConfirmed.TrySetException(ex);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _receiveCts.Cancel();
+        _flushConfirmed.TrySetResult();
+
+        await _sendLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            if (_ws.State == WebSocketState.Open)
+            {
+                try { await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None); }
+                catch (OperationCanceledException ex)
+                {
+                    Debug.WriteLine($"Reson8 WebSocket close canceled: {ex.Message}");
+                }
+                catch (WebSocketException ex)
+                {
+                    Debug.WriteLine($"Reson8 WebSocket close error: {ex.Message}");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Debug.WriteLine($"Reson8 WebSocket close skipped: {ex.Message}");
+                }
+            }
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+
+        if (_receiveTask is not null)
+        {
+            try { await _receiveTask; }
+            catch (OperationCanceledException ex)
+            {
+                Debug.WriteLine($"Reson8 receive loop canceled during dispose: {ex.Message}");
+            }
+            catch (WebSocketException ex)
+            {
+                Debug.WriteLine($"Reson8 receive loop closed during dispose: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                Debug.WriteLine($"Reson8 receive loop parse error during dispose: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.WriteLine($"Reson8 receive loop stopped during dispose: {ex.Message}");
+            }
+        }
+
+        _sendLock.Dispose();
+        _receiveCts.Dispose();
+        _ws.Dispose();
+    }
+}
+
+internal sealed class Reson8TranscriptCollector
+{
+    private readonly List<string> _finals = [];
+    private string _interim = "";
+
+    public bool IsFlushConfirmed { get; private set; }
+    public string FinalText => string.Join(" ", _finals);
+
+    public StreamingTranscriptEvent? ApplyEvent(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var type = GetString(root, "type");
+        if (string.IsNullOrWhiteSpace(type))
+            return null;
+
+        if (type.Equals("flush_confirmation", StringComparison.OrdinalIgnoreCase))
+        {
+            IsFlushConfirmed = true;
+            return null;
+        }
+
+        if (type.Contains("error", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(Reson8Plugin.ExtractApiError(json));
+
+        if (!type.Equals("transcript", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var text = GetString(root, "text")?.Trim() ?? "";
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var isFinal = GetBool(root, "is_final");
+        if (isFinal)
+        {
+            _finals.Add(text);
+            _interim = "";
+        }
+        else
+        {
+            _interim = text;
+        }
+
+        return new StreamingTranscriptEvent(text, isFinal);
+    }
+
+    public string ApplyEvent(StreamingTranscriptEvent evt)
+    {
+        if (evt.IsFinal)
+        {
+            var trimmed = evt.Text.Trim();
+            if (!string.IsNullOrWhiteSpace(trimmed))
+                _finals.Add(trimmed);
+            _interim = "";
+        }
+        else
+        {
+            _interim = evt.Text.Trim();
+        }
+
+        return CurrentText;
+    }
+
+    private string CurrentText
+    {
+        get
+        {
+            var parts = _finals.ToList();
+            if (!string.IsNullOrWhiteSpace(_interim))
+                parts.Add(_interim);
+            return string.Join(" ", parts);
+        }
+    }
+
+    private static bool GetBool(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var element)
+        && element.ValueKind == JsonValueKind.True;
+
+    private static string? GetString(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var element)
+        && element.ValueKind == JsonValueKind.String
+            ? element.GetString()
+            : null;
+}

--- a/plugins/TypeWhisper.Plugin.Reson8/TypeWhisper.Plugin.Reson8.csproj
+++ b/plugins/TypeWhisper.Plugin.Reson8/TypeWhisper.Plugin.Reson8.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>TypeWhisper.Plugin.Reson8</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" Private="false" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Target Name="RemoveHostSdkFromPluginOutput" AfterTargets="Build">
+    <Delete Files="$(TargetDir)TypeWhisper.PluginSDK.dll;$(TargetDir)TypeWhisper.PluginSDK.pdb" />
+  </Target>
+  <Target Name="CopyToAppPlugins" AfterTargets="Build">
+    <PropertyGroup>
+      <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
+      <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.reson8\</PluginOutputDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(PluginOutputDir)" />
+    <Delete Files="$(PluginOutputDir)TypeWhisper.PluginSDK.dll;$(PluginOutputDir)TypeWhisper.PluginSDK.pdb" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
+  </Target>
+</Project>

--- a/plugins/TypeWhisper.Plugin.Reson8/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Reson8/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "com.typewhisper.reson8",
+  "name": "Reson8",
+  "version": "1.0.0",
+  "author": "Y. Vos",
+  "description": "Cloud transcription via Reson8 speech-to-text API with real-time WebSocket streaming. Requires API key.",
+  "category": "transcription",
+  "categories": ["transcription"],
+  "isLocal": false,
+  "requiresApiKey": true,
+  "iconSystemName": "waveform.badge.mic",
+  "descriptions": {
+    "de": "Cloud-Transkription ueber die Reson8-Speech-to-Text-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key."
+  },
+  "assemblyName": "TypeWhisper.Plugin.Reson8.dll",
+  "pluginClass": "TypeWhisper.Plugin.Reson8.Reson8Plugin"
+}

--- a/src/TypeWhisper.Windows/ViewModels/PluginIconHelper.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginIconHelper.cs
@@ -45,6 +45,7 @@ internal static class PluginIconHelper
         "com.typewhisper.openai" => "\U0001F916",          // OpenAI - robot
         "com.typewhisper.openai-compatible" => "\U0001F310", // OpenAI Compatible - globe
         "com.typewhisper.smallest-ai" => "\U0001F399",        // Smallest AI Pulse - studio microphone
+        "com.typewhisper.reson8" => "\U0001F399",             // Reson8 - studio microphone
         "com.typewhisper.sherpa-onnx" => "\U0001F3AF",     // SherpaOnnx - local/target
         "com.typewhisper.elevenlabs" => "\U0001F399",       // ElevenLabs - studio microphone
         "com.typewhisper.supertonic-tts" => "\U0001F50A",   // Supertonic TTS - speaker
@@ -59,6 +60,7 @@ internal static class PluginIconHelper
         "com.typewhisper.openai" => "#10A37F",
         "com.typewhisper.openai-compatible" => "#6366F1",
         "com.typewhisper.smallest-ai" => "#14B8A6",
+        "com.typewhisper.reson8" => "#0F766E",
         "com.typewhisper.sherpa-onnx" => "#F59E0B",
         "com.typewhisper.elevenlabs" => "#111827",
         "com.typewhisper.supertonic-tts" => "#00A6A6",
@@ -73,6 +75,7 @@ internal static class PluginIconHelper
         "com.typewhisper.openai" => "#0D8A6A",
         "com.typewhisper.openai-compatible" => "#4F46E5",
         "com.typewhisper.smallest-ai" => "#2563EB",
+        "com.typewhisper.reson8" => "#0891B2",
         "com.typewhisper.sherpa-onnx" => "#D97706",
         "com.typewhisper.elevenlabs" => "#F97316",
         "com.typewhisper.supertonic-tts" => "#2563EB",

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginIconHelperTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginIconHelperTests.cs
@@ -57,6 +57,15 @@ public sealed class PluginIconHelperTests : IDisposable
         Assert.Equal("#2563EB", PluginIconHelper.GetGradientEnd("com.typewhisper.smallest-ai"));
     }
 
+    [Fact]
+    public void GetLogoPath_Reson8_UsesSpeechFallbackIconAndGradient()
+    {
+        Assert.Null(PluginIconHelper.GetLogoPath("com.typewhisper.reson8", _baseDirectory));
+        Assert.Equal("\U0001F399", PluginIconHelper.GetIcon("com.typewhisper.reson8"));
+        Assert.Equal("#0F766E", PluginIconHelper.GetGradientStart("com.typewhisper.reson8"));
+        Assert.Equal("#0891B2", PluginIconHelper.GetGradientEnd("com.typewhisper.reson8"));
+    }
+
     [Theory]
     [InlineData("com.typewhisper.openai", "openai.png")]
     [InlineData("com.typewhisper.groq", "groq.png")]

--- a/tests/TypeWhisper.PluginSystem.Tests/Reson8PluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/Reson8PluginTests.cs
@@ -1,0 +1,474 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.Plugin.Reson8;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class Reson8PluginTests
+{
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifest = LoadManifest();
+        var sut = new Reson8Plugin();
+
+        Assert.Equal(manifest.GetProperty("version").GetString(), sut.PluginVersion);
+    }
+
+    [Fact]
+    public void Manifest_AdvertisesTranscriptionCapabilitiesAndApiKeyRequirement()
+    {
+        var manifest = LoadManifest();
+
+        Assert.Equal("com.typewhisper.reson8", manifest.GetProperty("id").GetString());
+        Assert.Equal("Reson8", manifest.GetProperty("name").GetString());
+        Assert.Equal("transcription", manifest.GetProperty("category").GetString());
+        Assert.Equal(["transcription"], manifest.GetProperty("categories").EnumerateArray().Select(e => e.GetString()!).ToArray());
+        Assert.False(manifest.GetProperty("isLocal").GetBoolean());
+        Assert.True(manifest.GetProperty("requiresApiKey").GetBoolean());
+    }
+
+    [Fact]
+    public void Localization_ProvidesSettingsLabelsAndGermanDiacritics()
+    {
+        var en = LoadLocalization("en");
+        var de = LoadLocalization("de");
+
+        Assert.Equal("API Key", en.GetProperty("Settings.ApiKeyLabel").GetString());
+        Assert.Equal("API-Schlüssel", de.GetProperty("Settings.ApiKeyLabel").GetString());
+        Assert.Equal("API-Schlüssel gültig!", de.GetProperty("Settings.ApiKeyValid").GetString());
+        Assert.Equal("Ungültiger API-Schlüssel", de.GetProperty("Settings.ApiKeyInvalid").GetString());
+    }
+
+    [Fact]
+    public async Task ActivateAsync_RestoresApiKeySettingsAndCustomModels()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "reson-key";
+        host.SetSetting("selectedModel", "domain-model");
+        host.SetSetting("customBaseURL", "https://proxy.example.test/");
+        host.SetSetting("customAuthHeader", "X-Api-Key");
+        host.SetSetting("fetchedCustomModels", new[]
+        {
+            new Reson8CustomModel("domain-model", "Domain Model", "Support vocabulary", 42)
+        });
+
+        var sut = new Reson8Plugin();
+        await sut.ActivateAsync(host);
+
+        Assert.Equal("com.typewhisper.reson8", sut.PluginId);
+        Assert.Equal("reson8", sut.ProviderId);
+        Assert.Equal("Reson8", sut.ProviderDisplayName);
+        Assert.True(sut.IsConfigured);
+        Assert.True(sut.SupportsStreaming);
+        Assert.False(sut.SupportsTranslation);
+        Assert.Equal("domain-model", sut.SelectedModelId);
+        Assert.Equal(["__default__", "domain-model"], sut.TranscriptionModels.Select(m => m.Id).ToArray());
+        Assert.Equal("https://proxy.example.test", sut.CustomBaseUrl);
+        Assert.Equal("X-Api-Key", sut.CustomAuthHeader);
+        Assert.Contains("de", sut.SupportedLanguages);
+        Assert.DoesNotContain("ja", sut.SupportedLanguages);
+    }
+
+    [Fact]
+    public async Task SelectModel_PersistsSelectedModel()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new Reson8Plugin();
+        await sut.ActivateAsync(host);
+
+        sut.SetFetchedCustomModels([new Reson8CustomModel("domain-model", "Domain Model", null, null)]);
+        sut.SelectModel("domain-model");
+
+        Assert.Equal("domain-model", sut.SelectedModelId);
+        Assert.Equal("domain-model", host.GetSetting<string>("selectedModel"));
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_NotifiesOnlyWhenConfigurationStateChanges()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new Reson8Plugin();
+        await sut.ActivateAsync(host);
+
+        await sut.SetApiKeyAsync(" reson-key ");
+        await sut.SetApiKeyAsync("reson-key");
+        await sut.SetApiKeyAsync("");
+
+        Assert.False(host.Secrets.ContainsKey("api-key"));
+        Assert.Equal(2, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task AdvancedSettings_AreNormalizedAndPersisted()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new Reson8Plugin();
+        await sut.ActivateAsync(host);
+
+        sut.SetCustomBaseUrl(" https://proxy.example.test/// ");
+        sut.SetCustomAuthHeader(" X-Api-Key ");
+
+        Assert.Equal("https://proxy.example.test", sut.CustomBaseUrl);
+        Assert.Equal("X-Api-Key", sut.CustomAuthHeader);
+        Assert.Equal("https://proxy.example.test", host.GetSetting<string>("customBaseURL"));
+        Assert.Equal("X-Api-Key", host.GetSetting<string>("customAuthHeader"));
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsync_TreatsBadAudioAsAuthenticatedAndUnauthorizedAsInvalid()
+    {
+        var statuses = new Queue<HttpStatusCode>([HttpStatusCode.BadRequest, HttpStatusCode.Unauthorized]);
+        var handler = new CapturingHandler((request, body) =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("https://api.reson8.dev/v1/speech-to-text/prerecorded", request.RequestUri?.GetLeftPart(UriPartial.Path));
+            Assert.Equal("ApiKey probe-key", request.Headers.Authorization?.ToString());
+            Assert.Equal("application/octet-stream", request.Content?.Headers.ContentType?.MediaType);
+            Assert.Empty(body ?? []);
+
+            return JsonResponse("""{ "message": "probe" }""", statuses.Dequeue());
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new Reson8Plugin(httpClient);
+
+        Assert.True(await sut.ValidateApiKeyAsync("probe-key"));
+        Assert.False(await sut.ValidateApiKeyAsync("probe-key"));
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsync_MatchesMacBehaviorAndOnlyTreatsUnauthorizedAsInvalid()
+    {
+        var statuses = new Queue<HttpStatusCode>([
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.MethodNotAllowed,
+            HttpStatusCode.Forbidden,
+            HttpStatusCode.Unauthorized
+        ]);
+        var handler = new CapturingHandler((_, _) =>
+            JsonResponse("""{ "message": "probe" }""", statuses.Dequeue()));
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new Reson8Plugin(httpClient);
+
+        Assert.True(await sut.ValidateApiKeyAsync("probe-key"));
+        Assert.True(await sut.ValidateApiKeyAsync("probe-key"));
+        Assert.True(await sut.ValidateApiKeyAsync("probe-key"));
+        Assert.False(await sut.ValidateApiKeyAsync("probe-key"));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_PostsPcm16ToPrerecordedEndpointWithLanguageAndCustomModel()
+    {
+        var handler = new CapturingHandler((request, body) =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("https://api.reson8.dev/v1/speech-to-text/prerecorded", request.RequestUri?.GetLeftPart(UriPartial.Path));
+            Assert.Contains("encoding=pcm_s16le", request.RequestUri?.Query);
+            Assert.Contains("sample_rate=16000", request.RequestUri?.Query);
+            Assert.Contains("channels=1", request.RequestUri?.Query);
+            Assert.Contains("language=de", request.RequestUri?.Query);
+            Assert.Contains("custom_model_id=domain-model", request.RequestUri?.Query);
+            Assert.Equal("ApiKey reson-key", request.Headers.Authorization?.ToString());
+            Assert.Equal("application/octet-stream", request.Content?.Headers.ContentType?.MediaType);
+            Assert.Equal([0x01, 0x00, 0xFF, 0xFF], body);
+
+            return JsonResponse("""{ "text": "Hallo Welt", "language": "de" }""");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "reson-key";
+        host.SetSetting("selectedModel", "domain-model");
+        host.SetSetting("fetchedCustomModels", new[]
+        {
+            new Reson8CustomModel("domain-model", "Domain Model", null, null)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new Reson8Plugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(
+            BuildPcm16Wav([0x01, 0x00, 0xFF, 0xFF]),
+            "de",
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+
+        Assert.Equal("Hallo Welt", result.Text);
+        Assert.Equal("de", result.DetectedLanguage);
+        Assert.Equal(0.000125, result.DurationSeconds, precision: 6);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_UsesCustomBaseUrlAndAuthHeaderAndOmitsAutoLanguage()
+    {
+        var handler = new CapturingHandler((request, _) =>
+        {
+            Assert.Equal("https://proxy.example.test/v1/speech-to-text/prerecorded", request.RequestUri?.GetLeftPart(UriPartial.Path));
+            Assert.DoesNotContain("language=", request.RequestUri?.Query);
+            Assert.DoesNotContain("custom_model_id=", request.RequestUri?.Query);
+            Assert.True(request.Headers.TryGetValues("X-Api-Key", out var values));
+            Assert.Equal("reson-key", Assert.Single(values));
+            Assert.False(request.Headers.Contains("Authorization"));
+
+            return JsonResponse("""{ "text": "Hello" }""");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "reson-key";
+        host.SetSetting("customBaseURL", "https://proxy.example.test/");
+        host.SetSetting("customAuthHeader", "X-Api-Key");
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new Reson8Plugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(BuildPcm16Wav([0x00, 0x00]), "auto", false, null, CancellationToken.None);
+
+        Assert.Equal("Hello", result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_ThrowsActionableMessagesForKnownHttpErrors()
+    {
+        var statuses = new Queue<HttpStatusCode>([
+            HttpStatusCode.Unauthorized,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.RequestEntityTooLarge,
+            HttpStatusCode.TooManyRequests,
+            HttpStatusCode.InternalServerError
+        ]);
+        var handler = new CapturingHandler((_, _) =>
+            JsonResponse("""{ "code": "ERR", "message": "details" }""", statuses.Dequeue()));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "reson-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new Reson8Plugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var wav = BuildPcm16Wav([0x00, 0x00]);
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => sut.TranscribeAsync(wav, null, false, null, CancellationToken.None));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => sut.TranscribeAsync(wav, null, false, null, CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.TranscribeAsync(wav, null, false, null, CancellationToken.None));
+        await Assert.ThrowsAsync<HttpRequestException>(() => sut.TranscribeAsync(wav, null, false, null, CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => sut.TranscribeAsync(wav, null, false, null, CancellationToken.None));
+        Assert.Contains("Reson8 server error", ex.Message);
+    }
+
+    [Fact]
+    public async Task FetchCustomModelsAsync_LoadsAndPersistsModels()
+    {
+        var handler = new CapturingHandler((request, _) =>
+        {
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal("https://api.reson8.dev/v1/custom-model", request.RequestUri?.ToString());
+            Assert.Equal("ApiKey reson-key", request.Headers.Authorization?.ToString());
+            return JsonResponse("""
+                [
+                  { "id": "domain-model", "name": "Domain Model", "description": "Support vocabulary", "phraseCount": 42 }
+                ]
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "reson-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new Reson8Plugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var models = await sut.FetchCustomModelsAsync();
+        sut.SetFetchedCustomModels(models);
+
+        Assert.Equal("domain-model", Assert.Single(models).Id);
+        Assert.Equal(["__default__", "domain-model"], sut.TranscriptionModels.Select(m => m.Id).ToArray());
+        Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
+        Assert.Equal("domain-model", Assert.Single(host.GetSetting<List<Reson8CustomModel>>("fetchedCustomModels")!).Id);
+    }
+
+    [Fact]
+    public void StreamingSession_BuildsExpectedUrisHeadersAndCollectsTranscriptEvents()
+    {
+        var uri = Reson8StreamingSession.BuildRealtimeUri("https://api.reson8.dev", "domain-model", "de");
+        Assert.Equal("wss", uri.Scheme);
+        Assert.Equal("api.reson8.dev", uri.Host);
+        Assert.Equal("/v1/speech-to-text/realtime", uri.AbsolutePath);
+        Assert.Contains("encoding=pcm_s16le", uri.Query);
+        Assert.Contains("sample_rate=16000", uri.Query);
+        Assert.Contains("channels=1", uri.Query);
+        Assert.Contains("include_interim=true", uri.Query);
+        Assert.Contains("language=de", uri.Query);
+        Assert.Contains("custom_model_id=domain-model", uri.Query);
+
+        var localUri = Reson8StreamingSession.BuildRealtimeUri("http://localhost:8080/base", "__default__", "auto");
+        Assert.Equal("ws", localUri.Scheme);
+        Assert.Equal(8080, localUri.Port);
+        Assert.DoesNotContain("language=", localUri.Query);
+        Assert.DoesNotContain("custom_model_id=", localUri.Query);
+
+        var headers = Reson8StreamingSession.CreateStreamingHeaders("reson-key", "Authorization");
+        Assert.Equal("ApiKey reson-key", headers["Authorization"]);
+        var customHeaders = Reson8StreamingSession.CreateStreamingHeaders("reson-key", "X-Api-Key");
+        Assert.Equal("reson-key", customHeaders["X-Api-Key"]);
+
+        var collector = new Reson8TranscriptCollector();
+        var partial = collector.ApplyEvent("""{ "type": "transcript", "text": "Hel", "is_final": false }""");
+        Assert.Equal(new StreamingTranscriptEvent("Hel", false), partial);
+
+        var final = collector.ApplyEvent("""{ "type": "transcript", "text": "Hello", "is_final": true }""");
+        Assert.Equal(new StreamingTranscriptEvent("Hello", true), final);
+        Assert.Equal("Hello", collector.FinalText);
+
+        Assert.Null(collector.ApplyEvent("""{ "type": "flush_confirmation" }"""));
+        Assert.True(collector.IsFlushConfirmed);
+    }
+
+    [Fact]
+    public void StreamingCollector_ThrowsActionableMessageForApiErrors()
+    {
+        var collector = new Reson8TranscriptCollector();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            collector.ApplyEvent("""{ "type": "error", "message": "Invalid API key" }"""));
+
+        Assert.Contains("Invalid API key", ex.Message);
+    }
+
+    private static JsonElement LoadManifest()
+    {
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.Reson8", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
+        using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        return doc.RootElement.Clone();
+    }
+
+    private static JsonElement LoadLocalization(string language)
+    {
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeLocalizationPath = Path.Join(
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.Reson8", "Localization", $"{language}.json");
+        var localizationPath = Path.GetFullPath(relativeLocalizationPath, basePath);
+        using var doc = JsonDocument.Parse(File.ReadAllText(localizationPath));
+        return doc.RootElement.Clone();
+    }
+
+    private static byte[] BuildPcm16Wav(byte[] pcm)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
+        writer.Write("RIFF"u8.ToArray());
+        writer.Write(36 + pcm.Length);
+        writer.Write("WAVE"u8.ToArray());
+        writer.Write("fmt "u8.ToArray());
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write((short)1);
+        writer.Write(16000);
+        writer.Write(16000 * 2);
+        writer.Write((short)2);
+        writer.Write((short)16);
+        writer.Write("data"u8.ToArray());
+        writer.Write(pcm.Length);
+        writer.Write(pcm);
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static HttpResponseMessage JsonResponse(
+        string json,
+        HttpStatusCode statusCode = HttpStatusCode.OK) =>
+        new(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class CapturingHandler(
+        Func<HttpRequestMessage, byte[]?, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            return responder(request, body);
+        }
+    }
+
+    private sealed class TestPluginHostServices : IPluginHostServices
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private readonly Dictionary<string, JsonElement> _settings = [];
+        public Dictionary<string, string?> Secrets { get; } = [];
+        public int NotifyCapabilitiesChangedCount { get; private set; }
+
+        public Task StoreSecretAsync(string key, string value)
+        {
+            Secrets[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadSecretAsync(string key) =>
+            Task.FromResult(Secrets.TryGetValue(key, out var value) ? value : null);
+
+        public Task DeleteSecretAsync(string key)
+        {
+            Secrets.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value)
+                ? value.Deserialize<T>(JsonOptions)
+                : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new TestPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() => NotifyCapabilitiesChangedCount++;
+        public IPluginLocalization Localization { get; } = new TestPluginLocalization();
+    }
+
+    private sealed class TestPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TestPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Xai\TypeWhisper.Plugin.Xai.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Reson8\TypeWhisper.Plugin.Reson8.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SherpaOnnx\TypeWhisper.Plugin.SherpaOnnx.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />


### PR DESCRIPTION
## Summary
- Add a Reson8 cloud transcription plugin with REST transcription, WebSocket streaming, API key validation, custom model refresh, and advanced base URL/auth header settings.
- Add localized WPF settings UI and plugin manifest/build integration.
- Add plugin system tests for manifest metadata, settings persistence, REST request handling, validation behavior, streaming helpers, and Extension icon fallback.

## Root Cause / Notes
The Windows app did not yet have the Reson8 plugin that is already available on macOS. During local testing, API key validation was aligned with the macOS behavior so only HTTP 401 marks a key invalid; other authenticated probe responses are accepted.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore` (760 passed)
- Built and installed the Reson8 plugin locally under `%LocalAppData%\TypeWhisper\Plugins\com.typewhisper.reson8`
- Verified discovery with the app `PluginLoader`
- Launched the Release app and manually confirmed Reson8 API key validation, transcription, and WebSocket streaming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Reson8 as a cloud transcription provider with full configuration UI
  * Supports both real-time streaming and standard transcription modes
  * Added German and English localization support

* **Documentation**
  * Updated README to include Reson8 in available cloud transcription providers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->