### PR TITLE
Fix CUDA runtime delivery for local plugins

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -139,12 +139,21 @@ jobs:
           $runtimesDir = Join-Path $outputDir 'runtimes'
           if (Test-Path $runtimesDir) {
             New-Item -ItemType Directory -Path "$stagingDir/runtimes" -Force | Out-Null
-            foreach ($runtimeName in @('win-x64', 'win-arm64')) {
+            foreach ($runtimeName in @('win-x64', 'win-arm64', 'cuda/win-x64')) {
               $runtimeDir = Join-Path $runtimesDir $runtimeName
               if (Test-Path $runtimeDir) {
-                Copy-Item -Path $runtimeDir -Destination "$stagingDir/runtimes" -Recurse
+                $runtimeDestination = Join-Path "$stagingDir/runtimes" $runtimeName
+                New-Item -ItemType Directory -Path $runtimeDestination -Force | Out-Null
+                Copy-Item -Path (Join-Path $runtimeDir '*') -Destination $runtimeDestination -Recurse -Force
                 Write-Host "  Included native runtime: $runtimeName"
               }
+            }
+          }
+
+          if ($env:PLUGIN_NAME -eq 'whisper-cpp') {
+            $cudaRuntime = Join-Path $stagingDir 'runtimes/cuda/win-x64/ggml-cuda-whisper.dll'
+            if (-not (Test-Path $cudaRuntime)) {
+              throw "Missing required whisper.cpp CUDA runtime: $cudaRuntime"
             }
           }
 

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -36,6 +36,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
     private readonly object _sync = new();
     private readonly HttpClient _httpClient = new();
+    private readonly Func<string, string, string, OfflineRecognizer>? _recognizerFactory;
     private ISherpaCudaRuntimeInstaller? _cudaRuntimeInstaller;
     private IPluginHostServices? _host;
     private OfflineRecognizer? _recognizer;
@@ -53,8 +54,16 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     }
 
     internal SherpaOnnxPlugin(ISherpaCudaRuntimeInstaller cudaRuntimeInstaller)
+        : this(cudaRuntimeInstaller, null)
+    {
+    }
+
+    internal SherpaOnnxPlugin(
+        ISherpaCudaRuntimeInstaller cudaRuntimeInstaller,
+        Func<string, string, string, OfflineRecognizer>? recognizerFactory)
     {
         _cudaRuntimeInstaller = cudaRuntimeInstaller;
+        _recognizerFactory = recognizerFactory;
     }
 
     // Canary-specific state
@@ -206,21 +215,23 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
                 try
                 {
-                    _recognizer = CreateRecognizer(model, dir, activeProvider);
+                    _recognizer = CreateRecognizerForLoad(model, dir, activeProvider);
                 }
                 catch (Exception ex) when (
-                    _accelerationPreference == TranscriptionAccelerationPreference.Auto
-                    && string.Equals(activeProvider, "cuda", StringComparison.OrdinalIgnoreCase))
+                    string.Equals(activeProvider, "cuda", StringComparison.OrdinalIgnoreCase))
                 {
+                    accelerationStatus = CreateCudaUnavailableStatus(ex.Message);
+                    if (_accelerationPreference != TranscriptionAccelerationPreference.Auto)
+                    {
+                        _accelerationStatus = accelerationStatus;
+                        throw;
+                    }
+
                     _host?.Log(
                         PluginLogLevel.Warning,
                         $"CUDA provider failed for {modelId}; falling back to CPU: {ex.Message}");
                     activeProvider = "cpu";
-                    _recognizer = CreateRecognizer(model, dir, activeProvider);
-                    accelerationStatus = new TranscriptionAccelerationStatus(
-                        TranscriptionAccelerationBackend.Cpu,
-                        "CUDA unavailable",
-                        ex.Message);
+                    _recognizer = CreateRecognizerForLoad(model, dir, activeProvider);
                 }
 
                 _loadedModelId = modelId;
@@ -287,23 +298,31 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
         if (_accelerationPreference == TranscriptionAccelerationPreference.NvidiaCuda)
         {
-            EnsureCudaPlatformSupported();
-            var installer = _cudaRuntimeInstaller
-                ?? throw new InvalidOperationException("The sherpa-onnx CUDA runtime installer is not available.");
-
-            if (!installer.IsInstalled)
-                await installer.EnsureInstalledAsync(cancellationToken);
-
-            if (!installer.IsInstalled || string.IsNullOrWhiteSpace(installer.RuntimeDirectory))
+            try
             {
-                _accelerationStatus = new TranscriptionAccelerationStatus(
-                    TranscriptionAccelerationBackend.Cpu,
-                    "CUDA unavailable",
+                EnsureCudaPlatformSupported();
+                var installer = _cudaRuntimeInstaller
+                    ?? throw new InvalidOperationException("The sherpa-onnx CUDA runtime installer is not available.");
+
+                if (!installer.IsInstalled)
+                    await installer.EnsureInstalledAsync(cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _accelerationStatus = CreateCudaUnavailableStatus(ex.Message);
+                throw;
+            }
+
+            var resolvedInstaller = _cudaRuntimeInstaller
+                ?? throw new InvalidOperationException("The sherpa-onnx CUDA runtime installer is not available.");
+            if (!resolvedInstaller.IsInstalled || string.IsNullOrWhiteSpace(resolvedInstaller.RuntimeDirectory))
+            {
+                _accelerationStatus = CreateCudaUnavailableStatus(
                     "The sherpa-onnx CUDA runtime could not be installed.");
                 throw new InvalidOperationException(_accelerationStatus.Detail);
             }
 
-            SherpaOnnxNativeRuntime.ConfigureCudaRuntime(installer.RuntimeDirectory);
+            SherpaOnnxNativeRuntime.ConfigureCudaRuntime(resolvedInstaller.RuntimeDirectory);
             desiredProvider = "cuda";
         }
         else if (desiredProvider == "cuda" && _cudaRuntimeInstaller?.RuntimeDirectory is { } runtimeDirectory)
@@ -363,6 +382,12 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         string.Equals(provider, "cuda", StringComparison.OrdinalIgnoreCase)
             ? new(TranscriptionAccelerationBackend.NvidiaCuda, "Using CUDA")
             : new(TranscriptionAccelerationBackend.Cpu, "Using CPU");
+
+    private static TranscriptionAccelerationStatus CreateCudaUnavailableStatus(string detail) =>
+        new(
+            TranscriptionAccelerationBackend.Cpu,
+            "CUDA unavailable",
+            detail);
 
     private static TranscriptionAccelerationStatus CreateRestartRequiredStatus(
         string loadedProvider,
@@ -429,6 +454,14 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         model.SupportsTranslation
             ? CreateCanaryRecognizer(modelDir, "en", "en", provider)
             : CreateParakeetRecognizer(modelDir, provider);
+
+    private OfflineRecognizer CreateRecognizerForLoad(
+        ModelDefinition model,
+        string modelDir,
+        string provider) =>
+        _recognizerFactory is null
+            ? CreateRecognizer(model, modelDir, provider)
+            : _recognizerFactory(model.Id, modelDir, provider);
 
     internal static OfflineRecognizerConfig CreateCanaryConfig(
         string modelDir,

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -73,7 +73,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     // ITypeWhisperPlugin
     public string PluginId => "com.typewhisper.sherpa-onnx";
     public string PluginName => "Lokale Modelle (sherpa-onnx)";
-    public string PluginVersion => "1.0.1";
+    public string PluginVersion => "1.0.2";
 
     // ITranscriptionEnginePlugin
     public string ProviderId => "sherpa-onnx";
@@ -231,7 +231,16 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                         PluginLogLevel.Warning,
                         $"CUDA provider failed for {modelId}; falling back to CPU: {ex.Message}");
                     activeProvider = "cpu";
-                    _recognizer = CreateRecognizerForLoad(model, dir, activeProvider);
+                    try
+                    {
+                        _recognizer = CreateRecognizerForLoad(model, dir, activeProvider);
+                    }
+                    catch (Exception cpuEx)
+                    {
+                        _accelerationStatus = CreateNativeRuntimeUnavailableStatus(
+                            "CPU fallback failed after CUDA provider failed. " + cpuEx.Message);
+                        throw;
+                    }
                 }
 
                 _loadedModelId = modelId;
@@ -298,10 +307,11 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
         if (_accelerationPreference == TranscriptionAccelerationPreference.NvidiaCuda)
         {
+            ISherpaCudaRuntimeInstaller installer;
             try
             {
                 EnsureCudaPlatformSupported();
-                var installer = _cudaRuntimeInstaller
+                installer = _cudaRuntimeInstaller
                     ?? throw new InvalidOperationException("The sherpa-onnx CUDA runtime installer is not available.");
 
                 if (!installer.IsInstalled)
@@ -313,16 +323,14 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                 throw;
             }
 
-            var resolvedInstaller = _cudaRuntimeInstaller
-                ?? throw new InvalidOperationException("The sherpa-onnx CUDA runtime installer is not available.");
-            if (!resolvedInstaller.IsInstalled || string.IsNullOrWhiteSpace(resolvedInstaller.RuntimeDirectory))
+            if (!installer.IsInstalled || string.IsNullOrWhiteSpace(installer.RuntimeDirectory))
             {
                 _accelerationStatus = CreateCudaUnavailableStatus(
                     "The sherpa-onnx CUDA runtime could not be installed.");
                 throw new InvalidOperationException(_accelerationStatus.Detail);
             }
 
-            SherpaOnnxNativeRuntime.ConfigureCudaRuntime(resolvedInstaller.RuntimeDirectory);
+            SherpaOnnxNativeRuntime.ConfigureCudaRuntime(installer.RuntimeDirectory);
             desiredProvider = "cuda";
         }
         else if (desiredProvider == "cuda" && _cudaRuntimeInstaller?.RuntimeDirectory is { } runtimeDirectory)
@@ -387,6 +395,12 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         new(
             TranscriptionAccelerationBackend.Cpu,
             "CUDA unavailable",
+            detail);
+
+    private static TranscriptionAccelerationStatus CreateNativeRuntimeUnavailableStatus(string detail) =>
+        new(
+            TranscriptionAccelerationBackend.Cpu,
+            "Native runtime unavailable",
             detail);
 
     private static TranscriptionAccelerationStatus CreateRestartRequiredStatus(

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.sherpa-onnx",
   "name": "Lokale Modelle (sherpa-onnx)",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Offline transcription via sherpa-onnx (NVIDIA NeMo Parakeet + Canary)",
   "assemblyName": "TypeWhisper.Plugin.SherpaOnnx.dll",

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppCudaRuntimeInstaller.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppCudaRuntimeInstaller.cs
@@ -19,9 +19,10 @@ internal sealed record WhisperCppCudaRuntimePackage(
     string Sha256,
     IReadOnlyList<string> RequiredDlls);
 
-internal sealed class WhisperCppCudaRuntimeInstaller : IWhisperCppCudaRuntimeInstaller
+internal sealed class WhisperCppCudaRuntimeInstaller : IWhisperCppCudaRuntimeInstaller, IDisposable
 {
     private const string CudaRuntimeIdentifier = "win-x64";
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromMinutes(10);
 
     private static readonly WhisperCppCudaRuntimePackage DefaultPackage = new(
         "cuda-13.3.0-cublas-13.5.1.27",
@@ -91,22 +92,37 @@ internal sealed class WhisperCppCudaRuntimeInstaller : IWhisperCppCudaRuntimeIns
 
     private async Task DownloadArchiveAsync(string archivePath, CancellationToken cancellationToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, _package.DownloadUrl);
-        using var response = await _httpClient.SendAsync(
-            request,
-            HttpCompletionOption.ResponseHeadersRead,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
+        using var timeoutCts = new CancellationTokenSource(DownloadTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
+        var downloadToken = linkedCts.Token;
 
-        await using var input = await response.Content.ReadAsStreamAsync(cancellationToken);
-        await using var output = new FileStream(
-            archivePath,
-            FileMode.CreateNew,
-            FileAccess.Write,
-            FileShare.None,
-            81920,
-            useAsync: true);
-        await input.CopyToAsync(output, cancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, _package.DownloadUrl);
+        try
+        {
+            using var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                downloadToken);
+            response.EnsureSuccessStatusCode();
+
+            await using var input = await response.Content.ReadAsStreamAsync(downloadToken);
+            await using var output = new FileStream(
+                archivePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                81920,
+                useAsync: true);
+            await input.CopyToAsync(output, downloadToken);
+        }
+        catch (OperationCanceledException ex) when (
+            !cancellationToken.IsCancellationRequested
+            && timeoutCts.IsCancellationRequested)
+        {
+            throw new TimeoutException("The NVIDIA CUDA runtime download timed out.", ex);
+        }
     }
 
     private async Task ValidateArchiveHashAsync(string archivePath, CancellationToken cancellationToken)
@@ -175,4 +191,6 @@ internal sealed class WhisperCppCudaRuntimeInstaller : IWhisperCppCudaRuntimeIns
             Debug.WriteLine($"Failed to delete temporary CUDA runtime file '{path}': {ex.Message}");
         }
     }
+
+    public void Dispose() => _gate.Dispose();
 }

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppCudaRuntimeInstaller.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppCudaRuntimeInstaller.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Security.Cryptography;
+
+namespace TypeWhisper.Plugin.WhisperCpp;
+
+internal interface IWhisperCppCudaRuntimeInstaller
+{
+    bool IsInstalled { get; }
+    string RuntimeDirectory { get; }
+    Task EnsureInstalledAsync(CancellationToken cancellationToken);
+}
+
+internal sealed record WhisperCppCudaRuntimePackage(
+    string RuntimeVersion,
+    string DownloadUrl,
+    string Sha256,
+    IReadOnlyList<string> RequiredDlls);
+
+internal sealed class WhisperCppCudaRuntimeInstaller : IWhisperCppCudaRuntimeInstaller
+{
+    private const string CudaRuntimeIdentifier = "win-x64";
+
+    private static readonly WhisperCppCudaRuntimePackage DefaultPackage = new(
+        "cuda-13.3.0-cublas-13.5.1.27",
+        "https://developer.download.nvidia.com/compute/cuda/redist/libcublas/windows-x86_64/libcublas-windows-x86_64-13.5.1.27-archive.zip",
+        "c946e1c825e05895747a95ed4fee18030b08052c09783b9b7b19818fd2e31f58",
+        ["cublas64_13.dll", "cublasLt64_13.dll"]);
+
+    private readonly HttpClient _httpClient;
+    private readonly WhisperCppCudaRuntimePackage _package;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public WhisperCppCudaRuntimeInstaller(string pluginDirectory, HttpClient httpClient)
+        : this(pluginDirectory, httpClient, DefaultPackage)
+    {
+    }
+
+    internal WhisperCppCudaRuntimeInstaller(
+        string pluginDirectory,
+        HttpClient httpClient,
+        WhisperCppCudaRuntimePackage package)
+    {
+        var pluginRoot = Path.GetFullPath(pluginDirectory);
+        RuntimeDirectory = Path.Join(pluginRoot, "runtimes", "cuda", CudaRuntimeIdentifier);
+        _httpClient = httpClient;
+        _package = package;
+    }
+
+    public string RuntimeDirectory { get; }
+
+    public bool IsInstalled => _package.RequiredDlls.All(file =>
+        File.Exists(GetRuntimeFilePath(file)));
+
+    public async Task EnsureInstalledAsync(CancellationToken cancellationToken)
+    {
+        if (IsInstalled)
+            return;
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (IsInstalled)
+                return;
+
+            Directory.CreateDirectory(RuntimeDirectory);
+
+            var archivePath = Path.Join(
+                RuntimeDirectory,
+                $"nvidia-cublas-{_package.RuntimeVersion}.{Guid.NewGuid():N}.zip.tmp");
+
+            try
+            {
+                await DownloadArchiveAsync(archivePath, cancellationToken);
+                await ValidateArchiveHashAsync(archivePath, cancellationToken);
+                ExtractRequiredDlls(archivePath);
+                ValidateInstalledRuntime();
+            }
+            finally
+            {
+                TryDeleteFile(archivePath);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task DownloadArchiveAsync(string archivePath, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, _package.DownloadUrl);
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var input = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using var output = new FileStream(
+            archivePath,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            81920,
+            useAsync: true);
+        await input.CopyToAsync(output, cancellationToken);
+    }
+
+    private async Task ValidateArchiveHashAsync(string archivePath, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            archivePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            81920,
+            useAsync: true);
+        using var sha256 = SHA256.Create();
+        var hash = await sha256.ComputeHashAsync(stream, cancellationToken);
+        var actual = Convert.ToHexString(hash).ToLowerInvariant();
+
+        if (!string.Equals(actual, _package.Sha256, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "The downloaded NVIDIA CUDA runtime did not match the expected checksum.");
+        }
+    }
+
+    private void ExtractRequiredDlls(string archivePath)
+    {
+        using var archive = ZipFile.OpenRead(archivePath);
+        var remaining = new HashSet<string>(_package.RequiredDlls, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in archive.Entries.Where(entry =>
+                     remaining.Contains(entry.Name)))
+        {
+            var destination = GetRuntimeFilePath(entry.Name);
+            entry.ExtractToFile(destination, overwrite: true);
+            remaining.Remove(entry.Name);
+        }
+    }
+
+    private void ValidateInstalledRuntime()
+    {
+        var missing = _package.RequiredDlls
+            .Where(file => !File.Exists(GetRuntimeFilePath(file)))
+            .ToList();
+
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "The NVIDIA CUDA runtime download was incomplete. Missing: " + string.Join(", ", missing));
+        }
+    }
+
+    private string GetRuntimeFilePath(string fileName) =>
+        Path.Join(RuntimeDirectory, Path.GetFileName(fileName));
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException ex)
+        {
+            Debug.WriteLine($"Failed to delete temporary CUDA runtime file '{path}': {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Debug.WriteLine($"Failed to delete temporary CUDA runtime file '{path}': {ex.Message}");
+        }
+    }
+}

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Controls;
@@ -12,6 +13,13 @@ namespace TypeWhisper.Plugin.WhisperCpp;
 
 public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEnginePlugin
 {
+    private const string CudaRuntimeDependencyHint =
+        "Missing CUDA/cuBLAS runtime dependency cublas64_13.dll. TypeWhisper can download it when NVIDIA CUDA is selected.";
+    private const string CudaFallbackDetail =
+        "CUDA runtime could not be loaded; using CPU. " + CudaRuntimeDependencyHint;
+    private const string CudaLoadFailureDetail =
+        "CUDA runtime could not be loaded. " + CudaRuntimeDependencyHint;
+
     private static readonly IReadOnlyList<ModelDefinition> Models =
     [
         new("tiny", "Tiny", GgmlType.Tiny, QuantizationType.NoQuantization, "ggml-tiny.bin", "~75 MB", 75, 99, false),
@@ -31,6 +39,8 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     ];
 
     private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly HttpClient _httpClient = new();
+    private IWhisperCppCudaRuntimeInstaller? _cudaRuntimeInstaller;
     private IPluginHostServices? _host;
     private WhisperFactory? _factory;
     private string? _selectedModelId;
@@ -41,9 +51,18 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         TranscriptionAccelerationBackend.Cpu,
         "Using CPU");
 
+    public WhisperCppPlugin()
+    {
+    }
+
+    internal WhisperCppPlugin(IWhisperCppCudaRuntimeInstaller cudaRuntimeInstaller)
+    {
+        _cudaRuntimeInstaller = cudaRuntimeInstaller;
+    }
+
     public string PluginId => "com.typewhisper.whisper-cpp";
     public string PluginName => "whisper.cpp (Local)";
-    public string PluginVersion => "1.0.1";
+    public string PluginVersion => "1.0.2";
 
     public string ProviderId => "whisper-cpp";
     public string ProviderDisplayName => "Local (whisper.cpp)";
@@ -73,6 +92,8 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     {
         _host = host;
         _pluginDirectory = Path.GetDirectoryName(typeof(WhisperCppPlugin).Assembly.Location);
+        if (_pluginDirectory is not null)
+            _cudaRuntimeInstaller ??= new WhisperCppCudaRuntimeInstaller(_pluginDirectory, _httpClient);
         _selectedModelId = host.GetSetting<string>("selectedModel");
         host.Log(PluginLogLevel.Info, "Activated");
         return Task.CompletedTask;
@@ -91,7 +112,9 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     {
         _accelerationPreference = preference;
         ApplyRuntimeLibraryOrder(preference);
-        _accelerationStatus = CreatePendingAccelerationStatus(preference);
+        _accelerationStatus = CreatePendingAccelerationStatus(
+            preference,
+            _cudaRuntimeInstaller?.IsInstalled == true);
     }
 
     public void SelectModel(string modelId)
@@ -177,14 +200,20 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         {
             DisposeFactoryUnsafe();
             ApplyRuntimeLibraryOrder(_accelerationPreference);
+            await EnsureCudaRuntimeAvailableForLoadAsync(ct);
             try
             {
                 _factory = WhisperFactory.FromPath(modelPath);
             }
             catch (Exception ex) when (IsNativeLoadFailure(ex))
             {
-                _accelerationStatus = CreateNativeLoadFailureStatus(ex);
-                throw CreateNativeLoadFailureException(ex);
+                var loadException = CreateNativeLoadFailureException(ex);
+                _accelerationStatus = CreateNativeLoadFailureStatus(
+                    loadException,
+                    _accelerationPreference);
+                throw _accelerationPreference == TranscriptionAccelerationPreference.NvidiaCuda
+                    ? new InvalidOperationException(_accelerationStatus.Detail, loadException)
+                    : loadException;
             }
 
             var loadedLibrary = RuntimeOptions.LoadedLibrary;
@@ -282,6 +311,7 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     public void Dispose()
     {
         DisposeFactoryUnsafe();
+        _httpClient.Dispose();
         _gate.Dispose();
     }
 
@@ -301,13 +331,18 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         RuntimeOptions.RuntimeLibraryOrder = GetRuntimeLibraryOrder(preference).ToList();
 
     private static TranscriptionAccelerationStatus CreatePendingAccelerationStatus(
-        TranscriptionAccelerationPreference preference) =>
+        TranscriptionAccelerationPreference preference,
+        bool cudaRuntimeInstalled) =>
         preference switch
         {
+            TranscriptionAccelerationPreference.NvidiaCuda when cudaRuntimeInstalled => new(
+                    TranscriptionAccelerationBackend.Cpu,
+                    "Using CPU",
+                    "CUDA will be used when the model loads."),
             TranscriptionAccelerationPreference.NvidiaCuda => new(
-                TranscriptionAccelerationBackend.Cpu,
-                "Using CPU",
-                "CUDA will be used when the model loads."),
+                    TranscriptionAccelerationBackend.Cpu,
+                    "Using CPU",
+                    "CUDA support will be downloaded when the model loads."),
             _ => new(TranscriptionAccelerationBackend.Cpu, "Using CPU")
         };
 
@@ -322,15 +357,79 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                     TranscriptionAccelerationBackend.Cpu,
                     "Using CPU",
                     "CUDA runtime was not selected or could not be loaded.")
+                : preference == TranscriptionAccelerationPreference.NvidiaCuda
+                    ? new(
+                        TranscriptionAccelerationBackend.Cpu,
+                        "CUDA unavailable",
+                        CudaFallbackDetail)
                 : new(TranscriptionAccelerationBackend.Cpu, "Using CPU"),
             _ => new(TranscriptionAccelerationBackend.Cpu, "Using CPU")
         };
 
-    private static TranscriptionAccelerationStatus CreateNativeLoadFailureStatus(Exception error) =>
+    private static TranscriptionAccelerationStatus CreateNativeLoadFailureStatus(
+        Exception error,
+        TranscriptionAccelerationPreference preference) =>
+        new(
+            TranscriptionAccelerationBackend.Cpu,
+            preference == TranscriptionAccelerationPreference.NvidiaCuda
+                ? "CUDA unavailable"
+                : "Native runtime unavailable",
+            preference == TranscriptionAccelerationPreference.NvidiaCuda
+                ? CudaLoadFailureDetail
+                : error.Message);
+
+    private async Task EnsureCudaRuntimeAvailableForLoadAsync(CancellationToken cancellationToken)
+    {
+        if (_accelerationPreference != TranscriptionAccelerationPreference.NvidiaCuda)
+            return;
+
+        if (!OperatingSystem.IsWindows() || RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            _accelerationStatus = CreateCudaRuntimeInstallFailureStatus(
+                "NVIDIA CUDA acceleration for whisper.cpp is only available on Windows x64.");
+            throw new InvalidOperationException(_accelerationStatus.Detail);
+        }
+
+        var installer = _cudaRuntimeInstaller
+            ?? throw new InvalidOperationException("The whisper.cpp CUDA runtime installer is not available.");
+
+        if (installer.IsInstalled)
+            return;
+
+        _accelerationStatus = new(
+            TranscriptionAccelerationBackend.Cpu,
+            "Installing CUDA support",
+            "Downloading the NVIDIA CUDA runtime needed for whisper.cpp.");
+        _host?.Log(PluginLogLevel.Info, "Installing NVIDIA CUDA runtime for whisper.cpp.");
+
+        try
+        {
+            await installer.EnsureInstalledAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _accelerationStatus = CreateCudaRuntimeInstallFailureStatus(
+                "CUDA support download failed. " + ex.Message);
+            throw new InvalidOperationException(_accelerationStatus.Detail, ex);
+        }
+
+        if (!installer.IsInstalled)
+        {
+            _accelerationStatus = CreateCudaRuntimeInstallFailureStatus(
+                "CUDA support download completed, but the required NVIDIA runtime files are still missing.");
+            throw new InvalidOperationException(_accelerationStatus.Detail);
+        }
+
+        _host?.Log(
+            PluginLogLevel.Info,
+            $"Installed NVIDIA CUDA runtime for whisper.cpp at {installer.RuntimeDirectory}.");
+    }
+
+    private static TranscriptionAccelerationStatus CreateCudaRuntimeInstallFailureStatus(string detail) =>
         new(
             TranscriptionAccelerationBackend.Cpu,
             "CUDA unavailable",
-            error.Message);
+            detail);
 
     private string GetModelPath(string modelId)
     {
@@ -353,12 +452,14 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         var cudaRuntimeDirectory = Path.Join(pluginDirectory, "runtimes", "cuda", safeRuntimeIdentifier);
         const string requiredFiles =
             "whisper.dll, ggml-whisper.dll, ggml-base-whisper.dll, ggml-cpu-whisper.dll, " +
-            "ggml-cuda-whisper.dll (for CUDA), msvcp140.dll, vcruntime140.dll, " +
+            "ggml-cuda-whisper.dll (for CUDA), cublas64_13.dll (for CUDA/cuBLAS), " +
+            "msvcp140.dll, vcruntime140.dll, " +
             "vcruntime140_1.dll, VCOMP140.DLL";
 
         return "Unable to load the whisper.cpp native runtime. " +
             $"Expected CPU native DLLs under '{runtimeDirectory}' and CUDA native DLLs under " +
             $"'{cudaRuntimeDirectory}', including {requiredFiles}. " +
+            CudaRuntimeDependencyHint + " " +
             "Reinstall or update the whisper.cpp plugin. If the problem persists, install the " +
             "Microsoft Visual C++ 2015-2022 Redistributable for your Windows architecture. " +
             $"Original error: {error.Message}";

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -311,6 +311,8 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     public void Dispose()
     {
         DisposeFactoryUnsafe();
+        if (_cudaRuntimeInstaller is IDisposable disposableInstaller)
+            disposableInstaller.Dispose();
         _httpClient.Dispose();
         _gate.Dispose();
     }

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/manifest.json
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.whisper-cpp",
   "name": "whisper.cpp (Local)",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Offline transcription via whisper.cpp using Whisper.net",
   "category": "transcription",

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -205,9 +205,24 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         }
         catch (Exception ex)
         {
-            SetStatus(modelId, ModelStatus.Failed(ex.Message));
+            SetStatus(modelId, ModelStatus.Failed(GetModelLoadFailureMessage(plugin, ex)));
             throw;
         }
+    }
+
+    private static string GetModelLoadFailureMessage(ITranscriptionEnginePlugin plugin, Exception error)
+    {
+        var accelerationStatus = plugin.AccelerationStatus;
+        if (accelerationStatus.ActiveBackend == TranscriptionAccelerationBackend.Cpu
+            && string.Equals(
+                accelerationStatus.DisplayText,
+                "CUDA unavailable",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return accelerationStatus.DisplayText;
+        }
+
+        return error.Message;
     }
 
     internal static TranscriptionAccelerationPreference GetAccelerationPreference(string? value) =>

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
@@ -170,6 +170,41 @@ public class ModelManagerServiceTests
         Assert.Equal(expectedPreference, plugin.AccelerationPreferenceAtLoad);
     }
 
+    [Fact]
+    public async Task LoadModelAsync_UsesCompactCudaUnavailableModelStatusOnCudaLoadFailure()
+    {
+        const string pluginId = "com.typewhisper.whisper-cpp";
+        const string modelId = "whisper";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationNvidiaCuda
+        });
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true)
+        {
+            AccelerationStatusOverride = new TranscriptionAccelerationStatus(
+                TranscriptionAccelerationBackend.Cpu,
+                "CUDA unavailable",
+                "CUDA runtime could not be loaded. Missing CUDA/cuBLAS runtime dependency cublas64_13.dll."),
+            LoadException = new InvalidOperationException(
+                "CUDA runtime could not be loaded. Missing CUDA/cuBLAS runtime dependency cublas64_13.dll.")
+        };
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.LoadModelAsync(fullModelId));
+
+        var status = sut.GetStatus(fullModelId);
+        Assert.Equal(ModelStatusType.Error, status.Type);
+        Assert.Equal("CUDA unavailable", status.ErrorMessage);
+    }
+
     private PluginManager CreatePluginManager(params ITranscriptionEnginePlugin[] transcriptionEngines)
     {
         var pluginManager = new PluginManager(
@@ -222,6 +257,10 @@ public class ModelManagerServiceTests
         public TranscriptionAccelerationPreference LastAccelerationPreference { get; private set; } =
             TranscriptionAccelerationPreference.Auto;
         public TranscriptionAccelerationPreference? AccelerationPreferenceAtLoad { get; private set; }
+        public TranscriptionAccelerationStatus? AccelerationStatusOverride { get; init; }
+        public TranscriptionAccelerationStatus AccelerationStatus => AccelerationStatusOverride
+            ?? new TranscriptionAccelerationStatus(TranscriptionAccelerationBackend.Cpu, "Using CPU");
+        public Exception? LoadException { get; init; }
 
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
         public Task DeactivateAsync() => Task.CompletedTask;
@@ -235,6 +274,9 @@ public class ModelManagerServiceTests
             LoadCallCount++;
             AccelerationPreferenceAtLoad = LastAccelerationPreference;
             AccelerationPreferencesAtLoad.Add(LastAccelerationPreference);
+            if (LoadException is not null)
+                throw LoadException;
+
             LastLoadedModelId = modelId;
             SelectedModelId = modelId;
             return Task.CompletedTask;

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using TypeWhisper.PluginSDK;
 using TypeWhisper.Plugin.SherpaOnnx;
 using TypeWhisper.PluginSDK.Models;
 
@@ -52,6 +53,56 @@ public class SherpaOnnxPluginTests
         Assert.True(installer.EnsureInstalledCalled);
         Assert.Equal(TranscriptionAccelerationBackend.NvidiaCuda, sut.AccelerationStatus.ActiveBackend);
         Assert.Equal("Using CUDA", sut.AccelerationStatus.DisplayText);
+    }
+
+    [Fact]
+    public async Task ResolveProviderForLoadAsync_ExplicitCudaInstallFailureSetsUnavailableStatus()
+    {
+        var installer = new FakeCudaRuntimeInstaller(
+            isInstalled: false,
+            installException: new InvalidOperationException("download blocked"));
+        var sut = new SherpaOnnxPlugin(installer);
+
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ResolveProviderForLoadAsync(CancellationToken.None));
+
+        Assert.Contains("download blocked", ex.Message);
+        Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
+        Assert.Equal("CUDA unavailable", sut.AccelerationStatus.DisplayText);
+        Assert.Contains("download blocked", sut.AccelerationStatus.Detail);
+    }
+
+    [Fact]
+    public async Task LoadModelAsync_ExplicitCudaProviderFailureSetsUnavailableStatus()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-load-{Guid.NewGuid():N}");
+        try
+        {
+            var installer = new FakeCudaRuntimeInstaller(isInstalled: true);
+            var sut = new SherpaOnnxPlugin(
+                installer,
+                (_, _, _) => throw new InvalidOperationException("CUDA provider failed to initialize."));
+            var host = new FakePluginHostServices(tempDir);
+            CreateParakeetModelFiles(tempDir);
+
+            await sut.ActivateAsync(host);
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => sut.LoadModelAsync("parakeet-tdt-0.6b", CancellationToken.None));
+
+            Assert.Contains("CUDA provider failed to initialize", ex.Message);
+            Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
+            Assert.Equal("CUDA unavailable", sut.AccelerationStatus.DisplayText);
+            Assert.Contains("CUDA provider failed to initialize", sut.AccelerationStatus.Detail);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
@@ -113,11 +164,22 @@ public class SherpaOnnxPluginTests
         }
     }
 
+    private static void CreateParakeetModelFiles(string pluginDataDirectory)
+    {
+        var modelDir = Path.Join(pluginDataDirectory, "Models", "parakeet-tdt-0.6b");
+        Directory.CreateDirectory(modelDir);
+        foreach (var fileName in new[] { "encoder.int8.onnx", "decoder.int8.onnx", "joiner.int8.onnx", "tokens.txt" })
+            File.WriteAllText(Path.Join(modelDir, fileName), "test");
+    }
+
     private sealed class FakeCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
     {
-        public FakeCudaRuntimeInstaller(bool isInstalled)
+        private readonly Exception? _installException;
+
+        public FakeCudaRuntimeInstaller(bool isInstalled, Exception? installException = null)
         {
             IsInstalled = isInstalled;
+            _installException = installException;
         }
 
         public bool EnsureInstalledCalled { get; private set; }
@@ -127,8 +189,48 @@ public class SherpaOnnxPluginTests
         public Task EnsureInstalledAsync(CancellationToken cancellationToken)
         {
             EnsureInstalledCalled = true;
+            if (_installException is not null)
+                throw _installException;
+
             IsInstalled = true;
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class FakePluginHostServices(string pluginDataDirectory) : IPluginHostServices
+    {
+        public string PluginDataDirectory { get; } = pluginDataDirectory;
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new NoOpPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public IPluginLocalization Localization { get; } = new NoOpPluginLocalization();
+
+        public Task StoreSecretAsync(string key, string value) => Task.CompletedTask;
+        public Task<string?> LoadSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+        public T? GetSetting<T>(string key) => default;
+        public void SetSetting<T>(string key, T value) { }
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() { }
+    }
+
+    private sealed class NoOpPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent => new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    private sealed class NoOpPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.Plugin.SherpaOnnx;
 using TypeWhisper.PluginSDK.Models;
@@ -8,6 +9,28 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public class SherpaOnnxPluginTests
 {
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var repoRoot = Path.GetFullPath(Path.Join(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", ".."));
+        var manifestPath = Path.Join(
+            repoRoot,
+            "plugins",
+            "TypeWhisper.Plugin.SherpaOnnx",
+            "manifest.json");
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var sut = new SherpaOnnxPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal("1.0.2", manifest.Version);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
     [Theory]
     [InlineData(TranscriptionAccelerationPreference.Auto, false, "cpu")]
     [InlineData(TranscriptionAccelerationPreference.Auto, true, "cuda")]
@@ -97,6 +120,39 @@ public class SherpaOnnxPluginTests
             Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
             Assert.Equal("CUDA unavailable", sut.AccelerationStatus.DisplayText);
             Assert.Contains("CUDA provider failed to initialize", sut.AccelerationStatus.Detail);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadModelAsync_AutoCudaAndCpuFailureReportsCpuFallbackFailure()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-load-{Guid.NewGuid():N}");
+        try
+        {
+            var installer = new FakeCudaRuntimeInstaller(isInstalled: true);
+            var sut = new SherpaOnnxPlugin(
+                installer,
+                (_, _, provider) => throw new InvalidOperationException(
+                    $"{provider} provider failed to initialize."));
+            var host = new FakePluginHostServices(tempDir);
+            CreateParakeetModelFiles(tempDir);
+
+            await sut.ActivateAsync(host);
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Auto);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => sut.LoadModelAsync("parakeet-tdt-0.6b", CancellationToken.None));
+
+            Assert.Contains("cpu provider failed to initialize", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
+            Assert.Equal("Native runtime unavailable", sut.AccelerationStatus.DisplayText);
+            Assert.Contains("cpu provider failed to initialize", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("CUDA unavailable", sut.AccelerationStatus.DisplayText, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
@@ -253,7 +254,8 @@ public class WhisperCppPluginTests
         Directory.CreateDirectory(Path.Join(temp.Path, "Models"));
         await File.WriteAllTextAsync(Path.Join(temp.Path, "Models", "ggml-tiny.bin"), "not a real model");
 
-        _ = await Record.ExceptionAsync(() => sut.LoadModelAsync("tiny", CancellationToken.None));
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => sut.LoadModelAsync("tiny", CancellationToken.None));
 
         Assert.Equal(1, installer.EnsureInstalledCallCount);
     }
@@ -284,6 +286,22 @@ public class WhisperCppPluginTests
         Assert.Contains("network offline", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Dispose_DisposesCudaRuntimeInstaller()
+    {
+        var installer = new FakeCudaRuntimeInstaller(Path.Join(
+            Path.GetTempPath(),
+            "typewhisper-tests",
+            "runtimes",
+            "cuda",
+            "win-x64"));
+        var sut = new WhisperCppPlugin(installer);
+
+        sut.Dispose();
+
+        Assert.True(installer.DisposeCalled);
+    }
+
     private static byte[] CreateZipArchive(params (string Path, string Content)[] entries)
     {
         using var output = new MemoryStream();
@@ -302,19 +320,27 @@ public class WhisperCppPluginTests
 
     private sealed class StaticArchiveHandler(byte[] archiveBytes) : HttpMessageHandler
     {
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "The response is returned to HttpClient, which disposes it after the request pipeline completes.")]
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
-            CancellationToken cancellationToken) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ByteArrayContent(archiveBytes)
-            });
+            };
+            return Task.FromResult(response);
+        }
     }
 
-    private sealed class FakeCudaRuntimeInstaller(string runtimeDirectory) : IWhisperCppCudaRuntimeInstaller
+    private sealed class FakeCudaRuntimeInstaller(string runtimeDirectory) : IWhisperCppCudaRuntimeInstaller, IDisposable
     {
         private bool _isInstalled;
         public int EnsureInstalledCallCount { get; private set; }
+        public bool DisposeCalled { get; private set; }
         public Exception? InstallException { get; init; }
         public bool IsInstalledOverride { get; init; }
         public bool IsInstalled => _isInstalled || IsInstalledOverride;
@@ -329,6 +355,8 @@ public class WhisperCppPluginTests
             _isInstalled = true;
             return Task.CompletedTask;
         }
+
+        public void Dispose() => DisposeCalled = true;
     }
 
     private sealed class FakePluginHostServices(string pluginDataDirectory) : IPluginHostServices
@@ -370,7 +398,7 @@ public class WhisperCppPluginTests
 
     private sealed class TempDirectory : IDisposable
     {
-        public string Path { get; } = System.IO.Path.Combine(
+        public string Path { get; } = System.IO.Path.Join(
             System.IO.Path.GetTempPath(),
             $"typewhisper-tests-{Guid.NewGuid():N}");
 
@@ -383,8 +411,13 @@ public class WhisperCppPluginTests
                 if (Directory.Exists(Path))
                     Directory.Delete(Path, recursive: true);
             }
-            catch
+            catch (IOException ex)
             {
+                Console.Error.WriteLine($"Failed to delete temporary test directory '{Path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Console.Error.WriteLine($"Failed to delete temporary test directory '{Path}': {ex.Message}");
             }
         }
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -1,5 +1,10 @@
 using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text.Json;
+using TypeWhisper.PluginSDK;
 using TypeWhisper.Plugin.WhisperCpp;
 using TypeWhisper.PluginSDK.Models;
 using Whisper.net.LibraryLoader;
@@ -26,7 +31,7 @@ public class WhisperCppPluginTests
         var sut = new WhisperCppPlugin();
 
         Assert.NotNull(manifest);
-        Assert.Equal("1.0.1", manifest.Version);
+        Assert.Equal("1.0.2", manifest.Version);
         Assert.Equal(manifest.Version, sut.PluginVersion);
     }
 
@@ -62,6 +67,109 @@ public class WhisperCppPluginTests
     }
 
     [Fact]
+    public void PublishPluginsWorkflow_IncludesCudaRuntimeDirectoryInReleaseZip()
+    {
+        var repoRoot = Path.GetFullPath(Path.Join(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", ".."));
+        var workflowPath = Path.Join(
+            repoRoot,
+            ".github",
+            "workflows",
+            "publish-plugins.yml");
+
+        var workflow = File.ReadAllText(workflowPath);
+
+        Assert.Contains("cuda/win-x64", workflow);
+        Assert.Contains("ggml-cuda-whisper.dll", workflow);
+    }
+
+    [Fact]
+    public void CreateLoadedAccelerationStatus_ExplicitCudaCpuFallbackShowsUnavailableReason()
+    {
+        var method = typeof(WhisperCppPlugin).GetMethod(
+            "CreateLoadedAccelerationStatus",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        var status = Assert.IsType<TranscriptionAccelerationStatus>(method.Invoke(
+            null,
+            [RuntimeLibrary.Cpu, TranscriptionAccelerationPreference.NvidiaCuda]));
+
+        Assert.Equal(TranscriptionAccelerationBackend.Cpu, status.ActiveBackend);
+        Assert.Equal("CUDA unavailable", status.DisplayText);
+        Assert.Contains("could not be loaded", status.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cublas64_13.dll", status.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Expected CPU native DLLs", status.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.True(status.Detail?.Length < 180, $"Detail was too long for compact UI: {status.Detail}");
+    }
+
+    [Fact]
+    public void SetAccelerationPreference_ExplicitCudaWithoutRuntimeExplainsDownload()
+    {
+        var installer = new FakeCudaRuntimeInstaller(Path.Join(
+            Path.GetTempPath(),
+            "typewhisper-tests",
+            "runtimes",
+            "cuda",
+            "win-x64"));
+        var sut = new WhisperCppPlugin(installer);
+
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+        Assert.Equal("Using CPU", sut.AccelerationStatus.DisplayText);
+        Assert.Contains("download", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("CUDA", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SetAccelerationPreference_ExplicitCudaWithRuntimeShowsCudaPending()
+    {
+        var installer = new FakeCudaRuntimeInstaller(Path.Join(
+            Path.GetTempPath(),
+            "typewhisper-tests",
+            "runtimes",
+            "cuda",
+            "win-x64"))
+        {
+            IsInstalledOverride = true
+        };
+        var sut = new WhisperCppPlugin(installer);
+
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+        Assert.Equal("Using CPU", sut.AccelerationStatus.DisplayText);
+        Assert.DoesNotContain("download", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateNativeLoadFailureStatus_ExplicitCudaUsesCompactDependencyHint()
+    {
+        var method = typeof(WhisperCppPlugin).GetMethod(
+            "CreateNativeLoadFailureStatus",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var nativeError = new InvalidOperationException(
+            "Unable to load the whisper.cpp native runtime. Expected CPU native DLLs under " +
+            @"'C:\Users\Sal\AppData\Local\TypeWhisper\Plugins\com.typewhisper.whisper-cpp\runtimes\win-x64' " +
+            "and CUDA native DLLs under " +
+            @"'C:\Users\Sal\AppData\Local\TypeWhisper\Plugins\com.typewhisper.whisper-cpp\runtimes\cuda\win-x64', " +
+            "including cublas64_13.dll. Original error: 0x8007007E.");
+
+        Assert.NotNull(method);
+
+        var status = Assert.IsType<TranscriptionAccelerationStatus>(method.Invoke(
+            null,
+            [nativeError, TranscriptionAccelerationPreference.NvidiaCuda]));
+
+        Assert.Equal("CUDA unavailable", status.DisplayText);
+        Assert.Contains("cublas64_13.dll", status.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(@"C:\Users\Sal", status.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Expected CPU native DLLs", status.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.True(status.Detail?.Length < 180, $"Detail was too long for compact UI: {status.Detail}");
+    }
+
+    [Fact]
     public void BuildNativeLoadFailureMessage_NamesRuntimeFolderAndVcRedistFallback()
     {
         var pluginDirectory = Path.Join(
@@ -77,6 +185,7 @@ public class WhisperCppPluginTests
         Assert.Contains(Path.Join(pluginDirectory, "runtimes", "win-x64"), message);
         Assert.Contains("ggml-cpu-whisper.dll", message);
         Assert.Contains("VCOMP140.DLL", message);
+        Assert.Contains("cublas64_13.dll", message);
         Assert.Contains("Microsoft Visual C++ 2015-2022 Redistributable", message);
         Assert.Contains("0x8007007E", message);
     }
@@ -95,5 +204,188 @@ public class WhisperCppPluginTests
 
         Assert.Contains(Path.Join(pluginDirectory, "runtimes", "win-x64"), message);
         Assert.DoesNotContain(Path.Join(pluginDirectory, "runtimes", "unexpected"), message);
+    }
+
+    [Fact]
+    public async Task CudaRuntimeInstaller_DownloadsAndInstallsCublasRuntimeBesideCudaRuntime()
+    {
+        using var temp = new TempDirectory();
+        var runtimeDirectory = Path.Join(temp.Path, "runtimes", "cuda", "win-x64");
+        Directory.CreateDirectory(runtimeDirectory);
+        File.WriteAllText(Path.Join(runtimeDirectory, "ggml-cuda-whisper.dll"), "native");
+
+        var archiveBytes = CreateZipArchive(
+            ("libcublas/bin/cublas64_13.dll", "cublas"),
+            ("libcublas/bin/cublasLt64_13.dll", "cublasLt"),
+            ("libcublas/docs/readme.txt", "ignore"));
+        var package = new WhisperCppCudaRuntimePackage(
+            "test-runtime",
+            "https://example.test/libcublas.zip",
+            Convert.ToHexString(SHA256.HashData(archiveBytes)).ToLowerInvariant(),
+            ["cublas64_13.dll", "cublasLt64_13.dll"]);
+        using var httpClient = new HttpClient(new StaticArchiveHandler(archiveBytes));
+        var sut = new WhisperCppCudaRuntimeInstaller(temp.Path, httpClient, package);
+
+        Assert.False(sut.IsInstalled);
+
+        await sut.EnsureInstalledAsync(CancellationToken.None);
+
+        Assert.True(sut.IsInstalled);
+        Assert.Equal("cublas", File.ReadAllText(Path.Join(runtimeDirectory, "cublas64_13.dll")));
+        Assert.Equal("cublasLt", File.ReadAllText(Path.Join(runtimeDirectory, "cublasLt64_13.dll")));
+        Assert.False(File.Exists(Path.Join(runtimeDirectory, "readme.txt")));
+    }
+
+    [Fact]
+    public async Task LoadModelAsync_ExplicitCudaInstallsMissingRuntimeBeforeNativeLoad()
+    {
+        using var temp = new TempDirectory();
+        var host = new FakePluginHostServices(temp.Path);
+        var installer = new FakeCudaRuntimeInstaller(
+            Path.Join(temp.Path, "plugin", "runtimes", "cuda", "win-x64"))
+        {
+            InstallException = new OperationCanceledException("cancelled before native load")
+        };
+        var sut = new WhisperCppPlugin(installer);
+        await sut.ActivateAsync(host);
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+        Directory.CreateDirectory(Path.Join(temp.Path, "Models"));
+        await File.WriteAllTextAsync(Path.Join(temp.Path, "Models", "ggml-tiny.bin"), "not a real model");
+
+        _ = await Record.ExceptionAsync(() => sut.LoadModelAsync("tiny", CancellationToken.None));
+
+        Assert.Equal(1, installer.EnsureInstalledCallCount);
+    }
+
+    [Fact]
+    public async Task LoadModelAsync_ExplicitCudaRuntimeInstallFailureShowsDownloadReason()
+    {
+        using var temp = new TempDirectory();
+        var host = new FakePluginHostServices(temp.Path);
+        var installer = new FakeCudaRuntimeInstaller(
+            Path.Join(temp.Path, "plugin", "runtimes", "cuda", "win-x64"))
+        {
+            InstallException = new InvalidOperationException("network offline")
+        };
+        var sut = new WhisperCppPlugin(installer);
+        await sut.ActivateAsync(host);
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+        Directory.CreateDirectory(Path.Join(temp.Path, "Models"));
+        await File.WriteAllTextAsync(Path.Join(temp.Path, "Models", "ggml-tiny.bin"), "not a real model");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.LoadModelAsync("tiny", CancellationToken.None));
+
+        Assert.Equal("CUDA unavailable", sut.AccelerationStatus.DisplayText);
+        Assert.Contains("download", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("network offline", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("network offline", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[] CreateZipArchive(params (string Path, string Content)[] entries)
+    {
+        using var output = new MemoryStream();
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (path, content) in entries)
+            {
+                var entry = archive.CreateEntry(path);
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write(content);
+            }
+        }
+
+        return output.ToArray();
+    }
+
+    private sealed class StaticArchiveHandler(byte[] archiveBytes) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(archiveBytes)
+            });
+    }
+
+    private sealed class FakeCudaRuntimeInstaller(string runtimeDirectory) : IWhisperCppCudaRuntimeInstaller
+    {
+        private bool _isInstalled;
+        public int EnsureInstalledCallCount { get; private set; }
+        public Exception? InstallException { get; init; }
+        public bool IsInstalledOverride { get; init; }
+        public bool IsInstalled => _isInstalled || IsInstalledOverride;
+        public string RuntimeDirectory { get; } = runtimeDirectory;
+
+        public Task EnsureInstalledAsync(CancellationToken cancellationToken)
+        {
+            EnsureInstalledCallCount++;
+            if (InstallException is not null)
+                throw InstallException;
+
+            _isInstalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakePluginHostServices(string pluginDataDirectory) : IPluginHostServices
+    {
+        public string PluginDataDirectory { get; } = pluginDataDirectory;
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new NoOpPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public IPluginLocalization Localization { get; } = new NoOpPluginLocalization();
+
+        public Task StoreSecretAsync(string key, string value) => Task.CompletedTask;
+        public Task<string?> LoadSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+        public T? GetSetting<T>(string key) => default;
+        public void SetSetting<T>(string key, T value) { }
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() { }
+    }
+
+    private sealed class NoOpPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent => new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    private sealed class NoOpPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"typewhisper-tests-{Guid.NewGuid():N}");
+
+        public TempDirectory() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                    Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #184

## Summary
- Package the whisper.cpp CUDA runtime folder into the marketplace plugin ZIP and fail publishing if `ggml-cuda-whisper.dll` is missing.
- Add an on-demand NVIDIA cuBLAS runtime installer for whisper.cpp so CUDA users do not need to install the full CUDA Toolkit or manage PATH manually.
- Keep CUDA failures visible with compact `CUDA unavailable` status details for whisper.cpp and sherpa-onnx.
- Report CPU fallback failures separately after an automatic sherpa-onnx CUDA failure, so the status does not misleadingly keep blaming CUDA.
- Bump the whisper.cpp and sherpa-onnx plugin release versions to `1.0.2`.

## Root Cause
The app ZIP contained `runtimes/cuda/win-x64/ggml-cuda-whisper.dll`, but the published marketplace plugin ZIP did not. On machines without the CUDA/cuBLAS runtime dependency, explicit CUDA selection produced confusing native load failures or CPU fallback behavior.

## Validation
- `dotnet build plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj -c Release`
- `dotnet build plugins\TypeWhisper.Plugin.SherpaOnnx\TypeWhisper.Plugin.SherpaOnnx.csproj -c Release`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release --filter "WhisperCppPluginTests|SherpaOnnxPluginTests|ModelManagerViewModelTests|ModelManagerServiceTests|HttpApiServiceTests"` (`68/68` passed)
- Release-like whisper.cpp ZIP check confirmed `runtimes/cuda/win-x64/ggml-cuda-whisper.dll` is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic CUDA runtime installation and verification for Windows x64.

* **Bug Fixes**
  * Clearer native/CUDA failure messages with concise dependency hints.
  * Improved CPU fallback behavior when CUDA is unavailable.

* **Chores**
  * Plugin versions bumped to 1.0.2 (WhisperCpp, SherpaOnnx).

* **Tests**
  * Added coverage for CUDA install/load failure paths and packaging checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->