### PR TITLE
Fix sherpa-onnx native runtime loading

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -146,7 +146,7 @@ jobs:
           $runtimesDir = Join-Path $outputDir 'runtimes'
           if (Test-Path $runtimesDir) {
             New-Item -ItemType Directory -Path "$stagingDir/runtimes" -Force | Out-Null
-            foreach ($runtimeName in @('win-x64', 'win-arm64', 'cuda/win-x64', 'vulkan/win-x64')) {
+            foreach ($runtimeName in @('win-x64', 'win-arm64', 'win-x86', 'cuda/win-x64', 'vulkan/win-x64')) {
               $runtimeDir = Join-Path $runtimesDir $runtimeName
               if (Test-Path $runtimeDir) {
                 $runtimeDestination = Join-Path "$stagingDir/runtimes" $runtimeName
@@ -165,6 +165,22 @@ jobs:
             $vulkanRuntime = Join-Path $stagingDir 'runtimes/vulkan/win-x64/ggml-vulkan-whisper.dll'
             if (-not (Test-Path $vulkanRuntime)) {
               throw "Missing required whisper.cpp Vulkan runtime: $vulkanRuntime"
+            }
+          }
+
+          if ($env:PLUGIN_NAME -eq 'sherpa-onnx') {
+            foreach ($runtime in @(
+              'runtimes/win-x64/native/sherpa-onnx-c-api.dll',
+              'runtimes/win-x64/native/onnxruntime.dll',
+              'runtimes/win-arm64/native/sherpa-onnx-c-api.dll',
+              'runtimes/win-arm64/native/onnxruntime.dll',
+              'runtimes/win-x86/native/sherpa-onnx-c-api.dll',
+              'runtimes/win-x86/native/onnxruntime.dll'
+            )) {
+              $runtimePath = Join-Path $stagingDir $runtime
+              if (-not (Test-Path $runtimePath)) {
+                throw "Missing required sherpa-onnx runtime: $runtimePath"
+              }
             }
           }
 

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -172,10 +172,13 @@ jobs:
             foreach ($runtime in @(
               'runtimes/win-x64/native/sherpa-onnx-c-api.dll',
               'runtimes/win-x64/native/onnxruntime.dll',
+              'runtimes/win-x64/native/sherpaort.dll',
               'runtimes/win-arm64/native/sherpa-onnx-c-api.dll',
               'runtimes/win-arm64/native/onnxruntime.dll',
+              'runtimes/win-arm64/native/sherpaort.dll',
               'runtimes/win-x86/native/sherpa-onnx-c-api.dll',
-              'runtimes/win-x86/native/onnxruntime.dll'
+              'runtimes/win-x86/native/onnxruntime.dll',
+              'runtimes/win-x86/native/sherpaort.dll'
             )) {
               $runtimePath = Join-Path $stagingDir $runtime
               if (-not (Test-Path $runtimePath)) {

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeInstaller.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeInstaller.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using SharpCompress.Archives;
@@ -23,12 +24,22 @@ internal sealed class SherpaCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
     internal const string AssetFileName = "sherpa-onnx-v1.13.0-cuda-12.x-cudnn-9.x-win-x64-cuda.tar.bz2";
     internal const string DownloadUrl =
         "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.0/" + AssetFileName;
+    private const string SherpaNativeLibraryFileName = "sherpa-onnx-c-api.dll";
+    private const string OnnxRuntimeFileName = "onnxruntime.dll";
+    private const string SherpaOnnxRuntimeDependencyFileName = "sherpaort.dll";
+    private const string OnnxRuntimeCudaProviderFileName = "onnxruntime_providers_cuda.dll";
+
+    private static readonly string[] DownloadedRuntimeFiles =
+    [
+        SherpaNativeLibraryFileName,
+        OnnxRuntimeFileName,
+        OnnxRuntimeCudaProviderFileName
+    ];
 
     private static readonly string[] CoreRuntimeFiles =
     [
-        "sherpa-onnx-c-api.dll",
-        "onnxruntime.dll",
-        "onnxruntime_providers_cuda.dll"
+        .. DownloadedRuntimeFiles,
+        SherpaOnnxRuntimeDependencyFileName
     ];
 
     private static readonly CudaDependencyPackage[] CudaDependencyPackages =
@@ -85,7 +96,9 @@ internal sealed class SherpaCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
     /// <summary>
     /// Returns whether installed.
     /// </summary>
-    public bool IsInstalled => RequiredFiles.All(file => File.Exists(GetRuntimeFilePath(file)));
+    public bool IsInstalled =>
+        RequiredFiles.All(file => File.Exists(GetRuntimeFilePath(file)))
+        && IsRuntimeImportPatched(GetRuntimeFilePath(SherpaNativeLibraryFileName));
 
     /// <summary>
     /// Ensures installed asynchronously..
@@ -104,9 +117,10 @@ internal sealed class SherpaCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
             Directory.CreateDirectory(_runtimeRoot);
             Directory.CreateDirectory(RuntimeDirectory);
 
-            if (!HasRequiredFiles(CoreRuntimeFiles))
+            if (!HasRequiredFiles(DownloadedRuntimeFiles))
                 await InstallSherpaRuntimeAsync(cancellationToken);
 
+            EnsureSherpaRuntimeImportAlias(RuntimeDirectory);
             await InstallCudaProviderDependenciesAsync(cancellationToken);
             ValidateInstalledRuntime();
         }
@@ -263,9 +277,95 @@ internal sealed class SherpaCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
 
     private static string? FindNativeRuntimeDirectory(string rootDirectory) =>
         Directory
-            .EnumerateFiles(rootDirectory, "sherpa-onnx-c-api.dll", SearchOption.AllDirectories)
+            .EnumerateFiles(rootDirectory, SherpaNativeLibraryFileName, SearchOption.AllDirectories)
             .Select(Path.GetDirectoryName)
             .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
+
+    internal static void EnsureSherpaRuntimeImportAlias(string runtimeDirectory)
+    {
+        var onnxRuntimePath = Path.Join(runtimeDirectory, OnnxRuntimeFileName);
+        var sherpaRuntimePath = Path.Join(runtimeDirectory, SherpaOnnxRuntimeDependencyFileName);
+        if (!File.Exists(onnxRuntimePath))
+            throw new InvalidOperationException($"The sherpa-onnx CUDA runtime is missing {OnnxRuntimeFileName}.");
+
+        File.Copy(onnxRuntimePath, sherpaRuntimePath, overwrite: true);
+
+        PatchRuntimeImport(Path.Join(runtimeDirectory, SherpaNativeLibraryFileName), requireImport: true);
+        PatchRuntimeImport(Path.Join(runtimeDirectory, OnnxRuntimeCudaProviderFileName), requireImport: false);
+    }
+
+    private static void PatchRuntimeImport(string libraryPath, bool requireImport)
+    {
+        if (!File.Exists(libraryPath))
+        {
+            if (requireImport)
+                throw new InvalidOperationException($"The sherpa-onnx CUDA runtime is missing {Path.GetFileName(libraryPath)}.");
+
+            return;
+        }
+
+        var original = Encoding.ASCII.GetBytes(OnnxRuntimeFileName + '\0');
+        var patchedBytes = Encoding.ASCII.GetBytes(SherpaOnnxRuntimeDependencyFileName + '\0');
+        var patched = new byte[original.Length];
+        Array.Copy(patchedBytes, patched, patchedBytes.Length);
+
+        var bytes = File.ReadAllBytes(libraryPath);
+        var originalOffsets = FindNeedleOffsets(bytes, original).ToList();
+        var patchedOffsets = FindNeedleOffsets(bytes, patched).ToList();
+
+        if (originalOffsets.Count == 0 && patchedOffsets.Count > 0)
+            return;
+
+        if (originalOffsets.Count == 0)
+        {
+            if (requireImport)
+            {
+                throw new InvalidOperationException(
+                    $"Expected {Path.GetFileName(libraryPath)} to import {OnnxRuntimeFileName}.");
+            }
+
+            return;
+        }
+
+        foreach (var offset in originalOffsets)
+            Array.Copy(patched, 0, bytes, offset, patched.Length);
+
+        File.WriteAllBytes(libraryPath, bytes);
+    }
+
+    private static bool IsRuntimeImportPatched(string libraryPath)
+    {
+        if (!File.Exists(libraryPath))
+            return false;
+
+        var bytes = File.ReadAllBytes(libraryPath);
+        var original = Encoding.ASCII.GetBytes(OnnxRuntimeFileName + '\0');
+        var patchedBytes = Encoding.ASCII.GetBytes(SherpaOnnxRuntimeDependencyFileName + '\0');
+        var patched = new byte[original.Length];
+        Array.Copy(patchedBytes, patched, patchedBytes.Length);
+
+        return !FindNeedleOffsets(bytes, original).Any()
+               && FindNeedleOffsets(bytes, patched).Any();
+    }
+
+    private static IEnumerable<int> FindNeedleOffsets(byte[] bytes, byte[] needle)
+    {
+        for (var offset = 0; offset <= bytes.Length - needle.Length; offset++)
+        {
+            var matches = true;
+            for (var index = 0; index < needle.Length; index++)
+            {
+                if (bytes[offset + index] == needle[index])
+                    continue;
+
+                matches = false;
+                break;
+            }
+
+            if (matches)
+                yield return offset;
+        }
+    }
 
     private bool HasRequiredFiles(IEnumerable<string> files) =>
         files.All(file => File.Exists(GetRuntimeFilePath(file)));

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
@@ -10,9 +10,9 @@ internal static class SherpaOnnxNativeRuntime
 {
     private const string SherpaNativeLibraryBaseName = "sherpa-onnx-c-api";
     private const string SherpaNativeLibraryFileName = "sherpa-onnx-c-api.dll";
-    private const string OnnxRuntimeFileName = "onnxruntime.dll";
-    private const uint LoadLibrarySearchDllLoadDir = 0x00000100;
-    private const uint LoadLibrarySearchDefaultDirs = 0x00001000;
+    private const string SherpaOnnxRuntimeDependencyFileName = "sherpaort.dll";
+    private const DllImportSearchPath SherpaImportSearchPath =
+        DllImportSearchPath.UseDllDirectoryForDependencies | DllImportSearchPath.SafeDirectories;
 
     private static readonly object Sync = new();
     private static bool _resolverRegistered;
@@ -67,22 +67,23 @@ internal static class SherpaOnnxNativeRuntime
             throw new DllNotFoundException("Unable to determine the sherpa-onnx native runtime directory.");
 
         var candidate = Path.Join(runtimeDirectory, SherpaNativeLibraryFileName);
-        var onnxRuntime = Path.Join(runtimeDirectory, OnnxRuntimeFileName);
+        var onnxRuntime = Path.Join(runtimeDirectory, SherpaOnnxRuntimeDependencyFileName);
         if (!File.Exists(candidate) || !File.Exists(onnxRuntime))
             throw new DllNotFoundException(CreateMissingRuntimeMessage(runtimeDirectory));
 
-        var handle = LoadLibraryEx(
-            candidate,
-            IntPtr.Zero,
-            LoadLibrarySearchDllLoadDir | LoadLibrarySearchDefaultDirs);
-        if (handle == IntPtr.Zero)
+        try
         {
-            var error = Marshal.GetLastWin32Error();
-            throw new DllNotFoundException(
-                $"{CreateMissingRuntimeMessage(runtimeDirectory)} Windows loader error: {error}.");
+            return NativeLibrary.Load(
+                candidate,
+                typeof(SherpaOnnxNativeRuntime).Assembly,
+                SherpaImportSearchPath);
         }
-
-        return handle;
+        catch (Exception ex) when (ex is DllNotFoundException or BadImageFormatException or FileLoadException)
+        {
+            throw new DllNotFoundException(
+                $"{CreateMissingRuntimeMessage(runtimeDirectory)} Loader error: {ex.Message}",
+                ex);
+        }
     }
 
     internal static string? ResolveBundledRuntimeDirectory(string assemblyLocation, Architecture architecture)
@@ -106,7 +107,7 @@ internal static class SherpaOnnxNativeRuntime
 
     internal static string CreateMissingRuntimeMessage(string runtimeDirectory) =>
         "Unable to load the sherpa-onnx native runtime. Expected "
-        + $"{SherpaNativeLibraryFileName} and {OnnxRuntimeFileName} under '{runtimeDirectory}'. "
+        + $"{SherpaNativeLibraryFileName} and {SherpaOnnxRuntimeDependencyFileName} under '{runtimeDirectory}'. "
         + "Reinstall the sherpa-onnx plugin or update it from the plugin marketplace.";
 
     private static bool IsSherpaNativeLibrary(string libraryName)
@@ -124,7 +125,4 @@ internal static class SherpaOnnxNativeRuntime
 
         Environment.SetEnvironmentVariable("PATH", runtimeDirectory + Path.PathSeparator + current);
     }
-
-    [DllImport("kernel32.dll", EntryPoint = "LoadLibraryExW", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern IntPtr LoadLibraryEx(string lpLibFileName, IntPtr hFile, uint dwFlags);
 }

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
@@ -8,8 +8,15 @@ namespace TypeWhisper.Plugin.SherpaOnnx;
 
 internal static class SherpaOnnxNativeRuntime
 {
+    private const string SherpaNativeLibraryBaseName = "sherpa-onnx-c-api";
+    private const string SherpaNativeLibraryFileName = "sherpa-onnx-c-api.dll";
+    private const string OnnxRuntimeFileName = "onnxruntime.dll";
+    private const uint LoadLibrarySearchDllLoadDir = 0x00000100;
+    private const uint LoadLibrarySearchDefaultDirs = 0x00001000;
+
     private static readonly object Sync = new();
     private static bool _resolverRegistered;
+    private static string? _bundledRuntimeDirectory;
     private static string? _cudaRuntimeDirectory;
 
     /// <summary>
@@ -36,6 +43,10 @@ internal static class SherpaOnnxNativeRuntime
 
     private static void RegisterResolverUnsafe()
     {
+        _bundledRuntimeDirectory ??= ResolveBundledRuntimeDirectory(
+            typeof(SherpaOnnxNativeRuntime).Assembly.Location,
+            RuntimeInformation.ProcessArchitecture);
+
         if (_resolverRegistered)
             return;
 
@@ -48,19 +59,60 @@ internal static class SherpaOnnxNativeRuntime
         Assembly assembly,
         DllImportSearchPath? searchPath)
     {
-        var runtimeDirectory = _cudaRuntimeDirectory;
-        if (string.IsNullOrWhiteSpace(runtimeDirectory))
+        if (!IsSherpaNativeLibrary(libraryName))
             return IntPtr.Zero;
 
-        var libraryFileName = Path.GetFileName(libraryName);
-        var fileName = libraryFileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
-            ? libraryFileName
-            : libraryFileName + ".dll";
-        var candidate = Path.Join(runtimeDirectory, fileName);
+        var runtimeDirectory = _cudaRuntimeDirectory ?? _bundledRuntimeDirectory;
+        if (string.IsNullOrWhiteSpace(runtimeDirectory))
+            throw new DllNotFoundException("Unable to determine the sherpa-onnx native runtime directory.");
 
-        return File.Exists(candidate)
-            ? NativeLibrary.Load(candidate)
-            : IntPtr.Zero;
+        var candidate = Path.Join(runtimeDirectory, SherpaNativeLibraryFileName);
+        var onnxRuntime = Path.Join(runtimeDirectory, OnnxRuntimeFileName);
+        if (!File.Exists(candidate) || !File.Exists(onnxRuntime))
+            throw new DllNotFoundException(CreateMissingRuntimeMessage(runtimeDirectory));
+
+        var handle = LoadLibraryEx(
+            candidate,
+            IntPtr.Zero,
+            LoadLibrarySearchDllLoadDir | LoadLibrarySearchDefaultDirs);
+        if (handle == IntPtr.Zero)
+        {
+            var error = Marshal.GetLastWin32Error();
+            throw new DllNotFoundException(
+                $"{CreateMissingRuntimeMessage(runtimeDirectory)} Windows loader error: {error}.");
+        }
+
+        return handle;
+    }
+
+    internal static string? ResolveBundledRuntimeDirectory(string assemblyLocation, Architecture architecture)
+    {
+        var runtimeIdentifier = architecture switch
+        {
+            Architecture.X64 => "win-x64",
+            Architecture.Arm64 => "win-arm64",
+            Architecture.X86 => "win-x86",
+            _ => null
+        };
+
+        if (runtimeIdentifier is null || string.IsNullOrWhiteSpace(assemblyLocation))
+            return null;
+
+        var pluginDirectory = Path.GetDirectoryName(assemblyLocation);
+        return string.IsNullOrWhiteSpace(pluginDirectory)
+            ? null
+            : Path.Join(pluginDirectory, "runtimes", runtimeIdentifier, "native");
+    }
+
+    internal static string CreateMissingRuntimeMessage(string runtimeDirectory) =>
+        "Unable to load the sherpa-onnx native runtime. Expected "
+        + $"{SherpaNativeLibraryFileName} and {OnnxRuntimeFileName} under '{runtimeDirectory}'. "
+        + "Reinstall the sherpa-onnx plugin or update it from the plugin marketplace.";
+
+    private static bool IsSherpaNativeLibrary(string libraryName)
+    {
+        var fileName = Path.GetFileNameWithoutExtension(libraryName);
+        return string.Equals(fileName, SherpaNativeLibraryBaseName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static void PrependToPath(string runtimeDirectory)
@@ -72,4 +124,7 @@ internal static class SherpaOnnxNativeRuntime
 
         Environment.SetEnvironmentVariable("PATH", runtimeDirectory + Path.PathSeparator + current);
     }
+
+    [DllImport("kernel32.dll", EntryPoint = "LoadLibraryExW", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr LoadLibraryEx(string lpLibFileName, IntPtr hFile, uint dwFlags);
 }

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -158,8 +158,6 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         _host = host;
         _cudaRuntimeInstaller ??= new SherpaCudaRuntimeInstaller(host.PluginAssetDirectory, _httpClient);
         SherpaOnnxNativeRuntime.RegisterResolver();
-        if (_cudaRuntimeInstaller.IsInstalled && _cudaRuntimeInstaller.RuntimeDirectory is { } runtimeDirectory)
-            SherpaOnnxNativeRuntime.ConfigureCudaRuntime(runtimeDirectory);
         MigrateModelFiles();
         return Task.CompletedTask;
     }

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/TypeWhisper.Plugin.SherpaOnnx.csproj
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/TypeWhisper.Plugin.SherpaOnnx.csproj
@@ -21,6 +21,97 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <UsingTask TaskName="PatchSherpaOnnxRuntimeImport"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <SherpaNativeLibraries ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <OriginalImportName ParameterType="System.String" Required="true" />
+      <PatchedImportName ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+if (PatchedImportName.Length > OriginalImportName.Length)
+{
+    Log.LogError($"Patched import name '{PatchedImportName}' must not be longer than '{OriginalImportName}'.");
+    return false;
+}
+
+var original = Encoding.ASCII.GetBytes(OriginalImportName + '\0');
+var patchedBytes = Encoding.ASCII.GetBytes(PatchedImportName + '\0');
+var patched = new byte[original.Length];
+Array.Copy(patchedBytes, patched, patchedBytes.Length);
+
+foreach (var item in SherpaNativeLibraries)
+{
+    var path = item.ItemSpec;
+    if (!File.Exists(path))
+    {
+        Log.LogError($"Sherpa native library does not exist: {path}");
+        return false;
+    }
+
+    var bytes = File.ReadAllBytes(path);
+    var originalMatches = 0;
+    var originalOffset = -1;
+    for (var offset = 0; offset <= bytes.Length - original.Length; offset++)
+    {
+        var matches = true;
+        for (var index = 0; index < original.Length; index++)
+        {
+            if (bytes[offset + index] != original[index])
+            {
+                matches = false;
+                break;
+            }
+        }
+
+        if (matches)
+        {
+            originalMatches++;
+            originalOffset = offset;
+        }
+    }
+
+    var patchedMatches = 0;
+    for (var offset = 0; offset <= bytes.Length - patched.Length; offset++)
+    {
+        var matches = true;
+        for (var index = 0; index < patched.Length; index++)
+        {
+            if (bytes[offset + index] != patched[index])
+            {
+                matches = false;
+                break;
+            }
+        }
+
+        if (matches)
+            patchedMatches++;
+    }
+
+    if (originalMatches == 0 && patchedMatches > 0)
+    {
+        Log.LogMessage(MessageImportance.Low, $"Sherpa native import is already patched: {path}");
+        continue;
+    }
+
+    if (originalMatches != 1)
+    {
+        Log.LogError($"Expected one '{OriginalImportName}' import in {path}, found {originalMatches}.");
+        return false;
+    }
+
+    Array.Copy(patched, 0, bytes, originalOffset, patched.Length);
+    File.WriteAllBytes(path, bytes);
+    Log.LogMessage(MessageImportance.High, $"Patched Sherpa native import in {path}: {OriginalImportName} -> {PatchedImportName}");
+}
+]]></Code>
+    </Task>
+  </UsingTask>
   <Target Name="CopyToAppPlugins" AfterTargets="Build">
     <PropertyGroup>
       <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
@@ -39,7 +130,20 @@
       <_RuntimeFiles Include="$(TargetDir)runtimes\win-x86\**\*.*">
         <RuntimeIdentifier>win-x86</RuntimeIdentifier>
       </_RuntimeFiles>
+      <_SherpaOnnxRuntimeDll Include="@(_RuntimeFiles)"
+                             Condition="'%(_RuntimeFiles.Filename)%(_RuntimeFiles.Extension)' == 'onnxruntime.dll'" />
+      <_SherpaNativeLibraryRuntimeFiles Include="@(_RuntimeFiles)"
+                                        Condition="'%(_RuntimeFiles.Filename)%(_RuntimeFiles.Extension)' == 'sherpa-onnx-c-api.dll'" />
+      <_PatchedSherpaNativeLibraries Include="@(_SherpaNativeLibraryRuntimeFiles)" />
     </ItemGroup>
+    <Copy SourceFiles="@(_SherpaOnnxRuntimeDll)"
+          DestinationFiles="@(_SherpaOnnxRuntimeDll->'%(RootDir)%(Directory)sherpaort.dll')"
+          SkipUnchangedFiles="false"
+          Condition="'@(_SherpaOnnxRuntimeDll)' != ''" />
+    <PatchSherpaOnnxRuntimeImport SherpaNativeLibraries="@(_PatchedSherpaNativeLibraries)"
+                                  OriginalImportName="onnxruntime.dll"
+                                  PatchedImportName="sherpaort.dll"
+                                  Condition="'@(_PatchedSherpaNativeLibraries)' != ''" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
@@ -48,13 +152,20 @@
           DestinationFiles="@(_RuntimeFiles->'$(PluginOutputDir)runtimes\%(RuntimeIdentifier)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           Condition="'@(_RuntimeFiles)' != ''" />
+    <Copy SourceFiles="@(_SherpaOnnxRuntimeDll->'%(RootDir)%(Directory)sherpaort.dll')"
+          DestinationFiles="@(_SherpaOnnxRuntimeDll->'$(PluginOutputDir)runtimes\%(RuntimeIdentifier)\%(RecursiveDir)sherpaort.dll')"
+          SkipUnchangedFiles="false"
+          Condition="'@(_SherpaOnnxRuntimeDll)' != ''" />
     <ItemGroup>
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\native\sherpa-onnx-c-api.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\native\onnxruntime.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\native\sherpaort.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\native\sherpa-onnx-c-api.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\native\onnxruntime.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\native\sherpaort.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x86\native\sherpa-onnx-c-api.dll" />
       <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x86\native\onnxruntime.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x86\native\sherpaort.dll" />
     </ItemGroup>
     <Error Condition="'$(Configuration)' == 'Release' and !Exists('%(_RequiredRuntimeFiles.Identity)')"
            Text="Missing required sherpa-onnx runtime file: %(_RequiredRuntimeFiles.Identity)" />

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/TypeWhisper.Plugin.SherpaOnnx.csproj
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/TypeWhisper.Plugin.SherpaOnnx.csproj
@@ -13,9 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
-    <PackageReference Include="org.k2fsa.sherpa.onnx" Version="1.13.0">
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
+    <PackageReference Include="org.k2fsa.sherpa.onnx" Version="1.13.0" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
@@ -32,10 +30,33 @@
     <ItemGroup>
       <_DependencyDlls Include="$(TargetDir)*.dll"
                        Exclude="$(TargetPath);$(TargetDir)TypeWhisper.PluginSDK.dll" />
+      <_RuntimeFiles Include="$(TargetDir)runtimes\win-x64\**\*.*">
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+      </_RuntimeFiles>
+      <_RuntimeFiles Include="$(TargetDir)runtimes\win-arm64\**\*.*">
+        <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+      </_RuntimeFiles>
+      <_RuntimeFiles Include="$(TargetDir)runtimes\win-x86\**\*.*">
+        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+      </_RuntimeFiles>
     </ItemGroup>
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="@(_DependencyDlls)" DestinationFolder="$(PluginOutputDir)" SkipUnchangedFiles="true" Condition="'@(_DependencyDlls)' != ''" />
+    <Copy SourceFiles="@(_RuntimeFiles)"
+          DestinationFiles="@(_RuntimeFiles->'$(PluginOutputDir)runtimes\%(RuntimeIdentifier)\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_RuntimeFiles)' != ''" />
+    <ItemGroup>
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\native\sherpa-onnx-c-api.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x64\native\onnxruntime.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\native\sherpa-onnx-c-api.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-arm64\native\onnxruntime.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x86\native\sherpa-onnx-c-api.dll" />
+      <_RequiredRuntimeFiles Include="$(PluginOutputDir)runtimes\win-x86\native\onnxruntime.dll" />
+    </ItemGroup>
+    <Error Condition="'$(Configuration)' == 'Release' and !Exists('%(_RequiredRuntimeFiles.Identity)')"
+           Text="Missing required sherpa-onnx runtime file: %(_RequiredRuntimeFiles.Identity)" />
   </Target>
 </Project>

--- a/src/TypeWhisper.Windows/Services/SimpleVoiceActivityDetector.cs
+++ b/src/TypeWhisper.Windows/Services/SimpleVoiceActivityDetector.cs
@@ -1,0 +1,107 @@
+namespace TypeWhisper.Windows.Services;
+
+internal sealed record SimpleVoiceSegment(float[] Samples);
+
+internal sealed class SimpleVoiceActivityDetector : IDisposable
+{
+    private readonly Queue<SimpleVoiceSegment> _segments = [];
+    private readonly List<float> _currentSamples = [];
+    private readonly float _speechThreshold;
+    private readonly int _minSpeechSamples;
+    private readonly int _minSilenceSamples;
+    private readonly int _maxSegmentSamples;
+    private int _speechSamples;
+    private int _trailingSilenceSamples;
+    private bool _hasSpeech;
+    private bool _disposed;
+
+    public SimpleVoiceActivityDetector(
+        int sampleRate = 16000,
+        float speechThreshold = 0.02f,
+        TimeSpan? minSpeechDuration = null,
+        TimeSpan? minSilenceDuration = null,
+        TimeSpan? maxSegmentDuration = null)
+    {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+
+        _speechThreshold = speechThreshold;
+        _minSpeechSamples = Math.Max(1, (int)Math.Round(sampleRate * (minSpeechDuration ?? TimeSpan.FromSeconds(0.25)).TotalSeconds));
+        _minSilenceSamples = Math.Max(1, (int)Math.Round(sampleRate * (minSilenceDuration ?? TimeSpan.FromSeconds(0.5)).TotalSeconds));
+        _maxSegmentSamples = Math.Max(1, (int)Math.Round(sampleRate * (maxSegmentDuration ?? TimeSpan.FromSeconds(60)).TotalSeconds));
+    }
+
+    public void AcceptWaveform(ReadOnlySpan<float> samples)
+    {
+        ThrowIfDisposed();
+
+        foreach (var sample in samples)
+        {
+            if (Math.Abs(sample) >= _speechThreshold)
+            {
+                _hasSpeech = true;
+                _trailingSilenceSamples = 0;
+                _speechSamples++;
+                _currentSamples.Add(sample);
+                if (_currentSamples.Count >= _maxSegmentSamples)
+                    CompleteCurrentSegment();
+
+                continue;
+            }
+
+            if (!_hasSpeech)
+                continue;
+
+            _trailingSilenceSamples++;
+            if (_trailingSilenceSamples >= _minSilenceSamples)
+                CompleteCurrentSegment();
+        }
+    }
+
+    public void Flush()
+    {
+        ThrowIfDisposed();
+        CompleteCurrentSegment();
+    }
+
+    public bool IsEmpty()
+    {
+        ThrowIfDisposed();
+        return _segments.Count == 0;
+    }
+
+    public SimpleVoiceSegment Front()
+    {
+        ThrowIfDisposed();
+        return _segments.Peek();
+    }
+
+    public void Pop()
+    {
+        ThrowIfDisposed();
+        _segments.Dequeue();
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _segments.Clear();
+        _currentSamples.Clear();
+    }
+
+    private void CompleteCurrentSegment()
+    {
+        if (_hasSpeech && _speechSamples >= _minSpeechSamples)
+            _segments.Enqueue(new SimpleVoiceSegment([.. _currentSamples]));
+
+        _currentSamples.Clear();
+        _speechSamples = 0;
+        _trailingSilenceSamples = 0;
+        _hasSpeech = false;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/src/TypeWhisper.Windows/Services/SimpleVoiceActivityDetector.cs
+++ b/src/TypeWhisper.Windows/Services/SimpleVoiceActivityDetector.cs
@@ -12,6 +12,7 @@ internal sealed class SimpleVoiceActivityDetector : IDisposable
     private readonly int _maxSegmentSamples;
     private int _speechSamples;
     private int _trailingSilenceSamples;
+    private int _discardedShortSegmentCount;
     private bool _hasSpeech;
     private bool _disposed;
 
@@ -76,6 +77,15 @@ internal sealed class SimpleVoiceActivityDetector : IDisposable
         return _segments.Peek();
     }
 
+    public int DiscardedShortSegmentCount
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _discardedShortSegmentCount;
+        }
+    }
+
     public void Pop()
     {
         ThrowIfDisposed();
@@ -92,7 +102,13 @@ internal sealed class SimpleVoiceActivityDetector : IDisposable
     private void CompleteCurrentSegment()
     {
         if (_hasSpeech && _speechSamples >= _minSpeechSamples)
+        {
             _segments.Enqueue(new SimpleVoiceSegment([.. _currentSamples]));
+        }
+        else if (_hasSpeech)
+        {
+            _discardedShortSegmentCount++;
+        }
 
         _currentSamples.Clear();
         _speechSamples = 0;

--- a/src/TypeWhisper.Windows/TypeWhisper.Windows.csproj
+++ b/src/TypeWhisper.Windows/TypeWhisper.Windows.csproj
@@ -73,7 +73,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.1" />
-    <PackageReference Include="org.k2fsa.sherpa.onnx" Version="1.13.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
     <PackageReference Include="System.Speech" Version="10.0.0" />
     <PackageReference Include="WPF-UI" Version="4.2.0" />

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -2229,17 +2229,12 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     {
         if (_vad is null) return;
 
+        _lastVadDiscardedShortSegmentCount = _vad.DiscardedShortSegmentCount;
         while (!_vad.IsEmpty())
         {
             var segment = _vad.Front();
             _vad.Pop();
             _lastVadSegmentLength = segment.Samples.Length;
-
-            if (segment.Samples.Length < 1600)
-            {
-                _lastVadDiscardedShortSegmentCount++;
-                continue; // Skip very short segments
-            }
 
             try
             {

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -6,7 +6,6 @@ using System.Threading.Channels;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using SherpaOnnx;
 using TypeWhisper.Core;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
@@ -152,7 +151,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     // Live transcription
     private readonly StreamingHandler _streamingHandler;
     // VAD for live transcription (fallback for non-plugin models)
-    private VoiceActivityDetector? _vad;
+    private SimpleVoiceActivityDetector? _vad;
     private readonly List<string> _partialSegments = [];
     private readonly SemaphoreSlim _vadLock = new(1, 1);
     private bool _disposed;
@@ -2259,21 +2258,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         }
     }
 
-    private static VoiceActivityDetector CreateVoiceActivityDetector()
-    {
-        var config = new VadModelConfig
-        {
-            SileroVad = new SileroVadModelConfig
-            {
-                Model = Path.Combine(AppContext.BaseDirectory, "Resources", "silero_vad.onnx"),
-                Threshold = 0.5f,
-                MinSilenceDuration = 0.5f,
-                MinSpeechDuration = 0.25f,
-            },
-            SampleRate = 16000,
-        };
-        return new VoiceActivityDetector(config, 60);
-    }
+    private static SimpleVoiceActivityDetector CreateVoiceActivityDetector() => new();
 
     [RelayCommand]
     private void CancelProcessing()

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.Plugin.SherpaOnnx;
@@ -208,11 +209,39 @@ public class SherpaOnnxPluginTests
             Directory.CreateDirectory(nativeDir);
             File.WriteAllText(Path.Join(nativeDir, "sherpa-onnx-c-api.dll"), "");
             File.WriteAllText(Path.Join(nativeDir, "onnxruntime.dll"), "");
+            File.WriteAllText(Path.Join(nativeDir, "sherpaort.dll"), "");
             File.WriteAllText(Path.Join(nativeDir, "onnxruntime_providers_cuda.dll"), "");
 
             var installer = new SherpaCudaRuntimeInstaller(tempDir, new HttpClient());
 
             Assert.False(installer.IsInstalled);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CudaRuntimeInstaller_CopiesAndPatchesSherpaRuntimeAlias()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-cuda-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var sherpaNative = Path.Join(tempDir, "sherpa-onnx-c-api.dll");
+            File.WriteAllBytes(
+                sherpaNative,
+                Encoding.ASCII.GetBytes("prefix onnxruntime.dll\0 suffix"));
+            File.WriteAllText(Path.Join(tempDir, "onnxruntime.dll"), "runtime");
+
+            SherpaCudaRuntimeInstaller.EnsureSherpaRuntimeImportAlias(tempDir);
+
+            var patchedNative = Encoding.ASCII.GetString(File.ReadAllBytes(sherpaNative));
+            Assert.True(File.Exists(Path.Join(tempDir, "sherpaort.dll")));
+            Assert.DoesNotContain("onnxruntime.dll", patchedNative);
+            Assert.Contains("sherpaort.dll", patchedNative);
         }
         finally
         {

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.Plugin.SherpaOnnx;
@@ -220,6 +221,75 @@ public class SherpaOnnxPluginTests
         }
     }
 
+    [Fact]
+    public void NativeRuntime_ResolvesCpuRuntimeFromPluginAssemblyDirectory()
+    {
+        var pluginAssembly = Path.Join("C:", "TypeWhisper", "Plugins", "com.typewhisper.sherpa-onnx", "TypeWhisper.Plugin.SherpaOnnx.dll");
+
+        var runtimeDirectory = SherpaOnnxNativeRuntime.ResolveBundledRuntimeDirectory(
+            pluginAssembly,
+            Architecture.X64);
+
+        Assert.Equal(
+            Path.Join("C:", "TypeWhisper", "Plugins", "com.typewhisper.sherpa-onnx", "runtimes", "win-x64", "native"),
+            runtimeDirectory);
+    }
+
+    [Fact]
+    public void NativeRuntime_MissingRuntimeMessageNamesExpectedPluginDirectory()
+    {
+        var runtimeDirectory = Path.Join("C:", "TypeWhisper", "Plugins", "com.typewhisper.sherpa-onnx", "runtimes", "win-x64", "native");
+
+        var message = SherpaOnnxNativeRuntime.CreateMissingRuntimeMessage(runtimeDirectory);
+
+        Assert.Contains("sherpa-onnx-c-api.dll", message);
+        Assert.Contains("onnxruntime.dll", message);
+        Assert.Contains(runtimeDirectory, message);
+        Assert.DoesNotContain("AppContext.BaseDirectory", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WindowsAppProject_DoesNotReferenceSherpaOnnxPackage()
+    {
+        var repoRoot = GetRepoRoot();
+        var projectPath = Path.Join(repoRoot, "src", "TypeWhisper.Windows", "TypeWhisper.Windows.csproj");
+
+        var project = File.ReadAllText(projectPath);
+
+        Assert.DoesNotContain("org.k2fsa.sherpa.onnx", project, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SherpaPluginProject_CopiesWindowsNativeRuntimeDirectoriesToBundledPluginOutput()
+    {
+        var repoRoot = GetRepoRoot();
+        var projectPath = Path.Join(
+            repoRoot,
+            "plugins",
+            "TypeWhisper.Plugin.SherpaOnnx",
+            "TypeWhisper.Plugin.SherpaOnnx.csproj");
+
+        var project = File.ReadAllText(projectPath);
+
+        Assert.DoesNotContain("<ExcludeAssets>runtime</ExcludeAssets>", project, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(@"$(TargetDir)runtimes\win-x64\**\*.*", project);
+        Assert.Contains(@"$(TargetDir)runtimes\win-arm64\**\*.*", project);
+        Assert.Contains(@"$(PluginOutputDir)runtimes\win-x64\native\sherpa-onnx-c-api.dll", project);
+        Assert.Contains(@"$(PluginOutputDir)runtimes\win-x64\native\onnxruntime.dll", project);
+    }
+
+    [Fact]
+    public void PublishPluginsWorkflow_RequiresSherpaNativeRuntimeInReleaseZip()
+    {
+        var repoRoot = GetRepoRoot();
+        var workflowPath = Path.Join(repoRoot, ".github", "workflows", "publish-plugins.yml");
+
+        var workflow = File.ReadAllText(workflowPath);
+
+        Assert.Contains("sherpa-onnx-c-api.dll", workflow);
+        Assert.Contains("Missing required sherpa-onnx runtime", workflow);
+    }
+
     private static void CreateParakeetModelFiles(string pluginDataDirectory)
     {
         var modelDir = Path.Join(pluginDataDirectory, "Models", "parakeet-tdt-0.6b");
@@ -227,6 +297,9 @@ public class SherpaOnnxPluginTests
         foreach (var fileName in new[] { "encoder.int8.onnx", "decoder.int8.onnx", "joiner.int8.onnx", "tokens.txt" })
             File.WriteAllText(Path.Join(modelDir, fileName), "test");
     }
+
+    private static string GetRepoRoot() =>
+        Path.GetFullPath(Path.Join(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
 
     private sealed class FakeCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -243,7 +243,7 @@ public class SherpaOnnxPluginTests
         var message = SherpaOnnxNativeRuntime.CreateMissingRuntimeMessage(runtimeDirectory);
 
         Assert.Contains("sherpa-onnx-c-api.dll", message);
-        Assert.Contains("onnxruntime.dll", message);
+        Assert.Contains("sherpaort.dll", message);
         Assert.Contains(runtimeDirectory, message);
         Assert.DoesNotContain("AppContext.BaseDirectory", message, StringComparison.OrdinalIgnoreCase);
     }
@@ -274,8 +274,15 @@ public class SherpaOnnxPluginTests
         Assert.DoesNotContain("<ExcludeAssets>runtime</ExcludeAssets>", project, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(@"$(TargetDir)runtimes\win-x64\**\*.*", project);
         Assert.Contains(@"$(TargetDir)runtimes\win-arm64\**\*.*", project);
+        Assert.Contains(@"$(TargetDir)runtimes\win-x86\**\*.*", project);
+        Assert.Contains("PatchSherpaOnnxRuntimeImport", project);
+        Assert.Contains("sherpaort.dll", project);
         Assert.Contains(@"$(PluginOutputDir)runtimes\win-x64\native\sherpa-onnx-c-api.dll", project);
         Assert.Contains(@"$(PluginOutputDir)runtimes\win-x64\native\onnxruntime.dll", project);
+        Assert.Contains(@"$(PluginOutputDir)runtimes\win-x64\native\sherpaort.dll", project);
+        Assert.Contains(@"$(PluginOutputDir)runtimes\win-x86\native\sherpa-onnx-c-api.dll", project);
+        Assert.Contains(@"$(PluginOutputDir)runtimes\win-x86\native\onnxruntime.dll", project);
+        Assert.Contains(@"$(PluginOutputDir)runtimes\win-x86\native\sherpaort.dll", project);
     }
 
     [Fact]
@@ -287,6 +294,7 @@ public class SherpaOnnxPluginTests
         var workflow = File.ReadAllText(workflowPath);
 
         Assert.Contains("sherpa-onnx-c-api.dll", workflow);
+        Assert.Contains("sherpaort.dll", workflow);
         Assert.Contains("Missing required sherpa-onnx runtime", workflow);
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/SimpleVoiceActivityDetectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SimpleVoiceActivityDetectorTests.cs
@@ -1,0 +1,53 @@
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public class SimpleVoiceActivityDetectorTests
+{
+    [Fact]
+    public void AcceptWaveform_QueuesSpeechSegmentAfterSilence()
+    {
+        var sut = new SimpleVoiceActivityDetector(
+            sampleRate: 10,
+            speechThreshold: 0.1f,
+            minSpeechDuration: TimeSpan.FromMilliseconds(300),
+            minSilenceDuration: TimeSpan.FromMilliseconds(200));
+
+        sut.AcceptWaveform([0.2f, 0.2f, 0.2f, 0.0f, 0.0f]);
+
+        Assert.False(sut.IsEmpty());
+        var segment = sut.Front();
+        Assert.Equal([0.2f, 0.2f, 0.2f], segment.Samples);
+    }
+
+    [Fact]
+    public void Flush_DiscardsShortSpeechSegment()
+    {
+        var sut = new SimpleVoiceActivityDetector(
+            sampleRate: 10,
+            speechThreshold: 0.1f,
+            minSpeechDuration: TimeSpan.FromMilliseconds(300),
+            minSilenceDuration: TimeSpan.FromMilliseconds(200));
+
+        sut.AcceptWaveform([0.2f, 0.2f]);
+        sut.Flush();
+
+        Assert.True(sut.IsEmpty());
+    }
+
+    [Fact]
+    public void AcceptWaveform_QueuesSegmentAtMaxDuration()
+    {
+        var sut = new SimpleVoiceActivityDetector(
+            sampleRate: 10,
+            speechThreshold: 0.1f,
+            minSpeechDuration: TimeSpan.FromMilliseconds(300),
+            minSilenceDuration: TimeSpan.FromMilliseconds(200),
+            maxSegmentDuration: TimeSpan.FromMilliseconds(500));
+
+        sut.AcceptWaveform([0.2f, 0.2f, 0.2f, 0.2f, 0.2f]);
+
+        Assert.False(sut.IsEmpty());
+        Assert.Equal(5, sut.Front().Samples.Length);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/SimpleVoiceActivityDetectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SimpleVoiceActivityDetectorTests.cs
@@ -33,6 +33,7 @@ public class SimpleVoiceActivityDetectorTests
         sut.Flush();
 
         Assert.True(sut.IsEmpty());
+        Assert.Equal(1, sut.DiscardedShortSegmentCount);
     }
 
     [Fact]
@@ -49,5 +50,39 @@ public class SimpleVoiceActivityDetectorTests
 
         Assert.False(sut.IsEmpty());
         Assert.Equal(5, sut.Front().Samples.Length);
+    }
+
+    [Fact]
+    public void Constructor_RejectsInvalidSampleRate()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SimpleVoiceActivityDetector(sampleRate: 0));
+    }
+
+    [Fact]
+    public void Methods_ThrowAfterDispose()
+    {
+        var sut = new SimpleVoiceActivityDetector();
+
+        sut.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => sut.AcceptWaveform([0.2f]));
+        Assert.Throws<ObjectDisposedException>(() => sut.Flush());
+        Assert.Throws<ObjectDisposedException>(() => sut.IsEmpty());
+        Assert.Throws<ObjectDisposedException>(() => { _ = sut.DiscardedShortSegmentCount; });
+    }
+
+    [Fact]
+    public void AcceptWaveform_TrimsLeadingSilenceBeforeSpeech()
+    {
+        var sut = new SimpleVoiceActivityDetector(
+            sampleRate: 10,
+            speechThreshold: 0.1f,
+            minSpeechDuration: TimeSpan.FromMilliseconds(300),
+            minSilenceDuration: TimeSpan.FromMilliseconds(200));
+
+        sut.AcceptWaveform([0.0f, 0.0f, 0.2f, 0.2f, 0.2f, 0.0f, 0.0f]);
+
+        Assert.False(sut.IsEmpty());
+        Assert.Equal([0.2f, 0.2f, 0.2f], sut.Front().Samples);
     }
 }


### PR DESCRIPTION
## Summary
- keep sherpa-onnx native dependencies out of the Windows app root while preserving the app ONNX Runtime dependency used by translation
- load sherpa-onnx native libraries from the plugin runtime directory with Windows DLL-load flags that prefer the DLL's own dependency directory
- copy and guard Sherpa Windows runtime folders in plugin dev output and release packaging
- replace the app's direct Sherpa VAD dependency with an internal lightweight speech segmenter so the host app no longer references org.k2fsa.sherpa.onnx

Fixes #263

## Tests
- dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release --filter "SherpaOnnx|SimpleVoiceActivityDetector"
- dotnet test TypeWhisper.slnx --no-restore
- dotnet restore src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -r win-x64
- dotnet publish src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release -r win-x64 --no-restore -o artifacts\publish-sherpa-runtime-check

## Runtime checks
- publish root contains the app ONNX Runtime files but no sherpa-onnx.dll or sherpa-onnx-c-api.dll
- Sherpa plugin output and a simulated plugin ZIP include runtimes/win-x64/native/sherpa-onnx-c-api.dll and matching onnxruntime.dll
- with the cached Parakeet model, the local Release app starts with plugin:com.typewhisper.sherpa-onnx:parakeet-tdt-0.6b on CPU and does not create a crash log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight voice activity detector for live dictation, with speech segmenting, silence trimming, and short-segment tracking.

* **Bug Fixes**
  * Improved Sherpa ONNX native runtime handling on Windows by supporting an additional architecture and validating required native DLLs during release packaging.
  * Enhanced native runtime loading with clearer failure reasons when dependencies are missing or incompatible.

* **Chores**
  * Updated plugin build, packaging, and publish workflow to include the correct platform runtime artifacts and apply native DLL import patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->