### PR TITLE
Allow preview channel update downgrades

### DIFF
--- a/src/TypeWhisper.Windows/Services/UpdateService.cs
+++ b/src/TypeWhisper.Windows/Services/UpdateService.cs
@@ -87,7 +87,7 @@ public sealed class UpdateService
         {
             _updateManager = new UpdateManager(
                 new GithubSource(TypeWhisperEnvironment.GithubRepoUrl, null, resolvedChannel != ReleaseChannel.Stable),
-                new UpdateOptions { ExplicitChannel = GetVelopackChannel(RuntimeInformation.OSArchitecture, resolvedChannel) });
+                CreateUpdateOptions(RuntimeInformation.OSArchitecture, resolvedChannel));
         }
         catch
         {
@@ -194,6 +194,15 @@ public sealed class UpdateService
             ReleaseChannel.ReleaseCandidate => $"{arch}-rc",
             ReleaseChannel.Daily => $"{arch}-daily",
             _ => arch
+        };
+    }
+
+    internal static UpdateOptions CreateUpdateOptions(Architecture architecture, ReleaseChannel channel)
+    {
+        return new UpdateOptions
+        {
+            ExplicitChannel = GetVelopackChannel(architecture, channel),
+            AllowVersionDowngrade = channel is ReleaseChannel.ReleaseCandidate or ReleaseChannel.Daily
         };
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
@@ -34,6 +34,21 @@ public class UpdateServiceTests
     }
 
     [Theory]
+    [InlineData(ReleaseChannel.Stable, "win-x64", false)]
+    [InlineData(ReleaseChannel.ReleaseCandidate, "win-x64-rc", true)]
+    [InlineData(ReleaseChannel.Daily, "win-x64-daily", true)]
+    public void CreateUpdateOptions_AllowsDowngradeForExplicitPreviewChannelSwitches(
+        ReleaseChannel channel,
+        string expectedChannel,
+        bool expectedAllowDowngrade)
+    {
+        var options = UpdateService.CreateUpdateOptions(Architecture.X64, channel);
+
+        Assert.Equal(expectedChannel, options.ExplicitChannel);
+        Assert.Equal(expectedAllowDowngrade, options.AllowVersionDowngrade);
+    }
+
+    [Theory]
     [InlineData("stable", "0.7.0-rc1", ReleaseChannel.Stable)]
     [InlineData("release-candidate", "0.7.0", ReleaseChannel.ReleaseCandidate)]
     [InlineData("rc", "0.7.0", ReleaseChannel.ReleaseCandidate)]


### PR DESCRIPTION
## Summary
- Allow version downgrades only when an explicit preview channel is selected.
- Reuse the shared update option builder during update manager initialization.
- Add coverage for stable, release candidate, and daily update option behavior.

## Testing
- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --filter FullyQualifiedName~UpdateServiceTests --no-restore
- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore
- dotnet restore TypeWhisper.slnx
- dotnet test TypeWhisper.slnx --no-restore