### PR TITLE
Include plugin scripts in release packages

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -124,6 +124,13 @@ jobs:
             Copy-Item -Path $locDir -Destination "$stagingDir/Localization" -Recurse
           }
 
+          # Copy plugin scripts if present. Some local model plugins need these
+          # Python files at runtime after the ZIP is installed from the registry.
+          $scriptsDir = "plugins/$env:PROJECT_NAME/Scripts"
+          if (Test-Path $scriptsDir) {
+            Copy-Item -Path $scriptsDir -Destination "$stagingDir/Scripts" -Recurse
+          }
+
           # Copy NuGet dependency DLLs (excluding SDK/framework assemblies)
           $excludeAssemblies = @('TypeWhisper.PluginSDK.dll')
           Get-ChildItem -Path $outputDir -Filter '*.dll' | Where-Object {
@@ -159,6 +166,10 @@ jobs:
             if (-not (Test-Path $vulkanRuntime)) {
               throw "Missing required whisper.cpp Vulkan runtime: $vulkanRuntime"
             }
+          }
+
+          if ((Test-Path $scriptsDir) -and -not (Test-Path (Join-Path $stagingDir 'Scripts'))) {
+            throw "Plugin scripts were not copied to staging: $scriptsDir"
           }
 
           # Create ZIP

--- a/plugins/TypeWhisper.Plugin.GraniteSpeech/GraniteSpeechPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.GraniteSpeech/GraniteSpeechPlugin.cs
@@ -46,7 +46,7 @@ public sealed class GraniteSpeechPlugin : ITypeWhisperPlugin, ITranscriptionEngi
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.3";
+    public string PluginVersion => "1.0.4";
 
     // ITranscriptionEnginePlugin
     /// <summary>

--- a/plugins/TypeWhisper.Plugin.GraniteSpeech/manifest.json
+++ b/plugins/TypeWhisper.Plugin.GraniteSpeech/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.granite-speech",
   "name": "IBM Granite Speech (Local)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "minHostVersion": "0.8.4",
   "author": "TypeWhisper",
   "description": "Offline transcription via IBM Granite-4.0 1B Speech (ONNX Runtime)",


### PR DESCRIPTION
## Summary
- Copy plugin `Scripts` folders into registry release ZIPs when present.
- Add a packaging guard so future script-based plugins fail the release job if scripts are not staged.
- Bump Granite Speech to `1.0.4` because `1.0.3` was published before the release package included its runtime Python scripts.

## Validation
- Local release package simulation for Granite Speech produced `com.typewhisper.granite-speech-1.0.4.zip` with `Scripts/requirements.txt` and `Scripts/granite_speech_server.py`.
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter GraniteSpeechPluginTests`
- `dotnet test TypeWhisper.slnx --no-restore`