### PR TITLE
Add 1.0 stable release notes

### DIFF
--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,0 +1,29 @@
+# TypeWhisper v1.0.0
+
+TypeWhisper 1.0.0 is the stable Windows 1.0 release. It brings the 1.0 release candidate work to the stable update channel with update reliability, plugin lifecycle fixes, target-app learning improvements, and the Windows 1.0 screenshot set.
+
+## Highlights
+
+- Promoted the Windows 1.0 release line from release candidate to the stable Velopack channel.
+- Kept the stable release focused on reliability, update behavior, plugin lifecycle, and release polish.
+- Added the Windows 1.0 screenshot set for the current app surfaces.
+
+## Improvements
+
+- Improved update-channel behavior for explicit stable, release candidate, and daily channel selections.
+- Improved bundled plugin uninstall handling so app-bundled plugin directories are removed consistently.
+- Improved target-app autocorrection learning for Electron-based apps.
+- Included plugin script files in release packages and refreshed bundled plugin compatibility for the 1.0 line.
+
+## Fixes
+
+- Fixed bundled plugins returning after restart after uninstall.
+- Fixed daily release version-base resolution after RC/stable tags.
+- Fixed Groq recorder transcription on systems without Media Foundation AAC by falling back to WAV upload.
+- Resolved Granite Speech package audit issues for release packaging.
+
+## Validation Notes
+
+- Verify stable Velopack channels `win-x64` and `win-arm64`.
+- Confirm x64 and ARM64 installers, portable ZIPs, full nupkg packages, RELEASES files, and JSON manifests are present without `-rc` or `-daily` suffixes.
+- Check installer Authenticode status explicitly before announcing release quality.


### PR DESCRIPTION
## Summary
- Add curated release notes for the stable TypeWhisper 1.0.0 Windows release.
- Document the stable channel focus, post-RC improvements, fixes, and release validation notes.

## Validation
- git diff --check
- bash .github/scripts/resolve-release-metadata.tests.sh (via temporary LF-normalized copies because this Windows checkout has CRLF shell scripts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for TypeWhisper v1.0.0.
  * Documented the move from the 1.0 release candidate to the stable Velopack channel.
  * Included release highlights, improvements, fixes, and validation notes for installer/package availability and signature checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->