### PR TITLE
Fix Soniox API key handling

### DIFF
--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -58,7 +58,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
     public string PluginId => "com.typewhisper.soniox";
     public string PluginName => "Soniox";
-    public string PluginVersion => "1.0.1";
+    public string PluginVersion => "1.0.2";
 
     public async Task ActivateAsync(IPluginHostServices host)
     {
@@ -106,7 +106,8 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         if (translate)
             throw new InvalidOperationException("Soniox does not support translation.");
 
-        if (!IsConfigured)
+        var apiKey = _apiKey;
+        if (string.IsNullOrEmpty(apiKey))
             throw new InvalidOperationException("Plugin not configured. API key required.");
 
         string? fileId = null;
@@ -114,15 +115,15 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
         try
         {
-            fileId = await UploadFileAsync(wavAudio, ct);
-            transcriptionId = await CreateTranscriptionAsync(fileId, language, ct);
-            var completedDetails = await WaitUntilCompletedAsync(transcriptionId, ct);
-            var transcriptJson = await FetchTranscriptAsync(transcriptionId, ct);
+            fileId = await UploadFileAsync(wavAudio, apiKey, ct);
+            transcriptionId = await CreateTranscriptionAsync(fileId, language, apiKey, ct);
+            var completedDetails = await WaitUntilCompletedAsync(transcriptionId, apiKey, ct);
+            var transcriptJson = await FetchTranscriptAsync(transcriptionId, apiKey, ct);
             return ParseTranscript(transcriptJson, completedDetails, NormalizeLanguage(language));
         }
         finally
         {
-            await CleanupAsync(transcriptionId, fileId);
+            await CleanupAsync(transcriptionId, fileId, apiKey);
         }
     }
 
@@ -142,7 +143,9 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             var wasConfigured = IsConfigured;
             var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
 
-            _apiKey = normalized;
+            if (!changed)
+                return;
+
             if (_host is not null)
             {
                 if (normalized is null)
@@ -150,9 +153,13 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
                 else
                     await _host.StoreSecretAsync(ApiKeySecretName, normalized);
 
-                if (changed && wasConfigured != IsConfigured)
-                    hostToNotify = _host;
+                hostToNotify = _host;
             }
+
+            _apiKey = normalized;
+
+            if (wasConfigured == IsConfigured)
+                hostToNotify = null;
         }
         finally
         {
@@ -193,7 +200,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         }
     }
 
-    private async Task<string> UploadFileAsync(byte[] wavAudio, CancellationToken ct)
+    private async Task<string> UploadFileAsync(byte[] wavAudio, string apiKey, CancellationToken ct)
     {
         using var form = new MultipartFormDataContent();
         var fileContent = new ByteArrayContent(wavAudio);
@@ -201,7 +208,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         form.Add(fileContent, "file", "audio.wav");
 
         using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/files");
-        AddAuthorization(request);
+        AddAuthorization(request, apiKey);
         request.Content = form;
 
         var json = await SendJsonAsync(request, "Soniox file upload", ct);
@@ -210,7 +217,11 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             ?? throw new InvalidOperationException("Soniox file upload response did not include a file id.");
     }
 
-    private async Task<string> CreateTranscriptionAsync(string fileId, string? language, CancellationToken ct)
+    private async Task<string> CreateTranscriptionAsync(
+        string fileId,
+        string? language,
+        string apiKey,
+        CancellationToken ct)
     {
         var payload = new Dictionary<string, object?>
         {
@@ -222,7 +233,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             payload["language_hints"] = new[] { normalizedLanguage };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/transcriptions");
-        AddAuthorization(request);
+        AddAuthorization(request, apiKey);
         request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
         var json = await SendJsonAsync(request, "Soniox transcription creation", ct);
@@ -231,14 +242,14 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             ?? throw new InvalidOperationException("Soniox transcription response did not include a transcription id.");
     }
 
-    private async Task<JsonElement> WaitUntilCompletedAsync(string transcriptionId, CancellationToken ct)
+    private async Task<JsonElement> WaitUntilCompletedAsync(string transcriptionId, string apiKey, CancellationToken ct)
     {
         for (var attempt = 0; attempt < _maxPollAttempts; attempt++)
         {
             ct.ThrowIfCancellationRequested();
 
             using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/transcriptions/{transcriptionId}");
-            AddAuthorization(request);
+            AddAuthorization(request, apiKey);
 
             var json = await SendJsonAsync(request, "Soniox transcription status", ct);
             using var doc = JsonDocument.Parse(json);
@@ -259,12 +270,12 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             $"Soniox transcription {transcriptionId} did not complete within the configured polling window.");
     }
 
-    private async Task<string> FetchTranscriptAsync(string transcriptionId, CancellationToken ct)
+    private async Task<string> FetchTranscriptAsync(string transcriptionId, string apiKey, CancellationToken ct)
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
             $"{BaseUrl}/v1/transcriptions/{transcriptionId}/transcript");
-        AddAuthorization(request);
+        AddAuthorization(request, apiKey);
 
         return await SendJsonAsync(request, "Soniox transcript retrieval", ct);
     }
@@ -283,20 +294,20 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         return json;
     }
 
-    private async Task CleanupAsync(string? transcriptionId, string? fileId)
+    private async Task CleanupAsync(string? transcriptionId, string? fileId, string apiKey)
     {
         if (transcriptionId is not null)
-            await DeleteBestEffortAsync($"{BaseUrl}/v1/transcriptions/{transcriptionId}", "transcription");
+            await DeleteBestEffortAsync($"{BaseUrl}/v1/transcriptions/{transcriptionId}", "transcription", apiKey);
 
         if (fileId is not null)
-            await DeleteBestEffortAsync($"{BaseUrl}/v1/files/{fileId}", "file");
+            await DeleteBestEffortAsync($"{BaseUrl}/v1/files/{fileId}", "file", apiKey);
     }
 
-    private async Task DeleteBestEffortAsync(string uri, string resourceName)
+    private async Task DeleteBestEffortAsync(string uri, string resourceName, string apiKey)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
-        AddAuthorization(request);
+        AddAuthorization(request, apiKey);
 
         try
         {
@@ -364,9 +375,6 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         };
     }
 
-    private void AddAuthorization(HttpRequestMessage request) =>
-        AddAuthorization(request, _apiKey ?? throw new InvalidOperationException("Plugin not configured. API key required."));
-
     private static void AddAuthorization(HttpRequestMessage request, string apiKey) =>
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
 
@@ -420,10 +428,14 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     private static string? NormalizeApiKey(string? apiKey) =>
         string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
 
-    private static string? NormalizeLanguage(string? language) =>
-        string.IsNullOrWhiteSpace(language) || language.Equals("auto", StringComparison.OrdinalIgnoreCase)
-            ? null
-            : language.Trim();
+    private static string? NormalizeLanguage(string? language)
+    {
+        var trimmed = language?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed)
+            || trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase)
+                ? null
+                : trimmed;
+    }
 
     private static string? GetString(JsonElement element, string propertyName) =>
         element.TryGetProperty(propertyName, out var property)

--- a/plugins/TypeWhisper.Plugin.Soniox/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Soniox/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.soniox",
   "name": "Soniox",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Soniox speech-to-text transcription engine",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
@@ -69,6 +69,41 @@ public class SonioxPluginTests
     }
 
     [Fact]
+    public async Task SetApiKeyAsync_DoesNotConfigurePluginWhenStoreSecretFails()
+    {
+        var host = new TestPluginHostServices
+        {
+            StoreSecretException = new InvalidOperationException("store failed")
+        };
+        var sut = new SonioxPlugin();
+        await sut.ActivateAsync(host);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SetApiKeyAsync("soniox-key"));
+
+        Assert.False(sut.IsConfigured);
+        Assert.Null(sut.ApiKey);
+        Assert.False(host.Secrets.ContainsKey("api-key"));
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_KeepsExistingConfigurationWhenDeleteSecretFails()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        var sut = new SonioxPlugin();
+        await sut.ActivateAsync(host);
+        host.DeleteSecretException = new InvalidOperationException("delete failed");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SetApiKeyAsync(""));
+
+        Assert.True(sut.IsConfigured);
+        Assert.Equal("soniox-key", sut.ApiKey);
+        Assert.Equal("soniox-key", host.Secrets["api-key"]);
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
     public async Task ValidateApiKeyAsync_UsesModelsEndpointAndBearerHeader()
     {
         var handler = new CapturingHandler((request, _) =>
@@ -160,6 +195,50 @@ public class SonioxPluginTests
     }
 
     [Fact]
+    public async Task TranscribeAsync_UsesInitialApiKeyForWholeAsyncFlow()
+    {
+        var seenAuthorizations = new List<string?>();
+        SonioxPlugin? sut = null;
+        var handler = new AsyncCapturingHandler(async (request, _, _) =>
+        {
+            seenAuthorizations.Add(request.Headers.Authorization?.ToString());
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                await sut!.SetApiKeyAsync("");
+                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+                return JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "queued" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721")
+                return JsonResponse("""{ "status": "completed", "audio_duration_ms": 1000 }""");
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721/transcript")
+                return JsonResponse("""{ "text": "Hello", "tokens": [] }""");
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "initial-key";
+        using var httpClient = new HttpClient(handler);
+        sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 2);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None);
+
+        Assert.Equal("Hello", result.Text);
+        Assert.False(sut.IsConfigured);
+        Assert.DoesNotContain("api-key", host.Secrets.Keys);
+        Assert.All(seenAuthorizations, authorization => Assert.Equal("Bearer initial-key", authorization));
+    }
+
+    [Fact]
     public async Task TranscribeAsync_OmitsLanguageHintsForAuto()
     {
         var handler = new SonioxFlowHandler((createBody) =>
@@ -177,6 +256,27 @@ public class SonioxPluginTests
         var result = await sut.TranscribeAsync([1, 2, 3], "auto", translate: false, prompt: null, CancellationToken.None);
 
         Assert.Equal("Hello", result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_OmitsLanguageHintsForWhitespacePaddedAuto()
+    {
+        var handler = new SonioxFlowHandler((createBody) =>
+        {
+            using var doc = JsonDocument.Parse(createBody);
+            Assert.False(doc.RootElement.TryGetProperty("language_hints", out _));
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 2);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync([1, 2, 3], " auto ", translate: false, prompt: null, CancellationToken.None);
+
+        Assert.Equal("Hello", result.Text);
+        Assert.Null(result.DetectedLanguage);
     }
 
     [Fact]
@@ -357,6 +457,20 @@ public class SonioxPluginTests
         }
     }
 
+    private sealed class AsyncCapturingHandler(
+        Func<HttpRequestMessage, byte[]?, CancellationToken, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            return await responder(request, body, cancellationToken);
+        }
+    }
+
     private sealed class TestPluginHostServices : IPluginHostServices
     {
         private static readonly JsonSerializerOptions JsonOptions = new()
@@ -367,9 +481,14 @@ public class SonioxPluginTests
         private readonly Dictionary<string, JsonElement> _settings = [];
         public Dictionary<string, string?> Secrets { get; } = [];
         public int NotifyCapabilitiesChangedCount { get; private set; }
+        public Exception? StoreSecretException { get; init; }
+        public Exception? DeleteSecretException { get; set; }
 
         public Task StoreSecretAsync(string key, string value)
         {
+            if (StoreSecretException is not null)
+                throw StoreSecretException;
+
             Secrets[key] = value;
             return Task.CompletedTask;
         }
@@ -379,6 +498,9 @@ public class SonioxPluginTests
 
         public Task DeleteSecretAsync(string key)
         {
+            if (DeleteSecretException is not null)
+                throw DeleteSecretException;
+
             Secrets.Remove(key);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
## Summary
- use a single API key snapshot throughout the Soniox async transcription flow
- keep in-memory API key state unchanged when secret persistence fails
- treat whitespace-padded `auto` as automatic language selection
- bump Soniox plugin to v1.0.2 for the follow-up plugin release

## Verification
- dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter SonioxPluginTests
- dotnet build plugins\TypeWhisper.Plugin.Soniox\TypeWhisper.Plugin.Soniox.csproj -c Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Strengthened API key validation and initialization; keys are now validated upfront and consistently used throughout transcription workflows
- Improved language hint normalization to correctly handle whitespace-padded "auto" detection values

**Version Updates**
- Soniox plugin updated to v1.0.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->