### PR TITLE
Add Reson8 plugin release mapping

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -44,6 +44,7 @@ jobs:
             'deepgram'           = 'TypeWhisper.Plugin.Deepgram'
             'assemblyai'         = 'TypeWhisper.Plugin.AssemblyAi'
             'elevenlabs'         = 'TypeWhisper.Plugin.ElevenLabs'
+            'reson8'             = 'TypeWhisper.Plugin.Reson8'
             'gemini'             = 'TypeWhisper.Plugin.Gemini'
             'linear'             = 'TypeWhisper.Plugin.Linear'
             'obsidian'           = 'TypeWhisper.Plugin.Obsidian'


### PR DESCRIPTION
## Summary
- Add Reson8 to the plugin release workflow project map so plugin-reson8-v* tags can build and publish the plugin.

## Verification
- dotnet build plugins/TypeWhisper.Plugin.Reson8/TypeWhisper.Plugin.Reson8.csproj -c Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the `reson8` plugin in the build pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->