### PR TITLE
Fix plugin uninstall pending restart

### DIFF
--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -346,6 +346,7 @@
   "Plugins.Installing": "Installiere...",
   "Plugins.InstallFailedFormat": "Installation fehlgeschlagen: {0}",
   "Plugins.UpdateFailedFormat": "Aktualisierung fehlgeschlagen: {0}",
+  "Plugins.UninstallFailedFormat": "Deinstallation fehlgeschlagen: {0}",
   "Plugins.InstalledBadge": "Installiert",
   "Plugins.UpdateAvailablePrefix": "Update v",
   "Plugins.RestartRequiredBadge": "Neustart erforderlich",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -346,6 +346,7 @@
   "Plugins.Installing": "Installing...",
   "Plugins.InstallFailedFormat": "Install failed: {0}",
   "Plugins.UpdateFailedFormat": "Update failed: {0}",
+  "Plugins.UninstallFailedFormat": "Uninstall failed: {0}",
   "Plugins.InstalledBadge": "Installed",
   "Plugins.UpdateAvailablePrefix": "Update v",
   "Plugins.RestartRequiredBadge": "Restart required",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -339,6 +339,7 @@
   "Plugins.Installing": "インストール中...",
   "Plugins.InstallFailedFormat": "インストールに失敗しました: {0}",
   "Plugins.UpdateFailedFormat": "アップデートに失敗しました: {0}",
+  "Plugins.UninstallFailedFormat": "アンインストールに失敗しました: {0}",
   "Plugins.InstalledBadge": "インストール済み",
   "Plugins.UpdateAvailablePrefix": "アップデート v",
   "Plugins.RestartRequiredBadge": "再起動が必要です",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -339,6 +339,7 @@
   "Plugins.Installing": "Установка...",
   "Plugins.InstallFailedFormat": "Не удалось установить: {0}",
   "Plugins.UpdateFailedFormat": "Не удалось обновить: {0}",
+  "Plugins.UninstallFailedFormat": "Не удалось удалить: {0}",
   "Plugins.InstalledBadge": "Установлено",
   "Plugins.UpdateAvailablePrefix": "Обновление v",
   "Plugins.RestartRequiredBadge": "Требуется перезапуск",

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -188,19 +188,20 @@ public sealed class PluginRegistryService
                 CollectUnloadedPluginContexts();
             }
 
+            await ClearPendingUninstallAsync(registryPlugin.Id, ct);
+
             try
             {
                 await _replaceActiveDirectoryAsync(stagingDir, pluginDir, ct);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                QueuePendingUpdate(registryPlugin.Id, stagingDir);
+                await QueuePendingUpdateAsync(registryPlugin.Id, stagingDir, ct);
                 Debug.WriteLine($"[PluginRegistry] Queued plugin update pending restart: {registryPlugin.Id} ({ex.Message})");
                 return PluginInstallResult.PendingRestart;
             }
 
             DeleteDirectoryIfExists(GetValidatedPendingDirectory(registryPlugin.Id));
-            ClearPendingUninstall(registryPlugin.Id);
 
             await _pluginManager.LoadPluginFromDirectoryAsync(pluginDir, activate: true);
             if (_pluginManager.GetPlugin(registryPlugin.Id) is null)
@@ -424,13 +425,14 @@ public sealed class PluginRegistryService
             throw new InvalidOperationException("The downloaded plugin package version does not match the registry entry.");
     }
 
-    private void QueuePendingUpdate(string pluginId, string stagingDir)
+    private async Task QueuePendingUpdateAsync(string pluginId, string stagingDir, CancellationToken ct)
     {
+        await ClearPendingUninstallAsync(pluginId, ct);
+
         var pendingDir = GetValidatedPendingDirectory(pluginId);
         DeleteDirectoryIfExists(pendingDir);
         Directory.CreateDirectory(_pendingUpdatesPath);
         Directory.Move(stagingDir, pendingDir);
-        ClearPendingUninstall(pluginId);
     }
 
     private void QueuePendingUninstall(string pluginId)
@@ -449,9 +451,15 @@ public sealed class PluginRegistryService
         await _deleteActiveDirectoryAsync(pendingDir, ct);
     }
 
-    private void ClearPendingUninstall(string pluginId)
+    private async Task ClearPendingUninstallAsync(string pluginId, CancellationToken ct)
     {
-        DeleteDirectoryIfExists(GetValidatedPendingUninstallDirectory(pluginId));
+        var pendingDir = GetValidatedPendingUninstallDirectory(pluginId);
+        if (!Directory.Exists(pendingDir))
+            return;
+
+        await _deleteActiveDirectoryAsync(pendingDir, ct);
+        if (Directory.Exists(pendingDir))
+            throw new IOException($"Failed to clear pending uninstall marker for {pluginId}.");
     }
 
     private static Task DeleteActiveDirectoryAsync(string targetDirectory, CancellationToken ct)

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -232,7 +232,16 @@ public sealed class PluginRegistryService
         await _pluginManager.UnloadPluginAsync(pluginId);
         CollectUnloadedPluginContexts();
 
-        DeleteDirectoryIfExists(GetValidatedPendingDirectory(pluginId));
+        try
+        {
+            await DeletePendingUpdateDirectoryAsync(pluginId, ct);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            QueuePendingUninstall(pluginId);
+            Debug.WriteLine($"[PluginRegistry] Queued plugin uninstall pending restart after pending update cleanup failed: {pluginId} ({ex.Message})");
+            return PluginUninstallResult.PendingRestart;
+        }
 
         var pluginDir = GetValidatedPluginDirectory(pluginId);
         if (Directory.Exists(pluginDir))
@@ -273,6 +282,12 @@ public sealed class PluginRegistryService
                 continue;
             }
 
+            if (Directory.Exists(GetValidatedPendingUninstallDirectory(pluginId)))
+            {
+                Debug.WriteLine($"[PluginRegistry] Skipping pending update with pending uninstall: {pluginId}");
+                continue;
+            }
+
             var manifest = ReadManifest(pendingDir);
             if (!ManifestIdMatches(manifest, pluginId))
             {
@@ -310,7 +325,7 @@ public sealed class PluginRegistryService
             var pluginDir = GetValidatedPluginDirectory(pluginId);
             try
             {
-                DeleteDirectoryIfExists(GetValidatedPendingDirectory(pluginId));
+                await DeletePendingUpdateDirectoryAsync(pluginId, ct);
 
                 if (Directory.Exists(pluginDir))
                     await _deleteActiveDirectoryAsync(pluginDir, ct);
@@ -423,6 +438,15 @@ public sealed class PluginRegistryService
         var pendingDir = GetValidatedPendingUninstallDirectory(pluginId);
         Directory.CreateDirectory(_pendingUninstallsPath);
         Directory.CreateDirectory(pendingDir);
+    }
+
+    private async Task DeletePendingUpdateDirectoryAsync(string pluginId, CancellationToken ct)
+    {
+        var pendingDir = GetValidatedPendingDirectory(pluginId);
+        if (!Directory.Exists(pendingDir))
+            return;
+
+        await _deleteActiveDirectoryAsync(pendingDir, ct);
     }
 
     private void ClearPendingUninstall(string pluginId)

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -260,7 +260,7 @@ public sealed class PluginRegistryService
             }
         }
 
-        DeleteDirectoryIfExists(GetValidatedPendingUninstallDirectory(pluginId));
+        await ClearPendingUninstallAsync(pluginId, ct);
         return PluginUninstallResult.Uninstalled;
     }
 
@@ -331,7 +331,7 @@ public sealed class PluginRegistryService
                 if (Directory.Exists(pluginDir))
                     await _deleteActiveDirectoryAsync(pluginDir, ct);
 
-                DeleteDirectoryIfExists(pendingDir);
+                await ClearPendingUninstallAsync(pluginId, ct);
                 Debug.WriteLine($"[PluginRegistry] Applied pending plugin uninstall: {pluginId}");
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -199,12 +199,13 @@ public sealed class PluginRegistryService
                 return PluginInstallResult.PendingRestart;
             }
 
+            DeleteDirectoryIfExists(GetValidatedPendingDirectory(registryPlugin.Id));
+            ClearPendingUninstall(registryPlugin.Id);
+
             await _pluginManager.LoadPluginFromDirectoryAsync(pluginDir, activate: true);
             if (_pluginManager.GetPlugin(registryPlugin.Id) is null)
                 return PluginInstallResult.PendingRestart;
 
-            DeleteDirectoryIfExists(GetValidatedPendingDirectory(registryPlugin.Id));
-            DeleteDirectoryIfExists(GetValidatedPendingUninstallDirectory(registryPlugin.Id));
             Debug.WriteLine($"[PluginRegistry] Installed plugin: {registryPlugin.Id} v{registryPlugin.Version}");
             return PluginInstallResult.Installed;
         }
@@ -414,6 +415,7 @@ public sealed class PluginRegistryService
         DeleteDirectoryIfExists(pendingDir);
         Directory.CreateDirectory(_pendingUpdatesPath);
         Directory.Move(stagingDir, pendingDir);
+        ClearPendingUninstall(pluginId);
     }
 
     private void QueuePendingUninstall(string pluginId)
@@ -421,6 +423,11 @@ public sealed class PluginRegistryService
         var pendingDir = GetValidatedPendingUninstallDirectory(pluginId);
         Directory.CreateDirectory(_pendingUninstallsPath);
         Directory.CreateDirectory(pendingDir);
+    }
+
+    private void ClearPendingUninstall(string pluginId)
+    {
+        DeleteDirectoryIfExists(GetValidatedPendingUninstallDirectory(pluginId));
     }
 
     private static Task DeleteActiveDirectoryAsync(string targetDirectory, CancellationToken ct)

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -18,6 +18,7 @@ public sealed class PluginRegistryService
 {
     private const string RegistryUrl = "https://typewhisper.github.io/typewhisper-win/plugins.json";
     private const string PendingUpdatesDirectoryName = ".pending-updates";
+    private const string PendingUninstallsDirectoryName = ".pending-uninstalls";
     private const string StagingDirectoryName = ".staging";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan UpdateCheckInterval = TimeSpan.FromHours(24);
@@ -33,7 +34,9 @@ public sealed class PluginRegistryService
     private readonly HttpClient _httpClient;
     private readonly string _pluginsPath;
     private readonly string _pendingUpdatesPath;
+    private readonly string _pendingUninstallsPath;
     private readonly Func<string, string, CancellationToken, Task> _replaceActiveDirectoryAsync;
+    private readonly Func<string, CancellationToken, Task> _deleteActiveDirectoryAsync;
 
     private List<RegistryPlugin>? _cachedRegistry;
     private DateTime _cacheTimestamp;
@@ -48,7 +51,8 @@ public sealed class PluginRegistryService
         ISettingsService settings,
         HttpClient? httpClient = null,
         string? pluginsPath = null,
-        Func<string, string, CancellationToken, Task>? replaceActiveDirectoryAsync = null)
+        Func<string, string, CancellationToken, Task>? replaceActiveDirectoryAsync = null,
+        Func<string, CancellationToken, Task>? deleteActiveDirectoryAsync = null)
     {
         _pluginManager = pluginManager;
         _pluginLoader = pluginLoader;
@@ -56,7 +60,9 @@ public sealed class PluginRegistryService
         _httpClient = httpClient ?? new HttpClient();
         _pluginsPath = Path.GetFullPath(pluginsPath ?? TypeWhisperEnvironment.PluginsPath);
         _pendingUpdatesPath = GetValidatedChildDirectory(_pluginsPath, PendingUpdatesDirectoryName, "pending updates directory");
+        _pendingUninstallsPath = GetValidatedChildDirectory(_pluginsPath, PendingUninstallsDirectoryName, "pending uninstalls directory");
         _replaceActiveDirectoryAsync = replaceActiveDirectoryAsync ?? ReplaceActiveDirectoryAsync;
+        _deleteActiveDirectoryAsync = deleteActiveDirectoryAsync ?? DeleteActiveDirectoryAsync;
     }
 
     /// <summary>
@@ -94,8 +100,12 @@ public sealed class PluginRegistryService
     /// </summary>
     public PluginInstallState GetInstallState(RegistryPlugin registryPlugin)
     {
+        var pendingUninstallDir = GetValidatedPendingUninstallDirectory(registryPlugin.Id);
         var pendingDir = GetValidatedPendingDirectory(registryPlugin.Id);
         var pluginDir = GetValidatedPluginDirectory(registryPlugin.Id);
+
+        if (Directory.Exists(pendingUninstallDir))
+            return PluginInstallState.PendingRestart;
 
         var pendingManifest = ReadManifest(pendingDir);
         if (ManifestMatchesRegistry(pendingManifest, registryPlugin))
@@ -131,6 +141,7 @@ public sealed class PluginRegistryService
     {
         Directory.CreateDirectory(_pluginsPath);
         Directory.CreateDirectory(_pendingUpdatesPath);
+        Directory.CreateDirectory(_pendingUninstallsPath);
 
         ValidatePluginId(registryPlugin.Id);
         var pluginDir = GetValidatedPluginDirectory(registryPlugin.Id);
@@ -193,6 +204,7 @@ public sealed class PluginRegistryService
                 return PluginInstallResult.PendingRestart;
 
             DeleteDirectoryIfExists(GetValidatedPendingDirectory(registryPlugin.Id));
+            DeleteDirectoryIfExists(GetValidatedPendingUninstallDirectory(registryPlugin.Id));
             Debug.WriteLine($"[PluginRegistry] Installed plugin: {registryPlugin.Id} v{registryPlugin.Version}");
             return PluginInstallResult.Installed;
         }
@@ -211,10 +223,13 @@ public sealed class PluginRegistryService
     /// <summary>
     /// Uninstalls a plugin by unloading it and deleting its directory.
     /// </summary>
-    public async Task UninstallPluginAsync(string pluginId)
+    public async Task<PluginUninstallResult> UninstallPluginAsync(
+        string pluginId,
+        CancellationToken ct = default)
     {
         ValidatePluginId(pluginId);
         await _pluginManager.UnloadPluginAsync(pluginId);
+        CollectUnloadedPluginContexts();
 
         DeleteDirectoryIfExists(GetValidatedPendingDirectory(pluginId));
 
@@ -223,14 +238,19 @@ public sealed class PluginRegistryService
         {
             try
             {
-                Directory.Delete(pluginDir, recursive: true);
+                await _deleteActiveDirectoryAsync(pluginDir, ct);
                 Debug.WriteLine($"[PluginRegistry] Uninstalled plugin: {pluginId}");
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                Debug.WriteLine($"[PluginRegistry] Failed to delete directory for {pluginId}: {ex.Message}");
+                QueuePendingUninstall(pluginId);
+                Debug.WriteLine($"[PluginRegistry] Queued plugin uninstall pending restart: {pluginId} ({ex.Message})");
+                return PluginUninstallResult.PendingRestart;
             }
         }
+
+        DeleteDirectoryIfExists(GetValidatedPendingUninstallDirectory(pluginId));
+        return PluginUninstallResult.Uninstalled;
     }
 
     /// <summary>
@@ -238,6 +258,8 @@ public sealed class PluginRegistryService
     /// </summary>
     public async Task ApplyPendingUpdatesAsync(CancellationToken ct = default)
     {
+        await ApplyPendingUninstallsAsync(ct);
+
         if (!Directory.Exists(_pendingUpdatesPath))
             return;
 
@@ -266,6 +288,38 @@ public sealed class PluginRegistryService
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 Debug.WriteLine($"[PluginRegistry] Failed to apply pending update for {pluginId}: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task ApplyPendingUninstallsAsync(CancellationToken ct)
+    {
+        if (!Directory.Exists(_pendingUninstallsPath))
+            return;
+
+        foreach (var pendingDir in Directory.GetDirectories(_pendingUninstallsPath))
+        {
+            var pluginId = Path.GetFileName(pendingDir);
+            if (!IsValidPluginId(pluginId))
+            {
+                Debug.WriteLine($"[PluginRegistry] Skipping invalid pending uninstall directory: {pendingDir}");
+                continue;
+            }
+
+            var pluginDir = GetValidatedPluginDirectory(pluginId);
+            try
+            {
+                DeleteDirectoryIfExists(GetValidatedPendingDirectory(pluginId));
+
+                if (Directory.Exists(pluginDir))
+                    await _deleteActiveDirectoryAsync(pluginDir, ct);
+
+                DeleteDirectoryIfExists(pendingDir);
+                Debug.WriteLine($"[PluginRegistry] Applied pending plugin uninstall: {pluginId}");
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Debug.WriteLine($"[PluginRegistry] Failed to apply pending uninstall for {pluginId}: {ex.Message}");
             }
         }
     }
@@ -362,6 +416,22 @@ public sealed class PluginRegistryService
         Directory.Move(stagingDir, pendingDir);
     }
 
+    private void QueuePendingUninstall(string pluginId)
+    {
+        var pendingDir = GetValidatedPendingUninstallDirectory(pluginId);
+        Directory.CreateDirectory(_pendingUninstallsPath);
+        Directory.CreateDirectory(pendingDir);
+    }
+
+    private static Task DeleteActiveDirectoryAsync(string targetDirectory, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (Directory.Exists(targetDirectory))
+            Directory.Delete(targetDirectory, recursive: true);
+
+        return Task.CompletedTask;
+    }
+
     private static async Task ReplaceActiveDirectoryAsync(
         string sourceDirectory,
         string targetDirectory,
@@ -444,6 +514,12 @@ public sealed class PluginRegistryService
     {
         ValidatePluginId(pluginId);
         return GetValidatedChildDirectory(_pendingUpdatesPath, pluginId, "pending plugin directory");
+    }
+
+    private string GetValidatedPendingUninstallDirectory(string pluginId)
+    {
+        ValidatePluginId(pluginId);
+        return GetValidatedChildDirectory(_pendingUninstallsPath, pluginId, "pending uninstall directory");
     }
 
     private static string GetValidatedChildDirectory(string rootDirectory, string childName, string description)

--- a/src/TypeWhisper.Windows/Services/Plugins/RegistryPlugin.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/RegistryPlugin.cs
@@ -160,3 +160,18 @@ public enum PluginInstallResult
     /// </summary>
     PendingRestart
 }
+
+/// <summary>
+/// Lists the supported plugin uninstall result values.
+/// </summary>
+public enum PluginUninstallResult
+{
+    /// <summary>
+    /// Represents a plugin removed from disk in the current process.
+    /// </summary>
+    Uninstalled,
+    /// <summary>
+    /// Represents a plugin removal queued for the next app restart.
+    /// </summary>
+    PendingRestart
+}

--- a/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
@@ -589,6 +589,8 @@ public partial class PluginItemViewModel : ObservableObject
             return;
 
         await _registryService.UninstallPluginAsync(Id);
+        RegistryPlugin?.RefreshInstallState();
+        NotifyUpdateStateChanged();
     }
 
     [RelayCommand(CanExecute = nameof(CanUpdateRegistryPlugin))]

--- a/src/TypeWhisper.Windows/ViewModels/RegistryPluginItemViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/RegistryPluginItemViewModel.cs
@@ -162,11 +162,19 @@ public partial class RegistryPluginItemViewModel : ObservableObject
         if (IsWorking) return;
 
         IsWorking = true;
+        InstallErrorMessage = "";
 
         try
         {
-            await _registryService.UninstallPluginAsync(_registryPlugin.Id);
-            InstallState = PluginInstallState.NotInstalled;
+            var result = await _registryService.UninstallPluginAsync(_registryPlugin.Id);
+            InstallState = result == PluginUninstallResult.PendingRestart
+                ? PluginInstallState.PendingRestart
+                : PluginInstallState.NotInstalled;
+        }
+        catch (Exception ex)
+        {
+            RefreshInstallState();
+            InstallErrorMessage = Loc.Instance.GetString("Plugins.UninstallFailedFormat", ex.Message);
         }
         finally
         {

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -313,6 +313,18 @@ public class PluginRegistryServiceTests : IDisposable
         Assert.Equal(PluginInstallState.PendingRestart, service.GetInstallState(registryPlugin));
     }
 
+    [Fact]
+    public void GetInstallState_PendingRestart_WhenPendingUninstallExists()
+    {
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, pluginsPath: _pluginsRoot);
+        var registryPlugin = CreateRegistryPlugin("com.test.pending-uninstall", "1.0.0");
+        WritePluginManifest(Path.Combine(_pluginsRoot, registryPlugin.Id), registryPlugin.Id, "1.0.0");
+        Directory.CreateDirectory(Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id));
+
+        Assert.Equal(PluginInstallState.PendingRestart, service.GetInstallState(registryPlugin));
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
@@ -348,6 +360,27 @@ public class PluginRegistryServiceTests : IDisposable
         Assert.False(File.Exists(Path.Combine(activeDir, "active.txt")));
         Assert.True(File.Exists(Path.Combine(activeDir, "pending.txt")));
         Assert.Equal("1.0.2", ReadManifest(activeDir).Version);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_DeletesPendingUninstallBeforeLoad()
+    {
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, pluginsPath: _pluginsRoot);
+        var pluginId = "com.test.apply-pending-uninstall";
+        var activeDir = Path.Combine(_pluginsRoot, pluginId);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", pluginId);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", pluginId);
+        WritePluginManifest(activeDir, pluginId, "1.0.0");
+        File.WriteAllText(Path.Combine(activeDir, "active.txt"), "old");
+        Directory.CreateDirectory(pendingUninstallDir);
+        WritePluginManifest(pendingUpdateDir, pluginId, "1.0.2");
+
+        await service.ApplyPendingUpdatesAsync();
+
+        Assert.False(Directory.Exists(activeDir));
+        Assert.False(Directory.Exists(pendingUninstallDir));
+        Assert.False(Directory.Exists(pendingUpdateDir));
     }
 
     [Fact]
@@ -447,6 +480,49 @@ public class PluginRegistryServiceTests : IDisposable
         Assert.Equal(PluginInstallResult.PendingRestart, result);
         Assert.Equal("1.0.0", ReadManifest(activeDir).Version);
         Assert.Equal("1.0.2", ReadManifest(pendingDir).Version);
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_DeleteSuccess_ReturnsUninstalledAndRemovesDirectory()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.uninstall", "1.0.0");
+        var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
+        File.WriteAllText(Path.Combine(activeDir, "active.txt"), "old");
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, pluginsPath: _pluginsRoot);
+
+        var result = await service.UninstallPluginAsync(registryPlugin.Id);
+
+        Assert.Equal(PluginUninstallResult.Uninstalled, result);
+        Assert.False(Directory.Exists(activeDir));
+        Assert.Equal(PluginInstallState.NotInstalled, service.GetInstallState(registryPlugin));
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_DeleteLockFailure_QueuesPendingRestartAndClearsPendingUpdate()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.uninstall-locked", "1.0.0");
+        var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", registryPlugin.Id);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id);
+        WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
+        WritePluginManifest(pendingUpdateDir, registryPlugin.Id, "1.0.2");
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            deleteActiveDirectoryAsync: (_, _) => throw new IOException("locked"));
+
+        var result = await service.UninstallPluginAsync(registryPlugin.Id);
+
+        Assert.Equal(PluginUninstallResult.PendingRestart, result);
+        Assert.True(Directory.Exists(activeDir));
+        Assert.True(Directory.Exists(pendingUninstallDir));
+        Assert.False(Directory.Exists(pendingUpdateDir));
+        Assert.Equal(PluginInstallState.PendingRestart, service.GetInstallState(registryPlugin));
     }
 
     [Fact]
@@ -552,6 +628,59 @@ public class PluginRegistryServiceTests : IDisposable
 
         Assert.Equal(PluginInstallState.PendingRestart, item.InstallState);
         Assert.False(item.HasInstallError);
+    }
+
+    [Fact]
+    public async Task RegistryPluginItem_UninstallPendingRestart_ExposesPendingState()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.uninstall-pending-vm", "1.0.0");
+        WritePluginManifest(Path.Combine(_pluginsRoot, registryPlugin.Id), registryPlugin.Id, "1.0.0");
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            deleteActiveDirectoryAsync: (_, _) => throw new IOException("locked"));
+        var item = new RegistryPluginItemViewModel(registryPlugin, service);
+
+        await item.UninstallCommand.ExecuteAsync(null);
+
+        Assert.Equal(PluginInstallState.PendingRestart, item.InstallState);
+        Assert.False(item.HasInstallError);
+    }
+
+    [Fact]
+    public async Task RegistryPluginItem_UninstallFailure_ExposesErrorMessage()
+    {
+        Loc.Instance.Initialize();
+        var previousLanguage = Loc.Instance.CurrentLanguage;
+        Loc.Instance.CurrentLanguage = "en";
+
+        try
+        {
+            var manager = CreateManager();
+            var registryPlugin = CreateRegistryPlugin("com.test.uninstall-fails", "1.0.0");
+            WritePluginManifest(Path.Combine(_pluginsRoot, registryPlugin.Id), registryPlugin.Id, "1.0.0");
+            var service = new PluginRegistryService(
+                manager,
+                _loader,
+                _settings.Object,
+                pluginsPath: _pluginsRoot,
+                deleteActiveDirectoryAsync: (_, _) => throw new InvalidOperationException("boom"));
+            var item = new RegistryPluginItemViewModel(registryPlugin, service);
+
+            await item.UninstallCommand.ExecuteAsync(null);
+
+            Assert.Equal(PluginInstallState.Installed, item.InstallState);
+            Assert.False(item.IsWorking);
+            Assert.True(item.HasInstallError);
+            Assert.Contains("Uninstall failed", item.InstallErrorMessage);
+        }
+        finally
+        {
+            Loc.Instance.CurrentLanguage = previousLanguage;
+        }
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -430,6 +430,37 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ApplyPendingUpdatesAsync_PendingUninstallMarkerDeleteFailure_KeepsMarker()
+    {
+        var manager = CreateManager();
+        var pluginId = "com.test.apply-pending-uninstall-marker-delete-fails";
+        var activeDir = Path.Combine(_pluginsRoot, pluginId);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", pluginId);
+        WritePluginManifest(activeDir, pluginId, "1.0.0");
+        Directory.CreateDirectory(pendingUninstallDir);
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            deleteActiveDirectoryAsync: (path, _) =>
+            {
+                if (PathsEqual(path, pendingUninstallDir))
+                    throw new IOException("locked");
+
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+
+                return Task.CompletedTask;
+            });
+
+        await service.ApplyPendingUpdatesAsync();
+
+        Assert.False(Directory.Exists(activeDir));
+        Assert.True(Directory.Exists(pendingUninstallDir));
+    }
+
+    [Fact]
     public async Task ApplyPendingUpdatesAsync_UsesInjectedReplacementDelegate()
     {
         var manager = CreateManager();
@@ -563,6 +594,7 @@ public class PluginRegistryServiceTests : IDisposable
         var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
         var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", registryPlugin.Id);
         var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id);
+        WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
         Directory.CreateDirectory(pendingUninstallDir);
         var package = CreatePluginPackage(registryPlugin.Id, "1.0.2");
         var replaceCallCount = 0;
@@ -591,7 +623,7 @@ public class PluginRegistryServiceTests : IDisposable
         await Assert.ThrowsAsync<IOException>(() => service.InstallPluginAsync(registryPlugin));
 
         Assert.Equal(0, replaceCallCount);
-        Assert.False(Directory.Exists(activeDir));
+        Assert.Equal("1.0.0", ReadManifest(activeDir).Version);
         Assert.False(Directory.Exists(pendingUpdateDir));
         Assert.True(Directory.Exists(pendingUninstallDir));
     }
@@ -649,6 +681,37 @@ public class PluginRegistryServiceTests : IDisposable
         Assert.True(Directory.Exists(pendingUninstallDir));
         Assert.False(Directory.Exists(pendingUpdateDir));
         Assert.Equal(PluginInstallState.PendingRestart, service.GetInstallState(registryPlugin));
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_PendingUninstallMarkerDeleteFailure_DoesNotReturnUninstalled()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.uninstall-marker-locked", "1.0.0");
+        var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id);
+        WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
+        Directory.CreateDirectory(pendingUninstallDir);
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            deleteActiveDirectoryAsync: (path, _) =>
+            {
+                if (PathsEqual(path, pendingUninstallDir))
+                    throw new IOException("locked");
+
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+
+                return Task.CompletedTask;
+            });
+
+        await Assert.ThrowsAsync<IOException>(() => service.UninstallPluginAsync(registryPlugin.Id));
+
+        Assert.False(Directory.Exists(activeDir));
+        Assert.True(Directory.Exists(pendingUninstallDir));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -556,6 +556,47 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallPluginAsync_PendingUninstallDeleteFailure_FailsBeforeReplacingOrQueueing()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.pending-uninstall-locked", "1.0.2");
+        var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", registryPlugin.Id);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id);
+        Directory.CreateDirectory(pendingUninstallDir);
+        var package = CreatePluginPackage(registryPlugin.Id, "1.0.2");
+        var replaceCallCount = 0;
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            CreateMockHttpClient(package),
+            _pluginsRoot,
+            replaceActiveDirectoryAsync: (_, _, _) =>
+            {
+                replaceCallCount++;
+                return Task.CompletedTask;
+            },
+            deleteActiveDirectoryAsync: (path, _) =>
+            {
+                if (PathsEqual(path, pendingUninstallDir))
+                    throw new IOException("locked");
+
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+
+                return Task.CompletedTask;
+            });
+
+        await Assert.ThrowsAsync<IOException>(() => service.InstallPluginAsync(registryPlugin));
+
+        Assert.Equal(0, replaceCallCount);
+        Assert.False(Directory.Exists(activeDir));
+        Assert.False(Directory.Exists(pendingUpdateDir));
+        Assert.True(Directory.Exists(pendingUninstallDir));
+    }
+
+    [Fact]
     public async Task UninstallPluginAsync_DeleteSuccess_ReturnsUninstalledAndRemovesDirectory()
     {
         var manager = CreateManager();

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -483,6 +483,33 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallPluginAsync_ReplacementLockFailure_ClearsStalePendingUninstall()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.locked-reinstall", "1.0.2");
+        var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", registryPlugin.Id);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id);
+        WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
+        Directory.CreateDirectory(pendingUninstallDir);
+        var package = CreatePluginPackage(registryPlugin.Id, "1.0.2");
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            CreateMockHttpClient(package),
+            _pluginsRoot,
+            replaceActiveDirectoryAsync: (_, _, _) => throw new IOException("locked"));
+
+        var result = await service.InstallPluginAsync(registryPlugin);
+
+        Assert.Equal(PluginInstallResult.PendingRestart, result);
+        Assert.True(Directory.Exists(pendingUpdateDir));
+        Assert.False(Directory.Exists(pendingUninstallDir));
+        Assert.Equal("1.0.2", ReadManifest(pendingUpdateDir).Version);
+    }
+
+    [Fact]
     public async Task UninstallPluginAsync_DeleteSuccess_ReturnsUninstalledAndRemovesDirectory()
     {
         var manager = CreateManager();

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -366,7 +366,6 @@ public class PluginRegistryServiceTests : IDisposable
     public async Task ApplyPendingUpdatesAsync_DeletesPendingUninstallBeforeLoad()
     {
         var manager = CreateManager();
-        var service = new PluginRegistryService(manager, _loader, _settings.Object, pluginsPath: _pluginsRoot);
         var pluginId = "com.test.apply-pending-uninstall";
         var activeDir = Path.Combine(_pluginsRoot, pluginId);
         var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", pluginId);
@@ -375,12 +374,59 @@ public class PluginRegistryServiceTests : IDisposable
         File.WriteAllText(Path.Combine(activeDir, "active.txt"), "old");
         Directory.CreateDirectory(pendingUninstallDir);
         WritePluginManifest(pendingUpdateDir, pluginId, "1.0.2");
+        var replaceCallCount = 0;
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            replaceActiveDirectoryAsync: (_, _, _) =>
+            {
+                replaceCallCount++;
+                return Task.CompletedTask;
+            });
 
         await service.ApplyPendingUpdatesAsync();
 
         Assert.False(Directory.Exists(activeDir));
         Assert.False(Directory.Exists(pendingUninstallDir));
         Assert.False(Directory.Exists(pendingUpdateDir));
+        Assert.Equal(0, replaceCallCount);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_PendingUninstallKeepsMarkerWhenPendingUpdateDeleteFails()
+    {
+        var manager = CreateManager();
+        var pluginId = "com.test.apply-pending-uninstall-delete-fails";
+        var activeDir = Path.Combine(_pluginsRoot, pluginId);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", pluginId);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", pluginId);
+        WritePluginManifest(activeDir, pluginId, "1.0.0");
+        Directory.CreateDirectory(pendingUninstallDir);
+        WritePluginManifest(pendingUpdateDir, pluginId, "1.0.2");
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            replaceActiveDirectoryAsync: (_, _, _) => throw new InvalidOperationException("Pending update should be skipped."),
+            deleteActiveDirectoryAsync: (path, _) =>
+            {
+                if (PathsEqual(path, pendingUpdateDir))
+                    throw new IOException("locked");
+
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+
+                return Task.CompletedTask;
+            });
+
+        await service.ApplyPendingUpdatesAsync();
+
+        Assert.True(Directory.Exists(activeDir));
+        Assert.True(Directory.Exists(pendingUninstallDir));
+        Assert.True(Directory.Exists(pendingUpdateDir));
     }
 
     [Fact]
@@ -515,7 +561,9 @@ public class PluginRegistryServiceTests : IDisposable
         var manager = CreateManager();
         var registryPlugin = CreateRegistryPlugin("com.test.uninstall", "1.0.0");
         var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", registryPlugin.Id);
         WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
+        WritePluginManifest(pendingUpdateDir, registryPlugin.Id, "1.0.2");
         File.WriteAllText(Path.Combine(activeDir, "active.txt"), "old");
         var service = new PluginRegistryService(manager, _loader, _settings.Object, pluginsPath: _pluginsRoot);
 
@@ -523,6 +571,7 @@ public class PluginRegistryServiceTests : IDisposable
 
         Assert.Equal(PluginUninstallResult.Uninstalled, result);
         Assert.False(Directory.Exists(activeDir));
+        Assert.False(Directory.Exists(pendingUpdateDir));
         Assert.Equal(PluginInstallState.NotInstalled, service.GetInstallState(registryPlugin));
     }
 
@@ -541,7 +590,16 @@ public class PluginRegistryServiceTests : IDisposable
             _loader,
             _settings.Object,
             pluginsPath: _pluginsRoot,
-            deleteActiveDirectoryAsync: (_, _) => throw new IOException("locked"));
+            deleteActiveDirectoryAsync: (path, _) =>
+            {
+                if (PathsEqual(path, activeDir))
+                    throw new IOException("locked");
+
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+
+                return Task.CompletedTask;
+            });
 
         var result = await service.UninstallPluginAsync(registryPlugin.Id);
 
@@ -549,6 +607,41 @@ public class PluginRegistryServiceTests : IDisposable
         Assert.True(Directory.Exists(activeDir));
         Assert.True(Directory.Exists(pendingUninstallDir));
         Assert.False(Directory.Exists(pendingUpdateDir));
+        Assert.Equal(PluginInstallState.PendingRestart, service.GetInstallState(registryPlugin));
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_PendingUpdateDeleteLockFailure_QueuesPendingRestart()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.uninstall-pending-update-locked", "1.0.0");
+        var activeDir = Path.Combine(_pluginsRoot, registryPlugin.Id);
+        var pendingUpdateDir = Path.Combine(_pluginsRoot, ".pending-updates", registryPlugin.Id);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", registryPlugin.Id);
+        WritePluginManifest(activeDir, registryPlugin.Id, "1.0.0");
+        WritePluginManifest(pendingUpdateDir, registryPlugin.Id, "1.0.2");
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            deleteActiveDirectoryAsync: (path, _) =>
+            {
+                if (PathsEqual(path, pendingUpdateDir))
+                    throw new IOException("locked");
+
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+
+                return Task.CompletedTask;
+            });
+
+        var result = await service.UninstallPluginAsync(registryPlugin.Id);
+
+        Assert.Equal(PluginUninstallResult.PendingRestart, result);
+        Assert.True(Directory.Exists(activeDir));
+        Assert.True(Directory.Exists(pendingUpdateDir));
+        Assert.True(Directory.Exists(pendingUninstallDir));
         Assert.Equal(PluginInstallState.PendingRestart, service.GetInstallState(registryPlugin));
     }
 
@@ -797,6 +890,9 @@ public class PluginRegistryServiceTests : IDisposable
         var json = File.ReadAllText(Path.Combine(pluginDir, "manifest.json"));
         return JsonSerializer.Deserialize<PluginManifest>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
     }
+
+    private static bool PathsEqual(string first, string second) =>
+        string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), StringComparison.OrdinalIgnoreCase);
 
     private static byte[] CreatePluginPackage(string id, string version)
     {


### PR DESCRIPTION
## Summary
- Add a pending-uninstall path for plugins whose files cannot be fully removed while the app is running.
- Apply pending plugin uninstalls before plugin discovery on startup and clear conflicting pending updates.
- Surface pending restart and uninstall failures correctly in the integrations UI.

## Root Cause
Plugin uninstall removed the plugin from the running manager, but recursive directory deletion could partially fail on locked files. The failure was swallowed, so the UI appeared to remove the plugin while the remaining plugin directory could be rediscovered after restart.

## Validation
- `dotnet test TypeWhisper.slnx --no-restore`
- Manual runtime check with IBM Granite Speech (Local): reproduced the stale plugin folder, then verified the pending uninstall cleanup removed the leftover directory on restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin uninstall now reports an outcome, including a “restart required” state when cleanup can’t finish immediately.

* **Bug Fixes**
  * Pending uninstalls are staged and automatically handled on the next app start; plugins marked for uninstall are skipped during pending updates.
  * Uninstall UI state updates immediately and shows correct restart-required/error messaging.
  * Added localized “uninstall failed” message templates (including error details) for supported languages.

* **Tests**
  * Expanded coverage for pending-uninstall markers, restart-required behavior, and uninstall UI state/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->