### PR TITLE
Require restart after CUDA runtime installation

### DIFF
--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -425,6 +425,9 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         _host?.Log(
             PluginLogLevel.Info,
             $"Installed NVIDIA CUDA runtime for whisper.cpp at {installer.RuntimeDirectory}.");
+
+        _accelerationStatus = CreateCudaRuntimeInstalledRestartRequiredStatus();
+        throw new InvalidOperationException(_accelerationStatus.Detail);
     }
 
     private static TranscriptionAccelerationStatus CreateCudaRuntimeInstallFailureStatus(string detail) =>
@@ -432,6 +435,13 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             TranscriptionAccelerationBackend.Cpu,
             "CUDA unavailable",
             detail);
+
+    private static TranscriptionAccelerationStatus CreateCudaRuntimeInstalledRestartRequiredStatus() =>
+        new(
+            TranscriptionAccelerationBackend.Cpu,
+            "Restart required",
+            "CUDA support was installed. Restart TypeWhisper to load the CUDA runtime.",
+            RequiresRestart: true);
 
     private string GetModelPath(string modelId)
     {

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -46,6 +46,7 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     private string? _selectedModelId;
     private string? _loadedModelId;
     private string? _pluginDirectory;
+    private bool _cudaRuntimeRestartRequired;
     private TranscriptionAccelerationPreference _accelerationPreference = TranscriptionAccelerationPreference.Auto;
     private TranscriptionAccelerationStatus _accelerationStatus = new(
         TranscriptionAccelerationBackend.Cpu,
@@ -112,6 +113,12 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     {
         _accelerationPreference = preference;
         ApplyRuntimeLibraryOrder(preference);
+        if (preference == TranscriptionAccelerationPreference.NvidiaCuda && _cudaRuntimeRestartRequired)
+        {
+            _accelerationStatus = CreateCudaRuntimeInstalledRestartRequiredStatus();
+            return;
+        }
+
         _accelerationStatus = CreatePendingAccelerationStatus(
             preference,
             _cudaRuntimeInstaller?.IsInstalled == true);
@@ -385,6 +392,12 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         if (_accelerationPreference != TranscriptionAccelerationPreference.NvidiaCuda)
             return;
 
+        if (_cudaRuntimeRestartRequired)
+        {
+            _accelerationStatus = CreateCudaRuntimeInstalledRestartRequiredStatus();
+            throw new InvalidOperationException(_accelerationStatus.Detail);
+        }
+
         if (!OperatingSystem.IsWindows() || RuntimeInformation.ProcessArchitecture != Architecture.X64)
         {
             _accelerationStatus = CreateCudaRuntimeInstallFailureStatus(
@@ -426,6 +439,7 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             PluginLogLevel.Info,
             $"Installed NVIDIA CUDA runtime for whisper.cpp at {installer.RuntimeDirectory}.");
 
+        _cudaRuntimeRestartRequired = true;
         _accelerationStatus = CreateCudaRuntimeInstalledRestartRequiredStatus();
         throw new InvalidOperationException(_accelerationStatus.Detail);
     }

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -295,7 +295,8 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
 
         var targetAccelerationPreference = GetAccelerationPreference(_settings.Current.LocalModelAcceleration);
         if (ActiveModelId == targetModelId
-            && _activeModelAccelerationPreference == targetAccelerationPreference)
+            && _activeModelAccelerationPreference == targetAccelerationPreference
+            && IsActiveAccelerationSatisfied(targetAccelerationPreference))
         {
             CancelAutoUnload();
             return true;
@@ -312,6 +313,19 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
 
         await LoadModelAsync(targetModelId, cancellationToken);
         return true;
+    }
+
+    private bool IsActiveAccelerationSatisfied(TranscriptionAccelerationPreference targetPreference)
+    {
+        var status = ActiveTranscriptionPlugin?.AccelerationStatus;
+        if (status is null)
+            return true;
+
+        if (status.RequiresRestart)
+            return false;
+
+        return targetPreference != TranscriptionAccelerationPreference.NvidiaCuda
+            || status.ActiveBackend == TranscriptionAccelerationBackend.NvidiaCuda;
     }
 
     internal async Task<TranscriptionRequestModelScope> BeginTranscriptionRequestAsync(

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
@@ -123,7 +123,12 @@ public class ModelManagerServiceTests
             pluginId,
             configured: true,
             selectedModelId: null,
-            supportsModelDownload: true);
+            supportsModelDownload: true)
+        {
+            AccelerationStatusOverride = new TranscriptionAccelerationStatus(
+                TranscriptionAccelerationBackend.NvidiaCuda,
+                "Using CUDA")
+        };
         var pluginManager = CreatePluginManager(plugin);
         var sut = new ModelManagerService(pluginManager, _settings.Object);
 
@@ -134,6 +139,43 @@ public class ModelManagerServiceTests
         Assert.Equal(1, plugin.LoadCallCount);
         Assert.Equal(
             [TranscriptionAccelerationPreference.NvidiaCuda],
+            plugin.AccelerationPreferencesAtLoad);
+    }
+
+    [Fact]
+    public async Task EnsureModelLoadedAsync_ReloadsExplicitCudaActiveModel_WhenBackendIsCpu()
+    {
+        const string pluginId = "com.typewhisper.whisper-cpp";
+        const string modelId = "whisper";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            SelectedModelId = fullModelId,
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationNvidiaCuda
+        });
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true)
+        {
+            AccelerationStatusOverride = new TranscriptionAccelerationStatus(
+                TranscriptionAccelerationBackend.Cpu,
+                "CUDA unavailable",
+                "CUDA runtime was installed after the model had already loaded.")
+        };
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        await sut.EnsureModelLoadedAsync();
+        var loaded = await sut.EnsureModelLoadedAsync();
+
+        Assert.True(loaded);
+        Assert.Equal(2, plugin.LoadCallCount);
+        Assert.Equal(
+            [TranscriptionAccelerationPreference.NvidiaCuda, TranscriptionAccelerationPreference.NvidiaCuda],
             plugin.AccelerationPreferencesAtLoad);
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -287,6 +287,33 @@ public class WhisperCppPluginTests
     }
 
     [Fact]
+    public async Task EnsureCudaRuntimeAvailableForLoadAsync_ExplicitCudaRuntimeInstallRequiresRestart()
+    {
+        using var temp = new TempDirectory();
+        var host = new FakePluginHostServices(temp.Path);
+        var installer = new FakeCudaRuntimeInstaller(
+            Path.Join(temp.Path, "plugin", "runtimes", "cuda", "win-x64"));
+        var sut = new WhisperCppPlugin(installer);
+        await sut.ActivateAsync(host);
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+        var method = typeof(WhisperCppPlugin).GetMethod(
+            "EnsureCudaRuntimeAvailableForLoadAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(method);
+
+        var task = Assert.IsAssignableFrom<Task>(method.Invoke(sut, [CancellationToken.None]));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => task);
+
+        Assert.Equal(1, installer.EnsureInstalledCallCount);
+        Assert.True(sut.AccelerationStatus.RequiresRestart);
+        Assert.Equal("Restart required", sut.AccelerationStatus.DisplayText);
+        Assert.Contains("Restart TypeWhisper", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Restart TypeWhisper", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Dispose_DisposesCudaRuntimeInstaller()
     {
         var installer = new FakeCudaRuntimeInstaller(Path.Join(

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -311,6 +311,18 @@ public class WhisperCppPluginTests
         Assert.Equal("Restart required", sut.AccelerationStatus.DisplayText);
         Assert.Contains("Restart TypeWhisper", sut.AccelerationStatus.Detail, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Restart TypeWhisper", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+        Assert.True(sut.AccelerationStatus.RequiresRestart);
+        Assert.Equal("Restart required", sut.AccelerationStatus.DisplayText);
+
+        var secondTask = Assert.IsAssignableFrom<Task>(method.Invoke(sut, [CancellationToken.None]));
+        var secondEx = await Assert.ThrowsAsync<InvalidOperationException>(() => secondTask);
+
+        Assert.Equal(1, installer.EnsureInstalledCallCount);
+        Assert.True(sut.AccelerationStatus.RequiresRestart);
+        Assert.Equal("Restart required", sut.AccelerationStatus.DisplayText);
+        Assert.Contains("Restart TypeWhisper", secondEx.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Stop whisper.cpp model loading after a freshly installed CUDA runtime and surface a restart-required acceleration status.
- Treat explicit CUDA as unsatisfied when the active plugin is still using CPU or requires restart, so the model manager retries instead of silently accepting CPU fallback.
- Add regression coverage for both the CUDA runtime install restart flow and the explicit CUDA CPU-fallback reload path.

## Verification
- `dotnet build plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj -c Release`
- `dotnet build src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release --filter "WhisperCppPluginTests|ModelManagerServiceTests|ModelManagerViewModelTests|HttpApiServiceTests"`

No app or plugin release was created for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA acceleration handling: installs now surface a "restart required" state and prevent model loads until restart.
  * Model loading now correctly reloads when acceleration preference and active acceleration state diverge (including restart-required cases).
  * Fixed scenarios where acceleration-status mismatches failed to trigger a reload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-win/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->