### PR TITLE
Fix recording overlay recovery after display changes

### DIFF
--- a/src/TypeWhisper.Windows/Services/OverlayPlacementCalculator.cs
+++ b/src/TypeWhisper.Windows/Services/OverlayPlacementCalculator.cs
@@ -1,0 +1,48 @@
+using System.Windows;
+using TypeWhisper.Core.Models;
+
+namespace TypeWhisper.Windows.Services;
+
+internal enum OverlayPlacementTarget
+{
+    CursorMonitor,
+    PrimaryMonitor
+}
+
+internal static class OverlayPlacementCalculator
+{
+    public static Rect SelectWorkArea(
+        OverlayPlacementTarget target,
+        Rect? cursorWorkArea,
+        Rect? primaryWorkArea,
+        Rect fallbackWorkArea) =>
+        target == OverlayPlacementTarget.PrimaryMonitor
+            ? primaryWorkArea ?? fallbackWorkArea
+            : cursorWorkArea ?? fallbackWorkArea;
+
+    public static Point Calculate(
+        Rect workArea,
+        Size actualSize,
+        OverlayPosition overlayPosition,
+        Size fallbackSize)
+    {
+        var width = PositiveOrFallback(actualSize.Width, fallbackSize.Width);
+        var height = PositiveOrFallback(actualSize.Height, fallbackSize.Height);
+        var left = workArea.Left + (workArea.Width - width) / 2;
+        var top = overlayPosition == OverlayPosition.Top
+            ? workArea.Top
+            : workArea.Bottom - height;
+
+        return new Point(
+            ClampToWorkArea(left, workArea.Left, workArea.Right - width),
+            ClampToWorkArea(top, workArea.Top, workArea.Bottom - height));
+    }
+
+    private static double PositiveOrFallback(double value, double fallback) =>
+        value > 0 ? value : fallback;
+
+    private static double ClampToWorkArea(double value, double minimum, double maximum) =>
+        maximum < minimum
+            ? minimum
+            : Math.Clamp(value, minimum, maximum);
+}

--- a/src/TypeWhisper.Windows/Views/MainWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/MainWindow.xaml.cs
@@ -1,8 +1,16 @@
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Microsoft.Win32;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Services;
+using DrawingRectangle = System.Drawing.Rectangle;
+using FormsCursor = System.Windows.Forms.Cursor;
+using FormsScreen = System.Windows.Forms.Screen;
 
 namespace TypeWhisper.Windows.Views;
 
@@ -14,6 +22,8 @@ public partial class MainWindow : Window
     private const int GWL_EXSTYLE = -20;
     private const int WS_EX_NOACTIVATE = 0x08000000;
     private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private static readonly Size DefaultOverlaySize = new(300, 50);
+    private static readonly TimeSpan OverlayRecoveryDelay = TimeSpan.FromMilliseconds(700);
 
     [LibraryImport("user32.dll")]
     private static partial int GetWindowLongW(IntPtr hWnd, int nIndex);
@@ -21,45 +31,10 @@ public partial class MainWindow : Window
     [LibraryImport("user32.dll")]
     private static partial int SetWindowLongW(IntPtr hWnd, int nIndex, int dwNewLong);
 
-    [LibraryImport("user32.dll")]
-    private static partial IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
-
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool GetMonitorInfoW(IntPtr hMonitor, ref MonitorInfo lpmi);
-
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool GetCursorPos(out POINT lpPoint);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct POINT { public int X, Y; }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct MonitorInfo
-    {
-        /// <summary>
-        /// Gets the cb size.
-        /// </summary>
-        public int cbSize;
-        /// <summary>
-        /// Gets the rc monitor.
-        /// </summary>
-        public RECT rcMonitor;
-        /// <summary>
-        /// Gets the rc work.
-        /// </summary>
-        public RECT rcWork;
-        /// <summary>
-        /// Gets or sets the Win32 flags field.
-        /// </summary>
-        public uint dwFlags;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RECT { public int Left, Top, Right, Bottom; }
-
     private readonly ISettingsService _settings;
+    private readonly ViewModels.DictationViewModel _viewModel;
+    private readonly DispatcherTimer _overlayRecoveryTimer;
+    private OverlayPlacementTarget _currentPlacementTarget = OverlayPlacementTarget.CursorMonitor;
 
     /// <summary>
     /// Initializes a new instance of the MainWindow class.
@@ -68,7 +43,13 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         DataContext = viewModel;
+        _viewModel = viewModel;
         _settings = settings;
+        _overlayRecoveryTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
+        {
+            Interval = OverlayRecoveryDelay
+        };
+        _overlayRecoveryTimer.Tick += OnOverlayRecoveryTimerTick;
     }
 
     /// <summary>
@@ -85,8 +66,15 @@ public partial class MainWindow : Window
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        PositionOverlay();
-        _settings.SettingsChanged += _ => Dispatcher.Invoke(PositionOverlay);
+        PositionOverlay(OverlayPlacementTarget.CursorMonitor);
+        _settings.SettingsChanged += OnSettingsChanged;
+        PropertyChangedEventManager.AddHandler(
+            _viewModel,
+            OnViewModelPropertyChanged,
+            nameof(ViewModels.DictationViewModel.IsOverlayVisible));
+        SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
+        SystemEvents.PowerModeChanged += OnPowerModeChanged;
+        SystemEvents.SessionSwitch += OnSessionSwitch;
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -94,41 +82,121 @@ public partial class MainWindow : Window
         PositionOverlay();
     }
 
-    private void PositionOverlay()
+    /// <summary>
+    /// Releases static Windows event subscriptions that otherwise keep the overlay window alive.
+    /// </summary>
+    protected override void OnClosed(EventArgs e)
     {
-        // Get the monitor where the cursor is
-        GetCursorPos(out var cursor);
-        var hMonitor = MonitorFromPoint(cursor, 2 /* MONITOR_DEFAULTTONEAREST */);
+        _settings.SettingsChanged -= OnSettingsChanged;
+        PropertyChangedEventManager.RemoveHandler(
+            _viewModel,
+            OnViewModelPropertyChanged,
+            nameof(ViewModels.DictationViewModel.IsOverlayVisible));
+        SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+        SystemEvents.PowerModeChanged -= OnPowerModeChanged;
+        SystemEvents.SessionSwitch -= OnSessionSwitch;
+        _overlayRecoveryTimer.Stop();
+        _overlayRecoveryTimer.Tick -= OnOverlayRecoveryTimerTick;
 
-        var mi = new MonitorInfo { cbSize = Marshal.SizeOf<MonitorInfo>() };
-        if (!GetMonitorInfoW(hMonitor, ref mi))
+        base.OnClosed(e);
+    }
+
+    private void OnSettingsChanged(AppSettings settings) =>
+        Dispatcher.InvokeAsync(PositionOverlay);
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (!_viewModel.IsOverlayVisible)
+            return;
+
+        PositionOverlay(OverlayPlacementTarget.CursorMonitor);
+        ReassertTopmost();
+    }
+
+    private void OnDisplaySettingsChanged(object? sender, EventArgs e) =>
+        DispatchPrimaryOverlayRecovery();
+
+    private void OnPowerModeChanged(object? sender, PowerModeChangedEventArgs e)
+    {
+        if (e.Mode == PowerModes.Resume)
+            DispatchPrimaryOverlayRecovery();
+    }
+
+    private void OnSessionSwitch(object? sender, SessionSwitchEventArgs e)
+    {
+        if (e.Reason == SessionSwitchReason.SessionUnlock)
+            DispatchPrimaryOverlayRecovery();
+    }
+
+    private void DispatchPrimaryOverlayRecovery()
+    {
+        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+            return;
+
+        Dispatcher.InvokeAsync(SchedulePrimaryOverlayRecovery);
+    }
+
+    private void SchedulePrimaryOverlayRecovery()
+    {
+        if (!Dispatcher.CheckAccess())
         {
-            var fallback = SystemParameters.WorkArea;
-            Left = fallback.Left + (fallback.Width - ActualWidth) / 2;
-            Top = _settings.Current.OverlayPosition == OverlayPosition.Top
-                ? fallback.Top
-                : fallback.Bottom - ActualHeight;
+            Dispatcher.InvokeAsync(SchedulePrimaryOverlayRecovery);
             return;
         }
 
-        // Physical pixels to WPF DIPs
-        var source = PresentationSource.FromVisual(this);
-        var dpiToWpfX = source?.CompositionTarget?.TransformFromDevice.M11 ?? 1.0;
-        var dpiToWpfY = source?.CompositionTarget?.TransformFromDevice.M22 ?? 1.0;
+        _overlayRecoveryTimer.Stop();
+        _overlayRecoveryTimer.Start();
+    }
 
-        var workLeft = mi.rcWork.Left * dpiToWpfX;
-        var workTop = mi.rcWork.Top * dpiToWpfY;
-        var workWidth = (mi.rcWork.Right - mi.rcWork.Left) * dpiToWpfX;
-        var workBottom = mi.rcWork.Bottom * dpiToWpfY;
+    private void OnOverlayRecoveryTimerTick(object? sender, EventArgs e)
+    {
+        _overlayRecoveryTimer.Stop();
+        RecoverOverlayToPrimary();
+    }
 
-        var width = ActualWidth > 0 ? ActualWidth : 300;
-        var height = ActualHeight > 0 ? ActualHeight : 50;
+    private void RecoverOverlayToPrimary()
+    {
+        PositionOverlay(OverlayPlacementTarget.PrimaryMonitor);
+        ReassertTopmost();
+    }
 
-        Left = workLeft + (workWidth - width) / 2;
+    private void ReassertTopmost()
+    {
+        Topmost = false;
+        Topmost = true;
+    }
 
-        if (_settings.Current.OverlayPosition == OverlayPosition.Top)
-            Top = workTop;
-        else
-            Top = workBottom - height;
+    private void PositionOverlay() =>
+        PositionOverlay(_currentPlacementTarget);
+
+    private void PositionOverlay(OverlayPlacementTarget target)
+    {
+        _currentPlacementTarget = target;
+        var point = OverlayPlacementCalculator.Calculate(
+            GetWorkArea(target),
+            new Size(ActualWidth, ActualHeight),
+            _settings.Current.OverlayPosition,
+            DefaultOverlaySize);
+
+        Left = point.X;
+        Top = point.Y;
+    }
+
+    private Rect GetWorkArea(OverlayPlacementTarget target) =>
+        OverlayPlacementCalculator.SelectWorkArea(
+            target,
+            TryGetScreenWorkArea(FormsScreen.FromPoint(FormsCursor.Position)),
+            TryGetScreenWorkArea(FormsScreen.PrimaryScreen),
+            SystemParameters.WorkArea);
+
+    private Rect? TryGetScreenWorkArea(FormsScreen? screen) =>
+        screen is null ? null : DeviceRectToWpf(screen.WorkingArea);
+
+    private Rect DeviceRectToWpf(DrawingRectangle rectangle)
+    {
+        var transform = PresentationSource.FromVisual(this)?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
+        var topLeft = transform.Transform(new Point(rectangle.Left, rectangle.Top));
+        var bottomRight = transform.Transform(new Point(rectangle.Right, rectangle.Bottom));
+        return new Rect(topLeft, bottomRight);
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/AppearanceSectionLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppearanceSectionLayoutTests.cs
@@ -111,6 +111,21 @@ public sealed class AppearanceSectionLayoutTests
         Assert.Contains("IsEnabled=\"{Binding Settings.LiveTranscriptionEnabled}\"", row);
     }
 
+    [Fact]
+    public void AppearanceSection_DoesNotOfferManualOverlayLocationReset()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "AppearanceSection.xaml");
+
+        Assert.DoesNotContain("Appearance.ResetOverlayLocation", xaml);
+        Assert.DoesNotContain("Appearance.ResetOverlayLocationHint", xaml);
+        Assert.DoesNotContain("Settings.ResetOverlayLocationCommand", xaml);
+    }
+
     private static void AssertWidgetSettingCollapsesForCompactBadge(string xamlBlock)
     {
         Assert.Contains("Settings.IndicatorStyle", xamlBlock);

--- a/tests/TypeWhisper.PluginSystem.Tests/MainWindowLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/MainWindowLayoutTests.cs
@@ -32,4 +32,51 @@ public sealed class MainWindowLayoutTests
         Assert.Contains("TextOptions.TextRenderingMode=\"ClearType\"", xaml);
         Assert.Contains("RenderOptions.ClearTypeHint=\"Enabled\"", xaml);
     }
+
+    [Fact]
+    public void MainWindow_RepositionsAfterDisplayPowerAndUnlockEvents()
+    {
+        var code = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "MainWindow.xaml.cs");
+
+        Assert.Contains("SystemEvents.DisplaySettingsChanged", code);
+        Assert.Contains("SystemEvents.PowerModeChanged", code);
+        Assert.Contains("SystemEvents.SessionSwitch", code);
+        Assert.Contains("PowerModes.Resume", code);
+        Assert.Contains("SessionSwitchReason.SessionUnlock", code);
+        Assert.Contains("SchedulePrimaryOverlayRecovery", code);
+    }
+
+    [Fact]
+    public void MainWindow_ReassertsTopmostAfterPrimaryRecovery()
+    {
+        var code = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "MainWindow.xaml.cs");
+
+        Assert.Contains("OverlayPlacementTarget.PrimaryMonitor", code);
+        Assert.Contains("ReassertTopmost", code);
+        Assert.Contains("Topmost = false", code);
+        Assert.Contains("Topmost = true", code);
+    }
+
+    [Fact]
+    public void MainWindow_RepositionsToCursorMonitorWhenOverlayBecomesVisible()
+    {
+        var code = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "MainWindow.xaml.cs");
+
+        Assert.Contains("PropertyChangedEventManager.AddHandler", code);
+        Assert.Contains("nameof(ViewModels.DictationViewModel.IsOverlayVisible)", code);
+        Assert.Contains("OnViewModelPropertyChanged", code);
+        Assert.Contains("PositionOverlay(OverlayPlacementTarget.CursorMonitor)", code);
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/OverlayPlacementCalculatorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OverlayPlacementCalculatorTests.cs
@@ -1,0 +1,78 @@
+using System.Windows;
+using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class OverlayPlacementCalculatorTests
+{
+    private static readonly Size FallbackSize = new(300, 50);
+
+    [Fact]
+    public void Calculate_CentersOverlayAtTopOfWorkArea()
+    {
+        var point = OverlayPlacementCalculator.Calculate(
+            new Rect(100, 50, 1000, 700),
+            new Size(200, 80),
+            OverlayPosition.Top,
+            FallbackSize);
+
+        Assert.Equal(500, point.X);
+        Assert.Equal(50, point.Y);
+    }
+
+    [Fact]
+    public void Calculate_CentersOverlayAtBottomOfWorkArea()
+    {
+        var point = OverlayPlacementCalculator.Calculate(
+            new Rect(100, 50, 1000, 700),
+            new Size(200, 80),
+            OverlayPosition.Bottom,
+            FallbackSize);
+
+        Assert.Equal(500, point.X);
+        Assert.Equal(670, point.Y);
+    }
+
+    [Fact]
+    public void Calculate_ClampsOversizedOverlayInsideWorkArea()
+    {
+        var point = OverlayPlacementCalculator.Calculate(
+            new Rect(10, 20, 100, 80),
+            new Size(300, 120),
+            OverlayPosition.Bottom,
+            FallbackSize);
+
+        Assert.Equal(10, point.X);
+        Assert.Equal(20, point.Y);
+    }
+
+    [Fact]
+    public void Calculate_UsesFallbackSizeWhenActualSizeIsUnknown()
+    {
+        var point = OverlayPlacementCalculator.Calculate(
+            new Rect(100, 50, 1000, 700),
+            new Size(0, 0),
+            OverlayPosition.Bottom,
+            FallbackSize);
+
+        Assert.Equal(450, point.X);
+        Assert.Equal(700, point.Y);
+    }
+
+    [Fact]
+    public void SelectWorkArea_UsesPrimaryWorkAreaForPrimaryResetTarget()
+    {
+        var cursorWorkArea = new Rect(-1920, 0, 1920, 1040);
+        var primaryWorkArea = new Rect(0, 0, 2560, 1400);
+        var fallbackWorkArea = new Rect(0, 0, 1280, 720);
+
+        var selected = OverlayPlacementCalculator.SelectWorkArea(
+            OverlayPlacementTarget.PrimaryMonitor,
+            cursorWorkArea,
+            primaryWorkArea,
+            fallbackWorkArea);
+
+        Assert.Equal(primaryWorkArea, selected);
+    }
+}


### PR DESCRIPTION
## Summary
- Recover the recording overlay after display changes, resume from sleep/hibernate, and session unlock.
- Keep normal dictation placement cursor-based so the overlay follows the monitor where dictation starts.
- Clamp overlay placement inside the selected work area and reassert topmost state after recovery.

## Root Cause
The overlay window remembered primary-monitor recovery placement and did not switch back to cursor-monitor placement when recording made the overlay visible again.

## Test Plan
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj`

Fixes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlay now automatically recovers and repositions after display changes, power resume, or session unlock events.

* **Refactor**
  * Improved overlay positioning system with enhanced monitor work-area selection, bounds clamping, and fallback handling for more consistent placement across display configurations.

* **Tests**
  * Added comprehensive test coverage for overlay positioning calculations and window event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->