### PR TITLE
Fix startup audio warmup performance

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -280,12 +280,7 @@ public partial class App : Application
     }
 
     private static bool IsNonFatalTrayActionException(Exception ex) =>
-        ex is not OutOfMemoryException
-            and not StackOverflowException
-            and not AccessViolationException
-            and not AppDomainUnloadedException
-            and not BadImageFormatException
-            and not CannotUnloadAppDomainException;
+        NonFatalExceptionFilter.IsNonFatal(ex);
 
     internal static Task StartAudioWarmUpInBackground(
         AudioRecordingService audio,
@@ -307,12 +302,7 @@ public partial class App : Application
         });
 
     private static bool IsNonFatalStartupException(Exception ex) =>
-        ex is not OutOfMemoryException
-            and not StackOverflowException
-            and not AccessViolationException
-            and not AppDomainUnloadedException
-            and not BadImageFormatException
-            and not CannotUnloadAppDomainException;
+        NonFatalExceptionFilter.IsNonFatal(ex);
 
     private async Task ProcessProtocolArgsAsync(string[] args)
     {

--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -186,10 +186,7 @@ public partial class App : Application
 
         // Warm up audio
         var audio = _serviceProvider.GetRequiredService<AudioRecordingService>();
-        var mic = settings.Current.SelectedMicrophoneDevice;
-        if (mic.HasValue) audio.SetMicrophoneDevice(mic);
-        if (!audio.WarmUp())
-            System.Diagnostics.Debug.WriteLine("No audio input device available at startup. Polling for device...");
+        _ = StartAudioWarmUpInBackground(audio, settings.Current.SelectedMicrophoneDevice);
 
         // Start and keep the API server aligned with settings.
         var apiServer = _serviceProvider.GetRequiredService<ApiServerController>();
@@ -283,6 +280,33 @@ public partial class App : Application
     }
 
     private static bool IsNonFatalTrayActionException(Exception ex) =>
+        ex is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException
+            and not AppDomainUnloadedException
+            and not BadImageFormatException
+            and not CannotUnloadAppDomainException;
+
+    internal static Task StartAudioWarmUpInBackground(
+        AudioRecordingService audio,
+        int? selectedMicrophoneDevice) =>
+        Task.Run(() =>
+        {
+            try
+            {
+                if (selectedMicrophoneDevice.HasValue)
+                    audio.SetMicrophoneDevice(selectedMicrophoneDevice);
+
+                if (!audio.WarmUp())
+                    System.Diagnostics.Debug.WriteLine("No audio input device available at startup. Polling for device...");
+            }
+            catch (Exception ex) when (IsNonFatalStartupException(ex))
+            {
+                System.Diagnostics.Debug.WriteLine($"Audio warm-up failed: {ex.Message}");
+            }
+        });
+
+    private static bool IsNonFatalStartupException(Exception ex) =>
         ex is not OutOfMemoryException
             and not StackOverflowException
             and not AccessViolationException

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -60,7 +60,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// Initializes a new instance of the AudioRecordingService class.
     /// </summary>
     public AudioRecordingService()
-        : this(new WasapiAudioInputDeviceProvider(), new WasapiAudioInputCaptureFactory(), DefaultDevicePollInterval)
+        : this(new WaveInAudioInputDeviceProvider(), new WaveInAudioInputCaptureFactory(), DefaultDevicePollInterval)
     {
     }
 
@@ -229,7 +229,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// Returns available devices.
     /// </summary>
     public static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices() =>
-        GetAvailableDevices(new WasapiAudioInputDeviceProvider());
+        GetAvailableDevices(new WaveInAudioInputDeviceProvider());
 
     /// <summary>
     /// Returns available input devices.

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -680,12 +680,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     }
 
     private static bool IsNonFatalAudioException(Exception ex) =>
-        ex is not OutOfMemoryException
-            and not StackOverflowException
-            and not AccessViolationException
-            and not AppDomainUnloadedException
-            and not BadImageFormatException
-            and not CannotUnloadAppDomainException;
+        NonFatalExceptionFilter.IsNonFatal(ex);
 
     private int SafeDeviceCount()
     {

--- a/src/TypeWhisper.Windows/Services/NonFatalExceptionFilter.cs
+++ b/src/TypeWhisper.Windows/Services/NonFatalExceptionFilter.cs
@@ -1,0 +1,12 @@
+namespace TypeWhisper.Windows.Services;
+
+internal static class NonFatalExceptionFilter
+{
+    public static bool IsNonFatal(Exception ex) =>
+        ex is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException
+            and not AppDomainUnloadedException
+            and not BadImageFormatException
+            and not CannotUnloadAppDomainException;
+}

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -306,12 +306,11 @@ public partial class SettingsViewModel : ObservableObject
         RegisterShortcutHotkeyCollections();
 
         _isLoading = true;
-        RefreshLocalizedCollections();
+        RefreshLocalizedCollections(refreshMicrophones: false);
         LoadFromSettings(_settings.Current);
         RefreshSpokenFeedbackProviders();
         AutostartEnabled = StartupService.IsEnabled;
         RefreshMicrophones();
-        _audio.SetMicrophoneDevice(SelectedMicrophoneDevice);
         RefreshApiServerStatus();
         RefreshCliState();
         RefreshApiExamples();
@@ -883,12 +882,13 @@ public partial class SettingsViewModel : ObservableObject
         });
     }
 
-    private void RefreshLocalizedCollections()
+    private void RefreshLocalizedCollections(bool refreshMicrophones = true)
     {
         ReplaceCollection(TranslationTargetOptions, LocalizeTranslationOptions(TranslationModelInfo.GlobalTargetOptions));
         ReplaceCollection(HistoryRetentionOptions, BuildHistoryRetentionOptions());
         ReplaceCollection(WidgetOptions, BuildWidgetOptions());
-        RefreshMicrophones();
+        if (refreshMicrophones)
+            RefreshMicrophones();
     }
 
     private string? ResolveLastTranslationTarget()

--- a/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
@@ -14,4 +14,29 @@ public sealed class AppStartupPerformanceTests
         Assert.Contains("StartAudioWarmUpInBackground", startupWarmupBlock);
         Assert.DoesNotContain("audio.WarmUp()", startupWarmupBlock);
     }
+
+    [Fact]
+    public void NonFatalStartupAndAudioFilters_UseSharedFatalExceptionFilter()
+    {
+        var appSource = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var audioSource = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "AudioRecordingService.cs");
+
+        var trayFilter = TestFile.ExtractBlock(appSource, "private static bool IsNonFatalTrayActionException", 180);
+        var startupFilter = TestFile.ExtractBlock(appSource, "private static bool IsNonFatalStartupException", 180);
+        var audioFilter = TestFile.ExtractBlock(audioSource, "private static bool IsNonFatalAudioException", 180);
+
+        Assert.Contains("NonFatalExceptionFilter.IsNonFatal", trayFilter);
+        Assert.Contains("NonFatalExceptionFilter.IsNonFatal", startupFilter);
+        Assert.Contains("NonFatalExceptionFilter.IsNonFatal", audioFilter);
+        Assert.DoesNotContain("OutOfMemoryException", trayFilter);
+        Assert.DoesNotContain("OutOfMemoryException", startupFilter);
+        Assert.DoesNotContain("OutOfMemoryException", audioFilter);
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
@@ -1,0 +1,17 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class AppStartupPerformanceTests
+{
+    [Fact]
+    public void OnStartup_StartsAudioWarmupInBackground()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var startupWarmupBlock = TestFile.ExtractBlock(source, "// Warm up audio", 520);
+
+        Assert.Contains("StartAudioWarmUpInBackground", startupWarmupBlock);
+        Assert.DoesNotContain("audio.WarmUp()", startupWarmupBlock);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -605,10 +605,16 @@ public sealed class RecorderAudioPipelineTests
             "TypeWhisper.Windows",
             "Services",
             "AudioRecordingService.cs");
+        var filterSource = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "NonFatalExceptionFilter.cs");
 
         Assert.Contains("catch (Exception ex) when (IsNonFatalAudioException(ex))", source);
-        Assert.Contains("ex is not OutOfMemoryException", source);
-        Assert.Contains("and not AccessViolationException", source);
+        Assert.Contains("NonFatalExceptionFilter.IsNonFatal", source);
+        Assert.Contains("ex is not OutOfMemoryException", filterSource);
+        Assert.Contains("and not AccessViolationException", filterSource);
         Assert.DoesNotContain("catch\r\n        {\r\n            return -1;", source);
         Assert.DoesNotContain("catch { }", source);
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -13,6 +13,23 @@ namespace TypeWhisper.PluginSystem.Tests;
 public sealed class AudioRecordingServiceDeviceChangeTests
 {
     [Fact]
+    public void DefaultMicrophoneCapture_UsesWaveInInsteadOfWasapi()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "AudioRecordingService.cs");
+        var defaultConstructor = TestFile.ExtractBlock(source, "public AudioRecordingService()", 260);
+        var staticDeviceList = TestFile.ExtractBlock(source, "public static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices()", 180);
+
+        Assert.Contains("new WaveInAudioInputDeviceProvider()", defaultConstructor);
+        Assert.Contains("new WaveInAudioInputCaptureFactory()", defaultConstructor);
+        Assert.DoesNotContain("WasapiAudioInput", defaultConstructor);
+        Assert.Contains("new WaveInAudioInputDeviceProvider()", staticDeviceList);
+    }
+
+    [Fact]
     public void CheckForDeviceChanges_RaisesDevicesChanged_WhenDeviceNamesChangeWithSameCount()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
@@ -259,6 +276,26 @@ public sealed class AudioRecordingServiceDeviceChangeTests
 
 public sealed class SettingsViewModelMicrophoneDeviceTests
 {
+    [Fact]
+    public void Constructor_EnumeratesMicrophoneNamesOnlyOnce()
+    {
+        Loc.Instance.Initialize();
+        Loc.Instance.CurrentLanguage = "en";
+
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        var settings = new FakeSettingsService(AppSettings.Default with { SelectedMicrophoneDevice = 0 });
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        using var speech = new SpeechFeedbackService(settings, pluginManager, new FakeTtsProvider("windows-sapi", "System Voice"));
+
+        var sut = CreateSettingsViewModel(settings, audio, speech);
+
+        Assert.Equal(0, sut.SelectedMicrophoneDevice);
+        Assert.Equal("USB Microphone", sut.SelectedMicrophoneItem?.Name);
+        Assert.Equal(1, devices.DeviceNameRequestCount);
+    }
+
     [Fact]
     public void Constructor_SelectsDefaultMicrophoneItem_WhenNoDeviceIsConfigured()
     {
@@ -679,7 +716,13 @@ internal sealed class FakeAudioInputDeviceProvider : IAudioInputDeviceProvider
 
     public int DeviceCount => _deviceNames.Count;
 
-    public string GetDeviceName(int deviceNumber) => _deviceNames[deviceNumber];
+    public int DeviceNameRequestCount { get; private set; }
+
+    public string GetDeviceName(int deviceNumber)
+    {
+        DeviceNameRequestCount++;
+        return _deviceNames[deviceNumber];
+    }
 
     public void SetDevices(params string[] deviceNames)
     {


### PR DESCRIPTION
## Summary
- Move startup audio warm-up off the UI thread so the tray app can remain responsive while audio devices initialize.
- Restore WaveIn as the default microphone capture path while leaving the system-audio WASAPI path intact.
- Avoid duplicate microphone enumeration when constructing the settings view model.
- Add regression coverage for startup warm-up, default microphone capture, and settings microphone enumeration.

## Context
Related to #239. The reporter's symptoms point to the app becoming unresponsive shortly after the tray icon appears, with Voicemeeter present and no crash log. The local investigation also found that opening Settings could synchronously enumerate microphone devices more than once.

## Validation
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj --no-restore`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore`
- `dotnet build src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release --no-restore`

The Release build still reports existing nullable/MVVM Toolkit warnings unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup by warming up audio in the background instead of delaying launch.
  * Reduced startup errors by handling missing or non-fatal audio initialization issues more gracefully.
  * Updated microphone capture to use a more reliable default audio backend.

* **Performance**
  * Streamlined settings startup so microphone lists are refreshed less often during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->