### PR TITLE
Fix Python package audit for unresolved Torch advisory

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -159,6 +159,7 @@ jobs:
             PYSEC-2025-192
             PYSEC-2025-193
             PYSEC-2025-194
+            CVE-2025-3000
             PYSEC-2025-195
             PYSEC-2025-196
             PYSEC-2025-197


### PR DESCRIPTION
## Summary
- Add `CVE-2025-3000` to the Python package audit ignore list.
- Keep the existing OSV fixed-version guard active for this advisory.

## Root Cause
`pip-audit` reports the unresolved Torch advisory as `CVE-2025-3000`, while the workflow already ignored its OSV alias `PYSEC-2025-194`. Because `pip-audit` did not treat the PYSEC ignore as covering the CVE alias, the `python-package-audit` job failed for `torch==2.11.0`.

## Validation
- Queried OSV for `CVE-2025-3000`; the advisory has no `fixed` versions in its range events.
- Ran `python -m pip_audit -r plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt --progress-spinner off` with the workflow ignore list; result: `No known vulnerabilities found, 1 ignored`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration in GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->