### PR TITLE
Add Chinese spoken language option

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/FileTranscriptionViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/FileTranscriptionViewModel.cs
@@ -785,7 +785,8 @@ public partial class FileTranscriptionViewModel : ObservableObject
             new("de", "Deutsch"),
             new("en", "English"),
             new("fr", "Francais"),
-            new("es", "Espanol")
+            new("es", "Espanol"),
+            new("zh", "中文")
         ]);
 
         RefreshWatchFolderEnginesAndModels();

--- a/src/TypeWhisper.Windows/ViewModels/WorkflowsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WorkflowsViewModel.cs
@@ -988,7 +988,8 @@ public sealed partial class WorkflowsViewModel : ObservableObject
             new SettingOption("de", "Deutsch"),
             new SettingOption("en", "English"),
             new SettingOption("fr", "Francais"),
-            new SettingOption("es", "Espanol")
+            new SettingOption("es", "Espanol"),
+            new SettingOption("zh", "中文")
         ]);
         ReplaceCollection(TaskOptions,
         [
@@ -1253,6 +1254,7 @@ public sealed partial class WorkflowsViewModel : ObservableObject
         "en" => "English",
         "fr" => "Francais",
         "es" => "Espanol",
+        "zh" => "中文",
         _ => language
     };
 

--- a/src/TypeWhisper.Windows/Views/Sections/AudioSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/AudioSection.xaml
@@ -260,6 +260,7 @@
                                     <ComboBoxItem Content="English" Tag="en"/>
                                     <ComboBoxItem Content="Français" Tag="fr"/>
                                     <ComboBoxItem Content="Español" Tag="es"/>
+                                    <ComboBoxItem Content="中文" Tag="zh"/>
                                     <ComboBoxItem Content="Italiano" Tag="it"/>
                                     <ComboBoxItem Content="Português" Tag="pt"/>
                                     <ComboBoxItem Content="Nederlands" Tag="nl"/>

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioSectionLanguageTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioSectionLanguageTests.cs
@@ -1,0 +1,17 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class AudioSectionLanguageTests
+{
+    [Fact]
+    public void SpokenLanguageSelector_OffersChinese()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "AudioSection.xaml");
+
+        Assert.Contains("<ComboBoxItem Content=\"中文\" Tag=\"zh\"/>", xaml);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/FileTranscriptionViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/FileTranscriptionViewModelTests.cs
@@ -178,6 +178,15 @@ public class FileTranscriptionViewModelTests
         Assert.Equal(Loc.Instance["FileTranscription.StatusDefault"], sut.StatusText);
     }
 
+    [Fact]
+    public void WatchFolderLanguageOptions_IncludeChineseSpokenLanguage()
+    {
+        var sut = CreateSut(new FakeProcessor());
+
+        var option = Assert.Single(sut.WatchFolderLanguageOptions, option => option.Id == "zh");
+        Assert.Equal("中文", option.DisplayName);
+    }
+
     private static async Task WaitForAsync(Func<bool> condition)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/tests/TypeWhisper.PluginSystem.Tests/TestFile.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TestFile.cs
@@ -9,12 +9,24 @@ internal static class TestFile
 
     public static string ProjectFile(params string[] parts)
     {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Join(directory.FullName, "TypeWhisper.slnx")))
-            directory = directory.Parent;
+        var directory = FindProjectRoot(AppContext.BaseDirectory)
+            ?? FindProjectRoot(Environment.CurrentDirectory)
+            ?? FindProjectRoot(Environment.GetEnvironmentVariable("TYPEWHISPER_REPO_ROOT"));
 
         Assert.NotNull(directory);
         return Path.Join([directory.FullName, .. parts]);
+    }
+
+    private static DirectoryInfo? FindProjectRoot(string? startPath)
+    {
+        if (string.IsNullOrWhiteSpace(startPath))
+            return null;
+
+        var directory = new DirectoryInfo(startPath);
+        while (directory is not null && !File.Exists(Path.Join(directory.FullName, "TypeWhisper.slnx")))
+            directory = directory.Parent;
+
+        return directory;
     }
 
     public static string ExtractBlock(string text, string marker, int maxLength = 1800)

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowsViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowsViewModelTests.cs
@@ -102,6 +102,15 @@ public sealed class WorkflowsViewModelTests : IDisposable
     }
 
     [Fact]
+    public void LanguageOptions_IncludeChineseSpokenLanguage()
+    {
+        var sut = CreateViewModel();
+
+        var option = Assert.Single(sut.LanguageOptions, option => option.Value == "zh");
+        Assert.Equal("中文", option.DisplayName);
+    }
+
+    [Fact]
     public void StartEdit_LoadsSingleHotkeyWorkflowAsOneHotkeyChip()
     {
         var workflow = NewWorkflow("Rewrite", WorkflowTrigger.Hotkey("Ctrl+Alt+R"));


### PR DESCRIPTION
## Summary
- Add Chinese (`zh`) to the spoken language selector in dictation settings.
- Add Chinese to workflow and watch-folder spoken language override options.
- Cover the new options with focused regression tests.

## Root Cause
The Windows spoken-language option lists were hardcoded in separate UI/view-model surfaces and did not include `zh`, even though Chinese is already supported elsewhere in the app.

## Test Plan
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --artifacts-path F:\codex-artifacts\typewhisper-10d8 --filter "FullyQualifiedName~AudioSectionLanguageTests|FullyQualifiedName~WorkflowsViewModelTests.LanguageOptions_IncludeChineseSpokenLanguage|FullyQualifiedName~FileTranscriptionViewModelTests.WatchFolderLanguageOptions_IncludeChineseSpokenLanguage" --no-restore`
- `git diff --check`

Fixes #227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Chinese (中文) language support across audio transcription and workflow components, enabling users to select Chinese as their spoken language option.

* **Tests**
  * Added test coverage verifying Chinese language availability in audio interface and workflow language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->