### PR TITLE
Add file transcription queue clearing

### DIFF
--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -637,6 +637,7 @@
   "FileTranscription.SelectFile": "Dateien ausw\u00e4hlen...",
   "FileTranscription.Cancel": "Abbrechen",
   "FileTranscription.CancelAll": "Alle abbrechen",
+  "FileTranscription.ClearQueue": "Warteschlange leeren",
   "FileTranscription.Copy": "Kopieren",
   "FileTranscription.TextExport": "Text (.txt)",
   "FileTranscription.TextExportShort": "TXT",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -637,6 +637,7 @@
   "FileTranscription.SelectFile": "Select files...",
   "FileTranscription.Cancel": "Cancel",
   "FileTranscription.CancelAll": "Cancel all",
+  "FileTranscription.ClearQueue": "Clear queue",
   "FileTranscription.Copy": "Copy",
   "FileTranscription.TextExport": "Text (.txt)",
   "FileTranscription.TextExportShort": "TXT",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -616,6 +616,7 @@
   "FileTranscription.SelectFile": "ファイルを選択...",
   "FileTranscription.Cancel": "キャンセル",
   "FileTranscription.CancelAll": "すべてキャンセル",
+  "FileTranscription.ClearQueue": "キューをクリア",
   "FileTranscription.Copy": "コピー",
   "FileTranscription.TextExport": "テキスト (.txt)",
   "FileTranscription.TextExportShort": "TXT",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -621,6 +621,7 @@
   "FileTranscription.SelectFile": "Выбрать файлы…",
   "FileTranscription.Cancel": "Отмена",
   "FileTranscription.CancelAll": "Отменить всё",
+  "FileTranscription.ClearQueue": "Очистить очередь",
   "FileTranscription.Copy": "Копировать",
   "FileTranscription.TextExport": "Текст (.txt)",
   "FileTranscription.TextExportShort": "TXT",

--- a/src/TypeWhisper.Windows/ViewModels/FileTranscriptionViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/FileTranscriptionViewModel.cs
@@ -63,6 +63,7 @@ public partial class FileTranscriptionViewModel : ObservableObject
     public ObservableCollection<WatchFolderModelOption> WatchFolderModelOptions { get; } = [];
     public ObservableCollection<WatchFolderHistoryItem> WatchFolderHistory { get; } = [];
     public bool HasItems => Items.Count > 0;
+    public bool HasClearableItems => Items.Any(IsClearableQueueItem);
     public bool HasWatchFolderPath => !string.IsNullOrWhiteSpace(WatchFolderPath);
     public bool HasWatchFolderOutputPath => !string.IsNullOrWhiteSpace(WatchFolderOutputPath);
     public bool HasWatchFolderHistory => WatchFolderHistory.Count > 0;
@@ -129,6 +130,7 @@ public partial class FileTranscriptionViewModel : ObservableObject
         Items.CollectionChanged += (_, _) =>
         {
             OnPropertyChanged(nameof(HasItems));
+            RefreshQueueCommandState();
             RefreshStatusText();
         };
 
@@ -198,6 +200,24 @@ public partial class FileTranscriptionViewModel : ObservableObject
         }
 
         item.Cancellation?.Cancel();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanClearQueue))]
+    private void ClearQueue()
+    {
+        var itemsToRemove = Items.Where(IsClearableQueueItem).ToList();
+        if (itemsToRemove.Count == 0)
+            return;
+
+        var selectedWasRemoved = SelectedItem is not null && itemsToRemove.Contains(SelectedItem);
+        foreach (var item in itemsToRemove)
+            Items.Remove(item);
+
+        if (selectedWasRemoved)
+            SelectedItem = Items.FirstOrDefault();
+
+        RefreshQueueCommandState();
+        RefreshStatusText();
     }
 
     [RelayCommand]
@@ -323,7 +343,22 @@ public partial class FileTranscriptionViewModel : ObservableObject
         item.Status = status;
         item.StatusText = statusText;
         RefreshStatusText();
+        RefreshQueueCommandState();
     }
+
+    private bool CanClearQueue() => HasClearableItems;
+
+    private void RefreshQueueCommandState()
+    {
+        OnPropertyChanged(nameof(HasClearableItems));
+        ClearQueueCommand.NotifyCanExecuteChanged();
+    }
+
+    private static bool IsClearableQueueItem(FileTranscriptionQueueItemViewModel item) =>
+        item.Status is FileTranscriptionQueueItemStatus.Completed
+            or FileTranscriptionQueueItemStatus.Cancelled
+            or FileTranscriptionQueueItemStatus.Error
+            or FileTranscriptionQueueItemStatus.Unsupported;
 
     private void RefreshStatusText()
     {

--- a/src/TypeWhisper.Windows/Views/FileTranscriptionWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/FileTranscriptionWindow.xaml
@@ -46,12 +46,19 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" Foreground="{StaticResource HintBrush}"/>
-                <Button Grid.Column="1"
-                        Content="{loc:Str FileTranscription.CancelAll}"
-                        Command="{Binding CancelCommand}"
-                        Visibility="{Binding IsProcessing, Converter={StaticResource BoolToVis}}"
-                        Style="{StaticResource SecondaryButtonStyle}"
-                        Padding="12,6"/>
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button Content="{loc:Str FileTranscription.ClearQueue}"
+                            Command="{Binding ClearQueueCommand}"
+                            Visibility="{Binding HasClearableItems, Converter={StaticResource BoolToVis}}"
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Padding="12,6"
+                            Margin="0,0,8,0"/>
+                    <Button Content="{loc:Str FileTranscription.CancelAll}"
+                            Command="{Binding CancelCommand}"
+                            Visibility="{Binding IsProcessing, Converter={StaticResource BoolToVis}}"
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Padding="12,6"/>
+                </StackPanel>
             </Grid>
         </StackPanel>
 

--- a/src/TypeWhisper.Windows/Views/Sections/FileTranscriptionSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/FileTranscriptionSection.xaml
@@ -146,12 +146,19 @@
                                            Style="{StaticResource SectionHeaderStyle}"
                                            FontSize="15"
                                            Margin="0"/>
-                                <Button Grid.Column="1"
-                                        Content="{loc:Str FileTranscription.CancelAll}"
-                                        Command="{Binding FileTranscription.CancelCommand}"
-                                        Visibility="{Binding FileTranscription.IsProcessing, Converter={StaticResource BoolToVis}}"
-                                        Style="{StaticResource SecondaryButtonStyle}"
-                                        Padding="14,8"/>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                    <Button Content="{loc:Str FileTranscription.ClearQueue}"
+                                            Command="{Binding FileTranscription.ClearQueueCommand}"
+                                            Visibility="{Binding FileTranscription.HasClearableItems, Converter={StaticResource BoolToVis}}"
+                                            Style="{StaticResource SecondaryButtonStyle}"
+                                            Padding="14,8"
+                                            Margin="0,0,8,0"/>
+                                    <Button Content="{loc:Str FileTranscription.CancelAll}"
+                                            Command="{Binding FileTranscription.CancelCommand}"
+                                            Visibility="{Binding FileTranscription.IsProcessing, Converter={StaticResource BoolToVis}}"
+                                            Style="{StaticResource SecondaryButtonStyle}"
+                                            Padding="14,8"/>
+                                </StackPanel>
                             </Grid>
                         </Border>
                         <Border Height="1" Background="#18FFFFFF"/>

--- a/tests/TypeWhisper.PluginSystem.Tests/FileTranscriptionViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/FileTranscriptionViewModelTests.cs
@@ -1,6 +1,7 @@
 using TypeWhisper.Core.Models;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.ViewModels;
 
 namespace TypeWhisper.PluginSystem.Tests;
@@ -114,6 +115,67 @@ public class FileTranscriptionViewModelTests
 
         Assert.True(sut.Items[0].HasResult);
         Assert.True(sut.Items[0].CanExportSubtitles);
+    }
+
+    [Fact]
+    public async Task ClearQueue_RemovesInactiveItemsAndKeepsActiveQueue()
+    {
+        var processor = new BlockingProcessor();
+        var sut = CreateSut(processor);
+
+        sut.AddFilesCommand.Execute(new[] { "active.wav", "queued.wav" });
+        await WaitForAsync(() => sut.Items.Count == 2
+            && sut.Items[0].Status == FileTranscriptionQueueItemStatus.Transcribing);
+
+        var completed = new FileTranscriptionQueueItemViewModel("done.wav", FileTranscriptionQueueItemStatus.Completed);
+        var cancelled = new FileTranscriptionQueueItemViewModel("cancelled.wav", FileTranscriptionQueueItemStatus.Cancelled);
+        var error = new FileTranscriptionQueueItemViewModel("bad.wav", FileTranscriptionQueueItemStatus.Error);
+        var unsupported = new FileTranscriptionQueueItemViewModel("notes.txt", FileTranscriptionQueueItemStatus.Unsupported);
+        sut.Items.Add(completed);
+        sut.Items.Add(cancelled);
+        sut.Items.Add(error);
+        sut.Items.Add(unsupported);
+        sut.SelectedItem = completed;
+
+        sut.ClearQueueCommand.Execute(null);
+
+        Assert.Equal(["active.wav", "queued.wav"], sut.Items.Select(i => i.FilePath).ToArray());
+        Assert.Equal(
+            [FileTranscriptionQueueItemStatus.Transcribing, FileTranscriptionQueueItemStatus.Queued],
+            sut.Items.Select(i => i.Status).ToArray());
+        Assert.Same(sut.Items[0], sut.SelectedItem);
+        Assert.True(sut.HasItems);
+        Assert.Equal(
+            Loc.Instance.GetString("FileTranscription.QueueStatusFormat", 0, 0, 0, 1, 2),
+            sut.StatusText);
+
+        processor.Release("active.wav");
+        await WaitForAsync(() => sut.Items[1].Status == FileTranscriptionQueueItemStatus.Transcribing);
+        processor.Release("queued.wav");
+        await WaitForAsync(() => sut.Items.All(i => i.Status == FileTranscriptionQueueItemStatus.Completed));
+    }
+
+    [Fact]
+    public void ClearQueue_RemovesAllInactiveItemsAndResetsEmptyState()
+    {
+        var sut = CreateSut(new FakeProcessor());
+        var completed = new FileTranscriptionQueueItemViewModel("done.wav", FileTranscriptionQueueItemStatus.Completed);
+        var cancelled = new FileTranscriptionQueueItemViewModel("cancelled.wav", FileTranscriptionQueueItemStatus.Cancelled);
+        var error = new FileTranscriptionQueueItemViewModel("bad.wav", FileTranscriptionQueueItemStatus.Error);
+        var unsupported = new FileTranscriptionQueueItemViewModel("notes.txt", FileTranscriptionQueueItemStatus.Unsupported);
+        sut.Items.Add(completed);
+        sut.Items.Add(cancelled);
+        sut.Items.Add(error);
+        sut.Items.Add(unsupported);
+        sut.SelectedItem = error;
+
+        sut.ClearQueueCommand.Execute(null);
+
+        Assert.Empty(sut.Items);
+        Assert.Null(sut.SelectedItem);
+        Assert.False(sut.HasItems);
+        Assert.False(sut.ClearQueueCommand.CanExecute(null));
+        Assert.Equal(Loc.Instance["FileTranscription.StatusDefault"], sut.StatusText);
     }
 
     private static async Task WaitForAsync(Func<bool> condition)


### PR DESCRIPTION
## Summary
- Add a clear queue action for file transcription results that removes completed, cancelled, failed, and unsupported items.
- Keep queued and actively processing items visible so in-flight work is not interrupted.
- Expose the action in both file transcription surfaces and localize it for supported UI languages.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-build --filter "FullyQualifiedName~FileTranscriptionViewModelTests|FullyQualifiedName~AppLocalizationResourcesTests"`

Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Clear Queue" button to file transcription interface that removes inactive queue items while preserving active transcriptions. Button visibility depends on clearable item availability.

* **Localization**
  * Added German, English, Japanese, and Russian translations for the new "Clear Queue" feature.

* **Tests**
  * Added unit tests validating clear queue command behavior and queue state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->