### PR TITLE
Fix Electron target-app correction learning

### DIFF
--- a/src/TypeWhisper.Windows/Native/NativeMethods.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.cs
@@ -235,6 +235,11 @@ internal static partial class NativeMethods
 
     // Active window APIs
     /// <summary>
+    /// Defines the get ancestor root flag.
+    /// </summary>
+    public const uint GA_ROOT = 2;
+
+    /// <summary>
     /// Returns foreground window.
     /// </summary>
     [LibraryImport("user32.dll")]
@@ -253,6 +258,12 @@ internal static partial class NativeMethods
     [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool SetForegroundWindow(IntPtr hWnd);
+
+    /// <summary>
+    /// Returns an ancestor window for the supplied window handle.
+    /// </summary>
+    [LibraryImport("user32.dll")]
+    public static partial IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
 
     /// <summary>
     /// Returns window thread process id.

--- a/src/TypeWhisper.Windows/Native/NativeMethods.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.cs
@@ -241,6 +241,13 @@ internal static partial class NativeMethods
     public static partial IntPtr GetForegroundWindow();
 
     /// <summary>
+    /// Returns cursor position.
+    /// </summary>
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool GetCursorPos(out POINT lpPoint);
+
+    /// <summary>
     /// Sets foreground window.
     /// </summary>
     [LibraryImport("user32.dll")]
@@ -264,6 +271,23 @@ internal static partial class NativeMethods
     /// </summary>
     [LibraryImport("user32.dll", SetLastError = true)]
     public static partial int GetWindowTextLengthW(IntPtr hWnd);
+
+    /// <summary>
+    /// Represents a Win32 point.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct POINT
+    {
+        /// <summary>
+        /// Gets or sets the x coordinate.
+        /// </summary>
+        public int X;
+
+        /// <summary>
+        /// Gets or sets the y coordinate.
+        /// </summary>
+        public int Y;
+    }
 
     // Navigation / editing keys
     /// <summary>

--- a/src/TypeWhisper.Windows/Services/TargetAppCorrectionCommitObserver.cs
+++ b/src/TypeWhisper.Windows/Services/TargetAppCorrectionCommitObserver.cs
@@ -130,6 +130,9 @@ public sealed class TargetAppCorrectionCommitObserver : ITargetAppCorrectionComm
 
     private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
+        if (nCode < 0)
+            return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
+
         try
         {
             var hookStruct = Marshal.PtrToStructure<NativeMethods.KBDLLHOOKSTRUCT>(lParam);

--- a/src/TypeWhisper.Windows/Services/TargetAppCorrectionCommitObserver.cs
+++ b/src/TypeWhisper.Windows/Services/TargetAppCorrectionCommitObserver.cs
@@ -1,10 +1,18 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows;
+using TypeWhisper.Windows.Native;
+
 namespace TypeWhisper.Windows.Services;
 
 /// <summary>
-/// Stores explicit target-app correction commit signals.
+/// Observes explicit target-app correction commit signals.
 /// </summary>
 public sealed class TargetAppCorrectionCommitObserver : ITargetAppCorrectionCommitObserver
 {
+    private readonly object _hookLock = new();
+    private readonly NativeMethods.LowLevelKeyboardProc _proc;
+    private IntPtr _hookId;
     private int _commitSignal;
     private bool _disposed;
 
@@ -13,6 +21,7 @@ public sealed class TargetAppCorrectionCommitObserver : ITargetAppCorrectionComm
     /// </summary>
     public TargetAppCorrectionCommitObserver()
     {
+        _proc = HookCallback;
     }
 
     /// <summary>
@@ -21,6 +30,7 @@ public sealed class TargetAppCorrectionCommitObserver : ITargetAppCorrectionComm
     public void Start()
     {
         Interlocked.Exchange(ref _commitSignal, 0);
+        StartHook();
     }
 
     /// <summary>
@@ -29,6 +39,7 @@ public sealed class TargetAppCorrectionCommitObserver : ITargetAppCorrectionComm
     public void Stop()
     {
         Interlocked.Exchange(ref _commitSignal, 0);
+        StopHook();
     }
 
     /// <summary>
@@ -43,6 +54,94 @@ public sealed class TargetAppCorrectionCommitObserver : ITargetAppCorrectionComm
     public void SignalCommitForAutomation()
     {
         Interlocked.Exchange(ref _commitSignal, 1);
+    }
+
+    internal static bool ShouldSignalCommitKey(
+        int nCode,
+        IntPtr wParam,
+        in NativeMethods.KBDLLHOOKSTRUCT hookStruct)
+    {
+        if (nCode < 0 ||
+            (wParam != NativeMethods.WM_KEYDOWN && wParam != NativeMethods.WM_SYSKEYDOWN) ||
+            (hookStruct.flags & NativeMethods.LLKHF_INJECTED) != 0)
+        {
+            return false;
+        }
+
+        return hookStruct.vkCode == (uint)NativeMethods.VK_RETURN ||
+            hookStruct.vkCode == (uint)NativeMethods.VK_TAB;
+    }
+
+    private void StartHook()
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is not null && !dispatcher.CheckAccess())
+        {
+            dispatcher.Invoke(StartHookOnCurrentThread);
+            return;
+        }
+
+        StartHookOnCurrentThread();
+    }
+
+    private void StartHookOnCurrentThread()
+    {
+        lock (_hookLock)
+        {
+            if (_hookId != IntPtr.Zero)
+                return;
+
+            using var process = Process.GetCurrentProcess();
+            using var module = process.MainModule;
+            if (module is null)
+                return;
+
+            _hookId = NativeMethods.SetWindowsHookExW(
+                NativeMethods.WH_KEYBOARD_LL,
+                _proc,
+                NativeMethods.GetModuleHandleW(module.ModuleName),
+                0);
+        }
+    }
+
+    private void StopHook()
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is not null && !dispatcher.CheckAccess())
+        {
+            dispatcher.Invoke(StopHookOnCurrentThread);
+            return;
+        }
+
+        StopHookOnCurrentThread();
+    }
+
+    private void StopHookOnCurrentThread()
+    {
+        lock (_hookLock)
+        {
+            if (_hookId == IntPtr.Zero)
+                return;
+
+            NativeMethods.UnhookWindowsHookEx(_hookId);
+            _hookId = IntPtr.Zero;
+        }
+    }
+
+    private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        try
+        {
+            var hookStruct = Marshal.PtrToStructure<NativeMethods.KBDLLHOOKSTRUCT>(lParam);
+            if (ShouldSignalCommitKey(nCode, wParam, hookStruct))
+                Interlocked.Exchange(ref _commitSignal, 1);
+        }
+        catch (ArgumentException ex)
+        {
+            Debug.WriteLine($"Target-app correction commit hook failed: {ex.Message}");
+        }
+
+        return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
     }
 
     /// <summary>

--- a/src/TypeWhisper.Windows/Services/TargetAppCorrectionLearningService.cs
+++ b/src/TypeWhisper.Windows/Services/TargetAppCorrectionLearningService.cs
@@ -13,12 +13,14 @@ namespace TypeWhisper.Windows.Services;
 /// <param name="WindowHandle">Owning top-level window handle.</param>
 /// <param name="MaxValueLength">Maximum text length this observation may read on recapture.</param>
 /// <param name="Element">Captured UI Automation element used for bounded recapture after focus leaves.</param>
+/// <param name="AllowElementKeyChangeOnCommit">Whether an explicit commit may accept a same-window recapture with a changed element key.</param>
 public sealed record TargetAppTextObservation(
     string ElementKey,
     string Value,
     IntPtr WindowHandle,
     int MaxValueLength = 4096,
-    AutomationElement? Element = null);
+    AutomationElement? Element = null,
+    bool AllowElementKeyChangeOnCommit = false);
 
 /// <summary>
 /// Lists possible focus relationships for a previously observed text element.
@@ -34,6 +36,11 @@ public enum TargetAppTextElementMatch
     /// Focus moved to a different element or window.
     /// </summary>
     Different,
+
+    /// <summary>
+    /// Focus moved to another top-level window or process.
+    /// </summary>
+    DifferentWindow,
 
     /// <summary>
     /// The current focus state could not be observed safely.
@@ -56,6 +63,16 @@ public interface ITargetAppTextObserver
     /// </summary>
     TargetAppTextObservation? Capture(IntPtr targetHwnd, int maxTextLength, string preferredText)
         => Capture(targetHwnd, maxTextLength);
+
+    /// <summary>
+    /// Best-effort capture that may inspect descendant text elements when focus alone is insufficient.
+    /// </summary>
+    TargetAppTextObservation? CaptureDeep(
+        IntPtr targetHwnd,
+        int maxTextLength,
+        string preferredText,
+        bool allowDescendantScan = false)
+        => Capture(targetHwnd, maxTextLength, preferredText);
 
     /// <summary>
     /// Recaptures the same text element if it is still observable.
@@ -212,7 +229,26 @@ public sealed class TargetAppCorrectionLearningService
                 if (focusMatch == TargetAppTextElementMatch.Unavailable)
                     continue;
 
-                return LearnFromCurrentObservation(insertedText, baseline, lastObserved);
+                if (focusMatch == TargetAppTextElementMatch.Different)
+                {
+                    if (baseline.AllowElementKeyChangeOnCommit)
+                    {
+                        if (TryRecaptureCommittedElement(baseline) is { } current)
+                            lastObserved = current;
+
+                        continue;
+                    }
+
+                    return LearnFromCurrentObservation(insertedText, baseline, lastObserved);
+                }
+
+                var learned = LearnFromCurrentObservation(insertedText, baseline, lastObserved);
+                if (learned.Count > 0 ||
+                    !baseline.AllowElementKeyChangeOnCommit ||
+                    focusMatch == TargetAppTextElementMatch.DifferentWindow)
+                {
+                    return learned;
+                }
             }
         }
         catch (OperationCanceledException)
@@ -243,7 +279,7 @@ public sealed class TargetAppCorrectionLearningService
         TargetAppTextObservation baseline,
         TargetAppTextObservation fallbackObservation)
     {
-        var current = TryRecaptureSameElement(baseline);
+        var current = TryRecaptureCommittedElement(baseline);
         if (current is null ||
             (string.Equals(current.Value, baseline.Value, StringComparison.Ordinal) &&
              !string.Equals(fallbackObservation.Value, baseline.Value, StringComparison.Ordinal)))
@@ -257,6 +293,21 @@ public sealed class TargetAppCorrectionLearningService
         var current = _textObserver.Recapture(baseline);
         return current is not null &&
             string.Equals(current.ElementKey, baseline.ElementKey, StringComparison.Ordinal)
+            ? current
+            : null;
+    }
+
+    private TargetAppTextObservation? TryRecaptureCommittedElement(TargetAppTextObservation baseline)
+    {
+        var current = _textObserver.Recapture(baseline);
+        if (current is null)
+            return null;
+
+        if (string.Equals(current.ElementKey, baseline.ElementKey, StringComparison.Ordinal))
+            return current;
+
+        return baseline.AllowElementKeyChangeOnCommit &&
+            current.WindowHandle == baseline.WindowHandle
                 ? current
                 : null;
     }

--- a/src/TypeWhisper.Windows/Services/TargetAppTextObservationService.cs
+++ b/src/TypeWhisper.Windows/Services/TargetAppTextObservationService.cs
@@ -406,13 +406,16 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
                     continue;
                 }
 
-                var observation = CaptureElement(
+                var observationCandidate = CaptureElement(
                     candidate,
                     targetHwnd,
                     maxTextLength,
                     allowElementKeyChangeOnCommit: true);
-                if (observation?.Value.Contains(preferredText, StringComparison.Ordinal) != true)
+                if (observationCandidate is not { } observation ||
+                    !observation.Value.Contains(preferredText, StringComparison.Ordinal))
+                {
                     continue;
+                }
 
                 if (match is not null &&
                     !string.Equals(match.ElementKey, observation.ElementKey, StringComparison.Ordinal))

--- a/src/TypeWhisper.Windows/Services/TargetAppTextObservationService.cs
+++ b/src/TypeWhisper.Windows/Services/TargetAppTextObservationService.cs
@@ -21,19 +21,52 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
     public TargetAppTextObservation? Capture(IntPtr targetHwnd, int maxTextLength, string preferredText) =>
         CaptureCore(targetHwnd, maxTextLength, string.IsNullOrEmpty(preferredText) ? null : preferredText);
 
+    /// <summary>
+    /// Best-effort capture that may inspect descendant text elements when focus alone is insufficient.
+    /// </summary>
+    public TargetAppTextObservation? CaptureDeep(
+        IntPtr targetHwnd,
+        int maxTextLength,
+        string preferredText,
+        bool allowDescendantScan = false)
+    {
+        var normalizedPreferredText = string.IsNullOrEmpty(preferredText) ? null : preferredText;
+        var focused = CaptureCore(targetHwnd, maxTextLength, normalizedPreferredText);
+        if (focused is not null || normalizedPreferredText is null)
+            return focused;
+
+        if (targetHwnd == IntPtr.Zero)
+            return null;
+
+        var observableWindow = ResolveObservableWindow(targetHwnd);
+        var pointed = CaptureElementAtCursor(
+            observableWindow,
+            maxTextLength,
+            normalizedPreferredText,
+            allowElementKeyChangeOnCommit: true);
+        if (pointed is not null)
+            return pointed;
+
+        if (!allowDescendantScan)
+            return null;
+
+        return CaptureUniqueDescendantContaining(observableWindow, maxTextLength, normalizedPreferredText);
+    }
+
     private static TargetAppTextObservation? CaptureCore(IntPtr targetHwnd, int maxTextLength, string? preferredText)
     {
         if (targetHwnd == IntPtr.Zero)
             return null;
 
-        var focused = CaptureFocusedElement(targetHwnd, maxTextLength);
+        var observableWindow = ResolveObservableWindow(targetHwnd);
+        var focused = CaptureFocusedElement(observableWindow, maxTextLength);
         if (preferredText is null ||
             focused?.Value.Contains(preferredText, StringComparison.Ordinal) == true)
         {
             return focused;
         }
 
-        return CaptureUniqueDescendantContaining(targetHwnd, maxTextLength, preferredText);
+        return null;
     }
 
     /// <summary>
@@ -46,10 +79,15 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
             if (baseline.Element is { } baselineElement)
             {
                 var baselineElementKey = GetElementKey(baselineElement);
-                if (!string.Equals(baselineElementKey, baseline.ElementKey, StringComparison.Ordinal))
-                    return null;
+                if (string.Equals(baselineElementKey, baseline.ElementKey, StringComparison.Ordinal) &&
+                    CaptureElement(baselineElement, baseline.WindowHandle, baseline.MaxValueLength) is { } captured)
+                {
+                    return captured;
+                }
 
-                return CaptureElement(baselineElement, baseline.WindowHandle, baseline.MaxValueLength);
+                return baseline.AllowElementKeyChangeOnCommit
+                    ? CaptureElementAtCursor(baseline.WindowHandle, baseline.MaxValueLength)
+                    : null;
             }
 
             var element = AutomationElement.FocusedElement;
@@ -81,8 +119,11 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
         try
         {
             var foreground = NativeMethods.GetForegroundWindow();
-            if (foreground != IntPtr.Zero && foreground != baseline.WindowHandle)
-                return TargetAppTextElementMatch.Different;
+            if (foreground != IntPtr.Zero &&
+                ResolveObservableWindow(baseline.WindowHandle, foreground, GetWindowProcessId) != foreground)
+            {
+                return TargetAppTextElementMatch.DifferentWindow;
+            }
 
             var element = AutomationElement.FocusedElement;
             var currentKey = GetElementKey(element);
@@ -110,7 +151,8 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
     private static TargetAppTextObservation? CaptureElement(
         AutomationElement element,
         IntPtr windowHandle,
-        int maxTextLength)
+        int maxTextLength,
+        bool allowElementKeyChangeOnCommit = false)
     {
         if (element is null)
             return null;
@@ -127,7 +169,13 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
         var value = ReadPlainText(element, maxTextLength);
         return value is null
             ? null
-            : new TargetAppTextObservation(elementKey, value, windowHandle, maxTextLength, element);
+            : new TargetAppTextObservation(
+                elementKey,
+                value,
+                windowHandle,
+                maxTextLength,
+                element,
+                allowElementKeyChangeOnCommit);
     }
 
     private static TargetAppTextObservation? CaptureFocusedElement(IntPtr targetHwnd, int maxTextLength)
@@ -153,42 +201,42 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
         }
     }
 
-    private static TargetAppTextObservation? CaptureUniqueDescendantContaining(
+    private static TargetAppTextObservation? CaptureElementAtCursor(
         IntPtr targetHwnd,
         int maxTextLength,
-        string preferredText)
+        string? preferredText = null,
+        bool allowElementKeyChangeOnCommit = false)
     {
         try
         {
-            var root = AutomationElement.FromHandle(targetHwnd);
-            if (root is null)
+            if (!NativeMethods.GetCursorPos(out var cursor))
                 return null;
 
-            var textCondition = new OrCondition(
-                new PropertyCondition(AutomationElement.IsTextPatternAvailableProperty, true),
-                new PropertyCondition(AutomationElement.IsValuePatternAvailableProperty, true));
-            var elements = root.FindAll(TreeScope.Element | TreeScope.Descendants, textCondition);
-            TargetAppTextObservation? match = null;
+            var element = AutomationElement.FromPoint(new System.Windows.Point(cursor.X, cursor.Y));
+            if (!IsElementInWindow(element, targetHwnd))
+                return null;
 
-            foreach (AutomationElement element in elements)
+            var walker = TreeWalker.ControlViewWalker;
+            var current = element;
+            while (current is not null && current != AutomationElement.RootElement)
             {
-                var observation = CaptureElement(element, targetHwnd, maxTextLength);
-                if (observation is null ||
-                    !observation.Value.Contains(preferredText, StringComparison.Ordinal))
+                var observation = CaptureElement(
+                    current,
+                    targetHwnd,
+                    maxTextLength,
+                    allowElementKeyChangeOnCommit);
+                if (observation is not null &&
+                    (preferredText is null ||
+                     observation.Value.Contains(preferredText, StringComparison.Ordinal)))
                 {
-                    continue;
+                    return observation;
                 }
 
-                if (match is not null &&
-                    !string.Equals(match.ElementKey, observation.ElementKey, StringComparison.Ordinal))
-                {
+                if ((IntPtr)current.Current.NativeWindowHandle == targetHwnd)
                     return null;
-                }
 
-                match = observation;
+                current = walker.GetParent(current);
             }
-
-            return match;
         }
         catch (ElementNotAvailableException)
         {
@@ -202,6 +250,38 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
         {
             return null;
         }
+
+        return null;
+    }
+
+    internal static IntPtr ResolveObservableWindow(
+        IntPtr targetHwnd,
+        IntPtr foregroundHwnd,
+        Func<IntPtr, uint> getProcessId)
+    {
+        if (targetHwnd == IntPtr.Zero ||
+            foregroundHwnd == IntPtr.Zero ||
+            foregroundHwnd == targetHwnd)
+        {
+            return targetHwnd;
+        }
+
+        var targetProcessId = getProcessId(targetHwnd);
+        return targetProcessId != 0 && targetProcessId == getProcessId(foregroundHwnd)
+            ? foregroundHwnd
+            : targetHwnd;
+    }
+
+    private static IntPtr ResolveObservableWindow(IntPtr targetHwnd) =>
+        ResolveObservableWindow(targetHwnd, NativeMethods.GetForegroundWindow(), GetWindowProcessId);
+
+    private static uint GetWindowProcessId(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero)
+            return 0;
+
+        NativeMethods.GetWindowThreadProcessId(hwnd, out var processId);
+        return processId;
     }
 
     private static string? ReadPlainText(AutomationElement element, int maxTextLength)
@@ -300,5 +380,62 @@ public sealed class TargetAppTextObservationService : ITargetAppTextObserver
         }
 
         return false;
+    }
+
+    private static TargetAppTextObservation? CaptureUniqueDescendantContaining(
+        IntPtr targetHwnd,
+        int maxTextLength,
+        string preferredText)
+    {
+        if (targetHwnd == IntPtr.Zero || string.IsNullOrEmpty(preferredText))
+            return null;
+
+        try
+        {
+            var root = AutomationElement.FromHandle(targetHwnd);
+            var candidates = root.FindAll(TreeScope.Descendants, new OrCondition(
+                new PropertyCondition(AutomationElement.IsTextPatternAvailableProperty, true),
+                new PropertyCondition(AutomationElement.IsValuePatternAvailableProperty, true)));
+            TargetAppTextObservation? match = null;
+
+            foreach (AutomationElement candidate in candidates)
+            {
+                if (!candidate.TryGetCurrentPattern(TextPattern.Pattern, out _) &&
+                    !candidate.TryGetCurrentPattern(ValuePattern.Pattern, out _))
+                {
+                    continue;
+                }
+
+                var observation = CaptureElement(
+                    candidate,
+                    targetHwnd,
+                    maxTextLength,
+                    allowElementKeyChangeOnCommit: true);
+                if (observation?.Value.Contains(preferredText, StringComparison.Ordinal) != true)
+                    continue;
+
+                if (match is not null &&
+                    !string.Equals(match.ElementKey, observation.ElementKey, StringComparison.Ordinal))
+                {
+                    return null;
+                }
+
+                match = observation;
+            }
+
+            return match;
+        }
+        catch (ElementNotAvailableException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
     }
 }

--- a/src/TypeWhisper.Windows/Services/TextInsertionService.cs
+++ b/src/TypeWhisper.Windows/Services/TextInsertionService.cs
@@ -219,8 +219,8 @@ public sealed class TextInsertionService
         if (foregroundHwnd == IntPtr.Zero || targetHwnd == IntPtr.Zero)
             return false;
 
-        var targetProcessId = _platform.GetWindowProcessId(targetHwnd);
-        return targetProcessId != 0 && targetProcessId == _platform.GetWindowProcessId(foregroundHwnd);
+        var targetRoot = _platform.GetRootWindow(targetHwnd);
+        return targetRoot != IntPtr.Zero && targetRoot == _platform.GetRootWindow(foregroundHwnd);
     }
 
     private async Task<string?> WaitForClipboardTextChangeAsync(string marker)
@@ -296,6 +296,7 @@ internal interface ITextInsertionPlatform
     IntPtr GetForegroundWindow();
     bool SetForegroundWindow(IntPtr hwnd);
     uint GetWindowProcessId(IntPtr hwnd);
+    IntPtr GetRootWindow(IntPtr hwnd);
     uint SendModifierKeyUpInputs();
     uint SendForegroundActivationInput();
     uint SendCopyInput();
@@ -427,6 +428,18 @@ internal sealed class WindowsTextInsertionPlatform : ITextInsertionPlatform
 
         NativeMethods.GetWindowThreadProcessId(hwnd, out var processId);
         return processId;
+    }
+
+    /// <summary>
+    /// Returns the root ancestor for the supplied window handle.
+    /// </summary>
+    public IntPtr GetRootWindow(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero)
+            return IntPtr.Zero;
+
+        var root = NativeMethods.GetAncestor(hwnd, NativeMethods.GA_ROOT);
+        return root == IntPtr.Zero ? hwnd : root;
     }
 
     /// <summary>

--- a/src/TypeWhisper.Windows/Services/TextInsertionService.cs
+++ b/src/TypeWhisper.Windows/Services/TextInsertionService.cs
@@ -213,7 +213,14 @@ public sealed class TextInsertionService
     private bool IsTargetForeground(IntPtr targetHwnd)
     {
         var foregroundHwnd = _platform.GetForegroundWindow();
-        return foregroundHwnd == targetHwnd;
+        if (foregroundHwnd == targetHwnd)
+            return true;
+
+        if (foregroundHwnd == IntPtr.Zero || targetHwnd == IntPtr.Zero)
+            return false;
+
+        var targetProcessId = _platform.GetWindowProcessId(targetHwnd);
+        return targetProcessId != 0 && targetProcessId == _platform.GetWindowProcessId(foregroundHwnd);
     }
 
     private async Task<string?> WaitForClipboardTextChangeAsync(string marker)

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -1781,85 +1781,88 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         Task? backgroundTask = null;
         backgroundTask = Task.Run(async () =>
         {
-            try
+            using (cts)
             {
-                var maxObservedTextLength = TargetAppCorrectionLearningService.GetMaxObservedTextLength(insertedText);
-                var baselineResult = await CaptureTargetAppCorrectionBaselineAsync(
-                    insertedText,
-                    preferredText => observer.CaptureDeep(
-                        targetWindowHandle,
-                        maxObservedTextLength,
-                        preferredText,
-                        allowDescendantScan: true),
-                    TargetAppCorrectionBaselineRetryDelays,
-                    Task.Delay,
-                    cts.Token).ConfigureAwait(false);
-
-                if (baselineResult.Baseline is null)
-                    return;
-
-                trackingCts = CancellationTokenSource.CreateLinkedTokenSource(_consumerCts.Token);
-                lock (_targetAppCorrectionLearningSync)
+                try
                 {
-                    if (!ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                    var maxObservedTextLength = TargetAppCorrectionLearningService.GetMaxObservedTextLength(insertedText);
+                    var baselineResult = await CaptureTargetAppCorrectionBaselineAsync(
+                        insertedText,
+                        preferredText => observer.CaptureDeep(
+                            targetWindowHandle,
+                            maxObservedTextLength,
+                            preferredText,
+                            allowDescendantScan: true),
+                        TargetAppCorrectionBaselineRetryDelays,
+                        Task.Delay,
+                        cts.Token).ConfigureAwait(false);
+
+                    if (baselineResult.Baseline is null)
                         return;
 
-                    _targetAppCorrectionLearningCts = trackingCts;
-                }
-
-                var learned = await learning
-                    .TrackInsertionAsync(insertedText, baselineResult.Baseline, trackingCts.Token)
-                    .ConfigureAwait(false);
-
-                if (learned.Count == 0 || trackingCts.IsCancellationRequested)
-                    return;
-
-                DispatchToUi(() => ShowLearnedCorrectionsFeedback(learned));
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected when the background capture times out or a newer recording starts.
-            }
-            catch (System.Windows.Automation.ElementNotAvailableException ex)
-            {
-                LogTargetAppCorrectionLearningFailure(ex);
-            }
-            catch (ObjectDisposedException ex)
-            {
-                LogTargetAppCorrectionLearningFailure(ex);
-            }
-            catch (InvalidOperationException ex)
-            {
-                LogTargetAppCorrectionLearningFailure(ex);
-            }
-            catch (IOException ex)
-            {
-                LogTargetAppCorrectionLearningFailure(ex);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                LogTargetAppCorrectionLearningFailure(ex);
-            }
-            catch (System.Runtime.InteropServices.COMException ex)
-            {
-                LogTargetAppCorrectionLearningFailure(ex);
-            }
-            finally
-            {
-                lock (_targetAppCorrectionLearningSync)
-                {
-                    if (ReferenceEquals(_targetAppCorrectionLearningCts, trackingCts) ||
-                        ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                    trackingCts = CancellationTokenSource.CreateLinkedTokenSource(_consumerCts.Token);
+                    using (trackingCts)
                     {
-                        _targetAppCorrectionLearningCts = null;
+                        lock (_targetAppCorrectionLearningSync)
+                        {
+                            if (!ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                                return;
+
+                            _targetAppCorrectionLearningCts = trackingCts;
+                        }
+
+                        var learned = await learning
+                            .TrackInsertionAsync(insertedText, baselineResult.Baseline, trackingCts.Token)
+                            .ConfigureAwait(false);
+
+                        if (learned.Count == 0 || trackingCts.IsCancellationRequested)
+                            return;
+
+                        DispatchToUi(() => ShowLearnedCorrectionsFeedback(learned));
                     }
-
-                    if (ReferenceEquals(_targetAppCorrectionLearningTask, backgroundTask))
-                        _targetAppCorrectionLearningTask = null;
                 }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the background capture times out or a newer recording starts.
+                }
+                catch (System.Windows.Automation.ElementNotAvailableException ex)
+                {
+                    LogTargetAppCorrectionLearningFailure(ex);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    LogTargetAppCorrectionLearningFailure(ex);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    LogTargetAppCorrectionLearningFailure(ex);
+                }
+                catch (IOException ex)
+                {
+                    LogTargetAppCorrectionLearningFailure(ex);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    LogTargetAppCorrectionLearningFailure(ex);
+                }
+                catch (System.Runtime.InteropServices.COMException ex)
+                {
+                    LogTargetAppCorrectionLearningFailure(ex);
+                }
+                finally
+                {
+                    lock (_targetAppCorrectionLearningSync)
+                    {
+                        if (ReferenceEquals(_targetAppCorrectionLearningCts, trackingCts) ||
+                            ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                        {
+                            _targetAppCorrectionLearningCts = null;
+                        }
 
-                trackingCts?.Dispose();
-                cts.Dispose();
+                        if (ReferenceEquals(_targetAppCorrectionLearningTask, backgroundTask))
+                            _targetAppCorrectionLearningTask = null;
+                    }
+                }
             }
         });
 
@@ -2098,17 +2101,35 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         Func<TimeSpan, CancellationToken, Task> delayAsync,
         TimeSpan timeout,
         CancellationToken cancellationToken)
-        => await Task.Run(
-                async () => await CaptureTargetAppCorrectionBaselineAsync(
-                        insertedText,
-                        capture,
-                        retryDelays,
-                        delayAsync,
-                        cancellationToken)
-                    .ConfigureAwait(false),
-                CancellationToken.None)
-            .WaitAsync(timeout, cancellationToken)
-            .ConfigureAwait(false);
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var captureTask = Task.Run(
+            async () => await CaptureTargetAppCorrectionBaselineAsync(
+                    insertedText,
+                    capture,
+                    retryDelays,
+                    delayAsync,
+                    timeoutCts.Token)
+                .ConfigureAwait(false),
+            CancellationToken.None);
+
+        try
+        {
+            return await captureTask
+                .WaitAsync(timeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            timeoutCts.Cancel();
+            _ = captureTask.ContinueWith(
+                static task => _ = task.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            throw;
+        }
+    }
 
     internal static async Task<TargetAppCorrectionBaselineResult> CaptureTargetAppCorrectionBaselineAsync(
         string insertedText,

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -128,6 +128,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     private const string ExternalLiveTranscriptPluginId = "com.typewhisper.live-transcript";
     private static readonly IReadOnlyList<TimeSpan> TargetAppCorrectionBaselineRetryDelays =
         Enumerable.Repeat(TimeSpan.FromMilliseconds(50), 10).ToArray();
+    private static readonly TimeSpan TargetAppCorrectionBackgroundStartTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan TargetAppCorrectionAutomationStartTimeout = TimeSpan.FromSeconds(2);
     private readonly object _apiSessionLock = new();
     private readonly Dictionary<Guid, ApiDictationSessionSnapshot> _apiDictationSessions = [];
     private readonly List<Guid> _apiDictationSessionOrder = [];
@@ -1618,7 +1620,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                         job.ActiveWorkflow?.Output.AutoEnter == true,
                         job.CapturedWindowHandle);
                     textInsertedEventText = insertionText;
-                    await StartTargetAppCorrectionLearningIfEligibleAsync(job, insertionText, insertResult, ct);
+                    StartTargetAppCorrectionLearningInBackground(job, insertionText, insertResult);
                 }
             }
             else
@@ -1636,7 +1638,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                     job.ActiveWorkflow?.Output.AutoEnter == true,
                     job.CapturedWindowHandle);
                 textInsertedEventText = insertionText;
-                await StartTargetAppCorrectionLearningIfEligibleAsync(job, insertionText, insertResult, ct);
+                StartTargetAppCorrectionLearningInBackground(job, insertionText, insertResult);
             }
 
             _eventBus.Publish(new TextInsertedEvent
@@ -1740,6 +1742,134 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         return result.Started;
     }
 
+    private void StartTargetAppCorrectionLearningInBackground(
+        TranscriptionJob job,
+        string insertedText,
+        InsertionResult insertResult)
+        => StartTargetAppCorrectionLearningInBackground(
+            job.ActiveWorkflow,
+            job.CapturedWindowHandle,
+            insertedText,
+            insertResult);
+
+    private void StartTargetAppCorrectionLearningInBackground(
+        Workflow? activeWorkflow,
+        IntPtr targetWindowHandle,
+        string insertedText,
+        InsertionResult insertResult)
+    {
+        if (GetTargetAppCorrectionLearningSkipReason(activeWorkflow, insertedText) is not null ||
+            insertResult != InsertionResult.Pasted ||
+            _targetAppTextObserver is null ||
+            _targetAppCorrectionLearning is null)
+        {
+            return;
+        }
+
+        var observer = _targetAppTextObserver;
+        var learning = _targetAppCorrectionLearning;
+        CancelTargetAppCorrectionLearning();
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(_consumerCts.Token);
+        cts.CancelAfter(TargetAppCorrectionBackgroundStartTimeout);
+        lock (_targetAppCorrectionLearningSync)
+        {
+            _targetAppCorrectionLearningCts = cts;
+        }
+
+        CancellationTokenSource? trackingCts = null;
+        Task? backgroundTask = null;
+        backgroundTask = Task.Run(async () =>
+        {
+            try
+            {
+                var maxObservedTextLength = TargetAppCorrectionLearningService.GetMaxObservedTextLength(insertedText);
+                var baselineResult = await CaptureTargetAppCorrectionBaselineAsync(
+                    insertedText,
+                    preferredText => observer.CaptureDeep(
+                        targetWindowHandle,
+                        maxObservedTextLength,
+                        preferredText,
+                        allowDescendantScan: true),
+                    TargetAppCorrectionBaselineRetryDelays,
+                    Task.Delay,
+                    cts.Token).ConfigureAwait(false);
+
+                if (baselineResult.Baseline is null)
+                    return;
+
+                trackingCts = CancellationTokenSource.CreateLinkedTokenSource(_consumerCts.Token);
+                lock (_targetAppCorrectionLearningSync)
+                {
+                    if (!ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                        return;
+
+                    _targetAppCorrectionLearningCts = trackingCts;
+                }
+
+                var learned = await learning
+                    .TrackInsertionAsync(insertedText, baselineResult.Baseline, trackingCts.Token)
+                    .ConfigureAwait(false);
+
+                if (learned.Count == 0 || trackingCts.IsCancellationRequested)
+                    return;
+
+                DispatchToUi(() => ShowLearnedCorrectionsFeedback(learned));
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the background capture times out or a newer recording starts.
+            }
+            catch (System.Windows.Automation.ElementNotAvailableException ex)
+            {
+                LogTargetAppCorrectionLearningFailure(ex);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                LogTargetAppCorrectionLearningFailure(ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogTargetAppCorrectionLearningFailure(ex);
+            }
+            catch (IOException ex)
+            {
+                LogTargetAppCorrectionLearningFailure(ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogTargetAppCorrectionLearningFailure(ex);
+            }
+            catch (System.Runtime.InteropServices.COMException ex)
+            {
+                LogTargetAppCorrectionLearningFailure(ex);
+            }
+            finally
+            {
+                lock (_targetAppCorrectionLearningSync)
+                {
+                    if (ReferenceEquals(_targetAppCorrectionLearningCts, trackingCts) ||
+                        ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                    {
+                        _targetAppCorrectionLearningCts = null;
+                    }
+
+                    if (ReferenceEquals(_targetAppCorrectionLearningTask, backgroundTask))
+                        _targetAppCorrectionLearningTask = null;
+                }
+
+                trackingCts?.Dispose();
+                cts.Dispose();
+            }
+        });
+
+        lock (_targetAppCorrectionLearningSync)
+        {
+            if (ReferenceEquals(_targetAppCorrectionLearningCts, cts))
+                _targetAppCorrectionLearningTask = backgroundTask;
+        }
+    }
+
     private async Task<TargetAppCorrectionLearningStartResult> TryStartTargetAppCorrectionLearningAsync(
         Workflow? activeWorkflow,
         IntPtr targetWindowHandle,
@@ -1764,12 +1894,21 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         try
         {
             var maxObservedTextLength = TargetAppCorrectionLearningService.GetMaxObservedTextLength(insertedText);
-            baselineResult = await CaptureTargetAppCorrectionBaselineAsync(
+            baselineResult = await CaptureTargetAppCorrectionBaselineWithTimeoutAsync(
                 insertedText,
-                preferredText => _targetAppTextObserver.Capture(targetWindowHandle, maxObservedTextLength, preferredText),
+                preferredText => _targetAppTextObserver.CaptureDeep(
+                    targetWindowHandle,
+                    maxObservedTextLength,
+                    preferredText,
+                    allowDescendantScan: false),
                 TargetAppCorrectionBaselineRetryDelays,
                 Task.Delay,
+                TargetAppCorrectionAutomationStartTimeout,
                 cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            return new TargetAppCorrectionLearningStartResult(false, "capture_timeout");
         }
         catch (OperationCanceledException)
         {
@@ -1952,6 +2091,25 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             delayAsync,
             cancellationToken);
 
+    internal static async Task<TargetAppCorrectionBaselineResult> CaptureTargetAppCorrectionBaselineWithTimeoutAsync(
+        string insertedText,
+        Func<string, TargetAppTextObservation?> capture,
+        IReadOnlyList<TimeSpan> retryDelays,
+        Func<TimeSpan, CancellationToken, Task> delayAsync,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+        => await Task.Run(
+                async () => await CaptureTargetAppCorrectionBaselineAsync(
+                        insertedText,
+                        capture,
+                        retryDelays,
+                        delayAsync,
+                        cancellationToken)
+                    .ConfigureAwait(false),
+                CancellationToken.None)
+            .WaitAsync(timeout, cancellationToken)
+            .ConfigureAwait(false);
+
     internal static async Task<TargetAppCorrectionBaselineResult> CaptureTargetAppCorrectionBaselineAsync(
         string insertedText,
         Func<string, TargetAppTextObservation?> capture,
@@ -1965,6 +2123,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         {
             cancellationToken.ThrowIfCancellationRequested();
             lastObservation = capture(insertedText);
+            cancellationToken.ThrowIfCancellationRequested();
             if (lastObservation?.Value.Contains(insertedText, StringComparison.Ordinal) == true)
                 return new TargetAppCorrectionBaselineResult(lastObservation, null);
 

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationTargetAppCorrectionLearningGateTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationTargetAppCorrectionLearningGateTests.cs
@@ -229,10 +229,38 @@ public class DictationTargetAppCorrectionLearningGateTests
                 {
                     cts.Cancel();
                     return new TargetAppTextObservation("editable", "alpha watre beta", new IntPtr(42));
+            },
+            retryDelays: [],
+            delayAsync: (_, _) => Task.CompletedTask,
+            cts.Token));
+    }
+
+    [Fact]
+    public async Task CaptureTargetAppCorrectionBaselineWithTimeoutAsync_CancelsInnerCaptureWhenTimeoutElapses()
+    {
+        using var cts = new CancellationTokenSource();
+        var delayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delayCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken retryToken = default;
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            DictationViewModel.CaptureTargetAppCorrectionBaselineWithTimeoutAsync(
+                insertedText: "alpha watre beta",
+                capture: _ => null,
+                retryDelays: [TimeSpan.FromMinutes(1)],
+                delayAsync: (_, token) =>
+                {
+                    retryToken = token;
+                    delayStarted.SetResult();
+                    token.Register(() => delayCancelled.SetResult());
+                    return delayCancelled.Task;
                 },
-                retryDelays: [],
-                delayAsync: (_, _) => Task.CompletedTask,
+                timeout: TimeSpan.FromMilliseconds(10),
                 cts.Token));
+
+        await delayStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(retryToken.IsCancellationRequested);
+        await delayCancelled.Task.WaitAsync(TimeSpan.FromSeconds(1));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationTargetAppCorrectionLearningGateTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationTargetAppCorrectionLearningGateTests.cs
@@ -218,6 +218,24 @@ public class DictationTargetAppCorrectionLearningGateTests
     }
 
     [Fact]
+    public async Task CaptureTargetAppCorrectionBaselineAsync_ThrowsWhenCancelledAfterSlowCapture()
+    {
+        using var cts = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            DictationViewModel.CaptureTargetAppCorrectionBaselineAsync(
+                insertedText: "alpha watre beta",
+                capture: _ =>
+                {
+                    cts.Cancel();
+                    return new TargetAppTextObservation("editable", "alpha watre beta", new IntPtr(42));
+                },
+                retryDelays: [],
+                delayAsync: (_, _) => Task.CompletedTask,
+                cts.Token));
+    }
+
+    [Fact]
     public async Task CaptureTargetAppCorrectionBaselineAsync_ReturnsReasonWhenInsertedTextNeverAppears()
     {
         var result = await DictationViewModel.CaptureTargetAppCorrectionBaselineAsync(
@@ -241,11 +259,70 @@ public class DictationTargetAppCorrectionLearningGateTests
             "DictationViewModel.cs");
         var captureBlock = TestFile.ExtractBlock(
             source,
-            "baselineResult = await CaptureTargetAppCorrectionBaselineAsync",
-            1700);
+            "private async Task<TargetAppCorrectionLearningStartResult> TryStartTargetAppCorrectionLearningAsync",
+            3200);
 
         Assert.Contains("catch (UnauthorizedAccessException)", captureBlock);
         Assert.Contains("return new TargetAppCorrectionLearningStartResult(false, \"capture_error\");", captureBlock);
+    }
+
+    [Fact]
+    public void ProcessSingleJob_StartsTargetAppCorrectionLearningInBackground()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+        var processBlock = TestFile.ExtractBlock(
+            source,
+            "private async Task ProcessSingleJobAsync",
+            30000);
+
+        Assert.Contains("StartTargetAppCorrectionLearningInBackground(job, insertionText, insertResult);", processBlock);
+        Assert.DoesNotContain("await StartTargetAppCorrectionLearningIfEligibleAsync(job, insertionText, insertResult, ct);", processBlock);
+    }
+
+    [Fact]
+    public void BackgroundTargetAppCorrectionLearning_UsesTimeoutAndDeepCapture()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+        var backgroundBlock = TestFile.ExtractBlock(
+            source,
+            "private void StartTargetAppCorrectionLearningInBackground",
+            4200);
+
+        Assert.Contains("TargetAppCorrectionBackgroundStartTimeout", source);
+        Assert.Contains("cts.CancelAfter(TargetAppCorrectionBackgroundStartTimeout);", backgroundBlock);
+        Assert.Contains("_targetAppCorrectionLearningCts = cts;", backgroundBlock);
+        Assert.Contains(".CaptureDeep(", backgroundBlock);
+        Assert.Contains("allowDescendantScan: true", backgroundBlock);
+        Assert.Contains("Task.Run", backgroundBlock);
+    }
+
+    [Fact]
+    public void AutomationTargetAppCorrectionLearning_DoesNotUseSlowDescendantScan()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+        var startBlock = TestFile.ExtractBlock(
+            source,
+            "private async Task<TargetAppCorrectionLearningStartResult> TryStartTargetAppCorrectionLearningAsync",
+            3200);
+
+        Assert.Contains(".CaptureDeep(", startBlock);
+        Assert.Contains("allowDescendantScan: false", startBlock);
+        Assert.DoesNotContain("allowDescendantScan: true", startBlock);
+        Assert.Contains("TargetAppCorrectionAutomationStartTimeout", source);
+        Assert.Contains("CaptureTargetAppCorrectionBaselineWithTimeoutAsync", startBlock);
+        Assert.Contains("catch (TimeoutException)", startBlock);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -1,6 +1,7 @@
 using System.Windows.Input;
 using TypeWhisper.Windows.Controls;
 using TypeWhisper.Windows.Native;
+using TypeWhisper.Windows.Services;
 
 namespace TypeWhisper.PluginSystem.Tests;
 
@@ -361,6 +362,57 @@ public class HotkeyInputTests
         Assert.True(KeyboardHook.ShouldIgnoreInjectedInput(selfInjected));
         Assert.False(KeyboardHook.ShouldIgnoreInjectedInput(externalInjected));
         Assert.False(KeyboardHook.ShouldIgnoreInjectedInput(hardwareInput));
+    }
+
+    [Theory]
+    [InlineData(NativeMethods.VK_RETURN)]
+    [InlineData(NativeMethods.VK_TAB)]
+    public void TargetAppCorrectionCommitObserver_SignalsHardwareEnterAndTab(int virtualKey)
+    {
+        var input = new NativeMethods.KBDLLHOOKSTRUCT
+        {
+            vkCode = (uint)virtualKey
+        };
+
+        var result = TargetAppCorrectionCommitObserver.ShouldSignalCommitKey(
+            0,
+            NativeMethods.WM_KEYDOWN,
+            input);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void TargetAppCorrectionCommitObserver_IgnoresInjectedEnter()
+    {
+        var input = new NativeMethods.KBDLLHOOKSTRUCT
+        {
+            vkCode = NativeMethods.VK_RETURN,
+            flags = NativeMethods.LLKHF_INJECTED
+        };
+
+        var result = TargetAppCorrectionCommitObserver.ShouldSignalCommitKey(
+            0,
+            NativeMethods.WM_KEYDOWN,
+            input);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void TargetAppCorrectionCommitObserver_IgnoresNonCommitKeys()
+    {
+        var input = new NativeMethods.KBDLLHOOKSTRUCT
+        {
+            vkCode = (uint)'A'
+        };
+
+        var result = TargetAppCorrectionCommitObserver.ShouldSignalCommitKey(
+            0,
+            NativeMethods.WM_KEYDOWN,
+            input);
+
+        Assert.False(result);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/TargetAppCorrectionLearningServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TargetAppCorrectionLearningServiceTests.cs
@@ -198,6 +198,74 @@ public sealed class TargetAppCorrectionLearningServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task TrackInsertionAsync_DoesNotStopEarlyWhenElectronFocusReportsDocumentBeforeEdit()
+    {
+        var observer = new FakeTargetTextObserver();
+        var baseline = new TargetAppTextObservation(
+            "compose",
+            "hello teh world",
+            new IntPtr(42),
+            AllowElementKeyChangeOnCommit: true);
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("document", "hello teh world", new IntPtr(42)));
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("document", "hello the world", new IntPtr(42)));
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("document", "hello the world", new IntPtr(42)));
+        observer.Matches.Enqueue(TargetAppTextElementMatch.Different);
+        observer.Matches.Enqueue(TargetAppTextElementMatch.Different);
+        var service = CreateService(observer, new FakeCommitObserver([false, false, true]), polls: 3);
+
+        var learned = await service.TrackInsertionAsync("teh", baseline);
+
+        var correction = Assert.Single(learned);
+        Assert.Equal("teh", correction.Original);
+        Assert.Equal("the", correction.Replacement);
+        Assert.Equal(3, observer.RecaptureCalls);
+        Assert.Equal(2, observer.FocusedElementMatchCalls);
+    }
+
+    [Fact]
+    public async Task TrackInsertionAsync_DoesNotLearnElectronSameWindowEditBeforeCommit()
+    {
+        var observer = new FakeTargetTextObserver();
+        var baseline = new TargetAppTextObservation(
+            "compose",
+            "hello teh world",
+            new IntPtr(42),
+            AllowElementKeyChangeOnCommit: true);
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("document", "hello the world", new IntPtr(42)));
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("document", "hello the world", new IntPtr(42)));
+        observer.Matches.Enqueue(TargetAppTextElementMatch.Different);
+        observer.Matches.Enqueue(TargetAppTextElementMatch.Different);
+        var service = CreateService(observer, new FakeCommitObserver([false, false]), polls: 2);
+
+        var learned = await service.TrackInsertionAsync("teh", baseline);
+
+        Assert.Empty(learned);
+        Assert.Empty(_dictionary.Entries);
+        Assert.Equal(2, observer.RecaptureCalls);
+        Assert.Equal(2, observer.FocusedElementMatchCalls);
+    }
+
+    [Fact]
+    public async Task TrackInsertionAsync_LearnsElectronEditAfterWindowFocusChange()
+    {
+        var observer = new FakeTargetTextObserver();
+        var baseline = new TargetAppTextObservation(
+            "compose",
+            "hello teh world",
+            new IntPtr(42),
+            AllowElementKeyChangeOnCommit: true);
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("document", "hello the world", new IntPtr(42)));
+        observer.Matches.Enqueue(TargetAppTextElementMatch.DifferentWindow);
+        var service = CreateService(observer, new FakeCommitObserver([false]));
+
+        var learned = await service.TrackInsertionAsync("teh", baseline);
+
+        var correction = Assert.Single(learned);
+        Assert.Equal("teh", correction.Original);
+        Assert.Equal("the", correction.Replacement);
+    }
+
+    [Fact]
     public async Task TrackInsertionAsync_DoesNotLearnWhenFocusChangeRecaptureIsUnsupported()
     {
         var observer = new FakeTargetTextObserver();
@@ -219,6 +287,43 @@ public sealed class TargetAppCorrectionLearningServiceTests : IDisposable
         var observer = new FakeTargetTextObserver();
         var baseline = Observation("hello teh world");
         observer.Recaptures.Enqueue(new TargetAppTextObservation("other", "hello the world", new IntPtr(42)));
+        var service = CreateService(observer, new FakeCommitObserver([true]));
+
+        var learned = await service.TrackInsertionAsync("teh", baseline);
+
+        Assert.Empty(learned);
+        Assert.Empty(_dictionary.Entries);
+    }
+
+    [Fact]
+    public async Task TrackInsertionAsync_LearnsCommittedSameWindowRecaptureWhenBaselineAllowsElementKeyChange()
+    {
+        var observer = new FakeTargetTextObserver();
+        var baseline = new TargetAppTextObservation(
+            "editable",
+            "hello teh world",
+            new IntPtr(42),
+            AllowElementKeyChangeOnCommit: true);
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("other", "hello the world", new IntPtr(42)));
+        var service = CreateService(observer, new FakeCommitObserver([true]));
+
+        var learned = await service.TrackInsertionAsync("teh", baseline);
+
+        var correction = Assert.Single(learned);
+        Assert.Equal("teh", correction.Original);
+        Assert.Equal("the", correction.Replacement);
+    }
+
+    [Fact]
+    public async Task TrackInsertionAsync_DoesNotUseElementKeyChangeFallbackAcrossWindows()
+    {
+        var observer = new FakeTargetTextObserver();
+        var baseline = new TargetAppTextObservation(
+            "editable",
+            "hello teh world",
+            new IntPtr(42),
+            AllowElementKeyChangeOnCommit: true);
+        observer.Recaptures.Enqueue(new TargetAppTextObservation("other", "hello the world", new IntPtr(99)));
         var service = CreateService(observer, new FakeCommitObserver([true]));
 
         var learned = await service.TrackInsertionAsync("teh", baseline);

--- a/tests/TypeWhisper.PluginSystem.Tests/TargetAppTextObservationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TargetAppTextObservationServiceTests.cs
@@ -1,0 +1,85 @@
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class TargetAppTextObservationServiceTests
+{
+    [Fact]
+    public void ResolveObservableWindow_UsesForegroundWindowFromSameProcess()
+    {
+        var targetHwnd = new IntPtr(200);
+        var foregroundHwnd = new IntPtr(300);
+        var processIds = new Dictionary<IntPtr, uint>
+        {
+            [targetHwnd] = 42,
+            [foregroundHwnd] = 42
+        };
+
+        var result = TargetAppTextObservationService.ResolveObservableWindow(
+            targetHwnd,
+            foregroundHwnd,
+            hwnd => processIds.GetValueOrDefault(hwnd));
+
+        Assert.Equal(foregroundHwnd, result);
+    }
+
+    [Fact]
+    public void ResolveObservableWindow_KeepsTargetWindowForDifferentForegroundProcess()
+    {
+        var targetHwnd = new IntPtr(200);
+        var foregroundHwnd = new IntPtr(300);
+        var processIds = new Dictionary<IntPtr, uint>
+        {
+            [targetHwnd] = 42,
+            [foregroundHwnd] = 99
+        };
+
+        var result = TargetAppTextObservationService.ResolveObservableWindow(
+            targetHwnd,
+            foregroundHwnd,
+            hwnd => processIds.GetValueOrDefault(hwnd));
+
+        Assert.Equal(targetHwnd, result);
+    }
+
+    [Fact]
+    public void CaptureCore_DoesNotScanDescendantsWhenPreferredTextIsMissingFromFocus()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "TargetAppTextObservationService.cs");
+        var captureBlock = TestFile.ExtractBlock(
+            source,
+            "private static TargetAppTextObservation? CaptureCore",
+            700);
+
+        Assert.DoesNotContain("CaptureUniqueDescendantContaining", captureBlock);
+    }
+
+    [Fact]
+    public void CaptureDeep_UsesCursorPointBeforeOptionalDescendantScan()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "TargetAppTextObservationService.cs");
+        var deepCaptureBlock = TestFile.ExtractBlock(
+            source,
+            "public TargetAppTextObservation? CaptureDeep",
+            1800);
+        var descendantBlock = TestFile.ExtractBlock(
+            source,
+            "private static TargetAppTextObservation? CaptureUniqueDescendantContaining",
+            2400);
+
+        Assert.Contains("CaptureElementAtCursor", deepCaptureBlock);
+        Assert.Contains("if (!allowDescendantScan)", deepCaptureBlock);
+        Assert.Contains("CaptureUniqueDescendantContaining", deepCaptureBlock);
+        Assert.Contains("FindAll(TreeScope.Descendants", descendantBlock);
+        Assert.Contains("TextPattern.Pattern", descendantBlock);
+        Assert.Contains("ValuePattern.Pattern", descendantBlock);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
@@ -147,6 +147,7 @@ public sealed class TextInsertionServiceTests
     {
         var targetHwnd = new IntPtr(200);
         var currentForegroundHwnd = new IntPtr(300);
+        var rootHwnd = new IntPtr(100);
         var platform = new FakeTextInsertionPlatform
         {
             ClipboardText = "previous",
@@ -156,6 +157,11 @@ public sealed class TextInsertionServiceTests
             {
                 [targetHwnd] = 42,
                 [currentForegroundHwnd] = 42
+            },
+            RootWindows =
+            {
+                [targetHwnd] = rootHwnd,
+                [currentForegroundHwnd] = rootHwnd
             }
         };
         var sut = new TextInsertionService(platform);
@@ -165,6 +171,31 @@ public sealed class TextInsertionServiceTests
         Assert.Equal(InsertionResult.Pasted, result);
         Assert.Equal("previous", platform.ClipboardText);
         Assert.Equal(1, platform.PasteInputCalls);
+    }
+
+    [Fact]
+    public async Task FocusRetry_DoesNotAcceptDifferentForegroundWindowFromSameProcess()
+    {
+        var targetHwnd = new IntPtr(200);
+        var otherWindowHwnd = new IntPtr(300);
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            ForegroundWindow = otherWindowHwnd,
+            SetForegroundWindowResult = false,
+            WindowProcessIds =
+            {
+                [targetHwnd] = 42,
+                [otherWindowHwnd] = 42
+            }
+        };
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated", targetHwnd: targetHwnd);
+
+        Assert.Equal(InsertionResult.CopiedToClipboard, result);
+        Assert.Equal("dictated", platform.ClipboardText);
+        Assert.Equal(0, platform.PasteInputCalls);
     }
 
     [Fact]
@@ -297,6 +328,7 @@ public sealed class TextInsertionServiceTests
         public Queue<bool> SetForegroundWindowResults { get; set; } = [];
         public bool MoveForegroundOnSetForegroundWindowSuccess { get; set; } = true;
         public Dictionary<IntPtr, uint> WindowProcessIds { get; set; } = [];
+        public Dictionary<IntPtr, IntPtr> RootWindows { get; set; } = [];
         public IntPtr LastSetForegroundWindow { get; private set; }
         public uint PasteInputResult { get; set; } = 4;
         public uint EnterInputResult { get; set; } = 2;
@@ -390,6 +422,9 @@ public sealed class TextInsertionServiceTests
 
         public uint GetWindowProcessId(IntPtr hwnd) =>
             WindowProcessIds.GetValueOrDefault(hwnd);
+
+        public IntPtr GetRootWindow(IntPtr hwnd) =>
+            RootWindows.GetValueOrDefault(hwnd, hwnd);
 
         public uint SendModifierKeyUpInputs()
         {

--- a/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
@@ -143,7 +143,7 @@ public sealed class TextInsertionServiceTests
     }
 
     [Fact]
-    public async Task FocusFailure_FallsBackWhenForegroundWindowMovedWithinSameProcess()
+    public async Task FocusRetry_AcceptsForegroundWindowMovedWithinSameProcess()
     {
         var targetHwnd = new IntPtr(200);
         var currentForegroundHwnd = new IntPtr(300);
@@ -162,9 +162,9 @@ public sealed class TextInsertionServiceTests
 
         var result = await sut.InsertTextAsync("dictated", targetHwnd: targetHwnd);
 
-        Assert.Equal(InsertionResult.CopiedToClipboard, result);
-        Assert.Equal("dictated", platform.ClipboardText);
-        Assert.Equal(0, platform.PasteInputCalls);
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.Equal(1, platform.PasteInputCalls);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowPaletteServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowPaletteServiceTests.cs
@@ -386,6 +386,8 @@ public sealed class WorkflowPaletteServiceTests : IDisposable
 
         public uint GetWindowProcessId(IntPtr hwnd) => 0;
 
+        public IntPtr GetRootWindow(IntPtr hwnd) => hwnd;
+
         public uint SendModifierKeyUpInputs() => 0;
 
         public uint SendForegroundActivationInput() => 0;


### PR DESCRIPTION
## Summary
- keep text insertion responsive by starting target-app correction learning in the background
- make Electron target text capture tolerate same-process foreground and unstable UI Automation element keys
- require an explicit commit or real window focus change before learning same-window Electron edits
- add regression coverage for Discord/Electron insertion, capture, commit, and learning behavior

## Root cause
Discord and other Electron apps can move focus between same-process child windows or expose the composer as a document-level UI Automation element instead of a stable text field. The previous target-app learning path could block insertion during deep capture, then either lose tracking or learn too early when the composer reported a same-window element change.

## Validation
- `dotnet restore TypeWhisper.slnx`
- `dotnet test TypeWhisper.slnx --no-restore` after merging `origin/main`
- `dotnet build src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release --no-restore`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commit-aware text learning so corrections can be captured more reliably after Enter or Tab.
  * Improved text capture to better handle focus changes, cursor-based recovery, and same-window edits.
  * Enhanced insertion behavior to recognize related windows more accurately during retry flows.

* **Bug Fixes**
  * Reduced missed corrections when the active element changes during editing.
  * Improved handling of foreground-window changes and clipboard fallback during text insertion.

* **Tests**
  * Expanded automated coverage for commit detection, learning behavior, and window-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->