### PR TITLE
Release Live Transcript plugin 1.0.2

### DIFF
--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -48,7 +48,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.1";
+    public string PluginVersion => "1.0.2";
 
     /// <summary>
     /// Gets whether uses host appearance.

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/manifest.json
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.live-transcript",
   "name": "Live Transcript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Floating window showing real-time transcription",
   "assemblyName": "TypeWhisper.Plugin.LiveTranscript.dll",


### PR DESCRIPTION
## Summary
- Bump the Live Transcript plugin source version to 1.0.2.
- Keep the plugin manifest and runtime-reported version aligned before publishing the plugin release.

## Validation
- dotnet test tests\\TypeWhisper.PluginSystem.Tests\\TypeWhisper.PluginSystem.Tests.csproj --filter LiveTranscriptPluginTests
- dotnet build plugins\\TypeWhisper.Plugin.LiveTranscript\\TypeWhisper.Plugin.LiveTranscript.csproj -c Release

## Release Notes
- Ships the already-merged Live Transcript no-speech cleanup and appearance-setting fixes through the marketplace plugin release flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Live Transcript plugin version updated to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->