### PR TITLE
Release Soniox plugin 1.0.3

### DIFF
--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -62,7 +62,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
     public string PluginId => "com.typewhisper.soniox";
     public string PluginName => "Soniox";
-    public string PluginVersion => "1.0.2";
+    public string PluginVersion => "1.0.3";
 
     public async Task ActivateAsync(IPluginHostServices host)
     {

--- a/plugins/TypeWhisper.Plugin.Soniox/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Soniox/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.soniox",
   "name": "Soniox",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "TypeWhisper",
   "description": "Soniox speech-to-text transcription engine",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
@@ -21,6 +21,16 @@ public class SonioxPluginTests
     }
 
     [Fact]
+    public void PluginVersion_IsSonioxMarketplaceReleaseVersion()
+    {
+        var manifest = LoadManifest();
+        var sut = new SonioxPlugin();
+
+        Assert.Equal("1.0.3", manifest.GetProperty("version").GetString());
+        Assert.Equal("1.0.3", sut.PluginVersion);
+    }
+
+    [Fact]
     public void Manifest_AdvertisesTranscriptionCapabilitiesAndApiKeyRequirement()
     {
         var manifest = LoadManifest();


### PR DESCRIPTION
## Summary
- Bump the Soniox plugin manifest and runtime `PluginVersion` to `1.0.3`.
- Add a release-version test so the marketplace release version cannot accidentally stay at `1.0.2`.

## Why
PR #207 fixed Soniox token grouping in the repository and the daily app build can mention the fix, but marketplace-installed plugins are distributed separately. The plugin registry compares the installed manifest version with the remote registry version. Without publishing a new Soniox plugin release, users who already have `com.typewhisper.soniox` `1.0.2` installed keep running the old plugin package, so SRT/VTT exports can still appear fragmented.

Publishing `plugin-soniox-v1.0.3` after this PR merges will run the plugin release workflow, upload the new ZIP, and update `plugins.json` so installed Soniox users can receive the fixed plugin.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~SonioxPluginTests.PluginVersion_IsSonioxMarketplaceReleaseVersion"`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~SonioxPluginTests"`
- `dotnet build plugins\TypeWhisper.Plugin.Soniox\TypeWhisper.Plugin.Soniox.csproj -c Release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Soniox plugin version to 1.0.3

* **Tests**
  * Added test to verify Soniox plugin version matches marketplace release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->