### PR TITLE
Group Soniox transcript tokens for subtitles

### DIFF
--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -370,6 +370,9 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
                 var start = startMs / 1000.0;
                 var end = endMs / 1000.0;
                 var displayText = ResolveDisplayText(text, tokenText, ref transcriptCursor);
+                if (end <= start)
+                    continue;
+
                 if (!string.IsNullOrWhiteSpace(displayText))
                     segmentTokens.Add(new SonioxTimedToken(displayText, start, end));
 

--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -16,6 +16,10 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     private const string ApiKeySecretName = "api-key";
     private const string SonioxAsyncModelId = "stt-async-v4";
     private const int DefaultMaxPollAttempts = 3600;
+    private const int MaxSubtitleSegmentCharacters = 84;
+    private const int MinSentenceSegmentCharacters = 20;
+    private const double MaxSubtitleSegmentDurationSeconds = 6.0;
+    private const double SubtitleSegmentPauseSplitSeconds = 0.75;
 
     private static readonly TimeSpan DefaultPollDelay = TimeSpan.FromSeconds(1);
 
@@ -342,8 +346,9 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             ? durationMs / 1000.0
             : 0.0;
 
-        var segments = new List<PluginTranscriptionSegment>();
+        var segmentTokens = new List<SonioxTimedToken>();
         string? detectedLanguage = null;
+        var transcriptCursor = 0;
 
         if (root.TryGetProperty("tokens", out var tokens)
             && tokens.ValueKind == JsonValueKind.Array)
@@ -364,15 +369,153 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
                 var start = startMs / 1000.0;
                 var end = endMs / 1000.0;
-                segments.Add(new PluginTranscriptionSegment(tokenText.Trim(), start, end));
+                var displayText = ResolveDisplayText(text, tokenText, ref transcriptCursor);
+                if (!string.IsNullOrWhiteSpace(displayText))
+                    segmentTokens.Add(new SonioxTimedToken(displayText, start, end));
+
                 duration = Math.Max(duration, end);
             }
         }
 
         return new PluginTranscriptionResult(text, detectedLanguage ?? fallbackLanguage, duration, NoSpeechProbability: null)
         {
-            Segments = segments
+            Segments = BuildSubtitleSegments(segmentTokens)
         };
+    }
+
+    private static List<PluginTranscriptionSegment> BuildSubtitleSegments(IReadOnlyList<SonioxTimedToken> tokens)
+    {
+        var segments = new List<PluginTranscriptionSegment>();
+        var text = new StringBuilder();
+        var start = 0.0;
+        var end = 0.0;
+        var hasSegment = false;
+
+        foreach (var token in tokens)
+        {
+            if (hasSegment && ShouldStartNewSubtitleSegment(token, text, start, end))
+                FlushSegment();
+
+            if (!hasSegment)
+            {
+                text.Clear();
+                start = token.Start;
+                hasSegment = true;
+            }
+
+            text.Append(token.Text);
+            end = token.End;
+
+            if (ShouldEndSubtitleSegment(text, start, end))
+                FlushSegment();
+        }
+
+        FlushSegment();
+        return segments;
+
+        void FlushSegment()
+        {
+            if (!hasSegment)
+                return;
+
+            var normalizedText = NormalizeSubtitleText(text.ToString());
+            if (normalizedText.Length > 0)
+                segments.Add(new PluginTranscriptionSegment(normalizedText, start, end));
+
+            text.Clear();
+            hasSegment = false;
+        }
+    }
+
+    private static bool ShouldStartNewSubtitleSegment(
+        SonioxTimedToken token,
+        StringBuilder currentText,
+        double currentStart,
+        double currentEnd)
+    {
+        if (token.Start - currentEnd > SubtitleSegmentPauseSplitSeconds)
+            return true;
+
+        if (token.End - currentStart > MaxSubtitleSegmentDurationSeconds)
+            return true;
+
+        var currentLength = NormalizeSubtitleText(currentText.ToString()).Length;
+        var tokenLength = NormalizeSubtitleText(token.Text).Length;
+        return currentLength > 0 && currentLength + tokenLength > MaxSubtitleSegmentCharacters;
+    }
+
+    private static bool ShouldEndSubtitleSegment(StringBuilder currentText, double start, double end)
+    {
+        var normalizedText = NormalizeSubtitleText(currentText.ToString());
+        if (normalizedText.Length >= MinSentenceSegmentCharacters
+            && EndsWithSentenceTerminator(normalizedText))
+        {
+            return true;
+        }
+
+        return end - start >= MaxSubtitleSegmentDurationSeconds;
+    }
+
+    private static string ResolveDisplayText(string transcriptText, string tokenText, ref int transcriptCursor)
+    {
+        var trimmedToken = tokenText.Trim();
+        if (trimmedToken.Length == 0)
+            return "";
+
+        if (transcriptText.Length > 0 && transcriptCursor <= transcriptText.Length)
+        {
+            var match = transcriptText.IndexOf(trimmedToken, transcriptCursor, StringComparison.Ordinal);
+            if (match >= 0)
+            {
+                var end = match + trimmedToken.Length;
+                var displayText = transcriptText[transcriptCursor..end];
+                transcriptCursor = end;
+                return displayText;
+            }
+        }
+
+        return trimmedToken;
+    }
+
+    private static string NormalizeSubtitleText(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.Length == 0)
+            return "";
+
+        var sb = new StringBuilder(trimmed.Length);
+        var previousWasWhitespace = false;
+
+        foreach (var ch in trimmed)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!previousWasWhitespace)
+                    sb.Append(' ');
+
+                previousWasWhitespace = true;
+                continue;
+            }
+
+            sb.Append(ch);
+            previousWasWhitespace = false;
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool EndsWithSentenceTerminator(string text)
+    {
+        for (var i = text.Length - 1; i >= 0; i--)
+        {
+            var ch = text[i];
+            if (ch is '"' or '\'' or ')' or ']' or '}')
+                continue;
+
+            return ch is '.' or '!' or '?';
+        }
+
+        return false;
     }
 
     private static void AddAuthorization(HttpRequestMessage request, string apiKey) =>
@@ -457,6 +600,8 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     }
 
     private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromMinutes(5) };
+
+    private sealed record SonioxTimedToken(string Text, double Start, double End);
 
     public void Dispose()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
@@ -189,9 +189,74 @@ public class SonioxPluginTests
         Assert.Equal("Hallo Welt", result.Text);
         Assert.Equal("de", result.DetectedLanguage);
         Assert.Equal(660.0, result.DurationSeconds);
-        Assert.Equal(["Hallo", "Welt"], result.Segments.Select(s => s.Text).ToArray());
+        Assert.Equal(["Hallo Welt"], result.Segments.Select(s => s.Text).ToArray());
         Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721", seen);
         Assert.Contains("DELETE https://api.soniox.com/v1/files/84c32fc6-4fb5-4e7a-b656-b5ec70493753", seen);
+    }
+
+    [Fact]
+    public void ParseTranscript_GroupsTokenTimestampsIntoReadableSubtitleSegments()
+    {
+        using var completedDetails = JsonDocument.Parse("""{ "audio_duration_ms": 5200 }""");
+
+        var result = SonioxPlugin.ParseTranscript(
+            """
+            {
+              "text": "Well, this is an illustration. It has another sentence.",
+              "tokens": [
+                { "text": "W", "start_ms": 900, "end_ms": 960, "language": "en" },
+                { "text": "ell,", "start_ms": 960, "end_ms": 1020, "language": "en" },
+                { "text": "this", "start_ms": 1139, "end_ms": 1200, "language": "en" },
+                { "text": "is", "start_ms": 1260, "end_ms": 1320, "language": "en" },
+                { "text": "an", "start_ms": 1379, "end_ms": 1440, "language": "en" },
+                { "text": "ill", "start_ms": 1560, "end_ms": 1620, "language": "en" },
+                { "text": "ustration.", "start_ms": 1680, "end_ms": 2100, "language": "en" },
+                { "text": "It", "start_ms": 2600, "end_ms": 2700, "language": "en" },
+                { "text": "has", "start_ms": 2760, "end_ms": 2860, "language": "en" },
+                { "text": "another", "start_ms": 2920, "end_ms": 3160, "language": "en" },
+                { "text": "sentence.", "start_ms": 3220, "end_ms": 3600, "language": "en" }
+              ]
+            }
+            """,
+            completedDetails.RootElement,
+            fallbackLanguage: null);
+
+        Assert.Equal("Well, this is an illustration. It has another sentence.", result.Text);
+        Assert.Equal("en", result.DetectedLanguage);
+        Assert.Equal(5.2, result.DurationSeconds);
+        Assert.Equal(["Well, this is an illustration.", "It has another sentence."], result.Segments.Select(s => s.Text).ToArray());
+        Assert.Equal(0.9, result.Segments[0].Start);
+        Assert.Equal(2.1, result.Segments[0].End);
+        Assert.Equal(2.6, result.Segments[1].Start);
+        Assert.Equal(3.6, result.Segments[1].End);
+    }
+
+    [Fact]
+    public void ParseTranscript_SplitsSubtitleSegmentsOnLongPauses()
+    {
+        using var completedDetails = JsonDocument.Parse("""{ "audio_duration_ms": 4000 }""");
+
+        var result = SonioxPlugin.ParseTranscript(
+            """
+            {
+              "text": "First phrase continues after pause",
+              "tokens": [
+                { "text": "First", "start_ms": 0, "end_ms": 300, "language": "en" },
+                { "text": "phrase", "start_ms": 350, "end_ms": 700, "language": "en" },
+                { "text": "continues", "start_ms": 2000, "end_ms": 2400, "language": "en" },
+                { "text": "after", "start_ms": 2450, "end_ms": 2700, "language": "en" },
+                { "text": "pause", "start_ms": 2750, "end_ms": 3100, "language": "en" }
+              ]
+            }
+            """,
+            completedDetails.RootElement,
+            fallbackLanguage: null);
+
+        Assert.Equal(["First phrase", "continues after pause"], result.Segments.Select(s => s.Text).ToArray());
+        Assert.Equal(0.0, result.Segments[0].Start);
+        Assert.Equal(0.7, result.Segments[0].End);
+        Assert.Equal(2.0, result.Segments[1].Start);
+        Assert.Equal(3.1, result.Segments[1].End);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
@@ -260,6 +260,30 @@ public class SonioxPluginTests
     }
 
     [Fact]
+    public void ParseTranscript_SkipsInvalidTokenTimingsWithoutReusingSkippedText()
+    {
+        using var completedDetails = JsonDocument.Parse("""{ "audio_duration_ms": 2000 }""");
+
+        var result = SonioxPlugin.ParseTranscript(
+            """
+            {
+              "text": "Bad good",
+              "tokens": [
+                { "text": "Bad", "start_ms": 1000, "end_ms": 1000, "language": "en" },
+                { "text": "good", "start_ms": 1200, "end_ms": 1500, "language": "en" }
+              ]
+            }
+            """,
+            completedDetails.RootElement,
+            fallbackLanguage: null);
+
+        var segment = Assert.Single(result.Segments);
+        Assert.Equal("good", segment.Text);
+        Assert.Equal(1.2, segment.Start);
+        Assert.Equal(1.5, segment.End);
+    }
+
+    [Fact]
     public async Task TranscribeAsync_UsesInitialApiKeyForWholeAsyncFlow()
     {
         var seenAuthorizations = new List<string?>();


### PR DESCRIPTION
## Summary
- Group Soniox token and subword timestamps into readable subtitle segments.
- Preserve the full transcript text while reconstructing segment text from the transcript so spaces and subword joins remain natural.
- Add regression coverage for subword grouping and long-pause segment splits.

## Root cause
Soniox intentionally returns token-level timestamps, including word and subword tokens. TypeWhisper was exposing those raw tokens directly as transcription segments, which made SRT/VTT exports fragmented into very short cues.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~SonioxPluginTests"`
- `dotnet build plugins\TypeWhisper.Plugin.Soniox\TypeWhisper.Plugin.Soniox.csproj -c Release`

Fixes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent subtitle segmentation: transcriptions now group tokens into readable subtitle segments.
  * Pause-aware splitting: segments automatically split on long pauses for better timing.
  * Configurable formatting: controls for pause thresholds, max segment duration, and character limits.
  * Improved language detection and handling of invalid token timings for cleaner outputs.

* **Tests**
  * Added tests covering segmentation, pause splitting, and handling of invalid token timings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->