### PR TITLE
Add smart trailing space after dictation

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1321,6 +1321,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable
             var targetActionPluginId = job.ActiveWorkflow?.Output.TargetActionPluginId;
 
             InsertionResult insertResult;
+            var textInsertedEventText = finalText;
             if (!string.IsNullOrEmpty(targetActionPluginId))
             {
                 var actionPlugin = _modelManager.PluginManager.ActionPlugins
@@ -1361,11 +1362,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                         State = DictationState.Inserting;
                         StatusText = Loc.Instance["Status.Inserting"];
                     });
+                    var insertionText = DictationInsertionTextFormatter.TextForInsertion(finalText);
                     insertResult = await _textInsertion.InsertTextAsync(
-                        finalText,
+                        insertionText,
                         _settings.Current.AutoPaste,
                         job.ActiveWorkflow?.Output.AutoEnter == true,
                         job.CapturedWindowHandle);
+                    textInsertedEventText = insertionText;
                 }
             }
             else
@@ -1376,16 +1379,18 @@ public partial class DictationViewModel : ObservableObject, IDisposable
                     State = DictationState.Inserting;
                     StatusText = Loc.Instance["Status.Inserting"];
                 });
+                var insertionText = DictationInsertionTextFormatter.TextForInsertion(finalText);
                 insertResult = await _textInsertion.InsertTextAsync(
-                    finalText,
+                    insertionText,
                     _settings.Current.AutoPaste,
                     job.ActiveWorkflow?.Output.AutoEnter == true,
                     job.CapturedWindowHandle);
+                textInsertedEventText = insertionText;
             }
 
             _eventBus.Publish(new TextInsertedEvent
             {
-                Text = finalText,
+                Text = textInsertedEventText,
                 TargetApp = job.CapturedProcessName,
                 RecordingId = job.RecordingId
             });
@@ -1862,6 +1867,17 @@ internal static class DictationFinalTextPolicy
     }
 
     private readonly record struct WordToken(int Start, int End, string Normalized);
+}
+
+internal static class DictationInsertionTextFormatter
+{
+    public static string TextForInsertion(string text)
+    {
+        if (string.IsNullOrEmpty(text) || char.IsWhiteSpace(text[^1]))
+            return text;
+
+        return text + " ";
+    }
 }
 
 internal static class DictationShortSpeechPolicy

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOutputPersistenceTests.cs
@@ -23,6 +23,36 @@ public sealed class DictationOutputPersistenceTests
     }
 
     [Fact]
+    public void ProcessSingleJobAsync_UsesInsertionTextOnlyForDirectTextInsertion()
+    {
+        var processJob = ReadProcessSingleJobAsync();
+        var normalizedProcessJob = processJob.Replace("\r\n", "\n");
+
+        var finalTextIndex = processJob.IndexOf("var finalText = pipelineResult.Text;", StringComparison.Ordinal);
+        var insertionTextIndex = processJob.IndexOf(
+            "var insertionText = DictationInsertionTextFormatter.TextForInsertion(finalText);",
+            StringComparison.Ordinal);
+        var directInsertionArgs = System.Text.RegularExpressions.Regex
+            .Matches(processJob, @"_textInsertion\.InsertTextAsync\(\s*(?<arg>\w+),")
+            .Select(match => match.Groups["arg"].Value)
+            .ToArray();
+        var actionOutputIndex = processJob.IndexOf("actionPlugin.ExecuteAsync(finalText,", StringComparison.Ordinal);
+        var eventTextAssignmentIndex = processJob.IndexOf("textInsertedEventText = insertionText;", StringComparison.Ordinal);
+        var eventIndex = processJob.IndexOf("Text = textInsertedEventText,", StringComparison.Ordinal);
+
+        Assert.True(insertionTextIndex > finalTextIndex, "Insertion text must be derived after post-processing.");
+        Assert.Equal(["insertionText", "insertionText"], directInsertionArgs);
+        Assert.True(actionOutputIndex > 0, "Action plugins should continue receiving the clean final text.");
+        Assert.True(eventTextAssignmentIndex > insertionTextIndex, "Direct insertion should capture the inserted text for the event.");
+        Assert.True(eventIndex > eventTextAssignmentIndex, "TextInsertedEvent should report the text that was inserted.");
+        Assert.Contains("LastTranscribedText = finalText;", processJob);
+        Assert.Contains("CompleteApiDictationSession(job.ApiSessionId, new ApiDictationTranscription(\n                finalText,", normalizedProcessJob);
+        Assert.Contains("_recentTranscriptions.RecordTranscription(\n                recordId,\n                finalText,", normalizedProcessJob);
+        Assert.Contains("FinalText = finalText,", processJob);
+        Assert.Contains("_speechFeedback.AnnounceTranscriptionComplete(finalText, detectedLanguage);", processJob);
+    }
+
+    [Fact]
     public void ProcessSingleJobAsync_PreservesCompletedApiSessionWhenOutputDeliveryFails()
     {
         var processJob = ReadProcessSingleJobAsync();

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationShortSpeechPolicyTests.cs
@@ -300,3 +300,38 @@ public class DictationFinalTextPolicyTests
         Assert.False(reject);
     }
 }
+
+public class DictationInsertionTextFormatterTests
+{
+    [Fact]
+    public void TextForInsertion_AddsTrailingSpaceToTextWithoutTrailingWhitespace()
+    {
+        var result = DictationInsertionTextFormatter.TextForInsertion("Hello");
+
+        Assert.Equal("Hello ", result);
+    }
+
+    [Fact]
+    public void TextForInsertion_LeavesExistingTrailingSpaceUntouched()
+    {
+        var result = DictationInsertionTextFormatter.TextForInsertion("Hello ");
+
+        Assert.Equal("Hello ", result);
+    }
+
+    [Fact]
+    public void TextForInsertion_LeavesExistingTrailingNewlineUntouched()
+    {
+        var result = DictationInsertionTextFormatter.TextForInsertion("Hello\n");
+
+        Assert.Equal("Hello\n", result);
+    }
+
+    [Fact]
+    public void TextForInsertion_LeavesEmptyTextUntouched()
+    {
+        var result = DictationInsertionTextFormatter.TextForInsertion("");
+
+        Assert.Equal("", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add smart trailing-space formatting for direct dictation insertion so consecutive dictations do not concatenate words.
- Keep stored transcription surfaces clean: API session text, history, recent transcriptions, readback, and action plugins continue to use the final post-processed text.
- Cover the insertion formatter and direct insertion flow with regression tests.

Closes #179

## Test Plan
- `dotnet test TypeWhisper.slnx --filter "DictationInsertionTextFormatter|DictationOutputPersistence|TextInsertionService"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text insertion formatting to automatically append trailing spaces to dictated text when needed, ensuring proper word spacing and punctuation placement when content is inserted into target applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->