### PR TITLE
Fix daily release version base

### DIFF
--- a/.github/scripts/resolve-release-metadata.sh
+++ b/.github/scripts/resolve-release-metadata.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT=""
+REF_NAME=""
+SHA=""
+INPUT_BASE_VERSION=""
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: resolve-release-metadata.sh --event <event> --ref-name <ref> --sha <sha> --base-version <version>
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event)
+      EVENT="${2:-}"
+      shift 2
+      ;;
+    --ref-name)
+      REF_NAME="${2:-}"
+      shift 2
+      ;;
+    --sha)
+      SHA="${2:-}"
+      shift 2
+      ;;
+    --base-version)
+      INPUT_BASE_VERSION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$EVENT" ]; then
+  usage
+  echo "--event is required" >&2
+  exit 1
+fi
+
+if [ -z "$SHA" ]; then
+  usage
+  echo "--sha is required" >&2
+  exit 1
+fi
+
+emit() {
+  printf '%s=%s\n' "$1" "$2"
+}
+
+latest_matching_tag() {
+  local pattern="$1"
+
+  git tag --list 'v[0-9]*' --sort=-v:refname |
+    grep -E "$pattern" |
+    head -1 || true
+}
+
+next_patch_version() {
+  local version="$1"
+  local major minor patch
+
+  IFS='.' read -r major minor patch <<< "$version"
+  echo "${major}.${minor}.$((patch + 1))"
+}
+
+highest_base_version() {
+  local first="$1"
+  local second="$2"
+
+  if [ -z "$first" ]; then
+    echo "$second"
+    return
+  fi
+
+  if [ -z "$second" ]; then
+    echo "$first"
+    return
+  fi
+
+  printf '%s\n%s\n' "$first" "$second" | sort -V | tail -1
+}
+
+resolve_default_daily_base_version() {
+  local latest_stable stable_candidate latest_rc rc_base
+
+  latest_stable="$(latest_matching_tag '^v[0-9]+\.[0-9]+\.[0-9]+$')"
+  if [ -n "$latest_stable" ]; then
+    stable_candidate="$(next_patch_version "${latest_stable#v}")"
+  else
+    stable_candidate="0.0.1"
+  fi
+
+  latest_rc="$(latest_matching_tag '^v[0-9]+\.[0-9]+\.[0-9]+-rc(\.?[0-9]+)?$')"
+  if [ -n "$latest_rc" ]; then
+    rc_base="${latest_rc#v}"
+    rc_base="${rc_base%%-rc*}"
+  else
+    rc_base=""
+  fi
+
+  highest_base_version "$stable_candidate" "$rc_base"
+}
+
+TAG=""
+VERSION=""
+RELEASE_TARGET=""
+
+if [ "$EVENT" = "push" ]; then
+  TAG="$REF_NAME"
+  VERSION="${TAG#v}"
+else
+  BASE_VERSION="${INPUT_BASE_VERSION#v}"
+
+  if [ -z "$BASE_VERSION" ]; then
+    BASE_VERSION="$(resolve_default_daily_base_version)"
+  fi
+
+  if ! [[ "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "base_version must look like 0.7.1, got: $BASE_VERSION" >&2
+    exit 1
+  fi
+
+  DATE="${TYPEWHISPER_RELEASE_DATE:-$(date -u +%Y%m%d)}"
+  if ! [[ "$DATE" =~ ^[0-9]{8}$ ]]; then
+    echo "TYPEWHISPER_RELEASE_DATE must look like 20260701, got: $DATE" >&2
+    exit 1
+  fi
+
+  TAG="v${BASE_VERSION}-daily.${DATE}"
+  VERSION="${BASE_VERSION}-daily.${DATE}"
+  RELEASE_TARGET="$SHA"
+
+  if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "Daily tag $TAG already exists; skipping." >&2
+    emit "tag" "$TAG"
+    emit "version" "$VERSION"
+    emit "channel_suffix" "-daily"
+    emit "is_prerelease" "true"
+    emit "is_stable" "false"
+    emit "should_run" "false"
+    emit "release_target" "$RELEASE_TARGET"
+    exit 0
+  fi
+fi
+
+CHANNEL_SUFFIX=""
+IS_PRERELEASE="false"
+IS_STABLE="true"
+
+if [[ "$VERSION" == *"-daily."* ]]; then
+  CHANNEL_SUFFIX="-daily"
+  IS_PRERELEASE="true"
+  IS_STABLE="false"
+elif [[ "$VERSION" == *"-rc"* ]]; then
+  CHANNEL_SUFFIX="-rc"
+  IS_PRERELEASE="true"
+  IS_STABLE="false"
+elif [[ "$VERSION" == *"-"* ]]; then
+  echo "Unsupported prerelease version for Windows app release channels: $VERSION" >&2
+  exit 1
+fi
+
+emit "tag" "$TAG"
+emit "version" "$VERSION"
+emit "channel_suffix" "$CHANNEL_SUFFIX"
+emit "is_prerelease" "$IS_PRERELEASE"
+emit "is_stable" "$IS_STABLE"
+emit "should_run" "true"
+emit "release_target" "$RELEASE_TARGET"
+
+echo "Release tag: $TAG" >&2
+echo "Package version: $VERSION" >&2
+echo "Velopack channel suffix: ${CHANNEL_SUFFIX:-<stable>}" >&2

--- a/.github/scripts/resolve-release-metadata.tests.sh
+++ b/.github/scripts/resolve-release-metadata.tests.sh
@@ -109,6 +109,22 @@ test_existing_daily_tag_skips_build() {
   assert_eq "should_run" "false" "$(metadata_value "$output" should_run)"
 }
 
+test_push_stable_release_uses_plain_channel() {
+  local output
+  output="$(TYPEWHISPER_RELEASE_DATE=20260701 bash "$RESOLVER" \
+    --event push \
+    --ref-name v1.0.0 \
+    --sha "$(git rev-parse HEAD)" \
+    --base-version "")"
+
+  assert_eq "tag" "v1.0.0" "$(metadata_value "$output" tag)"
+  assert_eq "version" "1.0.0" "$(metadata_value "$output" version)"
+  assert_eq "channel_suffix" "" "$(metadata_value "$output" channel_suffix)"
+  assert_eq "is_prerelease" "false" "$(metadata_value "$output" is_prerelease)"
+  assert_eq "is_stable" "true" "$(metadata_value "$output" is_stable)"
+  assert_eq "should_run" "true" "$(metadata_value "$output" should_run)"
+}
+
 test_push_release_candidate_uses_rc_channel() {
   local output
   output="$(TYPEWHISPER_RELEASE_DATE=20260701 bash "$RESOLVER" \
@@ -125,11 +141,23 @@ test_push_release_candidate_uses_rc_channel() {
   assert_eq "should_run" "true" "$(metadata_value "$output" should_run)"
 }
 
+test_unsupported_prerelease_version_fails() {
+  if TYPEWHISPER_RELEASE_DATE=20260701 bash "$RESOLVER" \
+    --event push \
+    --ref-name v1.0.0-beta1 \
+    --sha "$(git rev-parse HEAD)" \
+    --base-version "" >/dev/null 2>&1; then
+    fail "expected resolver to reject unsupported prerelease version"
+  fi
+}
+
 with_repo test_daily_uses_release_candidate_base_when_it_is_newer_than_stable
 with_repo test_daily_uses_next_stable_patch_without_release_candidate
 with_repo test_daily_uses_next_patch_after_stable_catches_up_to_release_candidate
 with_repo test_explicit_base_version_wins
 with_repo test_existing_daily_tag_skips_build
+with_repo test_push_stable_release_uses_plain_channel
 with_repo test_push_release_candidate_uses_rc_channel
+with_repo test_unsupported_prerelease_version_fails
 
 echo "release metadata resolver tests passed"

--- a/.github/scripts/resolve-release-metadata.tests.sh
+++ b/.github/scripts/resolve-release-metadata.tests.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="$SCRIPT_DIR/resolve-release-metadata.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$actual" != "$expected" ]; then
+    fail "$name: expected '$expected', got '$actual'"
+  fi
+}
+
+metadata_value() {
+  local output="$1"
+  local key="$2"
+
+  echo "$output" | awk -F= -v wanted="$key" '$1 == wanted { print substr($0, length($1) + 2) }'
+}
+
+with_repo() {
+  local tmp
+  tmp="$(mktemp -d)"
+
+  (
+    cd "$tmp"
+    git init -q
+    git config user.email "release-test@example.invalid"
+    git config user.name "Release Metadata Test"
+    git commit --allow-empty -m initial >/dev/null
+    "$@"
+  )
+
+  rm -rf "$tmp"
+}
+
+resolve_daily_with_tags() {
+  local sha
+  for tag in "$@"; do
+    git tag "$tag"
+  done
+
+  sha="$(git rev-parse HEAD)"
+  TYPEWHISPER_RELEASE_DATE=20260701 bash "$RESOLVER" \
+    --event schedule \
+    --ref-name main \
+    --sha "$sha" \
+    --base-version ""
+}
+
+test_daily_uses_release_candidate_base_when_it_is_newer_than_stable() {
+  local output
+  output="$(resolve_daily_with_tags v0.8.4 v1.0.0-rc1)"
+
+  assert_eq "tag" "v1.0.0-daily.20260701" "$(metadata_value "$output" tag)"
+  assert_eq "version" "1.0.0-daily.20260701" "$(metadata_value "$output" version)"
+  assert_eq "channel_suffix" "-daily" "$(metadata_value "$output" channel_suffix)"
+  assert_eq "is_prerelease" "true" "$(metadata_value "$output" is_prerelease)"
+  assert_eq "is_stable" "false" "$(metadata_value "$output" is_stable)"
+  assert_eq "should_run" "true" "$(metadata_value "$output" should_run)"
+}
+
+test_daily_uses_next_stable_patch_without_release_candidate() {
+  local output
+  output="$(resolve_daily_with_tags v0.8.4)"
+
+  assert_eq "tag" "v0.8.5-daily.20260701" "$(metadata_value "$output" tag)"
+  assert_eq "version" "0.8.5-daily.20260701" "$(metadata_value "$output" version)"
+}
+
+test_daily_uses_next_patch_after_stable_catches_up_to_release_candidate() {
+  local output
+  output="$(resolve_daily_with_tags v0.8.4 v1.0.0-rc1 v1.0.0)"
+
+  assert_eq "tag" "v1.0.1-daily.20260701" "$(metadata_value "$output" tag)"
+  assert_eq "version" "1.0.1-daily.20260701" "$(metadata_value "$output" version)"
+}
+
+test_explicit_base_version_wins() {
+  local output
+
+  git tag v0.8.4
+  git tag v1.0.0-rc1
+  git tag v1.0.0-daily.20260701
+
+  output="$(TYPEWHISPER_RELEASE_DATE=20260701 bash "$RESOLVER" \
+    --event workflow_dispatch \
+    --ref-name main \
+    --sha "$(git rev-parse HEAD)" \
+    --base-version v2.0.0)"
+
+  assert_eq "tag" "v2.0.0-daily.20260701" "$(metadata_value "$output" tag)"
+  assert_eq "version" "2.0.0-daily.20260701" "$(metadata_value "$output" version)"
+}
+
+test_existing_daily_tag_skips_build() {
+  local output
+  output="$(resolve_daily_with_tags v0.8.4 v1.0.0-rc1 v1.0.0-daily.20260701)"
+
+  assert_eq "tag" "v1.0.0-daily.20260701" "$(metadata_value "$output" tag)"
+  assert_eq "should_run" "false" "$(metadata_value "$output" should_run)"
+}
+
+test_push_release_candidate_uses_rc_channel() {
+  local output
+  output="$(TYPEWHISPER_RELEASE_DATE=20260701 bash "$RESOLVER" \
+    --event push \
+    --ref-name v1.0.0-rc1 \
+    --sha "$(git rev-parse HEAD)" \
+    --base-version "")"
+
+  assert_eq "tag" "v1.0.0-rc1" "$(metadata_value "$output" tag)"
+  assert_eq "version" "1.0.0-rc1" "$(metadata_value "$output" version)"
+  assert_eq "channel_suffix" "-rc" "$(metadata_value "$output" channel_suffix)"
+  assert_eq "is_prerelease" "true" "$(metadata_value "$output" is_prerelease)"
+  assert_eq "is_stable" "false" "$(metadata_value "$output" is_stable)"
+  assert_eq "should_run" "true" "$(metadata_value "$output" should_run)"
+}
+
+with_repo test_daily_uses_release_candidate_base_when_it_is_newer_than_stable
+with_repo test_daily_uses_next_stable_patch_without_release_candidate
+with_repo test_daily_uses_next_patch_after_stable_catches_up_to_release_candidate
+with_repo test_explicit_base_version_wins
+with_repo test_existing_daily_tag_skips_build
+with_repo test_push_release_candidate_uses_rc_channel
+
+echo "release metadata resolver tests passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       base_version:
-        description: 'Base version for daily builds, without v or prerelease suffix. Defaults to latest stable patch + 1.'
+        description: 'Base version for daily builds, without v or prerelease suffix. Defaults to the active release line.'
         required: false
         type: string
 
@@ -31,93 +31,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test release metadata resolver
+        run: bash .github/scripts/resolve-release-metadata.tests.sh
+
       - name: Resolve release metadata
         id: resolve
         env:
           INPUT_BASE_VERSION: ${{ inputs.base_version || '' }}
         run: |
           set -euo pipefail
-
-          EVENT="${{ github.event_name }}"
-          RELEASE_TARGET=""
-
-          if [ "$EVENT" = "push" ]; then
-            TAG="${{ github.ref_name }}"
-            VERSION="${TAG#v}"
-          else
-            BASE_VERSION="${INPUT_BASE_VERSION#v}"
-
-            if [ -z "$BASE_VERSION" ]; then
-              LATEST_STABLE=$(git tag --list 'v[0-9]*' --sort=-v:refname \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-                | head -1 || true)
-
-              if [ -n "$LATEST_STABLE" ]; then
-                STABLE_VERSION="${LATEST_STABLE#v}"
-              else
-                STABLE_VERSION="0.0.0"
-              fi
-
-              IFS='.' read -r MAJOR MINOR PATCH <<< "$STABLE_VERSION"
-              PATCH=$((PATCH + 1))
-              BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-            fi
-
-            if ! echo "$BASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "base_version must look like 0.7.1, got: $BASE_VERSION" >&2
-              exit 1
-            fi
-
-            DATE=$(date -u +%Y%m%d)
-            TAG="v${BASE_VERSION}-daily.${DATE}"
-            VERSION="${BASE_VERSION}-daily.${DATE}"
-            RELEASE_TARGET="${{ github.sha }}"
-
-            if git rev-parse "$TAG" >/dev/null 2>&1; then
-              echo "Daily tag $TAG already exists; skipping."
-              {
-                echo "tag=$TAG"
-                echo "version=$VERSION"
-                echo "channel_suffix=-daily"
-                echo "is_prerelease=true"
-                echo "is_stable=false"
-                echo "should_run=false"
-                echo "release_target=$RELEASE_TARGET"
-              } >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          CHANNEL_SUFFIX=""
-          IS_PRERELEASE="false"
-          IS_STABLE="true"
-
-          if [[ "$VERSION" == *"-daily."* ]]; then
-            CHANNEL_SUFFIX="-daily"
-            IS_PRERELEASE="true"
-            IS_STABLE="false"
-          elif [[ "$VERSION" == *"-rc"* ]]; then
-            CHANNEL_SUFFIX="-rc"
-            IS_PRERELEASE="true"
-            IS_STABLE="false"
-          elif [[ "$VERSION" == *"-"* ]]; then
-            echo "Unsupported prerelease version for Windows app release channels: $VERSION" >&2
-            exit 1
-          fi
-
-          {
-            echo "tag=$TAG"
-            echo "version=$VERSION"
-            echo "channel_suffix=$CHANNEL_SUFFIX"
-            echo "is_prerelease=$IS_PRERELEASE"
-            echo "is_stable=$IS_STABLE"
-            echo "should_run=true"
-            echo "release_target=$RELEASE_TARGET"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "Release tag: $TAG"
-          echo "Package version: $VERSION"
-          echo "Velopack channel suffix: ${CHANNEL_SUFFIX:-<stable>}"
+          bash .github/scripts/resolve-release-metadata.sh \
+            --event "${{ github.event_name }}" \
+            --ref-name "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}" \
+            --base-version "$INPUT_BASE_VERSION" >> "$GITHUB_OUTPUT"
 
   build:
     needs: prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,12 @@ jobs:
         id: resolve
         env:
           INPUT_BASE_VERSION: ${{ inputs.base_version || '' }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           bash .github/scripts/resolve-release-metadata.sh \
             --event "${{ github.event_name }}" \
-            --ref-name "${{ github.ref_name }}" \
+            --ref-name "$RELEASE_REF_NAME" \
             --sha "${{ github.sha }}" \
             --base-version "$INPUT_BASE_VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Move Windows release metadata resolution into a tested script.
- Use the active release line for scheduled daily builds, including the latest release-candidate base version.
- Run the resolver tests in the release workflow before publishing packages.

## Root Cause
Scheduled daily builds only looked at the latest stable tag and incremented its patch version. After `v1.0.0-rc1` was published, the scheduler still based daily builds on `v0.8.4`, producing `v0.8.5-daily.*` instead of `v1.0.0-daily.*`.

## Validation
- `bash .github/scripts/resolve-release-metadata.tests.sh`
- `bash -n .github/scripts/resolve-release-metadata.sh`
- `bash -n .github/scripts/resolve-release-metadata.tests.sh`
- Simulated the current repository state for July 1, 2026 and confirmed `v1.0.0-daily.20260701` with `should_run=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved release metadata handling for automated release workflows, including clearer tag, version, channel, and release-target output.
* **Bug Fixes**
  * Added safeguards to skip release runs when a daily tag already exists.
  * Added validation for unsupported prerelease version formats.
* **Tests**
  * Added coverage for daily releases, push releases, existing-tag skips, and invalid prerelease cases.
* **Chores**
  * Updated the release workflow to use the new metadata resolver and test it before preparing a release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->