### PR TITLE
Fix CJK dictionary corrections

### DIFF
--- a/src/TypeWhisper.Core/Services/DictionaryService.cs
+++ b/src/TypeWhisper.Core/Services/DictionaryService.cs
@@ -608,7 +608,8 @@ public sealed class DictionaryService : IDictionaryService
     private static bool IsScriptWithoutWhitespaceBoundaries(char ch) =>
         ch is >= '\u3040' and <= '\u30FF' // Hiragana and Katakana
             or >= '\u3400' and <= '\u9FFF' // CJK ideographs
-            or >= '\uAC00' and <= '\uD7AF'; // Hangul syllables
+            or >= '\uAC00' and <= '\uD7AF' // Hangul syllables
+            or >= '\uF900' and <= '\uFAFF'; // CJK Compatibility Ideographs
 
     private static DictionaryEntry BackfillTimestamps(DictionaryEntry entry)
     {

--- a/src/TypeWhisper.Core/Services/DictionaryService.cs
+++ b/src/TypeWhisper.Core/Services/DictionaryService.cs
@@ -124,9 +124,9 @@ public sealed class DictionaryService : IDictionaryService
 
             if (text.Contains(entry.Original, comparison))
             {
-                var pattern = Regex.Escape(entry.Original);
+                var pattern = BuildCorrectionPattern(entry.Original);
                 var options = entry.CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
-                text = Regex.Replace(text, @"\b" + pattern + @"\b", entry.Replacement!, options);
+                text = Regex.Replace(text, pattern, entry.Replacement!, options);
 
                 IncrementUsageCount(entry.Id);
             }
@@ -595,6 +595,20 @@ public sealed class DictionaryService : IDictionaryService
 
     private static bool IsUserAuthored(DictionaryEntry entry) =>
         !entry.Id.StartsWith(PackEntryPrefix, StringComparison.Ordinal);
+
+    private static string BuildCorrectionPattern(string original)
+    {
+        var pattern = Regex.Escape(original);
+        return ContainsScriptWithoutWhitespaceBoundaries(original) ? pattern : @"\b" + pattern + @"\b";
+    }
+
+    private static bool ContainsScriptWithoutWhitespaceBoundaries(string text) =>
+        text.Any(IsScriptWithoutWhitespaceBoundaries);
+
+    private static bool IsScriptWithoutWhitespaceBoundaries(char ch) =>
+        ch is >= '\u3040' and <= '\u30FF' // Hiragana and Katakana
+            or >= '\u3400' and <= '\u9FFF' // CJK ideographs
+            or >= '\uAC00' and <= '\uD7AF'; // Hangul syllables
 
     private static DictionaryEntry BackfillTimestamps(DictionaryEntry entry)
     {

--- a/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
@@ -137,6 +137,22 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void ApplyCorrections_ReplacesCjkCompatibilityIdeographWithoutWhitespace()
+    {
+        _sut.AddEntry(new DictionaryEntry
+        {
+            Id = "1",
+            EntryType = DictionaryEntryType.Correction,
+            Original = "\uF900",
+            Replacement = "compat"
+        });
+
+        var result = _sut.ApplyCorrections("before\uF900after");
+
+        Assert.Equal("beforecompatafter", result);
+    }
+
+    [Fact]
     public void GetTermsForPrompt_ReturnsCommaSeparated()
     {
         _sut.AddEntry(new DictionaryEntry { Id = "1", EntryType = DictionaryEntryType.Term, Original = "React" });

--- a/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/DictionaryServiceTests.cs
@@ -121,6 +121,22 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void ApplyCorrections_ReplacesChinesePhraseWithoutWhitespace()
+    {
+        _sut.AddEntry(new DictionaryEntry
+        {
+            Id = "1",
+            EntryType = DictionaryEntryType.Correction,
+            Original = "北京",
+            Replacement = "上海"
+        });
+
+        var result = _sut.ApplyCorrections("我想去北京吃饭");
+
+        Assert.Equal("我想去上海吃饭", result);
+    }
+
+    [Fact]
     public void GetTermsForPrompt_ReturnsCommaSeparated()
     {
         _sut.AddEntry(new DictionaryEntry { Id = "1", EntryType = DictionaryEntryType.Term, Original = "React" });


### PR DESCRIPTION
## Summary
- Fix dictionary corrections for CJK and similar scripts that do not rely on whitespace-delimited word boundaries.
- Keep existing whole-word behavior for whitespace-delimited terms.
- Add a regression test for a Chinese phrase without spaces.

## Root Cause
Dictionary corrections were wrapped in `\b` regex word boundaries. That works for English whole-word replacements, but it does not match Chinese terms embedded in continuous text such as `我想去北京吃饭`.

## Validation
- `dotnet test TypeWhisper.slnx`
- Note: I do not speak Chinese, so I verified this through the regression test and .NET regex behavior rather than native-language review.

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text correction accuracy for scripts without whitespace boundaries. Corrections now properly replace phrases in Chinese, Japanese, and Korean text (including compatibility ideographs) without requiring whitespace separation.

* **Tests**
  * Added tests verifying corrections work correctly for CJK inputs and compatibility ideographs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->