### PR TITLE
Resolve Granite Speech PyTorch security alert

### DIFF
--- a/plugins/TypeWhisper.Plugin.GraniteSpeech/GraniteSpeechPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.GraniteSpeech/GraniteSpeechPlugin.cs
@@ -46,7 +46,7 @@ public sealed class GraniteSpeechPlugin : ITypeWhisperPlugin, ITranscriptionEngi
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.1";
+    public string PluginVersion => "1.0.3";
 
     // ITranscriptionEnginePlugin
     /// <summary>

--- a/plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt
+++ b/plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.11.0
+torch==2.12.1
 torchaudio==2.11.0
 transformers==5.8.1
 soundfile==0.13.1

--- a/plugins/TypeWhisper.Plugin.GraniteSpeech/manifest.json
+++ b/plugins/TypeWhisper.Plugin.GraniteSpeech/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.granite-speech",
   "name": "IBM Granite Speech (Local)",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minHostVersion": "0.8.4",
   "author": "TypeWhisper",
   "description": "Offline transcription via IBM Granite-4.0 1B Speech (ONNX Runtime)",

--- a/tests/TypeWhisper.PluginSystem.Tests/GraniteSpeechPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GraniteSpeechPluginTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using TypeWhisper.Plugin.GraniteSpeech;
 using TypeWhisper.PluginSDK.Models;
 
 namespace TypeWhisper.PluginSystem.Tests;
@@ -8,12 +9,25 @@ public sealed class GraniteSpeechPluginTests
     [Fact]
     public void Manifest_TargetsTypeWhisper084OrNewer()
     {
-        var manifest = JsonSerializer.Deserialize<PluginManifest>(
-            TestFile.ReadProjectFile("plugins", "TypeWhisper.Plugin.GraniteSpeech", "manifest.json"),
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var manifest = ReadManifest();
 
         Assert.NotNull(manifest);
         Assert.Equal("com.typewhisper.granite-speech", manifest.Id);
         Assert.Equal("0.8.4", manifest.MinHostVersion);
     }
+
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifest = ReadManifest();
+        var sut = new GraniteSpeechPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    private static PluginManifest? ReadManifest() =>
+        JsonSerializer.Deserialize<PluginManifest>(
+            TestFile.ReadProjectFile("plugins", "TypeWhisper.Plugin.GraniteSpeech", "manifest.json"),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.WhisperCpp\TypeWhisper.Plugin.WhisperCpp.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SherpaOnnx\TypeWhisper.Plugin.SherpaOnnx.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.GraniteSpeech\TypeWhisper.Plugin.GraniteSpeech.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SmallestAi\TypeWhisper.Plugin.SmallestAi.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Cli\TypeWhisper.Cli.csproj" />


### PR DESCRIPTION
## Summary
- Update Granite Speech's PyTorch CPU requirement to `torch==2.12.1` for the open Dependabot alert on `torch`.
- Keep the verified `torchaudio==2.11.0` pairing and bump Granite Speech plugin metadata to `1.0.3`.
- Add a Granite Speech test that keeps the plugin-reported version aligned with `manifest.json`.

## Validation
- `python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu`
- `python -m pip index versions torchaudio --index-url https://download.pytorch.org/whl/cpu`
- Installed the updated Granite Speech requirements in a disposable Python 3.12.10 embedded runtime using the plugin's PyTorch CPU index command.
- Verified imports for `torch 2.12.1+cpu`, `torchaudio 2.11.0+cpu`, `transformers 5.8.1`, `soundfile 0.13.1`, and `huggingface_hub 1.21.0`.
- Verified `torchaudio.functional.resample(...)` and `python -m pip check`.
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter GraniteSpeechPluginTests`
- `dotnet test TypeWhisper.slnx --no-restore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Granite Speech plugin to version 1.0.3.

* **Bug Fixes**
  * Aligned the plugin’s reported version with the version shown in its manifest.
  * Updated a bundled dependency to a newer patch release.

* **Tests**
  * Added coverage to verify the plugin version matches its manifest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->