### PR TITLE
Fix Soniox async transcription

### DIFF
--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Windows.Controls;
 using TypeWhisper.PluginSDK;
@@ -9,28 +10,61 @@ namespace TypeWhisper.Plugin.Soniox;
 
 public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 {
-    private const string BaseUrl = "https://api.soniox.com/v1";
+    internal const string DefaultModelId = "default";
 
-    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(120) };
-    private IPluginHostServices? _host;
-    private string? _apiKey;
-    private string? _selectedModelId;
+    private const string BaseUrl = "https://api.soniox.com";
+    private const string ApiKeySecretName = "api-key";
+    private const string SonioxAsyncModelId = "stt-async-v4";
+    private const int DefaultMaxPollAttempts = 3600;
+
+    private static readonly TimeSpan DefaultPollDelay = TimeSpan.FromSeconds(1);
 
     private static readonly IReadOnlyList<PluginModelInfo> Models =
     [
-        new("default", "Soniox (Auto)"),
+        new(DefaultModelId, "Soniox Async")
+        {
+            IsRecommended = true
+        },
     ];
+
+    private readonly HttpClient _httpClient;
+    private readonly TimeSpan _pollDelay;
+    private readonly int _maxPollAttempts;
+    private readonly SemaphoreSlim _apiKeyWriteLock = new(1, 1);
+
+    private IPluginHostServices? _host;
+    private string? _apiKey;
+    private string _selectedModelId = DefaultModelId;
+
+    public SonioxPlugin()
+        : this(CreateHttpClient())
+    {
+    }
+
+    internal SonioxPlugin(
+        HttpClient httpClient,
+        TimeSpan? pollDelay = null,
+        int maxPollAttempts = DefaultMaxPollAttempts)
+    {
+        if (maxPollAttempts <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxPollAttempts), "Poll attempts must be positive.");
+
+        _httpClient = httpClient;
+        _pollDelay = pollDelay ?? DefaultPollDelay;
+        _maxPollAttempts = maxPollAttempts;
+    }
 
     // ITypeWhisperPlugin
 
     public string PluginId => "com.typewhisper.soniox";
     public string PluginName => "Soniox";
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.1";
 
     public async Task ActivateAsync(IPluginHostServices host)
     {
         _host = host;
-        _apiKey = await host.LoadSecretAsync("api-key");
+        _apiKey = NormalizeApiKey(await host.LoadSecretAsync(ApiKeySecretName));
+        _selectedModelId = DefaultModelId;
         host.Log(PluginLogLevel.Info, $"Activated (configured={IsConfigured})");
     }
 
@@ -40,35 +74,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         return Task.CompletedTask;
     }
 
-    public UserControl? CreateSettingsView()
-    {
-        var panel = new StackPanel { Margin = new System.Windows.Thickness(8) };
-        var label = new TextBlock { Text = "API Key", Margin = new System.Windows.Thickness(0, 0, 0, 4) };
-        var box = new PasswordBox { MaxLength = 200 };
-        if (!string.IsNullOrEmpty(_apiKey)) box.Password = _apiKey;
-        var btn = new Button
-        {
-            Content = "Save",
-            Margin = new System.Windows.Thickness(0, 8, 0, 0),
-            HorizontalAlignment = System.Windows.HorizontalAlignment.Left,
-        };
-        btn.Click += async (_, _) =>
-        {
-            var key = box.Password;
-            _apiKey = string.IsNullOrWhiteSpace(key) ? null : key;
-            if (_host is not null)
-            {
-                if (string.IsNullOrWhiteSpace(key))
-                    await _host.DeleteSecretAsync("api-key");
-                else
-                    await _host.StoreSecretAsync("api-key", key);
-            }
-        };
-        panel.Children.Add(label);
-        panel.Children.Add(box);
-        panel.Children.Add(btn);
-        return new UserControl { Content = panel };
-    }
+    public UserControl? CreateSettingsView() => new SonioxSettingsView(this);
 
     // ITranscriptionEnginePlugin
 
@@ -84,65 +90,354 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
     public void SelectModel(string modelId)
     {
-        if (Models.All(m => m.Id != modelId))
+        if (!string.Equals(modelId, DefaultModelId, StringComparison.Ordinal))
             throw new ArgumentException($"Unknown model: {modelId}");
-        _selectedModelId = modelId;
+
+        _selectedModelId = DefaultModelId;
     }
 
     public async Task<PluginTranscriptionResult> TranscribeAsync(
-        byte[] wavAudio, string? language, bool translate, string? prompt, CancellationToken ct)
+        byte[] wavAudio,
+        string? language,
+        bool translate,
+        string? prompt,
+        CancellationToken ct)
     {
+        if (translate)
+            throw new InvalidOperationException("Soniox does not support translation.");
+
         if (!IsConfigured)
             throw new InvalidOperationException("Plugin not configured. API key required.");
 
-        using var content = new MultipartFormDataContent();
+        string? fileId = null;
+        string? transcriptionId = null;
+
+        try
+        {
+            fileId = await UploadFileAsync(wavAudio, ct);
+            transcriptionId = await CreateTranscriptionAsync(fileId, language, ct);
+            var completedDetails = await WaitUntilCompletedAsync(transcriptionId, ct);
+            var transcriptJson = await FetchTranscriptAsync(transcriptionId, ct);
+            return ParseTranscript(transcriptJson, completedDetails, NormalizeLanguage(language));
+        }
+        finally
+        {
+            await CleanupAsync(transcriptionId, fileId);
+        }
+    }
+
+    // Settings support
+
+    internal string? ApiKey => _apiKey;
+    internal IPluginLocalization? Loc => _host?.Localization;
+
+    internal async Task SetApiKeyAsync(string apiKey)
+    {
+        var normalized = NormalizeApiKey(apiKey);
+        IPluginHostServices? hostToNotify = null;
+
+        await _apiKeyWriteLock.WaitAsync();
+        try
+        {
+            var wasConfigured = IsConfigured;
+            var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
+
+            _apiKey = normalized;
+            if (_host is not null)
+            {
+                if (normalized is null)
+                    await _host.DeleteSecretAsync(ApiKeySecretName);
+                else
+                    await _host.StoreSecretAsync(ApiKeySecretName, normalized);
+
+                if (changed && wasConfigured != IsConfigured)
+                    hostToNotify = _host;
+            }
+        }
+        finally
+        {
+            _apiKeyWriteLock.Release();
+        }
+
+        hostToNotify?.NotifyCapabilitiesChanged();
+    }
+
+    internal async Task<bool> ValidateApiKeyAsync(string apiKey, CancellationToken ct = default)
+    {
+        var normalized = NormalizeApiKey(apiKey);
+        if (normalized is null)
+            return false;
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/models");
+        AddAuthorization(request, normalized);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<string> UploadFileAsync(byte[] wavAudio, CancellationToken ct)
+    {
+        using var form = new MultipartFormDataContent();
         var fileContent = new ByteArrayContent(wavAudio);
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
-        content.Add(fileContent, "audio", "audio.wav");
+        form.Add(fileContent, "file", "audio.wav");
 
-        if (!string.IsNullOrEmpty(language) && language != "auto")
-            content.Add(new StringContent(language), "language");
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/files");
+        AddAuthorization(request);
+        request.Content = form;
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/speech:transcribe");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
-        request.Content = content;
+        var json = await SendJsonAsync(request, "Soniox file upload", ct);
+        using var doc = JsonDocument.Parse(json);
+        return GetString(doc.RootElement, "id")
+            ?? throw new InvalidOperationException("Soniox file upload response did not include a file id.");
+    }
 
-        var response = await _httpClient.SendAsync(request, ct);
+    private async Task<string> CreateTranscriptionAsync(string fileId, string? language, CancellationToken ct)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = SonioxAsyncModelId,
+            ["file_id"] = fileId,
+        };
+
+        if (NormalizeLanguage(language) is { } normalizedLanguage)
+            payload["language_hints"] = new[] { normalizedLanguage };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/transcriptions");
+        AddAuthorization(request);
+        request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        var json = await SendJsonAsync(request, "Soniox transcription creation", ct);
+        using var doc = JsonDocument.Parse(json);
+        return GetString(doc.RootElement, "id")
+            ?? throw new InvalidOperationException("Soniox transcription response did not include a transcription id.");
+    }
+
+    private async Task<JsonElement> WaitUntilCompletedAsync(string transcriptionId, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < _maxPollAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/transcriptions/{transcriptionId}");
+            AddAuthorization(request);
+
+            var json = await SendJsonAsync(request, "Soniox transcription status", ct);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var status = GetString(root, "status");
+
+            if (string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase))
+                return root.Clone();
+
+            if (string.Equals(status, "error", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"Soniox transcription failed: {ExtractApiError(root)}");
+
+            if (attempt < _maxPollAttempts - 1 && _pollDelay > TimeSpan.Zero)
+                await Task.Delay(_pollDelay, ct);
+        }
+
+        throw new TimeoutException(
+            $"Soniox transcription {transcriptionId} did not complete within the configured polling window.");
+    }
+
+    private async Task<string> FetchTranscriptAsync(string transcriptionId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"{BaseUrl}/v1/transcriptions/{transcriptionId}/transcript");
+        AddAuthorization(request);
+
+        return await SendJsonAsync(request, "Soniox transcript retrieval", ct);
+    }
+
+    private async Task<string> SendJsonAsync(HttpRequestMessage request, string operation, CancellationToken ct)
+    {
+        using var response = await _httpClient.SendAsync(request, ct);
         var json = await response.Content.ReadAsStringAsync(ct);
 
         if (!response.IsSuccessStatusCode)
-            throw new HttpRequestException($"Soniox API error {(int)response.StatusCode}: {json}");
-
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-
-        var transcript = "";
-        if (root.TryGetProperty("results", out var results)
-            && results.ValueKind == JsonValueKind.Array
-            && results.GetArrayLength() > 0)
         {
-            var firstResult = results[0];
-            if (firstResult.TryGetProperty("alternatives", out var alts)
-                && alts.ValueKind == JsonValueKind.Array
-                && alts.GetArrayLength() > 0)
+            throw new HttpRequestException(
+                $"{operation} error {(int)response.StatusCode}: {ExtractApiError(json)}");
+        }
+
+        return json;
+    }
+
+    private async Task CleanupAsync(string? transcriptionId, string? fileId)
+    {
+        if (transcriptionId is not null)
+            await DeleteBestEffortAsync($"{BaseUrl}/v1/transcriptions/{transcriptionId}", "transcription");
+
+        if (fileId is not null)
+            await DeleteBestEffortAsync($"{BaseUrl}/v1/files/{fileId}", "file");
+    }
+
+    private async Task DeleteBestEffortAsync(string uri, string resourceName)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
+        AddAuthorization(request);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, cts.Token);
+            if (!response.IsSuccessStatusCode)
             {
-                transcript = alts[0].GetProperty("transcript").GetString() ?? "";
+                var json = await response.Content.ReadAsStringAsync(cts.Token);
+                _host?.Log(
+                    PluginLogLevel.Warning,
+                    $"Soniox cleanup could not delete {resourceName}: {(int)response.StatusCode} {ExtractApiError(json)}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _host?.Log(PluginLogLevel.Warning, $"Soniox cleanup could not delete {resourceName}: {ex.Message}");
+        }
+    }
+
+    internal static PluginTranscriptionResult ParseTranscript(
+        string transcriptJson,
+        JsonElement completedDetails,
+        string? fallbackLanguage)
+    {
+        using var doc = JsonDocument.Parse(transcriptJson);
+        var root = doc.RootElement;
+        var text = GetString(root, "text")?.Trim() ?? "";
+        var duration = TryGetDouble(completedDetails, "audio_duration_ms", out var durationMs)
+            ? durationMs / 1000.0
+            : 0.0;
+
+        var segments = new List<PluginTranscriptionSegment>();
+        string? detectedLanguage = null;
+
+        if (root.TryGetProperty("tokens", out var tokens)
+            && tokens.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var token in tokens.EnumerateArray())
+            {
+                var tokenText = GetString(token, "text");
+                if (string.IsNullOrWhiteSpace(tokenText))
+                    continue;
+
+                detectedLanguage ??= GetString(token, "language");
+
+                if (!TryGetDouble(token, "start_ms", out var startMs)
+                    || !TryGetDouble(token, "end_ms", out var endMs))
+                {
+                    continue;
+                }
+
+                var start = startMs / 1000.0;
+                var end = endMs / 1000.0;
+                segments.Add(new PluginTranscriptionSegment(tokenText.Trim(), start, end));
+                duration = Math.Max(duration, end);
             }
         }
 
-        double duration = 0;
-        if (root.TryGetProperty("duration", out var durEl))
-            duration = durEl.GetDouble();
-
-        string? detectedLanguage = null;
-        if (root.TryGetProperty("language", out var langEl))
-            detectedLanguage = langEl.GetString();
-
-        return new PluginTranscriptionResult(transcript.Trim(), detectedLanguage, duration, NoSpeechProbability: null);
+        return new PluginTranscriptionResult(text, detectedLanguage ?? fallbackLanguage, duration, NoSpeechProbability: null)
+        {
+            Segments = segments
+        };
     }
+
+    private void AddAuthorization(HttpRequestMessage request) =>
+        AddAuthorization(request, _apiKey ?? throw new InvalidOperationException("Plugin not configured. API key required."));
+
+    private static void AddAuthorization(HttpRequestMessage request, string apiKey) =>
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+    private static string ExtractApiError(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return ExtractApiError(doc.RootElement);
+        }
+        catch (JsonException)
+        {
+            return string.IsNullOrWhiteSpace(json) ? "Unknown error" : json;
+        }
+    }
+
+    private static string ExtractApiError(JsonElement root)
+    {
+        var errorType = GetString(root, "error_type");
+        var message = GetString(root, "error_message")
+            ?? GetString(root, "message")
+            ?? GetNestedErrorMessage(root)
+            ?? "Unknown error";
+        var requestId = GetString(root, "request_id");
+
+        var sb = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(errorType))
+            sb.Append(errorType).Append(": ");
+
+        sb.Append(message);
+
+        if (!string.IsNullOrWhiteSpace(requestId))
+            sb.Append(" (request_id: ").Append(requestId).Append(')');
+
+        return sb.ToString();
+    }
+
+    private static string? GetNestedErrorMessage(JsonElement root)
+    {
+        if (!root.TryGetProperty("error", out var error))
+            return null;
+
+        return error.ValueKind switch
+        {
+            JsonValueKind.String => error.GetString(),
+            JsonValueKind.Object => GetString(error, "message") ?? GetString(error, "detail"),
+            _ => null
+        };
+    }
+
+    private static string? NormalizeApiKey(string? apiKey) =>
+        string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
+
+    private static string? NormalizeLanguage(string? language) =>
+        string.IsNullOrWhiteSpace(language) || language.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : language.Trim();
+
+    private static string? GetString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static bool TryGetDouble(JsonElement element, string propertyName, out double value)
+    {
+        if (element.TryGetProperty(propertyName, out var property)
+            && property.ValueKind == JsonValueKind.Number
+            && property.TryGetDouble(out value))
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromMinutes(5) };
 
     public void Dispose()
     {
         _httpClient.Dispose();
+        _apiKeyWriteLock.Dispose();
     }
 }

--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -168,11 +168,10 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         if (normalized is null)
             return false;
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/models");
-        AddAuthorization(request, normalized);
-
         try
         {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/models");
+            AddAuthorization(request, normalized);
             using var response = await _httpClient.SendAsync(request, ct);
             return response.IsSuccessStatusCode;
         }
@@ -180,7 +179,15 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         {
             throw;
         }
-        catch
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (TaskCanceledException)
+        {
+            return false;
+        }
+        catch (FormatException)
         {
             return false;
         }
@@ -302,7 +309,11 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
                     $"Soniox cleanup could not delete {resourceName}: {(int)response.StatusCode} {ExtractApiError(json)}");
             }
         }
-        catch (Exception ex)
+        catch (HttpRequestException ex)
+        {
+            _host?.Log(PluginLogLevel.Warning, $"Soniox cleanup could not delete {resourceName}: {ex.Message}");
+        }
+        catch (TaskCanceledException ex)
         {
             _host?.Log(PluginLogLevel.Warning, $"Soniox cleanup could not delete {resourceName}: {ex.Message}");
         }

--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxSettingsView.xaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="TypeWhisper.Plugin.Soniox.SonioxSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="0,4">
+        <TextBlock x:Name="ApiKeyLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
+            <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
+                    Click="OnTestClick" x:Name="TestButton" />
+        </Grid>
+        <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />
+    </StackPanel>
+</UserControl>

--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxSettingsView.xaml.cs
@@ -1,0 +1,173 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace TypeWhisper.Plugin.Soniox;
+
+public partial class SonioxSettingsView : UserControl
+{
+    private static readonly TimeSpan ApiKeySaveDebounce = TimeSpan.FromMilliseconds(300);
+
+    private readonly SonioxPlugin _plugin;
+    private CancellationTokenSource? _saveDebounceCts;
+    private bool _suppressPasswordChanged;
+
+    public SonioxSettingsView(SonioxPlugin plugin)
+    {
+        _plugin = plugin;
+        InitializeComponent();
+
+        ApiKeyLabel.Text = L("Settings.ApiKeyLabel");
+        TestButton.Content = L("Settings.Test");
+
+        if (!string.IsNullOrEmpty(plugin.ApiKey))
+        {
+            _suppressPasswordChanged = true;
+            ApiKeyBox.Password = plugin.ApiKey;
+            _suppressPasswordChanged = false;
+        }
+    }
+
+    private async void OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (_suppressPasswordChanged)
+            return;
+
+        _saveDebounceCts?.Cancel();
+        using var cts = new CancellationTokenSource();
+        _saveDebounceCts = cts;
+
+        try
+        {
+            await Task.Delay(ApiKeySaveDebounce, cts.Token);
+            var key = ApiKeyBox.Password;
+            await _plugin.SetApiKeyAsync(key);
+            if (!IsCurrentSave(cts))
+                return;
+
+            StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
+            StatusText.Foreground = Brushes.Gray;
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // A newer password edit superseded this pending save.
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (IsCurrentSave(cts))
+                ShowError(ex);
+        }
+        catch (IOException ex)
+        {
+            if (IsCurrentSave(cts))
+                ShowError(ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            if (IsCurrentSave(cts))
+                ShowError(ex);
+        }
+        catch (SystemException ex)
+        {
+            if (IsCurrentSave(cts))
+                ShowError(ex);
+        }
+        catch (ApplicationException ex)
+        {
+            if (IsCurrentSave(cts))
+                ShowError(ex);
+        }
+        finally
+        {
+            if (ReferenceEquals(_saveDebounceCts, cts))
+                _saveDebounceCts = null;
+        }
+    }
+
+    private async void OnTestClick(object sender, RoutedEventArgs e)
+    {
+        var key = ApiKeyBox.Password;
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            StatusText.Text = L("Settings.EnterApiKey");
+            StatusText.Foreground = Brushes.Orange;
+            return;
+        }
+
+        TestButton.IsEnabled = false;
+        StatusText.Text = L("Settings.Testing");
+        StatusText.Foreground = Brushes.Gray;
+
+        try
+        {
+            var valid = await _plugin.ValidateApiKeyAsync(key);
+            StatusText.Text = valid ? L("Settings.ApiKeyValid") : L("Settings.ApiKeyInvalid");
+            StatusText.Foreground = valid ? Brushes.Green : Brushes.Red;
+        }
+        catch (OperationCanceledException ex)
+        {
+            ShowError(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ShowError(ex);
+        }
+        catch (SystemException ex)
+        {
+            ShowError(ex);
+        }
+        catch (ApplicationException ex)
+        {
+            ShowError(ex);
+        }
+        finally
+        {
+            TestButton.IsEnabled = true;
+        }
+    }
+
+    private void ShowError(Exception ex)
+    {
+        StatusText.Text = L("Settings.Error", ex.Message);
+        StatusText.Foreground = Brushes.Red;
+    }
+
+    private bool IsCurrentSave(CancellationTokenSource cts) =>
+        ReferenceEquals(_saveDebounceCts, cts)
+        && !cts.IsCancellationRequested;
+
+    private string L(string key) => L(key, []);
+
+    private string L(string key, params object[] args)
+    {
+        var localized = _plugin.Loc?.GetString(key, args);
+        if (!string.IsNullOrWhiteSpace(localized) && localized != key)
+            return localized;
+
+        return FormatFallbackText(key, args);
+    }
+
+    internal static string FormatFallbackText(string key, object[] args)
+    {
+        var text = key switch
+        {
+            "Settings.ApiKeyLabel" => "API Key",
+            "Settings.Test" => "Test",
+            "Settings.Saved" => "Saved",
+            "Settings.EnterApiKey" => "Enter an API key.",
+            "Settings.Testing" => "Testing...",
+            "Settings.ApiKeyValid" => "API key valid.",
+            "Settings.ApiKeyInvalid" => "Invalid API key.",
+            "Settings.Error" => "Error",
+            _ => key
+        };
+
+        if (args.Length == 0)
+            return text;
+
+        return text.Contains('{', StringComparison.Ordinal)
+            ? string.Format(text, args)
+            : $"{text}: {string.Join(", ", args)}";
+    }
+}

--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxSettingsView.xaml.cs
@@ -11,7 +11,7 @@ public partial class SonioxSettingsView : UserControl
 
     private readonly SonioxPlugin _plugin;
     private CancellationTokenSource? _saveDebounceCts;
-    private bool _suppressPasswordChanged;
+    private readonly bool _suppressPasswordChanged;
 
     public SonioxSettingsView(SonioxPlugin plugin)
     {

--- a/plugins/TypeWhisper.Plugin.Soniox/TypeWhisper.Plugin.Soniox.csproj
+++ b/plugins/TypeWhisper.Plugin.Soniox/TypeWhisper.Plugin.Soniox.csproj
@@ -8,6 +8,9 @@
     <RootNamespace>TypeWhisper.Plugin.Soniox</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -15,4 +18,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <Target Name="CopyToAppPlugins" AfterTargets="Build">
+    <PropertyGroup>
+      <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
+      <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.soniox\</PluginOutputDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+  </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.Soniox/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Soniox/manifest.json
@@ -1,9 +1,13 @@
 {
   "id": "com.typewhisper.soniox",
   "name": "Soniox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "TypeWhisper",
   "description": "Soniox speech-to-text transcription engine",
+  "category": "transcription",
+  "categories": ["transcription"],
+  "isLocal": false,
+  "requiresApiKey": true,
   "assemblyName": "TypeWhisper.Plugin.Soniox.dll",
   "pluginClass": "TypeWhisper.Plugin.Soniox.SonioxPlugin"
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
@@ -1,0 +1,424 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.Plugin.Soniox;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class SonioxPluginTests
+{
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifest = LoadManifest();
+        var sut = new SonioxPlugin();
+
+        Assert.Equal(manifest.GetProperty("version").GetString(), sut.PluginVersion);
+    }
+
+    [Fact]
+    public void Manifest_AdvertisesTranscriptionCapabilitiesAndApiKeyRequirement()
+    {
+        var manifest = LoadManifest();
+
+        Assert.Equal("com.typewhisper.soniox", manifest.GetProperty("id").GetString());
+        Assert.Equal("Soniox", manifest.GetProperty("name").GetString());
+        Assert.Equal("transcription", manifest.GetProperty("category").GetString());
+        Assert.Equal(["transcription"], manifest.GetProperty("categories").EnumerateArray().Select(e => e.GetString()!).ToArray());
+        Assert.False(manifest.GetProperty("isLocal").GetBoolean());
+        Assert.True(manifest.GetProperty("requiresApiKey").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ActivateAsync_RestoresApiKeyAndExposesAsyncModel()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+
+        var sut = new SonioxPlugin();
+        await sut.ActivateAsync(host);
+
+        Assert.Equal("com.typewhisper.soniox", sut.PluginId);
+        Assert.Equal("Soniox", sut.PluginName);
+        Assert.Equal("soniox", sut.ProviderId);
+        Assert.Equal("Soniox", sut.ProviderDisplayName);
+        Assert.True(sut.IsConfigured);
+        Assert.False(sut.SupportsTranslation);
+        Assert.Equal("default", sut.SelectedModelId);
+        Assert.Equal(["default"], sut.TranscriptionModels.Select(m => m.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_NotifiesOnlyWhenConfigurationStateChanges()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new SonioxPlugin();
+        await sut.ActivateAsync(host);
+
+        await sut.SetApiKeyAsync(" soniox-key ");
+        await sut.SetApiKeyAsync("soniox-key");
+        await sut.SetApiKeyAsync("");
+
+        Assert.Equal(2, host.NotifyCapabilitiesChangedCount);
+        Assert.False(host.Secrets.ContainsKey("api-key"));
+        Assert.False(sut.IsConfigured);
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsync_UsesModelsEndpointAndBearerHeader()
+    {
+        var handler = new CapturingHandler((request, _) =>
+        {
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal("https://api.soniox.com/v1/models", request.RequestUri?.ToString());
+            Assert.Equal("Bearer probe-key", request.Headers.Authorization?.ToString());
+            return JsonResponse("""{ "models": [] }""");
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient);
+
+        Assert.True(await sut.ValidateApiKeyAsync(" probe-key "));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_UsesAsyncTranscriptionFlowAndCleansUp()
+    {
+        var seen = new List<string>();
+        var handler = new CapturingHandler((request, body) =>
+        {
+            seen.Add($"{request.Method} {request.RequestUri}");
+            Assert.Equal("Bearer soniox-key", request.Headers.Authorization?.ToString());
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                Assert.StartsWith("multipart/form-data", request.Content?.Headers.ContentType?.MediaType);
+                Assert.NotNull(body);
+                var multipartBody = Encoding.UTF8.GetString(body);
+                Assert.Contains("name=file", multipartBody);
+                Assert.Contains("filename=audio.wav", multipartBody);
+                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753", "filename": "audio.wav", "size": 3 }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                using var doc = JsonDocument.Parse(body ?? throw new InvalidOperationException("Missing body"));
+                var root = doc.RootElement;
+                Assert.Equal("stt-async-v4", root.GetProperty("model").GetString());
+                Assert.Equal("84c32fc6-4fb5-4e7a-b656-b5ec70493753", root.GetProperty("file_id").GetString());
+                Assert.Equal(["de"], root.GetProperty("language_hints").EnumerateArray().Select(e => e.GetString()!).ToArray());
+                return JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "queued" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721")
+            {
+                var pollCount = seen.Count(item => item == "GET https://api.soniox.com/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721");
+                return pollCount == 1
+                    ? JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "processing", "audio_duration_ms": 660000 }""")
+                    : JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "completed", "audio_duration_ms": 660000 }""");
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721/transcript")
+            {
+                return JsonResponse("""
+                    {
+                      "id": "73d4357d-cad2-4338-a60d-ec6f2044f721",
+                      "text": "Hallo Welt",
+                      "tokens": [
+                        { "text": "Hallo", "start_ms": 0, "end_ms": 500, "language": "de" },
+                        { "text": " ", "start_ms": 500, "end_ms": 520, "language": "de" },
+                        { "text": "Welt", "start_ms": 520, "end_ms": 1100, "language": "de" }
+                      ]
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 3);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync([1, 2, 3], "de", translate: false, prompt: null, CancellationToken.None);
+
+        Assert.Equal("Hallo Welt", result.Text);
+        Assert.Equal("de", result.DetectedLanguage);
+        Assert.Equal(660.0, result.DurationSeconds);
+        Assert.Equal(["Hallo", "Welt"], result.Segments.Select(s => s.Text).ToArray());
+        Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/files/84c32fc6-4fb5-4e7a-b656-b5ec70493753", seen);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_OmitsLanguageHintsForAuto()
+    {
+        var handler = new SonioxFlowHandler((createBody) =>
+        {
+            using var doc = JsonDocument.Parse(createBody);
+            Assert.False(doc.RootElement.TryGetProperty("language_hints", out _));
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 2);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync([1, 2, 3], "auto", translate: false, prompt: null, CancellationToken.None);
+
+        Assert.Equal("Hello", result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_RejectsTranslation()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        var sut = new SonioxPlugin();
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: true, prompt: null, CancellationToken.None));
+
+        Assert.Contains("does not support translation", ex.Message);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_StatusErrorIncludesSonioxDetailsAndCleansUp()
+    {
+        var seen = new List<string>();
+        var handler = new CapturingHandler((request, body) =>
+        {
+            seen.Add($"{request.Method} {request.RequestUri}");
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+                return JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "queued" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721")
+            {
+                return JsonResponse("""
+                    {
+                      "status": "error",
+                      "error_type": "invalid_audio",
+                      "error_message": "Cannot decode audio",
+                      "request_id": "req-1"
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}; body={Encoding.UTF8.GetString(body ?? [])}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 2);
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
+
+        Assert.Contains("invalid_audio", ex.Message);
+        Assert.Contains("Cannot decode audio", ex.Message);
+        Assert.Contains("req-1", ex.Message);
+        Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/files/84c32fc6-4fb5-4e7a-b656-b5ec70493753", seen);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_HttpErrorIncludesSonioxDetails()
+    {
+        var handler = new CapturingHandler((request, _) =>
+            JsonResponse("""
+                {
+                  "status_code": 401,
+                  "error_type": "unauthenticated",
+                  "message": "Incorrect API key",
+                  "request_id": "req-unauth"
+                }
+                """, HttpStatusCode.Unauthorized));
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
+
+        Assert.Contains("unauthenticated", ex.Message);
+        Assert.Contains("Incorrect API key", ex.Message);
+        Assert.Contains("req-unauth", ex.Message);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_PollTimeoutThrowsTimeoutException()
+    {
+        var handler = new CapturingHandler((request, _) =>
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+                return JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "queued" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Get)
+                return JsonResponse("""{ "status": "processing" }""");
+
+            return JsonResponse("""{}""");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 2);
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
+
+        Assert.Contains("did not complete", ex.Message);
+    }
+
+    private static JsonElement LoadManifest()
+    {
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.Soniox", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
+        using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        return doc.RootElement.Clone();
+    }
+
+    private static HttpResponseMessage JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK) =>
+        new(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class SonioxFlowHandler(Action<string> inspectCreateBody) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+                inspectCreateBody(body);
+                return JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "queued" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721")
+                return JsonResponse("""{ "status": "completed", "audio_duration_ms": 1000 }""");
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721/transcript")
+                return JsonResponse("""{ "text": "Hello", "tokens": [] }""");
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        }
+    }
+
+    private sealed class CapturingHandler(
+        Func<HttpRequestMessage, byte[]?, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            return responder(request, body);
+        }
+    }
+
+    private sealed class TestPluginHostServices : IPluginHostServices
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private readonly Dictionary<string, JsonElement> _settings = [];
+        public Dictionary<string, string?> Secrets { get; } = [];
+        public int NotifyCapabilitiesChangedCount { get; private set; }
+
+        public Task StoreSecretAsync(string key, string value)
+        {
+            Secrets[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadSecretAsync(string key) =>
+            Task.FromResult(Secrets.TryGetValue(key, out var value) ? value : null);
+
+        public Task DeleteSecretAsync(string key)
+        {
+            Secrets.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value)
+                ? value.Deserialize<T>(JsonOptions)
+                : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new TestPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() => NotifyCapabilitiesChangedCount++;
+        public IPluginLocalization Localization { get; } = new TestPluginLocalization();
+    }
+
+    private sealed class TestPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TestPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Xai\TypeWhisper.Plugin.Xai.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Reson8\TypeWhisper.Plugin.Reson8.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Soniox\TypeWhisper.Plugin.Soniox.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SherpaOnnx\TypeWhisper.Plugin.SherpaOnnx.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />


### PR DESCRIPTION
## Summary
- Update the Soniox plugin to use the current async file transcription flow: upload file, create transcription, poll status, fetch transcript, and clean up remote resources.
- Add a debounced Soniox settings view with API key validation via the models endpoint.
- Bump the Soniox plugin to v1.0.1 and add regression tests for the async flow, errors, language hints, and timeout handling.

## Root Cause
The plugin still used the legacy synchronous `/v1/speech:transcribe` request path, which fails for longer file transcriptions. Soniox now documents file transcription through the async `/v1/files` and `/v1/transcriptions` APIs.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter SonioxPluginTests`
- `dotnet build plugins\TypeWhisper.Plugin.Soniox\TypeWhisper.Plugin.Soniox.csproj -c Release`
- Manual smoke test: installed `com.typewhisper.soniox` to `%LocalAppData%\TypeWhisper\Plugins`, verified PluginLoader discovery, launched the Release app, and user confirmed the plugin flow worked.

## Release Note
After merge, publish this as a plugin update with tag `plugin-soniox-v1.0.1`.

Fixes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Soniox plugin now supports asynchronous transcription workflow with progress polling
  * Added dedicated settings interface with API key configuration and built-in validation testing

* **Chores**
  * Updated Soniox plugin to version 1.0.1
  * Enhanced plugin deployment and build configuration

* **Tests**
  * Added comprehensive test suite for plugin functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->