### PR TITLE
Prepare 1.0 release candidate

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -16,6 +16,32 @@
 
 ---
 
+## 1.0 RC Release-Gates
+
+Vor einem `v1.0.0-rc1` Tag müssen diese Checks abgeschlossen sein:
+
+- [ ] `dotnet restore TypeWhisper.slnx`
+- [ ] `dotnet build TypeWhisper.slnx -c Release --no-restore`
+- [ ] `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-build`
+- [ ] `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release --no-build`
+- [ ] Alle Plugin-Projekte unter `plugins/` in `Release` bauen.
+- [ ] GitHub `Package Dry Run` mit Channel `rc` für `win-x64` und `win-arm64` prüfen.
+- [ ] Release-Artefakte enthalten `Setup.exe`, `Portable.zip`, `.nupkg`, `RELEASES-*`, `assets.*.json` und `releases.*.json` für beide Architekturen.
+- [ ] Signatur/Publisher der `Setup.exe` prüfen; nicht signierte Installer sind ein Release-Blocker.
+
+### 1.0 RC Manuelle Smoke-Tests
+
+- [ ] Frischer Portable-Start auf Windows 11 x64: App startet, Tray reagiert, Settings öffnen.
+- [ ] Windows 10 22H2 mit virtuellen Audiogeräten, z.B. Voicemeeter: Startup hängt nicht, Settings öffnen, Aufnahme funktioniert.
+- [ ] Upgrade von `v0.8.4` auf `v1.0.0-rc1`: Einstellungen, History, Plugins und Hotkeys bleiben erhalten.
+- [ ] Update-Channel in Settings auf Release Candidate stellen und Update-Check ausführen.
+- [ ] Gebundelte Plugins sind sichtbar, Marketplace-/User-Plugin mit gleicher ID überschreibt die gebundelte Kopie.
+- [ ] OpenAI und Supertonic TTS erscheinen auf einem `1.0.0-rc1` Host als kompatible Marketplace-Plugins.
+- [ ] Groq Recorder transkribiert auch auf Systemen ohne Media-Foundation-AAC-Encoder per WAV-Fallback.
+- [ ] AMD-Pfad dokumentiert prüfen: `whisper.cpp` + Vulkan ist der empfohlene AMD-Weg; Parakeet/ONNX ist CPU/NVIDIA CUDA; ROCm ist manuell über `TYPEWHISPER_WHISPERCPP_ROCM_LIBRARY_PATH`; ZLUDA ist experimentell.
+
+---
+
 ## Phase 1: PostProcessingPipeline + DB Migration v6
 
 ### 1.1 DB Migration

--- a/docs/releases/v1.0.0-rc1.md
+++ b/docs/releases/v1.0.0-rc1.md
@@ -1,0 +1,28 @@
+# TypeWhisper v1.0.0-rc1
+
+TypeWhisper 1.0.0-rc1 is the first release candidate for the Windows 1.0 release. It focuses on release quality, update reliability, plugin compatibility, and the stability fixes needed before the stable 1.0 tag.
+
+## Release Candidate Focus
+
+- Prepared the Windows app for the `1.0.0-rc1` release-candidate channel.
+- Kept the RC scope focused on blocker fixes, compatibility, documentation, and QA rather than new workflow surfaces.
+- Preserved the stable 1.0 path for a short RC soak before publishing `v1.0.0`.
+
+## Improvements
+
+- Loaded bundled app plugins from the installed application directory alongside marketplace and user-installed plugins.
+- Preferred marketplace or user-installed plugin copies when they share an id with a bundled plugin.
+- Aligned OpenAI and Supertonic TTS plugin host compatibility with the Windows 1.0 release line.
+- Documented the RC validation focus for Windows 10 startup, plugin loading, update channels, and local acceleration diagnostics.
+
+## Fixes
+
+- Fixed Groq recorder transcription on Windows systems where Media Foundation AAC encoding is unavailable by falling back to WAV upload.
+- Preserved cancellation behavior for Groq transcription while avoiding hard failures for AAC encoder availability issues.
+
+## RC Validation Notes
+
+- Validate startup responsiveness on Windows 10 22H2 systems with virtual audio devices such as Voicemeeter.
+- Validate upgrade behavior from `v0.8.4` to the RC channel and fresh portable RC launches.
+- Validate OpenAI and Supertonic TTS visibility in the plugin marketplace on a `1.0.0-rc1` host.
+- Treat signing, Velopack RC-channel assets, and x64/ARM64 package completeness as release blockers.

--- a/docs/releases/v1.0.0-rc1.md
+++ b/docs/releases/v1.0.0-rc1.md
@@ -22,7 +22,7 @@ TypeWhisper 1.0.0-rc1 is the first release candidate for the Windows 1.0 release
 
 ## RC Validation Notes
 
-- Validate startup responsiveness on Windows 10 22H2 systems with virtual audio devices such as Voicemeeter.
-- Validate upgrade behavior from `v0.8.4` to the RC channel and fresh portable RC launches.
-- Validate OpenAI and Supertonic TTS visibility in the plugin marketplace on a `1.0.0-rc1` host.
+- Check startup responsiveness on Windows 10 22H2 systems with virtual audio devices such as Voicemeeter.
+- Confirm upgrade behavior from `v0.8.4` to the RC channel and fresh portable RC launches.
+- Verify OpenAI and Supertonic TTS visibility in the plugin marketplace on a `1.0.0-rc1` host.
 - Treat signing, Velopack RC-channel assets, and x64/ARM64 package completeness as release blockers.

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -192,17 +192,17 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
         {
             throw CreateCompressionException(ex);
         }
-        catch (IOException ex)
+        catch (IOException)
         {
-            throw CreateCompressionException(ex);
+            upload = CreateWavUpload(wavAudio);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException)
         {
-            throw CreateCompressionException(ex);
+            upload = CreateWavUpload(wavAudio);
         }
-        catch (COMException ex)
+        catch (COMException)
         {
-            throw CreateCompressionException(ex);
+            upload = CreateWavUpload(wavAudio);
         }
 
         return await TranscribeUploadAsync(
@@ -404,6 +404,14 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
             throw new InvalidOperationException("Media Foundation produced an empty AAC upload.");
 
         return new GroqTranscriptionUpload(bytes, "audio.m4a", "audio/mp4");
+    }
+
+    private static GroqTranscriptionUpload CreateWavUpload(byte[] wavAudio)
+    {
+        if (wavAudio.Length == 0)
+            throw new InvalidOperationException("No WAV audio bytes were provided.");
+
+        return new GroqTranscriptionUpload(wavAudio, "audio.wav", "audio/wav");
     }
 
     private static async Task<PluginTranscriptionResult> TranscribeUploadAsync(

--- a/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
@@ -12,7 +12,7 @@ namespace TypeWhisper.PluginSystem.Tests;
 public class OpenAiPluginTests
 {
     [Fact]
-    public void PluginVersionAndManifest_TargetTypeWhisper14AndAdvertiseTts()
+    public void PluginVersionAndManifest_TargetTypeWhisper10AndAdvertiseTts()
     {
         var manifestPath = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory,
@@ -26,7 +26,7 @@ public class OpenAiPluginTests
 
         Assert.NotNull(manifest);
         Assert.Equal(manifest.Version, sut.PluginVersion);
-        Assert.Equal("1.4.0", manifest.MinHostVersion);
+        Assert.Equal("1.0.0", manifest.MinHostVersion);
         Assert.Contains("text-to-speech", manifest.Description, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(["transcription", "llm", "tts"], manifest.Categories);
     }

--- a/plugins/TypeWhisper.Plugin.OpenAi/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAi/manifest.json
@@ -2,7 +2,7 @@
   "id": "com.typewhisper.openai",
   "name": "OpenAI / ChatGPT",
   "version": "1.1.1",
-  "minHostVersion": "1.4.0",
+  "minHostVersion": "1.0.0",
   "author": "TypeWhisper",
   "description": "OpenAI transcription, ChatGPT/OpenAI prompt processing, and text-to-speech. Use an API key for STT/TTS or ChatGPT login for prompts.",
   "descriptions": {

--- a/plugins/TypeWhisper.Plugin.SupertonicTts/manifest.json
+++ b/plugins/TypeWhisper.Plugin.SupertonicTts/manifest.json
@@ -2,7 +2,7 @@
   "id": "com.typewhisper.supertonic-tts",
   "name": "Supertonic TTS",
   "version": "1.0.0",
-  "minHostVersion": "1.4.0",
+  "minHostVersion": "1.0.0",
   "author": "TypeWhisper",
   "description": "Local Supertonic 3 text-to-speech provider. Downloads OpenRAIL-M model assets on demand and runs synthesis on-device with ONNX Runtime.",
   "descriptions": {

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
@@ -122,7 +122,7 @@ public sealed class PluginManager : IDisposable
     [
         ..new[]
         {
-            Path.GetFullPath(Path.Combine(appBaseDirectory, "Plugins")),
+            Path.GetFullPath(Path.Join(appBaseDirectory, "Plugins")),
             Path.GetFullPath(userPluginsPath)
         }.Distinct(StringComparer.OrdinalIgnoreCase)
     ];
@@ -143,13 +143,44 @@ public sealed class PluginManager : IDisposable
         return orderedIds.Select(id => selectedById[id]).ToList();
     }
 
+    internal static void UnloadDiscardedSearchDirectoryPlugins(
+        IReadOnlyList<LoadedPlugin> loadedPlugins,
+        IReadOnlyCollection<LoadedPlugin> retainedPlugins)
+    {
+        foreach (var discarded in loadedPlugins)
+        {
+            if (retainedPlugins.Any(retained => ReferenceEquals(retained, discarded)))
+                continue;
+
+            try
+            {
+                discarded.Instance.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[PluginManager] Failed to dispose overridden plugin {discarded.Manifest.Id}: {ex.Message}");
+            }
+
+            try
+            {
+                discarded.LoadContext.Unload();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[PluginManager] Failed to unload overridden plugin {discarded.Manifest.Id}: {ex.Message}");
+            }
+        }
+    }
+
     /// <summary>
     /// Discovers plugins from the configured search directories, restores enabled
     /// state from settings, and activates all enabled plugins.
     /// </summary>
     public async Task InitializeAsync()
     {
-        var discovered = PreferLaterSearchDirectoryPlugins(_loader.DiscoverAndLoad(_searchDirectories));
+        var loadedPlugins = _loader.DiscoverAndLoad(_searchDirectories);
+        var discovered = PreferLaterSearchDirectoryPlugins(loadedPlugins);
+        UnloadDiscardedSearchDirectoryPlugins(loadedPlugins, discovered);
 
         lock (_lock)
         {

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
@@ -147,30 +147,51 @@ public sealed class PluginManager : IDisposable
         IReadOnlyList<LoadedPlugin> loadedPlugins,
         IReadOnlyCollection<LoadedPlugin> retainedPlugins)
     {
-        foreach (var discarded in loadedPlugins)
+        foreach (var discarded in loadedPlugins.Where(discarded =>
+            !retainedPlugins.Any(retained => ReferenceEquals(retained, discarded))))
         {
-            if (retainedPlugins.Any(retained => ReferenceEquals(retained, discarded)))
-                continue;
-
             try
             {
                 discarded.Instance.Dispose();
             }
-            catch (Exception ex)
+            catch (ObjectDisposedException ex)
             {
-                Debug.WriteLine($"[PluginManager] Failed to dispose overridden plugin {discarded.Manifest.Id}: {ex.Message}");
+                LogDiscardedPluginCleanupFailure("dispose", discarded, ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogDiscardedPluginCleanupFailure("dispose", discarded, ex);
+            }
+            catch (IOException ex)
+            {
+                LogDiscardedPluginCleanupFailure("dispose", discarded, ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogDiscardedPluginCleanupFailure("dispose", discarded, ex);
+            }
+            catch (NotSupportedException ex)
+            {
+                LogDiscardedPluginCleanupFailure("dispose", discarded, ex);
             }
 
             try
             {
                 discarded.LoadContext.Unload();
             }
-            catch (Exception ex)
+            catch (InvalidOperationException ex)
             {
-                Debug.WriteLine($"[PluginManager] Failed to unload overridden plugin {discarded.Manifest.Id}: {ex.Message}");
+                LogDiscardedPluginCleanupFailure("unload", discarded, ex);
+            }
+            catch (CannotUnloadAppDomainException ex)
+            {
+                LogDiscardedPluginCleanupFailure("unload", discarded, ex);
             }
         }
     }
+
+    private static void LogDiscardedPluginCleanupFailure(string action, LoadedPlugin plugin, Exception exception) =>
+        Debug.WriteLine($"[PluginManager] Failed to {action} overridden plugin {plugin.Manifest.Id}: {exception}");
 
     /// <summary>
     /// Discovers plugins from the configured search directories, restores enabled

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using TypeWhisper.Core;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.PluginSDK;
@@ -39,7 +40,13 @@ public sealed class PluginManager : IDisposable
         IActiveWindowService activeWindow,
         IWorkflowService workflows,
         ISettingsService settings)
-        : this(loader, eventBus, activeWindow, workflows, settings, [TypeWhisperEnvironment.PluginsPath])
+        : this(
+            loader,
+            eventBus,
+            activeWindow,
+            workflows,
+            settings,
+            BuildDefaultSearchDirectories(AppContext.BaseDirectory, TypeWhisperEnvironment.PluginsPath))
     {
     }
 
@@ -111,13 +118,38 @@ public sealed class PluginManager : IDisposable
     /// <summary>The shared event bus for plugin communication.</summary>
     public PluginEventBus EventBus => _eventBus;
 
+    internal static string[] BuildDefaultSearchDirectories(string appBaseDirectory, string userPluginsPath) =>
+    [
+        ..new[]
+        {
+            Path.GetFullPath(Path.Combine(appBaseDirectory, "Plugins")),
+            Path.GetFullPath(userPluginsPath)
+        }.Distinct(StringComparer.OrdinalIgnoreCase)
+    ];
+
+    internal static IReadOnlyList<LoadedPlugin> PreferLaterSearchDirectoryPlugins(IEnumerable<LoadedPlugin> plugins)
+    {
+        var selectedById = new Dictionary<string, LoadedPlugin>(StringComparer.OrdinalIgnoreCase);
+        var orderedIds = new List<string>();
+
+        foreach (var plugin in plugins)
+        {
+            if (!selectedById.ContainsKey(plugin.Manifest.Id))
+                orderedIds.Add(plugin.Manifest.Id);
+
+            selectedById[plugin.Manifest.Id] = plugin;
+        }
+
+        return orderedIds.Select(id => selectedById[id]).ToList();
+    }
+
     /// <summary>
     /// Discovers plugins from the configured search directories, restores enabled
     /// state from settings, and activates all enabled plugins.
     /// </summary>
     public async Task InitializeAsync()
     {
-        var discovered = _loader.DiscoverAndLoad(_searchDirectories);
+        var discovered = PreferLaterSearchDirectoryPlugins(_loader.DiscoverAndLoad(_searchDirectories));
 
         lock (_lock)
         {

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -182,10 +182,24 @@ public class GroqPluginTests
     }
 
     [Fact]
-    public async Task TranscribeAsync_EncoderFailureThrowsClearExceptionBeforeUpload()
+    public async Task TranscribeAsync_EncoderFailureFallsBackToWavUpload()
     {
-        var handler = new CapturingHandler((_, _) =>
-            throw new InvalidOperationException("Upload should not be attempted."));
+        string? transcriptionBody = null;
+        var handler = new CapturingHandler((request, body) =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("https://api.groq.com/openai/v1/audio/transcriptions", request.RequestUri?.ToString());
+            Assert.Equal("Bearer groq-key", request.Headers.Authorization?.ToString());
+
+            transcriptionBody = body;
+            Assert.NotNull(body);
+            AssertMultipartToken(body, "filename", "audio.wav");
+            Assert.Contains("Content-Type: audio/wav", body);
+            Assert.DoesNotContain("filename=\"audio.m4a\"", body);
+            Assert.DoesNotContain("filename=audio.m4a", body);
+
+            return JsonResponse("""{"text":"fallback","language":"en","duration":1.0}""");
+        });
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "groq-key";
 
@@ -197,11 +211,10 @@ public class GroqPluginTests
             _ => throw new InvalidOperationException("codec unavailable"));
         await sut.ActivateAsync(host);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.TranscribeAsync([1, 2, 3], null, false, null, CancellationToken.None));
+        var result = await sut.TranscribeAsync([1, 2, 3], null, false, null, CancellationToken.None);
 
-        Assert.Contains("Groq audio upload could not be compressed", ex.Message);
-        Assert.Contains("codec unavailable", ex.Message);
+        Assert.NotNull(transcriptionBody);
+        Assert.Equal("fallback", result.Text);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using TypeWhisper.Plugin.Groq;
@@ -181,11 +182,16 @@ public class GroqPluginTests
         Assert.Equal("ok", result.Text);
     }
 
-    [Fact]
-    public async Task TranscribeAsync_EncoderFailureFallsBackToWavUpload()
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(COMException))]
+    public async Task TranscribeAsync_EncoderFailureFallsBackToWavUpload(Type compressionExceptionType)
     {
         string? transcriptionBody = null;
-        var handler = new CapturingHandler((request, body) =>
+        var normalHandler = new CapturingHandler((_, _) =>
+            throw new InvalidOperationException("Normal HTTP client should not be used for transcription."));
+        var transcriptionHandler = new CapturingHandler((request, body) =>
         {
             Assert.Equal(HttpMethod.Post, request.Method);
             Assert.Equal("https://api.groq.com/openai/v1/audio/transcriptions", request.RequestUri?.ToString());
@@ -203,16 +209,18 @@ public class GroqPluginTests
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "groq-key";
 
-        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
-        using var transcriptionHttpClient = GroqPlugin.CreateTranscriptionHttpClient(handler);
+        using var httpClient = new HttpClient(normalHandler) { Timeout = TimeSpan.FromSeconds(5) };
+        using var transcriptionHttpClient = GroqPlugin.CreateTranscriptionHttpClient(transcriptionHandler);
+        var compressionException = CreateCompressionFailure(compressionExceptionType);
         var sut = new GroqPlugin(
             httpClient,
             transcriptionHttpClient,
-            _ => throw new InvalidOperationException("codec unavailable"));
+            _ => throw compressionException);
         await sut.ActivateAsync(host);
 
         var result = await sut.TranscribeAsync([1, 2, 3], null, false, null, CancellationToken.None);
 
+        Assert.Equal(TimeSpan.FromMinutes(10), transcriptionHttpClient.Timeout);
         Assert.NotNull(transcriptionBody);
         Assert.Equal("fallback", result.Text);
     }
@@ -345,6 +353,23 @@ public class GroqPluginTests
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
+
+    private static Exception CreateCompressionFailure(Type exceptionType)
+    {
+        if (exceptionType == typeof(IOException))
+            return new IOException("codec unavailable");
+
+        if (exceptionType == typeof(InvalidOperationException))
+            return new InvalidOperationException("codec unavailable");
+
+        if (exceptionType == typeof(COMException))
+            return new COMException("codec unavailable");
+
+        throw new ArgumentOutOfRangeException(
+            nameof(exceptionType),
+            exceptionType,
+            "Unsupported compression exception type.");
+    }
 
     private sealed class CapturingHandler(
         Func<HttpRequestMessage, string?, HttpResponseMessage> responder) : HttpMessageHandler

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
@@ -152,6 +152,35 @@ public class PluginManagerTests : IDisposable
     }
 
     [Fact]
+    public void BuildDefaultSearchDirectories_IncludesBundledPluginsBeforeUserPlugins()
+    {
+        var appBaseDirectory = Path.Combine(Path.GetTempPath(), "typewhisper-app");
+        var userPluginsPath = Path.Combine(Path.GetTempPath(), "typewhisper-user", "Plugins");
+
+        var result = PluginManager.BuildDefaultSearchDirectories(appBaseDirectory, userPluginsPath);
+
+        Assert.Equal(
+            [
+                Path.Combine(appBaseDirectory, "Plugins"),
+                userPluginsPath
+            ],
+            result);
+    }
+
+    [Fact]
+    public void PreferLaterSearchDirectoryPlugins_LocalPluginOverridesBundledPluginWithSameId()
+    {
+        var bundled = CreateLoadedPlugin("com.typewhisper.groq", "1.0.2", @"C:\App\Plugins\com.typewhisper.groq");
+        var local = CreateLoadedPlugin("com.typewhisper.groq", "1.0.3", @"C:\Users\me\AppData\Local\TypeWhisper\Plugins\com.typewhisper.groq");
+
+        var result = PluginManager.PreferLaterSearchDirectoryPlugins([bundled, local]);
+
+        var plugin = Assert.Single(result);
+        Assert.Equal("1.0.3", plugin.Manifest.Version);
+        Assert.Same(local, plugin);
+    }
+
+    [Fact]
     public void CapabilityIndices_IncludeAdditionalRolesWithoutDuplicatingAllPlugins()
     {
         var manager = CreateManager();
@@ -199,6 +228,25 @@ public class PluginManagerTests : IDisposable
         Assert.True(eventFired);
     }
 
+    private static LoadedPlugin CreateLoadedPlugin(string id, string version, string pluginDirectory)
+    {
+        var plugin = new MultiRolePlugin(id, version);
+        var manifest = new PluginManifest
+        {
+            Id = plugin.PluginId,
+            Name = plugin.PluginName,
+            Version = plugin.PluginVersion,
+            AssemblyName = "Fake.dll",
+            PluginClass = plugin.GetType().FullName!
+        };
+
+        return new LoadedPlugin(
+            manifest,
+            plugin,
+            new PluginAssemblyLoadContext(typeof(PluginManagerTests).Assembly.Location),
+            pluginDirectory);
+    }
+
     public void Dispose()
     {
         _manager?.Dispose();
@@ -221,11 +269,24 @@ public class PluginManagerTests : IDisposable
     {
         private readonly ProfileRole _profileRole = new("com.test.multi", "openai-compatible-profile-a", "Profile A");
         private readonly ProfileRole _duplicateProfileRole = new("com.test.multi", "openai-compatible-profile-a", "Profile A Duplicate");
+        private readonly string _pluginId;
+        private readonly string _pluginVersion;
         private bool _includeAdditionalRoles = true;
 
-        public string PluginId => "com.test.multi";
+        public MultiRolePlugin()
+            : this("com.test.multi", "1.0.0")
+        {
+        }
+
+        public MultiRolePlugin(string pluginId, string pluginVersion)
+        {
+            _pluginId = pluginId;
+            _pluginVersion = pluginVersion;
+        }
+
+        public string PluginId => _pluginId;
         public string PluginName => "Multi";
-        public string PluginVersion => "1.0.0";
+        public string PluginVersion => _pluginVersion;
         public string ProviderId => "multi";
         public string ProviderDisplayName => "Multi";
         public bool IsConfigured => true;

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
@@ -154,14 +154,14 @@ public class PluginManagerTests : IDisposable
     [Fact]
     public void BuildDefaultSearchDirectories_IncludesBundledPluginsBeforeUserPlugins()
     {
-        var appBaseDirectory = Path.Combine(Path.GetTempPath(), "typewhisper-app");
-        var userPluginsPath = Path.Combine(Path.GetTempPath(), "typewhisper-user", "Plugins");
+        var appBaseDirectory = Path.Join(Path.GetTempPath(), "typewhisper-app");
+        var userPluginsPath = Path.Join(Path.GetTempPath(), "typewhisper-user", "Plugins");
 
         var result = PluginManager.BuildDefaultSearchDirectories(appBaseDirectory, userPluginsPath);
 
         Assert.Equal(
             [
-                Path.Combine(appBaseDirectory, "Plugins"),
+                Path.Join(appBaseDirectory, "Plugins"),
                 userPluginsPath
             ],
             result);
@@ -178,6 +178,21 @@ public class PluginManagerTests : IDisposable
         var plugin = Assert.Single(result);
         Assert.Equal("1.0.3", plugin.Manifest.Version);
         Assert.Same(local, plugin);
+    }
+
+    [Fact]
+    public void UnloadDiscardedSearchDirectoryPlugins_DisposesPluginDroppedByOverride()
+    {
+        var bundled = CreateLoadedPlugin("com.typewhisper.groq", "1.0.2", @"C:\App\Plugins\com.typewhisper.groq");
+        var local = CreateLoadedPlugin("com.typewhisper.groq", "1.0.3", @"C:\Users\me\AppData\Local\TypeWhisper\Plugins\com.typewhisper.groq");
+        var bundledInstance = Assert.IsType<MultiRolePlugin>(bundled.Instance);
+        var localInstance = Assert.IsType<MultiRolePlugin>(local.Instance);
+
+        var preferred = PluginManager.PreferLaterSearchDirectoryPlugins([bundled, local]);
+        PluginManager.UnloadDiscardedSearchDirectoryPlugins([bundled, local], preferred);
+
+        Assert.Equal(1, bundledInstance.DisposeCount);
+        Assert.Equal(0, localInstance.DisposeCount);
     }
 
     [Fact]
@@ -300,6 +315,7 @@ public class PluginManagerTests : IDisposable
             _includeAdditionalRoles ? [_profileRole, _duplicateProfileRole] : [];
         public IReadOnlyList<ILlmProviderPlugin> AdditionalLlmProviders =>
             _includeAdditionalRoles ? [_profileRole, _duplicateProfileRole] : [];
+        public int DisposeCount { get; private set; }
 
         public void ClearAdditionalRoles() => _includeAdditionalRoles = false;
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
@@ -315,7 +331,7 @@ public class PluginManagerTests : IDisposable
             Task.FromResult(new PluginTranscriptionResult("", language ?? "", 0));
         public Task<string> ProcessAsync(string systemPrompt, string userText, string model, CancellationToken ct) =>
             Task.FromResult(userText);
-        public void Dispose() { }
+        public void Dispose() => DisposeCount++;
     }
 
     private sealed class ProfileRole :

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
@@ -282,8 +282,8 @@ public class PluginManagerTests : IDisposable
         IAdditionalTranscriptionEnginesProvider,
         IAdditionalLlmProvidersProvider
     {
-        private readonly ProfileRole _profileRole = new("com.test.multi", "openai-compatible-profile-a", "Profile A");
-        private readonly ProfileRole _duplicateProfileRole = new("com.test.multi", "openai-compatible-profile-a", "Profile A Duplicate");
+        private readonly ProfileRole _profileRole;
+        private readonly ProfileRole _duplicateProfileRole;
         private readonly string _pluginId;
         private readonly string _pluginVersion;
         private bool _includeAdditionalRoles = true;
@@ -297,6 +297,8 @@ public class PluginManagerTests : IDisposable
         {
             _pluginId = pluginId;
             _pluginVersion = pluginVersion;
+            _profileRole = new ProfileRole(pluginId, "openai-compatible-profile-a", "Profile A");
+            _duplicateProfileRole = new ProfileRole(pluginId, "openai-compatible-profile-a", "Profile A Duplicate");
         }
 
         public string PluginId => _pluginId;

--- a/tests/TypeWhisper.PluginSystem.Tests/SupertonicTtsPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SupertonicTtsPluginTests.cs
@@ -20,6 +20,7 @@ public class SupertonicTtsPluginTests
 
         Assert.Equal("com.typewhisper.supertonic-tts", root.GetProperty("id").GetString());
         Assert.Equal("Supertonic TTS", root.GetProperty("name").GetString());
+        Assert.Equal("1.0.0", root.GetProperty("minHostVersion").GetString());
         Assert.Equal("tts", root.GetProperty("category").GetString());
         Assert.Contains("tts", root.GetProperty("categories").EnumerateArray().Select(x => x.GetString()));
         Assert.True(root.GetProperty("isLocal").GetBoolean());


### PR DESCRIPTION
## Summary
- Prepare the TypeWhisper 1.0 RC branch with focused release-quality fixes and documentation.
- Fall back to WAV upload when Groq AAC compression fails while preserving cancellation behavior.
- Load bundled app plugins and user/marketplace plugins together, with user plugins overriding bundled plugins by plugin ID.
- Mark OpenAI and Supertonic TTS plugins compatible with host version 1.0.0 and harden tests around the manifest expectations.
- Add curated v1.0.0-rc1 release notes and 1.0 RC release gates/manual QA coverage.

## Validation
- `dotnet restore TypeWhisper.slnx`
- `dotnet build TypeWhisper.slnx -c Release --no-restore`
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-build` (287 passed)
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release --no-build` (1073 passed)
- Built all plugin projects in Release configuration
- Plugin smoke validation for manifests, built assemblies, localization, and scripts
- NuGet package audit passed
- Granite Speech Python package audit passed with the existing ignored advisory list checked for newly available fixes
- Local RC package dry run passed for `win-x64-rc` and `win-arm64-rc`

## Release Notes
- Local Velopack dry-run artifacts included `RELEASES-*`, `assets.*.json`, `releases.*.json`, Setup, and Portable outputs for both RC channels.
- Local dry-run `Setup.exe` files were unsigned because no signing parameters were supplied. Treat signing/publisher verification as a release gate before publishing v1.0.0-rc1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added v1.0 RC release notes plus a pre-release verification checklist.
  * Improved plugin discovery by building a deduplicated search set and resolving duplicate plugin IDs deterministically (later candidates take precedence).

* **Bug Fixes**
  * Improved Groq transcription resilience on Windows by falling back to WAV upload when audio compression fails, preserving cancellation behavior.

* **Tests**
  * Updated/expanded unit tests for plugin search/override behavior and WAV fallback transcription, including min host version expectations.

* **Documentation**
  * Updated plugin RC documentation and release testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->