### PR TITLE
Fix uninstall for bundled plugins

### DIFF
--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -33,6 +33,7 @@ public sealed class PluginRegistryService
     private readonly ISettingsService _settings;
     private readonly HttpClient _httpClient;
     private readonly string _pluginsPath;
+    private readonly string _bundledPluginsPath;
     private readonly string _pendingUpdatesPath;
     private readonly string _pendingUninstallsPath;
     private readonly Func<string, string, CancellationToken, Task> _replaceActiveDirectoryAsync;
@@ -52,13 +53,15 @@ public sealed class PluginRegistryService
         HttpClient? httpClient = null,
         string? pluginsPath = null,
         Func<string, string, CancellationToken, Task>? replaceActiveDirectoryAsync = null,
-        Func<string, CancellationToken, Task>? deleteActiveDirectoryAsync = null)
+        Func<string, CancellationToken, Task>? deleteActiveDirectoryAsync = null,
+        string? bundledPluginsPath = null)
     {
         _pluginManager = pluginManager;
         _pluginLoader = pluginLoader;
         _settings = settings;
         _httpClient = httpClient ?? new HttpClient();
         _pluginsPath = Path.GetFullPath(pluginsPath ?? TypeWhisperEnvironment.PluginsPath);
+        _bundledPluginsPath = Path.GetFullPath(bundledPluginsPath ?? Path.Join(AppContext.BaseDirectory, "Plugins"));
         _pendingUpdatesPath = GetValidatedChildDirectory(_pluginsPath, PendingUpdatesDirectoryName, "pending updates directory");
         _pendingUninstallsPath = GetValidatedChildDirectory(_pluginsPath, PendingUninstallsDirectoryName, "pending uninstalls directory");
         _replaceActiveDirectoryAsync = replaceActiveDirectoryAsync ?? ReplaceActiveDirectoryAsync;
@@ -244,20 +247,16 @@ public sealed class PluginRegistryService
             return PluginUninstallResult.PendingRestart;
         }
 
-        var pluginDir = GetValidatedPluginDirectory(pluginId);
-        if (Directory.Exists(pluginDir))
+        try
         {
-            try
-            {
-                await _deleteActiveDirectoryAsync(pluginDir, ct);
-                Debug.WriteLine($"[PluginRegistry] Uninstalled plugin: {pluginId}");
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-                QueuePendingUninstall(pluginId);
-                Debug.WriteLine($"[PluginRegistry] Queued plugin uninstall pending restart: {pluginId} ({ex.Message})");
-                return PluginUninstallResult.PendingRestart;
-            }
+            await DeleteInstalledPluginDirectoriesAsync(pluginId, ct);
+            Debug.WriteLine($"[PluginRegistry] Uninstalled plugin: {pluginId}");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            QueuePendingUninstall(pluginId);
+            Debug.WriteLine($"[PluginRegistry] Queued plugin uninstall pending restart: {pluginId} ({ex.Message})");
+            return PluginUninstallResult.PendingRestart;
         }
 
         await ClearPendingUninstallAsync(pluginId, ct);
@@ -323,13 +322,10 @@ public sealed class PluginRegistryService
                 continue;
             }
 
-            var pluginDir = GetValidatedPluginDirectory(pluginId);
             try
             {
                 await DeletePendingUpdateDirectoryAsync(pluginId, ct);
-
-                if (Directory.Exists(pluginDir))
-                    await _deleteActiveDirectoryAsync(pluginDir, ct);
+                await DeleteInstalledPluginDirectoriesAsync(pluginId, ct);
 
                 await ClearPendingUninstallAsync(pluginId, ct);
                 Debug.WriteLine($"[PluginRegistry] Applied pending plugin uninstall: {pluginId}");
@@ -451,6 +447,15 @@ public sealed class PluginRegistryService
         await _deleteActiveDirectoryAsync(pendingDir, ct);
     }
 
+    private async Task DeleteInstalledPluginDirectoriesAsync(string pluginId, CancellationToken ct)
+    {
+        foreach (var pluginDir in GetInstalledPluginDirectories(pluginId))
+        {
+            if (Directory.Exists(pluginDir))
+                await _deleteActiveDirectoryAsync(pluginDir, ct);
+        }
+    }
+
     private async Task ClearPendingUninstallAsync(string pluginId, CancellationToken ct)
     {
         var pendingDir = GetValidatedPendingUninstallDirectory(pluginId);
@@ -540,13 +545,35 @@ public sealed class PluginRegistryService
 
     private static void CollectUnloadedPluginContexts()
     {
+        GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
     }
 
     private string GetValidatedPluginDirectory(string pluginId)
     {
         ValidatePluginId(pluginId);
         return GetValidatedChildDirectory(_pluginsPath, pluginId, "plugin directory");
+    }
+
+    private IReadOnlyList<string> GetInstalledPluginDirectories(string pluginId)
+    {
+        var directories = new List<string>();
+        AddDistinctDirectory(GetValidatedPluginDirectory(pluginId));
+        AddDistinctDirectory(GetValidatedBundledPluginDirectory(pluginId));
+        return directories;
+
+        void AddDistinctDirectory(string path)
+        {
+            if (!directories.Any(existing => PathsEqual(existing, path)))
+                directories.Add(path);
+        }
+    }
+
+    private string GetValidatedBundledPluginDirectory(string pluginId)
+    {
+        ValidatePluginId(pluginId);
+        return GetValidatedChildDirectory(_bundledPluginsPath, pluginId, "bundled plugin directory");
     }
 
     private string GetValidatedPendingDirectory(string pluginId)
@@ -599,6 +626,9 @@ public sealed class PluginRegistryService
         path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar)
             ? path
             : path + Path.DirectorySeparatorChar;
+
+    private static bool PathsEqual(string first, string second) =>
+        string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), StringComparison.OrdinalIgnoreCase);
 
     private static void DeleteDirectoryIfExists(string path)
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -395,6 +395,30 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ApplyPendingUpdatesAsync_DeletesPendingBundledUninstallBeforeLoad()
+    {
+        var manager = CreateManager();
+        var pluginId = "com.test.apply-pending-bundled-uninstall";
+        var bundledPluginsRoot = Path.Combine(_pluginsRoot, "bundled");
+        var bundledDir = Path.Combine(bundledPluginsRoot, pluginId);
+        var pendingUninstallDir = Path.Combine(_pluginsRoot, ".pending-uninstalls", pluginId);
+        WritePluginManifest(bundledDir, pluginId, "1.0.0");
+        File.WriteAllText(Path.Combine(bundledDir, "bundled.txt"), "old");
+        Directory.CreateDirectory(pendingUninstallDir);
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            bundledPluginsPath: bundledPluginsRoot);
+
+        await service.ApplyPendingUpdatesAsync();
+
+        Assert.False(Directory.Exists(bundledDir));
+        Assert.False(Directory.Exists(pendingUninstallDir));
+    }
+
+    [Fact]
     public async Task ApplyPendingUpdatesAsync_PendingUninstallKeepsMarkerWhenPendingUpdateDeleteFails()
     {
         var manager = CreateManager();
@@ -645,6 +669,34 @@ public class PluginRegistryServiceTests : IDisposable
         Assert.Equal(PluginUninstallResult.Uninstalled, result);
         Assert.False(Directory.Exists(activeDir));
         Assert.False(Directory.Exists(pendingUpdateDir));
+        Assert.Equal(PluginInstallState.NotInstalled, service.GetInstallState(registryPlugin));
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_DeleteSuccess_RemovesBundledDirectory()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.uninstall-bundled", "1.0.0");
+        var bundledPluginsRoot = Path.Combine(_pluginsRoot, "bundled");
+        var bundledDir = Path.Combine(bundledPluginsRoot, registryPlugin.Id);
+        WritePluginManifest(bundledDir, registryPlugin.Id, "1.0.0");
+        File.WriteAllText(Path.Combine(bundledDir, "bundled.txt"), "old");
+        TestPluginManagerFactory.SetPrivateField(
+            manager,
+            "_allPlugins",
+            new List<LoadedPlugin> { CreateLoadedPlugin(registryPlugin.Id, registryPlugin.Version, bundledDir) });
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            pluginsPath: _pluginsRoot,
+            bundledPluginsPath: bundledPluginsRoot);
+
+        var result = await service.UninstallPluginAsync(registryPlugin.Id);
+
+        Assert.Equal(PluginUninstallResult.Uninstalled, result);
+        Assert.Null(manager.GetPlugin(registryPlugin.Id));
+        Assert.False(Directory.Exists(bundledDir));
         Assert.Equal(PluginInstallState.NotInstalled, service.GetInstallState(registryPlugin));
     }
 
@@ -987,6 +1039,29 @@ public class PluginRegistryServiceTests : IDisposable
             PluginClass = "TestPlugin"
         };
         File.WriteAllText(Path.Combine(pluginDir, "manifest.json"), JsonSerializer.Serialize(manifest));
+    }
+
+    private static LoadedPlugin CreateLoadedPlugin(string id, string version, string pluginDirectory)
+    {
+        var plugin = new Mock<ITypeWhisperPlugin>();
+        plugin.Setup(p => p.PluginId).Returns(id);
+        plugin.Setup(p => p.PluginName).Returns("Test Plugin");
+        plugin.Setup(p => p.PluginVersion).Returns(version);
+
+        var manifest = new PluginManifest
+        {
+            Id = id,
+            Name = "Test Plugin",
+            Version = version,
+            AssemblyName = "TestPlugin.dll",
+            PluginClass = "TestPlugin"
+        };
+
+        return new LoadedPlugin(
+            manifest,
+            plugin.Object,
+            new PluginAssemblyLoadContext(typeof(PluginRegistryServiceTests).Assembly.Location),
+            pluginDirectory);
     }
 
     private static PluginManifest ReadManifest(string pluginDir)


### PR DESCRIPTION
## Summary
- Delete bundled plugin directories from the app `Plugins` folder during uninstall, not only the user plugin root.
- Apply pending uninstall markers to both user and bundled plugin directories before plugin discovery.
- Force collection after unloading plugin load contexts before deleting plugin files.

## Root Cause
Bundled plugins such as Cerebras are loaded from `current/Plugins`, while uninstall only removed `%LocalAppData%/TypeWhisper/Plugins/<pluginId>`. That allowed the UI to unload the plugin for the current session while leaving the bundled directory behind, so the plugin returned after restart.

## Validation
- `dotnet test tests\\TypeWhisper.PluginSystem.Tests\\TypeWhisper.PluginSystem.Tests.csproj --no-restore`
- `dotnet test TypeWhisper.slnx --no-restore`
