### PR TITLE
Add AMD acceleration for whisper.cpp

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -139,7 +139,7 @@ jobs:
           $runtimesDir = Join-Path $outputDir 'runtimes'
           if (Test-Path $runtimesDir) {
             New-Item -ItemType Directory -Path "$stagingDir/runtimes" -Force | Out-Null
-            foreach ($runtimeName in @('win-x64', 'win-arm64', 'cuda/win-x64')) {
+            foreach ($runtimeName in @('win-x64', 'win-arm64', 'cuda/win-x64', 'vulkan/win-x64')) {
               $runtimeDir = Join-Path $runtimesDir $runtimeName
               if (Test-Path $runtimeDir) {
                 $runtimeDestination = Join-Path "$stagingDir/runtimes" $runtimeName
@@ -154,6 +154,10 @@ jobs:
             $cudaRuntime = Join-Path $stagingDir 'runtimes/cuda/win-x64/ggml-cuda-whisper.dll'
             if (-not (Test-Path $cudaRuntime)) {
               throw "Missing required whisper.cpp CUDA runtime: $cudaRuntime"
+            }
+            $vulkanRuntime = Join-Path $stagingDir 'runtimes/vulkan/win-x64/ggml-vulkan-whisper.dll'
+            if (-not (Test-Path $vulkanRuntime)) {
+              throw "Missing required whisper.cpp Vulkan runtime: $vulkanRuntime"
             }
           }
 

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/TypeWhisper.Plugin.WhisperCpp.csproj
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/TypeWhisper.Plugin.WhisperCpp.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Whisper.net" Version="1.9.0" />
     <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
     <PackageReference Include="Whisper.net.Runtime.Cuda.Windows" Version="1.9.0" />
+    <PackageReference Include="Whisper.net.Runtime.Vulkan" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,6 +48,9 @@
       <_RuntimeFiles Include="$(TargetDir)runtimes\cuda\win-x64\**\*.*">
         <RuntimeIdentifier>cuda\win-x64</RuntimeIdentifier>
       </_RuntimeFiles>
+      <_RuntimeFiles Include="$(TargetDir)runtimes\vulkan\win-x64\**\*.*">
+        <RuntimeIdentifier>vulkan\win-x64</RuntimeIdentifier>
+      </_RuntimeFiles>
     </ItemGroup>
 
     <RemoveDir Directories="$(PluginOutputDir)" Condition="Exists('$(PluginOutputDir)')" />
@@ -66,6 +70,7 @@
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\ggml-whisper.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\whisper.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\cuda\win-x64\ggml-cuda-whisper.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\vulkan\win-x64\ggml-vulkan-whisper.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\msvcp140.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\vcruntime140.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\vcruntime140_1.dll" />

--- a/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/WhisperCppPlugin.cs
@@ -19,6 +19,13 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         "CUDA runtime could not be loaded; using CPU. " + CudaRuntimeDependencyHint;
     private const string CudaLoadFailureDetail =
         "CUDA runtime could not be loaded. " + CudaRuntimeDependencyHint;
+    internal const string RocmLibraryPathEnvironmentVariable = "TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH";
+    private const string VulkanFallbackDetail =
+        "Vulkan runtime could not be loaded; using CPU. Make sure the AMD Vulkan driver is installed.";
+    private const string VulkanLoadFailureDetail =
+        "Vulkan runtime could not be loaded. Make sure the AMD Vulkan driver is installed.";
+    private const string RocmHookMissingDetail =
+        "Set TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH to a custom ROCm whisper.dll path and restart TypeWhisper.";
 
     private static readonly IReadOnlyList<ModelDefinition> Models =
     [
@@ -47,6 +54,8 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     private string? _loadedModelId;
     private string? _pluginDirectory;
     private TranscriptionAccelerationPreference _accelerationPreference = TranscriptionAccelerationPreference.Auto;
+    private bool _customRocmRuntimeLoaded;
+    private bool _runtimeRestartRequired;
     private TranscriptionAccelerationStatus _accelerationStatus = new(
         TranscriptionAccelerationBackend.Cpu,
         "Using CPU");
@@ -74,7 +83,9 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     public IReadOnlyList<TranscriptionAccelerationBackend> SupportedAccelerationBackends { get; } =
     [
         TranscriptionAccelerationBackend.Cpu,
-        TranscriptionAccelerationBackend.NvidiaCuda
+        TranscriptionAccelerationBackend.NvidiaCuda,
+        TranscriptionAccelerationBackend.AmdVulkan,
+        TranscriptionAccelerationBackend.AmdRocm
     ];
     public TranscriptionAccelerationPreference AccelerationPreference => _accelerationPreference;
     public TranscriptionAccelerationStatus AccelerationStatus => _accelerationStatus;
@@ -110,11 +121,17 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
     public void SetAccelerationPreference(TranscriptionAccelerationPreference preference)
     {
+        _runtimeRestartRequired = RequiresRuntimeRestart(preference);
         _accelerationPreference = preference;
-        ApplyRuntimeLibraryOrder(preference);
-        _accelerationStatus = CreatePendingAccelerationStatus(
-            preference,
-            _cudaRuntimeInstaller?.IsInstalled == true);
+        if (!_runtimeRestartRequired)
+            ApplyRuntimeConfiguration(preference);
+
+        _accelerationStatus = _runtimeRestartRequired
+            ? CreateRuntimeRestartStatus(preference)
+            : CreatePendingAccelerationStatus(
+                preference,
+                _cudaRuntimeInstaller?.IsInstalled == true,
+                ResolveRocmLibraryPathFromEnvironment() is not null);
     }
 
     public void SelectModel(string modelId)
@@ -198,9 +215,13 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         await _gate.WaitAsync(ct);
         try
         {
+            if (_accelerationStatus.RequiresRestart)
+                throw new InvalidOperationException(_accelerationStatus.Detail);
+
             DisposeFactoryUnsafe();
-            ApplyRuntimeLibraryOrder(_accelerationPreference);
+            ApplyRuntimeConfiguration(_accelerationPreference);
             await EnsureCudaRuntimeAvailableForLoadAsync(ct);
+            EnsureRocmRuntimeAvailableForLoad();
             try
             {
                 _factory = WhisperFactory.FromPath(modelPath);
@@ -220,6 +241,7 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             _accelerationStatus = CreateLoadedAccelerationStatus(
                 loadedLibrary,
                 _accelerationPreference);
+            _customRocmRuntimeLoaded = _accelerationPreference == TranscriptionAccelerationPreference.AmdRocm;
             _loadedModelId = modelId;
             _selectedModelId = modelId;
             _host?.SetSetting("selectedModel", modelId);
@@ -326,15 +348,23 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         {
             TranscriptionAccelerationPreference.Cpu => [RuntimeLibrary.Cpu],
             TranscriptionAccelerationPreference.NvidiaCuda => [RuntimeLibrary.Cuda],
-            _ => [RuntimeLibrary.Cuda, RuntimeLibrary.Cpu]
+            TranscriptionAccelerationPreference.AmdVulkan => [RuntimeLibrary.Vulkan],
+            TranscriptionAccelerationPreference.AmdRocm => [],
+            _ => [RuntimeLibrary.Cuda, RuntimeLibrary.Vulkan, RuntimeLibrary.Cpu]
         };
 
-    private static void ApplyRuntimeLibraryOrder(TranscriptionAccelerationPreference preference) =>
+    private static void ApplyRuntimeConfiguration(TranscriptionAccelerationPreference preference)
+    {
+        RuntimeOptions.LibraryPath = preference == TranscriptionAccelerationPreference.AmdRocm
+            ? ResolveRocmLibraryPathFromEnvironment()
+            : null;
         RuntimeOptions.RuntimeLibraryOrder = GetRuntimeLibraryOrder(preference).ToList();
+    }
 
     private static TranscriptionAccelerationStatus CreatePendingAccelerationStatus(
         TranscriptionAccelerationPreference preference,
-        bool cudaRuntimeInstalled) =>
+        bool cudaRuntimeInstalled,
+        bool rocmLibraryConfigured) =>
         preference switch
         {
             TranscriptionAccelerationPreference.NvidiaCuda when cudaRuntimeInstalled => new(
@@ -345,40 +375,59 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                     TranscriptionAccelerationBackend.Cpu,
                     "Using CPU",
                     "CUDA support will be downloaded when the model loads."),
+            TranscriptionAccelerationPreference.AmdVulkan => new(
+                    TranscriptionAccelerationBackend.Cpu,
+                    "Using CPU",
+                    "Vulkan will be used when the model loads."),
+            TranscriptionAccelerationPreference.AmdRocm when rocmLibraryConfigured => new(
+                    TranscriptionAccelerationBackend.Cpu,
+                    "Using CPU",
+                    "ROCm will be used when the model loads."),
+            TranscriptionAccelerationPreference.AmdRocm => new(
+                    TranscriptionAccelerationBackend.Cpu,
+                    "ROCm unavailable",
+                    RocmHookMissingDetail),
             _ => new(TranscriptionAccelerationBackend.Cpu, "Using CPU")
         };
 
     private static TranscriptionAccelerationStatus CreateLoadedAccelerationStatus(
         RuntimeLibrary? loadedLibrary,
-        TranscriptionAccelerationPreference preference) =>
-        loadedLibrary switch
+        TranscriptionAccelerationPreference preference)
+    {
+        if (preference == TranscriptionAccelerationPreference.AmdRocm)
+            return new(TranscriptionAccelerationBackend.AmdRocm, "Using ROCm");
+
+        return loadedLibrary switch
         {
             RuntimeLibrary.Cuda => new(TranscriptionAccelerationBackend.NvidiaCuda, "Using CUDA"),
-            RuntimeLibrary.Cpu => preference == TranscriptionAccelerationPreference.Auto
-                ? new(
+            RuntimeLibrary.Vulkan => new(TranscriptionAccelerationBackend.AmdVulkan, "Using Vulkan"),
+            RuntimeLibrary.Cpu => preference switch
+            {
+                TranscriptionAccelerationPreference.Auto => new(
                     TranscriptionAccelerationBackend.Cpu,
                     "Using CPU",
-                    "CUDA runtime was not selected or could not be loaded.")
-                : preference == TranscriptionAccelerationPreference.NvidiaCuda
-                    ? new(
-                        TranscriptionAccelerationBackend.Cpu,
-                        "CUDA unavailable",
-                        CudaFallbackDetail)
-                : new(TranscriptionAccelerationBackend.Cpu, "Using CPU"),
+                    "CUDA/Vulkan runtime was not selected or could not be loaded."),
+                TranscriptionAccelerationPreference.NvidiaCuda => new(
+                    TranscriptionAccelerationBackend.Cpu,
+                    "CUDA unavailable",
+                    CudaFallbackDetail),
+                TranscriptionAccelerationPreference.AmdVulkan => new(
+                    TranscriptionAccelerationBackend.Cpu,
+                    "Vulkan unavailable",
+                    VulkanFallbackDetail),
+                _ => new(TranscriptionAccelerationBackend.Cpu, "Using CPU")
+            },
             _ => new(TranscriptionAccelerationBackend.Cpu, "Using CPU")
         };
+    }
 
     private static TranscriptionAccelerationStatus CreateNativeLoadFailureStatus(
         Exception error,
         TranscriptionAccelerationPreference preference) =>
         new(
             TranscriptionAccelerationBackend.Cpu,
-            preference == TranscriptionAccelerationPreference.NvidiaCuda
-                ? "CUDA unavailable"
-                : "Native runtime unavailable",
-            preference == TranscriptionAccelerationPreference.NvidiaCuda
-                ? CudaLoadFailureDetail
-                : error.Message);
+            GetUnavailableDisplayText(preference),
+            GetNativeLoadFailureDetail(error, preference));
 
     private async Task EnsureCudaRuntimeAvailableForLoadAsync(CancellationToken cancellationToken)
     {
@@ -433,6 +482,31 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             "CUDA unavailable",
             detail);
 
+    private void EnsureRocmRuntimeAvailableForLoad()
+    {
+        if (_accelerationPreference != TranscriptionAccelerationPreference.AmdRocm)
+            return;
+
+        if (_runtimeRestartRequired)
+        {
+            _accelerationStatus = CreateRuntimeRestartStatus(_accelerationPreference);
+            throw new InvalidOperationException(_accelerationStatus.Detail);
+        }
+
+        var libraryPath = ResolveRocmLibraryPathFromEnvironment();
+        if (libraryPath is not null)
+        {
+            RuntimeOptions.LibraryPath = libraryPath;
+            return;
+        }
+
+        _accelerationStatus = new(
+            TranscriptionAccelerationBackend.Cpu,
+            "ROCm unavailable",
+            RocmHookMissingDetail);
+        throw new InvalidOperationException(_accelerationStatus.Detail);
+    }
+
     private string GetModelPath(string modelId)
     {
         var host = _host ?? throw new InvalidOperationException("Plugin is not activated.");
@@ -452,16 +526,20 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
         var runtimeDirectory = Path.Join(pluginDirectory, "runtimes", safeRuntimeIdentifier);
         var cudaRuntimeDirectory = Path.Join(pluginDirectory, "runtimes", "cuda", safeRuntimeIdentifier);
+        var vulkanRuntimeDirectory = Path.Join(pluginDirectory, "runtimes", "vulkan", safeRuntimeIdentifier);
         const string requiredFiles =
             "whisper.dll, ggml-whisper.dll, ggml-base-whisper.dll, ggml-cpu-whisper.dll, " +
             "ggml-cuda-whisper.dll (for CUDA), cublas64_13.dll (for CUDA/cuBLAS), " +
+            "ggml-vulkan-whisper.dll (for Vulkan), " +
             "msvcp140.dll, vcruntime140.dll, " +
             "vcruntime140_1.dll, VCOMP140.DLL";
 
         return "Unable to load the whisper.cpp native runtime. " +
             $"Expected CPU native DLLs under '{runtimeDirectory}' and CUDA native DLLs under " +
-            $"'{cudaRuntimeDirectory}', including {requiredFiles}. " +
+            $"'{cudaRuntimeDirectory}', Vulkan native DLLs under '{vulkanRuntimeDirectory}', " +
+            $"including {requiredFiles}. " +
             CudaRuntimeDependencyHint + " " +
+            $"For ROCm, set {RocmLibraryPathEnvironmentVariable} to a custom ROCm whisper.dll. " +
             "Reinstall or update the whisper.cpp plugin. If the problem persists, install the " +
             "Microsoft Visual C++ 2015-2022 Redistributable for your Windows architecture. " +
             $"Original error: {error.Message}";
@@ -501,6 +579,124 @@ public sealed class WhisperCppPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         _factory?.Dispose();
         _factory = null;
     }
+
+    internal static string? ResolveRocmLibraryPath(string? configuredPath)
+    {
+        if (string.IsNullOrWhiteSpace(configuredPath))
+            return null;
+
+        string candidate;
+        try
+        {
+            candidate = Path.GetFullPath(configuredPath.Trim());
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException
+                or NotSupportedException
+                or PathTooLongException
+                or System.Security.SecurityException)
+        {
+            return null;
+        }
+
+        if (Directory.Exists(candidate))
+            candidate = Path.Join(candidate, "whisper.dll");
+
+        return File.Exists(candidate) ? candidate : null;
+    }
+
+    private static string? ResolveRocmLibraryPathFromEnvironment() =>
+        ResolveRocmLibraryPath(Environment.GetEnvironmentVariable(RocmLibraryPathEnvironmentVariable));
+
+    private bool RequiresRuntimeRestart(TranscriptionAccelerationPreference targetPreference)
+    {
+        if (_customRocmRuntimeLoaded)
+            return targetPreference != TranscriptionAccelerationPreference.AmdRocm;
+
+        if (targetPreference == TranscriptionAccelerationPreference.AmdRocm)
+            return RuntimeOptions.LoadedLibrary is not null;
+
+        return RuntimeOptions.LoadedLibrary is { } loadedLibrary
+            && !IsLoadedLibraryCompatibleWithPreference(loadedLibrary, targetPreference);
+    }
+
+    private static bool IsLoadedLibraryCompatibleWithPreference(
+        RuntimeLibrary loadedLibrary,
+        TranscriptionAccelerationPreference preference) =>
+        preference switch
+        {
+            TranscriptionAccelerationPreference.Auto => true,
+            TranscriptionAccelerationPreference.Cpu => loadedLibrary == RuntimeLibrary.Cpu,
+            TranscriptionAccelerationPreference.NvidiaCuda => loadedLibrary == RuntimeLibrary.Cuda,
+            TranscriptionAccelerationPreference.AmdVulkan => loadedLibrary == RuntimeLibrary.Vulkan,
+            TranscriptionAccelerationPreference.AmdRocm => false,
+            _ => false
+        };
+
+    private TranscriptionAccelerationStatus CreateRuntimeRestartStatus(
+        TranscriptionAccelerationPreference targetPreference) =>
+        new(
+            GetCurrentRuntimeBackend(),
+            GetCurrentRuntimeDisplayText(),
+            $"Restart TypeWhisper to switch whisper.cpp to {GetPreferenceDisplayName(targetPreference)}.",
+            RequiresRestart: true);
+
+    private TranscriptionAccelerationBackend GetCurrentRuntimeBackend()
+    {
+        if (_customRocmRuntimeLoaded)
+            return TranscriptionAccelerationBackend.AmdRocm;
+
+        return RuntimeOptions.LoadedLibrary switch
+        {
+            RuntimeLibrary.Cuda => TranscriptionAccelerationBackend.NvidiaCuda,
+            RuntimeLibrary.Vulkan => TranscriptionAccelerationBackend.AmdVulkan,
+            _ => TranscriptionAccelerationBackend.Cpu
+        };
+    }
+
+    private string GetCurrentRuntimeDisplayText()
+    {
+        if (_customRocmRuntimeLoaded)
+            return "Using ROCm";
+
+        return RuntimeOptions.LoadedLibrary switch
+        {
+            RuntimeLibrary.Cuda => "Using CUDA",
+            RuntimeLibrary.Vulkan => "Using Vulkan",
+            _ => "Using CPU"
+        };
+    }
+
+    private static string GetPreferenceDisplayName(TranscriptionAccelerationPreference preference) =>
+        preference switch
+        {
+            TranscriptionAccelerationPreference.Cpu => "CPU",
+            TranscriptionAccelerationPreference.NvidiaCuda => "CUDA",
+            TranscriptionAccelerationPreference.AmdVulkan => "Vulkan",
+            TranscriptionAccelerationPreference.AmdRocm => "ROCm",
+            _ => "automatic acceleration"
+        };
+
+    private static string GetUnavailableDisplayText(TranscriptionAccelerationPreference preference) =>
+        preference switch
+        {
+            TranscriptionAccelerationPreference.NvidiaCuda => "CUDA unavailable",
+            TranscriptionAccelerationPreference.AmdVulkan => "Vulkan unavailable",
+            TranscriptionAccelerationPreference.AmdRocm => "ROCm unavailable",
+            _ => "Native runtime unavailable"
+        };
+
+    private static string GetNativeLoadFailureDetail(
+        Exception error,
+        TranscriptionAccelerationPreference preference) =>
+        preference switch
+        {
+            TranscriptionAccelerationPreference.NvidiaCuda => CudaLoadFailureDetail,
+            TranscriptionAccelerationPreference.AmdVulkan => VulkanLoadFailureDetail,
+            TranscriptionAccelerationPreference.AmdRocm =>
+                $"ROCm runtime could not be loaded from {RocmLibraryPathEnvironmentVariable}. {error.Message}",
+            _ => error.Message
+        };
 
     private static void TryDeleteFile(string path)
     {

--- a/src/TypeWhisper.Core/Models/AppSettings.cs
+++ b/src/TypeWhisper.Core/Models/AppSettings.cs
@@ -12,6 +12,8 @@ public record AppSettings
     public const string LocalModelAccelerationAuto = "auto";
     public const string LocalModelAccelerationCpu = "cpu";
     public const string LocalModelAccelerationNvidiaCuda = "nvidia-cuda";
+    public const string LocalModelAccelerationAmdVulkan = "amd-vulkan";
+    public const string LocalModelAccelerationAmdRocm = "amd-rocm";
 
     public string ToggleHotkey { get; init; } = "Ctrl+Shift+F9";
     public string PushToTalkHotkey { get; init; } = "Ctrl+Shift";
@@ -144,9 +146,18 @@ public record AppSettings
             LocalModelAccelerationAuto => LocalModelAccelerationAuto,
             LocalModelAccelerationCpu => LocalModelAccelerationCpu,
             LocalModelAccelerationNvidiaCuda => LocalModelAccelerationNvidiaCuda,
+            LocalModelAccelerationAmdVulkan => LocalModelAccelerationAmdVulkan,
+            LocalModelAccelerationAmdRocm => LocalModelAccelerationAmdRocm,
             "cuda" => LocalModelAccelerationNvidiaCuda,
             "nvidia cuda" => LocalModelAccelerationNvidiaCuda,
             "nvidia_cuda" => LocalModelAccelerationNvidiaCuda,
+            "vulkan" => LocalModelAccelerationAmdVulkan,
+            "amd vulkan" => LocalModelAccelerationAmdVulkan,
+            "amd_vulkan" => LocalModelAccelerationAmdVulkan,
+            "rocm" => LocalModelAccelerationAmdRocm,
+            "hip" => LocalModelAccelerationAmdRocm,
+            "amd rocm" => LocalModelAccelerationAmdRocm,
+            "amd_rocm" => LocalModelAccelerationAmdRocm,
             _ => LocalModelAccelerationAuto
         };
     }

--- a/src/TypeWhisper.PluginSDK/Models/TranscriptionAcceleration.cs
+++ b/src/TypeWhisper.PluginSDK/Models/TranscriptionAcceleration.cs
@@ -4,13 +4,17 @@ public enum TranscriptionAccelerationPreference
 {
     Auto,
     Cpu,
-    NvidiaCuda
+    NvidiaCuda,
+    AmdVulkan,
+    AmdRocm
 }
 
 public enum TranscriptionAccelerationBackend
 {
     Cpu,
-    NvidiaCuda
+    NvidiaCuda,
+    AmdVulkan,
+    AmdRocm
 }
 
 public sealed record TranscriptionAccelerationStatus(

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -147,6 +147,8 @@
   "Models.AccelerationAuto": "Auto",
   "Models.AccelerationCpu": "CPU",
   "Models.AccelerationNvidiaCuda": "NVIDIA CUDA",
+  "Models.AccelerationAmdVulkan": "AMD Vulkan",
+  "Models.AccelerationAmdRocm": "AMD ROCm",
   "Models.AccelerationStatusNoModel": "Kein lokales Modell ausgew\u00e4hlt",
   "Models.AccelerationRestartRequiredMessage": "Starte TypeWhisper neu, um diese Beschleunigungs\u00e4nderung anzuwenden.",
   "Models.AccelerationRestartNow": "Jetzt neu starten",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -147,6 +147,8 @@
   "Models.AccelerationAuto": "Auto",
   "Models.AccelerationCpu": "CPU",
   "Models.AccelerationNvidiaCuda": "NVIDIA CUDA",
+  "Models.AccelerationAmdVulkan": "AMD Vulkan",
+  "Models.AccelerationAmdRocm": "AMD ROCm",
   "Models.AccelerationStatusNoModel": "No local model selected",
   "Models.AccelerationRestartRequiredMessage": "Restart TypeWhisper to apply this acceleration change.",
   "Models.AccelerationRestartNow": "Restart now",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -143,6 +143,8 @@
   "Models.AccelerationAuto": "自動",
   "Models.AccelerationCpu": "CPU",
   "Models.AccelerationNvidiaCuda": "NVIDIA CUDA",
+  "Models.AccelerationAmdVulkan": "AMD Vulkan",
+  "Models.AccelerationAmdRocm": "AMD ROCm",
   "Models.AccelerationStatusNoModel": "ローカルモデルが選択されていません",
   "Models.AccelerationRestartRequiredMessage": "このアクセラレーション変更を適用するにはTypeWhisperを再起動してください。",
   "Models.AccelerationRestartNow": "今すぐ再起動",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -143,6 +143,8 @@
   "Models.AccelerationAuto": "Авто",
   "Models.AccelerationCpu": "CPU",
   "Models.AccelerationNvidiaCuda": "NVIDIA CUDA",
+  "Models.AccelerationAmdVulkan": "AMD Vulkan",
+  "Models.AccelerationAmdRocm": "AMD ROCm",
   "Models.AccelerationStatusNoModel": "Локальная модель не выбрана",
   "Models.AccelerationRestartRequiredMessage": "Перезапустите TypeWhisper, чтобы применить это изменение ускорения.",
   "Models.AccelerationRestartNow": "Перезапустить",

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -1044,6 +1044,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         backend switch
         {
             TranscriptionAccelerationBackend.NvidiaCuda => AppSettings.LocalModelAccelerationNvidiaCuda,
+            TranscriptionAccelerationBackend.AmdVulkan => AppSettings.LocalModelAccelerationAmdVulkan,
+            TranscriptionAccelerationBackend.AmdRocm => AppSettings.LocalModelAccelerationAmdRocm,
             _ => AppSettings.LocalModelAccelerationCpu
         };
 

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -214,9 +214,8 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
     {
         var accelerationStatus = plugin.AccelerationStatus;
         if (accelerationStatus.ActiveBackend == TranscriptionAccelerationBackend.Cpu
-            && string.Equals(
-                accelerationStatus.DisplayText,
-                "CUDA unavailable",
+            && accelerationStatus.DisplayText.EndsWith(
+                " unavailable",
                 StringComparison.OrdinalIgnoreCase))
         {
             return accelerationStatus.DisplayText;
@@ -230,6 +229,8 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         {
             AppSettings.LocalModelAccelerationCpu => TranscriptionAccelerationPreference.Cpu,
             AppSettings.LocalModelAccelerationNvidiaCuda => TranscriptionAccelerationPreference.NvidiaCuda,
+            AppSettings.LocalModelAccelerationAmdVulkan => TranscriptionAccelerationPreference.AmdVulkan,
+            AppSettings.LocalModelAccelerationAmdRocm => TranscriptionAccelerationPreference.AmdRocm,
             _ => TranscriptionAccelerationPreference.Auto
         };
 

--- a/src/TypeWhisper.Windows/ViewModels/ModelManagerViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/ModelManagerViewModel.cs
@@ -62,7 +62,9 @@ public partial class ModelManagerViewModel : ObservableObject
     [
         new(AppSettings.LocalModelAccelerationAuto, Loc.Instance["Models.AccelerationAuto"]),
         new(AppSettings.LocalModelAccelerationCpu, Loc.Instance["Models.AccelerationCpu"]),
-        new(AppSettings.LocalModelAccelerationNvidiaCuda, Loc.Instance["Models.AccelerationNvidiaCuda"])
+        new(AppSettings.LocalModelAccelerationNvidiaCuda, Loc.Instance["Models.AccelerationNvidiaCuda"]),
+        new(AppSettings.LocalModelAccelerationAmdVulkan, Loc.Instance["Models.AccelerationAmdVulkan"]),
+        new(AppSettings.LocalModelAccelerationAmdRocm, Loc.Instance["Models.AccelerationAmdRocm"])
     ];
 
     public ModelManagerViewModel(

--- a/tests/TypeWhisper.Core.Tests/Models/AppSettingsTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Models/AppSettingsTests.cs
@@ -67,6 +67,13 @@ public class AppSettingsTests
     [InlineData("cpu", AppSettings.LocalModelAccelerationCpu)]
     [InlineData("NVIDIA CUDA", AppSettings.LocalModelAccelerationNvidiaCuda)]
     [InlineData("cuda", AppSettings.LocalModelAccelerationNvidiaCuda)]
+    [InlineData("vulkan", AppSettings.LocalModelAccelerationAmdVulkan)]
+    [InlineData("AMD Vulkan", AppSettings.LocalModelAccelerationAmdVulkan)]
+    [InlineData("amd_vulkan", AppSettings.LocalModelAccelerationAmdVulkan)]
+    [InlineData("rocm", AppSettings.LocalModelAccelerationAmdRocm)]
+    [InlineData("HIP", AppSettings.LocalModelAccelerationAmdRocm)]
+    [InlineData("AMD ROCm", AppSettings.LocalModelAccelerationAmdRocm)]
+    [InlineData("amd_rocm", AppSettings.LocalModelAccelerationAmdRocm)]
     [InlineData("directml", AppSettings.LocalModelAccelerationAuto)]
     public void NormalizeLocalModelAcceleration_ReturnsSupportedStorageValue(
         string? value,

--- a/tests/TypeWhisper.Core.Tests/Services/SettingsServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/SettingsServiceTests.cs
@@ -41,7 +41,7 @@ public class SettingsServiceTests : IDisposable
             VocabularyBoostingEnabled = true,
             FileTranscriptionEngineOverride = "groq",
             FileTranscriptionModelOverride = "whisper-large-v3",
-            LocalModelAcceleration = AppSettings.LocalModelAccelerationNvidiaCuda,
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationAmdRocm,
             WatchFolderPath = @"C:\Watch",
             WatchFolderOutputPath = @"C:\Output",
             WatchFolderOutputFormat = "srt",
@@ -70,7 +70,7 @@ public class SettingsServiceTests : IDisposable
         Assert.True(sut2.Current.VocabularyBoostingEnabled);
         Assert.Equal("groq", sut2.Current.FileTranscriptionEngineOverride);
         Assert.Equal("whisper-large-v3", sut2.Current.FileTranscriptionModelOverride);
-        Assert.Equal(AppSettings.LocalModelAccelerationNvidiaCuda, sut2.Current.LocalModelAcceleration);
+        Assert.Equal(AppSettings.LocalModelAccelerationAmdRocm, sut2.Current.LocalModelAcceleration);
         Assert.Equal(@"C:\Watch", sut2.Current.WatchFolderPath);
         Assert.Equal(@"C:\Output", sut2.Current.WatchFolderOutputPath);
         Assert.Equal("srt", sut2.Current.WatchFolderOutputFormat);

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -311,6 +311,55 @@ public class HttpApiServiceTests : IDisposable
         Assert.True(acceleration.GetProperty("requires_restart").GetBoolean());
     }
 
+    [Theory]
+    [InlineData(
+        AppSettings.LocalModelAccelerationAmdVulkan,
+        TranscriptionAccelerationBackend.AmdVulkan,
+        AppSettings.LocalModelAccelerationAmdVulkan,
+        "Using Vulkan")]
+    [InlineData(
+        AppSettings.LocalModelAccelerationAmdRocm,
+        TranscriptionAccelerationBackend.AmdRocm,
+        AppSettings.LocalModelAccelerationAmdRocm,
+        "Using ROCm")]
+    public async Task Status_FormatsAmdAccelerationBackends(
+        string preference,
+        TranscriptionAccelerationBackend activeBackend,
+        string expectedBackend,
+        string displayText)
+    {
+        var plugin = new FakeTranscriptionPlugin
+        {
+            AccelerationStatusOverride = new TranscriptionAccelerationStatus(
+                activeBackend,
+                displayText)
+        };
+        var (service, modelManager) = CreateServiceWithModelManager(
+            new AppSettings
+            {
+                SelectedModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "tiny"),
+                LocalModelAcceleration = preference,
+                SaveToHistoryEnabled = true
+            },
+            plugin);
+
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "tiny"));
+
+        var response = await service.HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/status",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None);
+        var json = JsonObject(response);
+        var acceleration = json["acceleration"];
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal(preference, acceleration.GetProperty("preference").GetString());
+        Assert.Equal(expectedBackend, acceleration.GetProperty("active_backend").GetString());
+        Assert.Equal(displayText, acceleration.GetProperty("display_text").GetString());
+    }
+
     [Fact]
     public async Task HistorySearch_IncludesRaycastCompatibleAliases()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
@@ -141,7 +141,11 @@ public class ModelManagerServiceTests
     [InlineData(AppSettings.LocalModelAccelerationAuto, TranscriptionAccelerationPreference.Auto)]
     [InlineData(AppSettings.LocalModelAccelerationCpu, TranscriptionAccelerationPreference.Cpu)]
     [InlineData(AppSettings.LocalModelAccelerationNvidiaCuda, TranscriptionAccelerationPreference.NvidiaCuda)]
+    [InlineData(AppSettings.LocalModelAccelerationAmdVulkan, TranscriptionAccelerationPreference.AmdVulkan)]
+    [InlineData(AppSettings.LocalModelAccelerationAmdRocm, TranscriptionAccelerationPreference.AmdRocm)]
     [InlineData("CUDA", TranscriptionAccelerationPreference.NvidiaCuda)]
+    [InlineData("vulkan", TranscriptionAccelerationPreference.AmdVulkan)]
+    [InlineData("hip", TranscriptionAccelerationPreference.AmdRocm)]
     [InlineData("directml", TranscriptionAccelerationPreference.Auto)]
     public async Task LoadModelAsync_AppliesSavedAccelerationPreferenceBeforeLoading(
         string savedAcceleration,
@@ -168,6 +172,44 @@ public class ModelManagerServiceTests
 
         Assert.Equal(expectedPreference, plugin.LastAccelerationPreference);
         Assert.Equal(expectedPreference, plugin.AccelerationPreferenceAtLoad);
+    }
+
+    [Theory]
+    [InlineData("Vulkan unavailable", AppSettings.LocalModelAccelerationAmdVulkan)]
+    [InlineData("ROCm unavailable", AppSettings.LocalModelAccelerationAmdRocm)]
+    public async Task LoadModelAsync_UsesCompactAccelerationUnavailableModelStatusOnExplicitFailure(
+        string displayText,
+        string savedAcceleration)
+    {
+        const string pluginId = "com.typewhisper.whisper-cpp";
+        const string modelId = "whisper";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            LocalModelAcceleration = savedAcceleration
+        });
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true)
+        {
+            AccelerationStatusOverride = new TranscriptionAccelerationStatus(
+                TranscriptionAccelerationBackend.Cpu,
+                displayText,
+                $"{displayText}: native runtime could not be loaded."),
+            LoadException = new InvalidOperationException($"{displayText}: native runtime could not be loaded.")
+        };
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.LoadModelAsync(fullModelId));
+
+        var status = sut.GetStatus(fullModelId);
+        Assert.Equal(ModelStatusType.Error, status.Type);
+        Assert.Equal(displayText, status.ErrorMessage);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -63,6 +63,8 @@ public class ModelManagerViewModelTests
         Assert.Contains(sut.AccelerationOptions, o => o.Value == AppSettings.LocalModelAccelerationAuto);
         Assert.Contains(sut.AccelerationOptions, o => o.Value == AppSettings.LocalModelAccelerationCpu);
         Assert.Contains(sut.AccelerationOptions, o => o.Value == AppSettings.LocalModelAccelerationNvidiaCuda);
+        Assert.Contains(sut.AccelerationOptions, o => o.Value == AppSettings.LocalModelAccelerationAmdVulkan);
+        Assert.Contains(sut.AccelerationOptions, o => o.Value == AppSettings.LocalModelAccelerationAmdRocm);
     }
 
     [Fact]
@@ -81,6 +83,24 @@ public class ModelManagerViewModelTests
 
         Assert.Equal(AppSettings.LocalModelAccelerationNvidiaCuda, settings.Current.LocalModelAcceleration);
         Assert.Equal(AppSettings.LocalModelAccelerationNvidiaCuda, sut.SelectedAccelerationOptionValue);
+    }
+
+    [Fact]
+    public void SelectedAccelerationOptionValue_StoresAmdRocmAliasAsNormalizedSetting()
+    {
+        var settings = new FakeSettingsService(new AppSettings
+        {
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationAuto
+        });
+
+        var pluginManager = CreatePluginManager(settings);
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var sut = new ModelManagerViewModel(modelManager, settings);
+
+        sut.SelectedAccelerationOptionValue = "hip";
+
+        Assert.Equal(AppSettings.LocalModelAccelerationAmdRocm, settings.Current.LocalModelAcceleration);
+        Assert.Equal(AppSettings.LocalModelAccelerationAmdRocm, sut.SelectedAccelerationOptionValue);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -3,11 +3,14 @@ using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text.Json;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.Plugin.WhisperCpp;
 using TypeWhisper.PluginSDK.Models;
+using Whisper.net;
 using Whisper.net.LibraryLoader;
 
 namespace TypeWhisper.PluginSystem.Tests;
@@ -37,9 +40,11 @@ public class WhisperCppPluginTests
     }
 
     [Theory]
-    [InlineData(TranscriptionAccelerationPreference.Auto, RuntimeLibrary.Cuda, RuntimeLibrary.Cpu)]
+    [InlineData(TranscriptionAccelerationPreference.Auto, RuntimeLibrary.Cuda, RuntimeLibrary.Vulkan, RuntimeLibrary.Cpu)]
     [InlineData(TranscriptionAccelerationPreference.Cpu, RuntimeLibrary.Cpu)]
     [InlineData(TranscriptionAccelerationPreference.NvidiaCuda, RuntimeLibrary.Cuda)]
+    [InlineData(TranscriptionAccelerationPreference.AmdVulkan, RuntimeLibrary.Vulkan)]
+    [InlineData(TranscriptionAccelerationPreference.AmdRocm)]
     public void GetRuntimeLibraryOrder_MapsAccelerationPreference(
         TranscriptionAccelerationPreference preference,
         params RuntimeLibrary[] expectedOrder)
@@ -64,7 +69,9 @@ public class WhisperCppPluginTests
         var project = File.ReadAllText(projectPath);
 
         Assert.Contains("Whisper.net.Runtime.Cuda.Windows", project);
+        Assert.Contains("Whisper.net.Runtime.Vulkan", project);
         Assert.Contains("ggml-cuda-whisper.dll", project);
+        Assert.Contains("ggml-vulkan-whisper.dll", project);
     }
 
     [Fact]
@@ -82,7 +89,121 @@ public class WhisperCppPluginTests
         var workflow = File.ReadAllText(workflowPath);
 
         Assert.Contains("cuda/win-x64", workflow);
+        Assert.Contains("vulkan/win-x64", workflow);
         Assert.Contains("ggml-cuda-whisper.dll", workflow);
+        Assert.Contains("ggml-vulkan-whisper.dll", workflow);
+    }
+
+    [Fact]
+    public void SupportedAccelerationBackends_IncludeVulkanAndRocm()
+    {
+        var sut = new WhisperCppPlugin();
+
+        Assert.Contains(TranscriptionAccelerationBackend.AmdVulkan, sut.SupportedAccelerationBackends);
+        Assert.Contains(TranscriptionAccelerationBackend.AmdRocm, sut.SupportedAccelerationBackends);
+    }
+
+    [Fact]
+    public void SetAccelerationPreference_ExplicitRocmWithoutHookExplainsEnvironmentVariable()
+    {
+        var sut = new WhisperCppPlugin();
+
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdRocm);
+
+        Assert.Equal("ROCm unavailable", sut.AccelerationStatus.DisplayText);
+        Assert.Contains("TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH", sut.AccelerationStatus.Detail);
+    }
+
+    [Fact]
+    public void ResolveRocmLibraryPath_AcceptsDirectoryContainingWhisperDll()
+    {
+        using var temp = new TempDirectory();
+        var libraryPath = Path.Join(temp.Path, "whisper.dll");
+        File.WriteAllText(libraryPath, "native");
+
+        var resolved = WhisperCppPlugin.ResolveRocmLibraryPath(temp.Path);
+
+        Assert.Equal(libraryPath, resolved);
+    }
+
+    [Fact]
+    public void SetAccelerationPreference_ExplicitRocmWithHookShowsPendingLoad()
+    {
+        using var temp = new TempDirectory();
+        File.WriteAllText(Path.Join(temp.Path, "whisper.dll"), "native");
+        var previous = Environment.GetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable);
+        var previousLibraryPath = RuntimeOptions.LibraryPath;
+        try
+        {
+            Environment.SetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable, temp.Path);
+            var sut = new WhisperCppPlugin();
+
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdRocm);
+
+            Assert.Equal("Using CPU", sut.AccelerationStatus.DisplayText);
+            Assert.Contains("ROCm will be used", sut.AccelerationStatus.Detail);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable, previous);
+            RuntimeOptions.LibraryPath = previousLibraryPath;
+        }
+    }
+
+    [Fact]
+    public void SetAccelerationPreference_ExplicitVulkanAfterCudaLoadedRequiresRestart()
+    {
+        var previousLoadedLibrary = RuntimeOptions.LoadedLibrary;
+        try
+        {
+            RuntimeOptions.LoadedLibrary = RuntimeLibrary.Cuda;
+            var sut = new WhisperCppPlugin();
+
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdVulkan);
+
+            Assert.True(sut.AccelerationStatus.RequiresRestart);
+            Assert.Equal("Using CUDA", sut.AccelerationStatus.DisplayText);
+            Assert.Contains("Restart TypeWhisper", sut.AccelerationStatus.Detail);
+            Assert.Contains("Vulkan", sut.AccelerationStatus.Detail);
+        }
+        finally
+        {
+            RuntimeOptions.LoadedLibrary = previousLoadedLibrary;
+        }
+    }
+
+    [Fact]
+    public async Task LoadModelAsync_WhenRuntimeSwitchRequiresRestart_KeepsPreviouslyLoadedModel()
+    {
+        var previousLoadedLibrary = RuntimeOptions.LoadedLibrary;
+        try
+        {
+            RuntimeOptions.LoadedLibrary = RuntimeLibrary.Cpu;
+            using var temp = new TempDirectory();
+            var host = new FakePluginHostServices(temp.Path);
+            var sut = new WhisperCppPlugin();
+            await sut.ActivateAsync(host);
+
+            Directory.CreateDirectory(Path.Join(temp.Path, "Models"));
+            await File.WriteAllTextAsync(Path.Join(temp.Path, "Models", "ggml-tiny.bin"), "not a real model");
+
+            var factory = (WhisperFactory)RuntimeHelpers.GetUninitializedObject(typeof(WhisperFactory));
+            SetPrivateField(sut, "_factory", factory);
+            SetPrivateField(sut, "_loadedModelId", "tiny");
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdVulkan);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => sut.LoadModelAsync("tiny", CancellationToken.None));
+
+            Assert.Same(factory, GetPrivateField<WhisperFactory>(sut, "_factory"));
+            Assert.Equal("tiny", GetPrivateField<string>(sut, "_loadedModelId"));
+
+            SetPrivateField<WhisperFactory?>(sut, "_factory", null);
+        }
+        finally
+        {
+            RuntimeOptions.LoadedLibrary = previousLoadedLibrary;
+        }
     }
 
     [Fact]
@@ -300,6 +421,20 @@ public class WhisperCppPluginTests
         sut.Dispose();
 
         Assert.True(installer.DisposeCalled);
+    }
+
+    private static T? GetPrivateField<T>(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        return (T?)field.GetValue(target);
+    }
+
+    private static void SetPrivateField<T>(object target, string fieldName, T value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        field.SetValue(target, value);
     }
 
     private static byte[] CreateZipArchive(params (string Path, string Content)[] entries)

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -106,12 +106,26 @@ public class WhisperCppPluginTests
     [Fact]
     public void SetAccelerationPreference_ExplicitRocmWithoutHookExplainsEnvironmentVariable()
     {
-        var sut = new WhisperCppPlugin();
+        var previous = Environment.GetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable);
+        var previousLibraryPath = RuntimeOptions.LibraryPath;
+        var previousLoadedLibrary = RuntimeOptions.LoadedLibrary;
+        try
+        {
+            Environment.SetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable, null);
+            RuntimeOptions.LoadedLibrary = null;
+            var sut = new WhisperCppPlugin();
 
-        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdRocm);
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdRocm);
 
-        Assert.Equal("ROCm unavailable", sut.AccelerationStatus.DisplayText);
-        Assert.Contains("TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH", sut.AccelerationStatus.Detail);
+            Assert.Equal("ROCm unavailable", sut.AccelerationStatus.DisplayText);
+            Assert.Contains("TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH", sut.AccelerationStatus.Detail);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable, previous);
+            RuntimeOptions.LibraryPath = previousLibraryPath;
+            RuntimeOptions.LoadedLibrary = previousLoadedLibrary;
+        }
     }
 
     [Fact]
@@ -133,9 +147,11 @@ public class WhisperCppPluginTests
         File.WriteAllText(Path.Join(temp.Path, "whisper.dll"), "native");
         var previous = Environment.GetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable);
         var previousLibraryPath = RuntimeOptions.LibraryPath;
+        var previousLoadedLibrary = RuntimeOptions.LoadedLibrary;
         try
         {
             Environment.SetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable, temp.Path);
+            RuntimeOptions.LoadedLibrary = null;
             var sut = new WhisperCppPlugin();
 
             sut.SetAccelerationPreference(TranscriptionAccelerationPreference.AmdRocm);
@@ -147,6 +163,7 @@ public class WhisperCppPluginTests
         {
             Environment.SetEnvironmentVariable(WhisperCppPlugin.RocmLibraryPathEnvironmentVariable, previous);
             RuntimeOptions.LibraryPath = previousLibraryPath;
+            RuntimeOptions.LoadedLibrary = previousLoadedLibrary;
         }
     }
 


### PR DESCRIPTION
## Summary
- Add AMD Vulkan and AMD ROCm acceleration preferences/backends for local whisper.cpp models, including persisted setting aliases and status API formatting.
- Integrate the official Whisper.net Vulkan runtime package and package the Vulkan native runtime in plugin builds and release workflow output.
- Add the ROCm custom runtime hook via `TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH`, explicit backend failure messages, and restart-required handling when switching native runtimes.

## Fixes
- Prevent runtime-switch reload attempts from disposing the currently loaded whisper.cpp model before surfacing the restart requirement.

## Test Plan
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`
- `dotnet build plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj -c Release`

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AMD Vulkan and AMD ROCm GPU acceleration options for local transcription; UI and status now expose these choices.
  * Enhanced runtime-status messaging to show Vulkan/ROCm availability and when a runtime restart is required; added guidance for configuring ROCm.

* **Chores**
  * Windows plugin packaging now includes and validates AMD Vulkan runtime assets.

* **Localization**
  * Added localization strings for AMD acceleration options.

* **Tests**
  * Added broad tests covering AMD Vulkan/ROCm formatting, selection, runtime switching, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->