### PR TITLE
Stop installing plugins by default

### DIFF
--- a/.github/workflows/package-dry-run.yml
+++ b/.github/workflows/package-dry-run.yml
@@ -84,35 +84,8 @@ jobs:
       - name: Build solution
         run: dotnet build TypeWhisper.slnx -c Release --no-restore -p:Version=${{ steps.meta.outputs.version }} -bl:artifacts/logs/typewhisper-package.binlog
 
-      - name: Build bundled plugins
-        shell: pwsh
-        run: |
-          foreach ($project in Get-ChildItem plugins -Recurse -Filter *.csproj | Sort-Object FullName) {
-            dotnet restore $project.FullName
-            if ($LASTEXITCODE -ne 0) {
-              throw "Restore failed: $($project.FullName)"
-            }
-
-            dotnet build $project.FullName -c Release --no-restore -p:Version=${{ steps.meta.outputs.version }}
-            if ($LASTEXITCODE -ne 0) {
-              throw "Build failed: $($project.FullName)"
-            }
-          }
-
       - name: Publish app
         run: dotnet publish src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ steps.meta.outputs.version }} -o publish/${{ matrix.rid }}
-
-      - name: Copy bundled plugins into publish output
-        shell: pwsh
-        run: |
-          $pluginsSrc = Resolve-Path "src/TypeWhisper.Windows/bin/Release/net10.0-windows/Plugins"
-          $pluginDirs = Get-ChildItem $pluginsSrc -Directory
-
-          if (-not $pluginDirs) {
-            throw "No bundled plugins found in $pluginsSrc."
-          }
-
-          Copy-Item -Path $pluginsSrc -Destination "publish/${{ matrix.rid }}/Plugins" -Recurse -Force
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,21 +75,6 @@ jobs:
       - name: Build solution
         run: dotnet build TypeWhisper.slnx -c Release -p:Version=${{ env.VERSION }} --no-restore
 
-      - name: Build bundled plugins
-        shell: pwsh
-        run: |
-          foreach ($project in Get-ChildItem plugins -Recurse -Filter *.csproj | Sort-Object FullName) {
-            dotnet restore $project.FullName
-            if ($LASTEXITCODE -ne 0) {
-              throw "Restore failed: $($project.FullName)"
-            }
-
-            dotnet build $project.FullName -c Release --no-restore -p:Version=$env:VERSION
-            if ($LASTEXITCODE -ne 0) {
-              throw "Build failed: $($project.FullName)"
-            }
-          }
-
       - name: Test TypeWhisper.Core
         run: dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-build
         if: matrix.rid == 'win-x64'
@@ -100,18 +85,6 @@ jobs:
 
       - name: Publish app
         run: dotnet publish src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ env.VERSION }} -o publish/${{ matrix.rid }}
-
-      - name: Copy bundled plugins into publish output
-        shell: pwsh
-        run: |
-          $pluginsSrc = Resolve-Path "src/TypeWhisper.Windows/bin/Release/net10.0-windows/Plugins"
-          $pluginDirs = Get-ChildItem $pluginsSrc -Directory
-
-          if (-not $pluginDirs) {
-            throw "No bundled plugins found in $pluginsSrc."
-          }
-
-          Copy-Item -Path $pluginsSrc -Destination "publish/${{ matrix.rid }}/Plugins" -Recurse -Force
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk

--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -127,7 +127,7 @@ public partial class App : Application
         _ = ProcessProtocolArgsAsync(e.Args);
         StartProtocolCallbackWatcher();
 
-        // Plugin registry: first-run auto-install + update check (non-blocking)
+        // Plugin registry: mark first-run plugin setup complete without installing marketplace plugins.
         _ = pluginRegistry.FirstRunAutoInstallAsync()
             .ContinueWith(_ => pluginRegistry.CheckForUpdatesAsync(), TaskScheduler.Default)
             .ContinueWith(t =>

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -359,40 +359,16 @@ public sealed class PluginRegistryService
     }
 
     /// <summary>
-    /// On first run, auto-installs all compatible registry plugins.
-    /// Sets the PluginFirstRunCompleted flag to prevent re-running.
+    /// Marks first-run plugin setup as complete without installing marketplace plugins by default.
     /// </summary>
-    public async Task FirstRunAutoInstallAsync(CancellationToken ct = default)
+    public Task FirstRunAutoInstallAsync(CancellationToken ct = default)
     {
         if (_settings.Current.PluginFirstRunCompleted)
-            return;
+            return Task.CompletedTask;
 
-        Debug.WriteLine("[PluginRegistry] First run detected, auto-installing registry plugins...");
-
-        try
-        {
-            var registry = await FetchRegistryAsync(ct);
-            foreach (var plugin in registry)
-            {
-                if (GetInstallState(plugin) == PluginInstallState.NotInstalled)
-                {
-                    try
-                    {
-                        await InstallPluginAsync(plugin, ct: ct);
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine($"[PluginRegistry] Auto-install failed for {plugin.Id}: {ex.Message}");
-                    }
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[PluginRegistry] First run auto-install failed: {ex.Message}");
-        }
-
+        Debug.WriteLine("[PluginRegistry] First run detected; marketplace plugin auto-install is disabled.");
         _settings.Save(_settings.Current with { PluginFirstRunCompleted = true });
+        return Task.CompletedTask;
     }
 
     private static Version GetHostVersion()

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -1,0 +1,16 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class PluginPackagingWorkflowTests
+{
+    [Theory]
+    [InlineData(".github", "workflows", "release.yml")]
+    [InlineData(".github", "workflows", "package-dry-run.yml")]
+    public void InstallerWorkflows_DoNotBundlePluginsIntoAppPackage(params string[] workflowPath)
+    {
+        var workflow = TestFile.ReadProjectFile(workflowPath);
+
+        Assert.DoesNotContain("Copy bundled plugins into publish output", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("src/TypeWhisper.Windows/bin/Release/net10.0-windows/Plugins", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("publish/${{ matrix.rid }}/Plugins", workflow, StringComparison.Ordinal);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -978,6 +978,54 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FirstRunAutoInstallAsync_DoesNotFetchOrInstallMarketplacePlugins()
+    {
+        AppSettings? savedSettings = null;
+        _settings.Setup(s => s.Save(It.IsAny<AppSettings>()))
+            .Callback<AppSettings>(s => savedSettings = s);
+        _settings.Setup(s => s.Current).Returns(new AppSettings { PluginFirstRunCompleted = false });
+
+        var registryJson = JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                Id = "com.test.auto-install",
+                Name = "Auto Install",
+                Version = "1.0.0",
+                Author = "Tester",
+                Description = "Should not be installed automatically",
+                Size = 1024L,
+                DownloadUrl = "https://example.com/auto-install.zip",
+                RequiresApiKey = false
+            }
+        });
+        var requestCount = 0;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                requestCount++;
+                return TrackDisposable(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(registryJson)
+                });
+            });
+        var httpClient = TrackDisposable(new HttpClient(handler.Object));
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, httpClient, pluginsPath: _pluginsRoot);
+
+        await service.FirstRunAutoInstallAsync();
+
+        Assert.Equal(0, requestCount);
+        Assert.NotNull(savedSettings);
+        Assert.True(savedSettings!.PluginFirstRunCompleted);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(_pluginsRoot));
+    }
+
+    [Fact]
     public async Task FirstRunAutoInstallAsync_SkipsWhenAlreadyCompleted()
     {
         _settings.Setup(s => s.Current).Returns(new AppSettings { PluginFirstRunCompleted = true });


### PR DESCRIPTION
## Summary
- Stop first-run setup from automatically fetching and installing marketplace plugins.
- Remove release and package dry-run steps that copied bundled plugins into the app package.
- Add regression coverage for first-run no-install behavior and installer workflow packaging.

## Root Cause
Fresh installs could still show plugins as installed because the app package bundled plugin folders and first-run setup installed every compatible marketplace plugin by default.

## Validation
- `dotnet test TypeWhisper.slnx --no-restore -m:1`
- `git diff --check --cached`
- Temporary `dotnet publish src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release -r win-x64 --no-restore -p:Version=0.0.0-local` output contains no `Plugins` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows packaging now publishes the app without bundling marketplace plugins into the install output.
  * First-run setup no longer automatically fetches or installs marketplace plugins; it now simply marks setup as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->