### PR TITLE
Prepare 1.0.1 release notes

### DIFF
--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -1,0 +1,36 @@
+# TypeWhisper v1.0.1
+
+TypeWhisper 1.0.1 is a stable Windows maintenance release. It focuses on local
+speech-engine reliability, cleaner plugin startup behavior, and development
+dashboard tooling for support and QA workflows.
+
+## Highlights
+
+- Promoted the latest 1.0.1 maintenance fixes to the stable Velopack channel.
+- Improved Sherpa-ONNX native runtime loading for local transcription setups.
+- Kept optional plugins opt-in so a fresh app install starts with only bundled
+  capabilities active.
+
+## Improvements
+
+- Added development dashboard seed controls to make support, QA, and demo data
+  scenarios easier to reproduce.
+- Refined development seed busy-state handling and test cleanup.
+- Stopped installing marketplace plugins by default during first-run setup.
+
+## Fixes
+
+- Fixed Sherpa-ONNX native runtime probing so required runtime DLLs are resolved
+  from the plugin package.
+- Fixed Sherpa-ONNX CUDA runtime aliasing for systems that use accelerated local
+  transcription.
+- Addressed review feedback around Sherpa-ONNX runtime loading behavior.
+
+## Validation Notes
+
+- Verify stable Velopack channels `win-x64` and `win-arm64`.
+- Confirm x64 and ARM64 installers, portable ZIPs, full nupkg packages,
+  RELEASES files, and JSON manifests are present without `-rc` or `-daily`
+  suffixes.
+- Check installer Authenticode status explicitly before announcing release
+  quality.


### PR DESCRIPTION
## Summary
- Adds curated release notes for TypeWhisper v1.0.1.
- Covers Sherpa-ONNX runtime loading fixes, optional plugin startup behavior, and development dashboard seed controls.
- Prepares the stable release workflow to use `docs/releases/v1.0.1.md` when `v1.0.1` is tagged.

## Test Plan
- `dotnet restore TypeWhisper.slnx`
- `dotnet test TypeWhisper.slnx --no-restore`
- `dotnet build TypeWhisper.slnx -c Release --no-restore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for TypeWhisper v1.0.1, covering the Windows stable maintenance release.
  * Highlights include the move to the stable release channel, runtime loading and detection improvements, optional plugin opt-in behavior, and development dashboard seed tooling.
  * Included fixes and validation guidance for installer artifacts and code-signing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->