### PR TITLE
Protect user recordings during uninstall

### DIFF
--- a/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
+++ b/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
@@ -20,14 +20,24 @@ public static class TypeWhisperEnvironment
         false;
 #endif
 
+    private static readonly string _localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
     private static readonly string _basePath = Path.Join(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        _localAppDataPath,
         IsDevelopmentBuild ? "TypeWhisper-Dev" : "TypeWhisper");
+
+    private static readonly string _userDataBasePath = Path.Join(
+        _localAppDataPath,
+        IsDevelopmentBuild ? "TypeWhisper-DevUserData" : "TypeWhisper-UserData");
 
     /// <summary>
     /// Gets the base path.
     /// </summary>
     public static string BasePath => _basePath;
+    /// <summary>
+    /// Gets the base path for user-created data that must survive Velopack uninstall cleanup.
+    /// </summary>
+    public static string UserDataBasePath => _userDataBasePath;
     /// <summary>
     /// Gets the models path.
     /// </summary>
@@ -47,7 +57,11 @@ public static class TypeWhisperEnvironment
     /// <summary>
     /// Gets the audio path.
     /// </summary>
-    public static string AudioPath => Path.Join(_basePath, "Audio");
+    public static string AudioPath => Path.Join(_userDataBasePath, "Audio");
+    /// <summary>
+    /// Gets the previous audio path inside the Velopack install root.
+    /// </summary>
+    public static string LegacyAudioPath => Path.Join(_basePath, "Audio");
     /// <summary>
     /// Gets the plugin data path.
     /// </summary>

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using System.Diagnostics;
+using System.IO;
 using TypeWhisper.Windows.Services;
 using Velopack;
 using TypeWhisper.Core;
@@ -35,6 +35,10 @@ public static class Program
     public static void Main(string[] args)
     {
         VelopackApp.Build()
+            .OnBeforeUninstallFastCallback((v) =>
+            {
+                UninstallUserDataProtector.ProtectLegacyAudioDirectory();
+            })
             .OnAfterUpdateFastCallback((v) =>
             {
                 if (StartupService.IsEnabled)
@@ -59,6 +63,8 @@ public static class Program
 
         try
         {
+            UserAudioMigrationService.MigrateLegacyAudioIfNeeded();
+
             var app = new App();
             app.InitializeComponent();
             app.Run();

--- a/src/TypeWhisper.Windows/Services/UninstallUserDataProtector.cs
+++ b/src/TypeWhisper.Windows/Services/UninstallUserDataProtector.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
+using Microsoft.VisualBasic.FileIO;
 using TypeWhisper.Core;
 
 namespace TypeWhisper.Windows.Services;
@@ -38,7 +38,7 @@ internal sealed class UninstallUserDataProtector
             if (_recycleBin.TryMoveDirectoryToRecycleBin(legacyAudioPath))
                 return;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ExternalException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or OperationCanceledException)
         {
             Trace.TraceWarning("Could not move legacy audio directory to the Recycle Bin: {0}", ex.Message);
         }
@@ -53,15 +53,20 @@ internal sealed class UninstallUserDataProtector
         }
     }
 
-    private static string DefaultRecoveryRoot => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        RecoveryDirectoryName);
+    private static string DefaultRecoveryRoot
+    {
+        get
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return CombineWithSafeLeaf(localAppData, RecoveryDirectoryName);
+        }
+    }
 
     private void MoveLegacyAudioToRecovery(string legacyAudioPath, string recoveryRoot)
     {
         Directory.CreateDirectory(recoveryRoot);
         var timestamp = _clock().ToString("yyyyMMdd-HHmmss");
-        var target = ResolveUniquePath(Path.Combine(recoveryRoot, $"Audio-{timestamp}"));
+        var target = ResolveUniquePath(CombineWithSafeLeaf(recoveryRoot, $"Audio-{timestamp}"));
         Directory.Move(legacyAudioPath, target);
     }
 
@@ -77,47 +82,39 @@ internal sealed class UninstallUserDataProtector
                 return candidate;
         }
     }
+
+    private static string CombineWithSafeLeaf(string directory, string leafName)
+    {
+        var safeLeafName = Path.GetFileName(leafName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrWhiteSpace(safeLeafName) || Path.IsPathRooted(safeLeafName))
+            throw new InvalidOperationException("Invalid recovery directory name.");
+
+        return Path.Join(directory, safeLeafName);
+    }
 }
 
 internal sealed class ShellRecycleBinOperation : IRecycleBinOperation
 {
-    private const uint FileOperationDelete = 0x0003;
-    private const ushort FileOperationFlags =
-        0x0040 | // FOF_ALLOWUNDO
-        0x0010 | // FOF_NOCONFIRMATION
-        0x0400 | // FOF_NOERRORUI
-        0x0004;  // FOF_SILENT
-
     public bool TryMoveDirectoryToRecycleBin(string path)
     {
-        var operation = new ShFileOpStruct
+        var fullPath = Path.GetFullPath(path);
+        if (!Directory.Exists(fullPath))
+            return true;
+
+        try
         {
-            WFunc = FileOperationDelete,
-            PFrom = $"{Path.GetFullPath(path)}\0\0",
-            FFlags = FileOperationFlags
-        };
+            FileSystem.DeleteDirectory(
+                fullPath,
+                UIOption.OnlyErrorDialogs,
+                RecycleOption.SendToRecycleBin,
+                UICancelOption.DoNothing);
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException or UnauthorizedAccessException)
+        {
+            Trace.TraceWarning("Could not move directory to the Recycle Bin: {0}", ex.Message);
+            return false;
+        }
 
-        var result = SHFileOperation(ref operation);
-        return result == 0 && !operation.FAnyOperationsAborted && !Directory.Exists(path);
-    }
-
-    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
-    private static extern int SHFileOperation(ref ShFileOpStruct fileOperation);
-
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    private struct ShFileOpStruct
-    {
-        public IntPtr HWnd;
-        public uint WFunc;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string PFrom;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? PTo;
-        public ushort FFlags;
-        [MarshalAs(UnmanagedType.Bool)]
-        public bool FAnyOperationsAborted;
-        public IntPtr HNameMappings;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? LpszProgressTitle;
+        return !Directory.Exists(fullPath);
     }
 }

--- a/src/TypeWhisper.Windows/Services/UninstallUserDataProtector.cs
+++ b/src/TypeWhisper.Windows/Services/UninstallUserDataProtector.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.IO;
-using Microsoft.VisualBasic.FileIO;
+using System.Runtime.InteropServices;
 using TypeWhisper.Core;
 
 namespace TypeWhisper.Windows.Services;
@@ -38,7 +38,7 @@ internal sealed class UninstallUserDataProtector
             if (_recycleBin.TryMoveDirectoryToRecycleBin(legacyAudioPath))
                 return;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or OperationCanceledException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ExternalException)
         {
             Trace.TraceWarning("Could not move legacy audio directory to the Recycle Bin: {0}", ex.Message);
         }
@@ -95,26 +95,51 @@ internal sealed class UninstallUserDataProtector
 
 internal sealed class ShellRecycleBinOperation : IRecycleBinOperation
 {
+    // The uninstall fast callback must remain non-interactive; FileSystem.DeleteDirectory can show error dialogs.
+    private const uint FileOperationDelete = 0x0003;
+    private const ushort FileOperationFlags =
+        0x0040 | // FOF_ALLOWUNDO
+        0x0010 | // FOF_NOCONFIRMATION
+        0x0400 | // FOF_NOERRORUI
+        0x0004;  // FOF_SILENT
+
     public bool TryMoveDirectoryToRecycleBin(string path)
     {
         var fullPath = Path.GetFullPath(path);
         if (!Directory.Exists(fullPath))
             return true;
 
-        try
+        var operation = new ShFileOpStruct
         {
-            FileSystem.DeleteDirectory(
-                fullPath,
-                UIOption.OnlyErrorDialogs,
-                RecycleOption.SendToRecycleBin,
-                UICancelOption.DoNothing);
-        }
-        catch (Exception ex) when (ex is OperationCanceledException or IOException or UnauthorizedAccessException)
-        {
-            Trace.TraceWarning("Could not move directory to the Recycle Bin: {0}", ex.Message);
-            return false;
-        }
+            WFunc = FileOperationDelete,
+            PFrom = $"{fullPath}\0\0",
+            FFlags = FileOperationFlags
+        };
 
-        return !Directory.Exists(fullPath);
+        var result = SHFileOperation(ref operation);
+        if (result != 0 || operation.FAnyOperationsAborted || Directory.Exists(fullPath))
+            Trace.TraceWarning("Could not move directory to the Recycle Bin. Result: {0}, Aborted: {1}", result, operation.FAnyOperationsAborted);
+
+        return result == 0 && !operation.FAnyOperationsAborted && !Directory.Exists(fullPath);
+    }
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    private static extern int SHFileOperation(ref ShFileOpStruct fileOperation);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct ShFileOpStruct
+    {
+        public IntPtr HWnd;
+        public uint WFunc;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string PFrom;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? PTo;
+        public ushort FFlags;
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool FAnyOperationsAborted;
+        public IntPtr HNameMappings;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? LpszProgressTitle;
     }
 }

--- a/src/TypeWhisper.Windows/Services/UninstallUserDataProtector.cs
+++ b/src/TypeWhisper.Windows/Services/UninstallUserDataProtector.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using TypeWhisper.Core;
+
+namespace TypeWhisper.Windows.Services;
+
+internal interface IRecycleBinOperation
+{
+    bool TryMoveDirectoryToRecycleBin(string path);
+}
+
+internal sealed class UninstallUserDataProtector
+{
+    private const string RecoveryDirectoryName = "TypeWhisper-Recovered";
+    private readonly IRecycleBinOperation _recycleBin;
+    private readonly Func<DateTimeOffset> _clock;
+
+    internal UninstallUserDataProtector(IRecycleBinOperation recycleBin, Func<DateTimeOffset> clock)
+    {
+        _recycleBin = recycleBin;
+        _clock = clock;
+    }
+
+    public static void ProtectLegacyAudioDirectory()
+    {
+        var protector = new UninstallUserDataProtector(new ShellRecycleBinOperation(), () => DateTimeOffset.Now);
+        protector.ProtectLegacyAudioDirectory(TypeWhisperEnvironment.LegacyAudioPath, DefaultRecoveryRoot);
+    }
+
+    internal void ProtectLegacyAudioDirectory(string legacyAudioPath, string recoveryRoot)
+    {
+        if (!Directory.Exists(legacyAudioPath))
+            return;
+
+        try
+        {
+            if (_recycleBin.TryMoveDirectoryToRecycleBin(legacyAudioPath))
+                return;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ExternalException)
+        {
+            Trace.TraceWarning("Could not move legacy audio directory to the Recycle Bin: {0}", ex.Message);
+        }
+
+        try
+        {
+            MoveLegacyAudioToRecovery(legacyAudioPath, recoveryRoot);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Trace.TraceWarning("Could not move legacy audio directory to recovery: {0}", ex.Message);
+        }
+    }
+
+    private static string DefaultRecoveryRoot => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        RecoveryDirectoryName);
+
+    private void MoveLegacyAudioToRecovery(string legacyAudioPath, string recoveryRoot)
+    {
+        Directory.CreateDirectory(recoveryRoot);
+        var timestamp = _clock().ToString("yyyyMMdd-HHmmss");
+        var target = ResolveUniquePath(Path.Combine(recoveryRoot, $"Audio-{timestamp}"));
+        Directory.Move(legacyAudioPath, target);
+    }
+
+    private static string ResolveUniquePath(string target)
+    {
+        if (!File.Exists(target) && !Directory.Exists(target))
+            return target;
+
+        for (var index = 1; ; index++)
+        {
+            var candidate = $"{target}-{index}";
+            if (!File.Exists(candidate) && !Directory.Exists(candidate))
+                return candidate;
+        }
+    }
+}
+
+internal sealed class ShellRecycleBinOperation : IRecycleBinOperation
+{
+    private const uint FileOperationDelete = 0x0003;
+    private const ushort FileOperationFlags =
+        0x0040 | // FOF_ALLOWUNDO
+        0x0010 | // FOF_NOCONFIRMATION
+        0x0400 | // FOF_NOERRORUI
+        0x0004;  // FOF_SILENT
+
+    public bool TryMoveDirectoryToRecycleBin(string path)
+    {
+        var operation = new ShFileOpStruct
+        {
+            WFunc = FileOperationDelete,
+            PFrom = $"{Path.GetFullPath(path)}\0\0",
+            FFlags = FileOperationFlags
+        };
+
+        var result = SHFileOperation(ref operation);
+        return result == 0 && !operation.FAnyOperationsAborted && !Directory.Exists(path);
+    }
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    private static extern int SHFileOperation(ref ShFileOpStruct fileOperation);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct ShFileOpStruct
+    {
+        public IntPtr HWnd;
+        public uint WFunc;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string PFrom;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? PTo;
+        public ushort FFlags;
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool FAnyOperationsAborted;
+        public IntPtr HNameMappings;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? LpszProgressTitle;
+    }
+}

--- a/src/TypeWhisper.Windows/Services/UserAudioMigrationService.cs
+++ b/src/TypeWhisper.Windows/Services/UserAudioMigrationService.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.IO;
+using TypeWhisper.Core;
+
+namespace TypeWhisper.Windows.Services;
+
+internal static class UserAudioMigrationService
+{
+    public static void MigrateLegacyAudioIfNeeded()
+    {
+        try
+        {
+            MigrateLegacyAudio(TypeWhisperEnvironment.LegacyAudioPath, TypeWhisperEnvironment.AudioPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Trace.TraceWarning("Could not migrate legacy audio directory: {0}", ex.Message);
+        }
+    }
+
+    internal static void MigrateLegacyAudio(string legacyAudioPath, string audioPath)
+    {
+        var legacyRoot = Normalize(legacyAudioPath);
+        var audioRoot = Normalize(audioPath);
+
+        if (PathsEqual(legacyRoot, audioRoot) || !Directory.Exists(legacyRoot))
+            return;
+
+        if (!Directory.EnumerateFileSystemEntries(legacyRoot).Any())
+        {
+            TryDeleteDirectoryIfEmpty(legacyRoot);
+            return;
+        }
+
+        Directory.CreateDirectory(audioRoot);
+        foreach (var entry in Directory.EnumerateFileSystemEntries(legacyRoot))
+            MoveEntry(entry, Path.Combine(audioRoot, SafeLeafName(Path.GetFileName(entry))));
+
+        TryDeleteDirectoryIfEmpty(legacyRoot);
+    }
+
+    private static void MoveEntry(string source, string target)
+    {
+        if (Directory.Exists(source))
+        {
+            var resolvedTarget = ResolveUniquePath(target);
+            Directory.CreateDirectory(resolvedTarget);
+
+            foreach (var child in Directory.EnumerateFileSystemEntries(source))
+                MoveEntry(child, Path.Combine(resolvedTarget, SafeLeafName(Path.GetFileName(child))));
+
+            TryDeleteDirectoryIfEmpty(source);
+            return;
+        }
+
+        if (!File.Exists(source))
+            return;
+
+        var fileTarget = ResolveUniquePath(target);
+        Directory.CreateDirectory(Path.GetDirectoryName(fileTarget)!);
+        File.Move(source, fileTarget);
+    }
+
+    private static string ResolveUniquePath(string target)
+    {
+        if (!File.Exists(target) && !Directory.Exists(target))
+            return target;
+
+        var directory = Path.GetDirectoryName(target) ?? "";
+        var name = Path.GetFileNameWithoutExtension(target);
+        var extension = Path.GetExtension(target);
+
+        for (var index = 1; ; index++)
+        {
+            var candidate = Path.Combine(directory, $"{name}-{index}{extension}");
+            if (!File.Exists(candidate) && !Directory.Exists(candidate))
+                return candidate;
+        }
+    }
+
+    private static string SafeLeafName(string value)
+    {
+        var safeName = Path.GetFileName(value.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrWhiteSpace(safeName) || safeName is "." or "..")
+            throw new InvalidOperationException("Invalid audio path segment.");
+
+        return safeName;
+    }
+
+    private static string Normalize(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Normalize(left), Normalize(right), StringComparison.OrdinalIgnoreCase);
+
+    private static void TryDeleteDirectoryIfEmpty(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any())
+                Directory.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Trace.TraceWarning("Could not delete empty legacy audio directory '{0}': {1}", path, ex.Message);
+        }
+    }
+}

--- a/src/TypeWhisper.Windows/Services/UserAudioMigrationService.cs
+++ b/src/TypeWhisper.Windows/Services/UserAudioMigrationService.cs
@@ -33,8 +33,8 @@ internal static class UserAudioMigrationService
         }
 
         Directory.CreateDirectory(audioRoot);
-        foreach (var entry in Directory.EnumerateFileSystemEntries(legacyRoot))
-            MoveEntry(entry, Path.Combine(audioRoot, SafeLeafName(Path.GetFileName(entry))));
+        foreach (var entry in Directory.GetFileSystemEntries(legacyRoot))
+            MoveEntry(entry, GetSafeChildPath(audioRoot, entry));
 
         TryDeleteDirectoryIfEmpty(legacyRoot);
     }
@@ -46,8 +46,8 @@ internal static class UserAudioMigrationService
             var resolvedTarget = ResolveUniquePath(target);
             Directory.CreateDirectory(resolvedTarget);
 
-            foreach (var child in Directory.EnumerateFileSystemEntries(source))
-                MoveEntry(child, Path.Combine(resolvedTarget, SafeLeafName(Path.GetFileName(child))));
+            foreach (var child in Directory.GetFileSystemEntries(source))
+                MoveEntry(child, GetSafeChildPath(resolvedTarget, child));
 
             TryDeleteDirectoryIfEmpty(source);
             return;
@@ -72,11 +72,14 @@ internal static class UserAudioMigrationService
 
         for (var index = 1; ; index++)
         {
-            var candidate = Path.Combine(directory, $"{name}-{index}{extension}");
+            var candidate = Path.Join(directory, $"{name}-{index}{extension}");
             if (!File.Exists(candidate) && !Directory.Exists(candidate))
                 return candidate;
         }
     }
+
+    private static string GetSafeChildPath(string directory, string path) =>
+        Path.Join(directory, SafeLeafName(Path.GetFileName(path)));
 
     private static string SafeLeafName(string value)
     {

--- a/tests/TypeWhisper.Core.Tests/TypeWhisperEnvironmentTests.cs
+++ b/tests/TypeWhisper.Core.Tests/TypeWhisperEnvironmentTests.cs
@@ -1,0 +1,36 @@
+using TypeWhisper.Core;
+
+namespace TypeWhisper.Core.Tests;
+
+public class TypeWhisperEnvironmentTests
+{
+    [Fact]
+    public void AudioPath_IsOutsideVelopackInstallRoot()
+    {
+        var basePath = Normalize(TypeWhisperEnvironment.BasePath);
+        var audioPath = Normalize(TypeWhisperEnvironment.AudioPath);
+        var legacyAudioPath = Normalize(TypeWhisperEnvironment.LegacyAudioPath);
+
+        Assert.StartsWith(basePath, legacyAudioPath, StringComparison.OrdinalIgnoreCase);
+        Assert.False(
+            IsUnderDirectory(audioPath, basePath),
+            $"AudioPath '{audioPath}' must not live under Velopack install root '{basePath}'.");
+        Assert.EndsWith(
+            Path.Combine(TypeWhisperEnvironment.IsDevelopmentBuild ? "TypeWhisper-DevUserData" : "TypeWhisper-UserData", "Audio"),
+            audioPath,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    private static bool IsUnderDirectory(string path, string directory)
+    {
+        var normalizedPath = Normalize(path);
+        var normalizedDirectory = Normalize(directory);
+        return normalizedPath.Equals(normalizedDirectory, StringComparison.OrdinalIgnoreCase)
+            || normalizedPath.StartsWith(
+                normalizedDirectory + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/TypeWhisper.Core.Tests/TypeWhisperEnvironmentTests.cs
+++ b/tests/TypeWhisper.Core.Tests/TypeWhisperEnvironmentTests.cs
@@ -10,13 +10,16 @@ public class TypeWhisperEnvironmentTests
         var basePath = Normalize(TypeWhisperEnvironment.BasePath);
         var audioPath = Normalize(TypeWhisperEnvironment.AudioPath);
         var legacyAudioPath = Normalize(TypeWhisperEnvironment.LegacyAudioPath);
+        var userDataDirectoryName = TypeWhisperEnvironment.IsDevelopmentBuild
+            ? "TypeWhisper-DevUserData"
+            : "TypeWhisper-UserData";
 
         Assert.StartsWith(basePath, legacyAudioPath, StringComparison.OrdinalIgnoreCase);
         Assert.False(
             IsUnderDirectory(audioPath, basePath),
             $"AudioPath '{audioPath}' must not live under Velopack install root '{basePath}'.");
         Assert.EndsWith(
-            Path.Combine(TypeWhisperEnvironment.IsDevelopmentBuild ? "TypeWhisper-DevUserData" : "TypeWhisper-UserData", "Audio"),
+            $"{userDataDirectoryName}{Path.DirectorySeparatorChar}Audio",
             audioPath,
             StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class UninstallUserDataProtectorTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"tw_uninstall_protector_{Guid.NewGuid():N}");
+
+    [Fact]
+    public void ProtectLegacyAudioDirectory_SendsLegacyAudioDirectoryToRecycleBin()
+    {
+        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
+        var recoveryRoot = Path.Combine(_root, "TypeWhisper-Recovered");
+        Directory.CreateDirectory(legacyAudio);
+        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "wav");
+        var recycle = new FakeRecycleBinOperation(path =>
+        {
+            Directory.Delete(path, recursive: true);
+            return true;
+        });
+        var protector = new UninstallUserDataProtector(
+            recycle,
+            () => new DateTimeOffset(2026, 7, 8, 12, 30, 45, TimeSpan.Zero));
+
+        protector.ProtectLegacyAudioDirectory(legacyAudio, recoveryRoot);
+
+        Assert.Equal([legacyAudio], recycle.Paths);
+        Assert.False(Directory.Exists(legacyAudio));
+        Assert.False(Directory.Exists(recoveryRoot));
+    }
+
+    [Fact]
+    public void ProtectLegacyAudioDirectory_MovesLegacyAudioDirectoryToRecoveryWhenRecycleBinFails()
+    {
+        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
+        var recoveryRoot = Path.Combine(_root, "TypeWhisper-Recovered");
+        Directory.CreateDirectory(legacyAudio);
+        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "wav");
+        var recycle = new FakeRecycleBinOperation(_ => false);
+        var protector = new UninstallUserDataProtector(
+            recycle,
+            () => new DateTimeOffset(2026, 7, 8, 12, 30, 45, TimeSpan.Zero));
+
+        protector.ProtectLegacyAudioDirectory(legacyAudio, recoveryRoot);
+
+        var recoveredAudio = Path.Combine(recoveryRoot, "Audio-20260708-123045");
+        Assert.Equal([legacyAudio], recycle.Paths);
+        Assert.False(Directory.Exists(legacyAudio));
+        Assert.Equal("wav", File.ReadAllText(Path.Combine(recoveredAudio, "recording.wav")));
+    }
+
+    [Fact]
+    public void ProtectLegacyAudioDirectory_DoesNothingWhenLegacyAudioDirectoryIsMissing()
+    {
+        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
+        var recycle = new FakeRecycleBinOperation(_ => throw new InvalidOperationException("Should not be called."));
+        var protector = new UninstallUserDataProtector(recycle, () => DateTimeOffset.UtcNow);
+
+        protector.ProtectLegacyAudioDirectory(legacyAudio, Path.Combine(_root, "recovery"));
+
+        Assert.Empty(recycle.Paths);
+    }
+
+    [Fact]
+    public void Program_RegistersVelopackBeforeUninstallHook()
+    {
+        var source = TestFile.ReadProjectFile("src", "TypeWhisper.Windows", "Program.cs");
+
+        Assert.Contains(".OnBeforeUninstallFastCallback", source);
+        Assert.Contains("UninstallUserDataProtector.ProtectLegacyAudioDirectory()", source);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private sealed class FakeRecycleBinOperation(Func<string, bool> moveToRecycleBin) : IRecycleBinOperation
+    {
+        public List<string> Paths { get; } = [];
+
+        public bool TryMoveDirectoryToRecycleBin(string path)
+        {
+            Paths.Add(path);
+            return moveToRecycleBin(path);
+        }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
@@ -73,7 +73,23 @@ public sealed class UninstallUserDataProtectorTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_root, recursive: true); } catch { }
+        try
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            Console.Error.WriteLine($"Test cleanup skipped missing directory '{_root}': {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            Console.Error.WriteLine($"Test cleanup could not delete '{_root}': {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Console.Error.WriteLine($"Test cleanup could not access '{_root}': {ex.Message}");
+        }
     }
 
     private sealed class FakeRecycleBinOperation(Func<string, bool> moveToRecycleBin) : IRecycleBinOperation

--- a/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
@@ -5,15 +5,15 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class UninstallUserDataProtectorTests : IDisposable
 {
-    private readonly string _root = Path.Combine(Path.GetTempPath(), $"tw_uninstall_protector_{Guid.NewGuid():N}");
+    private readonly string _root = Path.Join(Path.GetTempPath(), $"tw_uninstall_protector_{Guid.NewGuid():N}");
 
     [Fact]
     public void ProtectLegacyAudioDirectory_SendsLegacyAudioDirectoryToRecycleBin()
     {
-        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
-        var recoveryRoot = Path.Combine(_root, "TypeWhisper-Recovered");
+        var legacyAudio = Path.Join(_root, "TypeWhisper", "Audio");
+        var recoveryRoot = Path.Join(_root, "TypeWhisper-Recovered");
         Directory.CreateDirectory(legacyAudio);
-        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "wav");
+        File.WriteAllText(Path.Join(legacyAudio, "recording.wav"), "wav");
         var recycle = new FakeRecycleBinOperation(path =>
         {
             Directory.Delete(path, recursive: true);
@@ -33,10 +33,10 @@ public sealed class UninstallUserDataProtectorTests : IDisposable
     [Fact]
     public void ProtectLegacyAudioDirectory_MovesLegacyAudioDirectoryToRecoveryWhenRecycleBinFails()
     {
-        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
-        var recoveryRoot = Path.Combine(_root, "TypeWhisper-Recovered");
+        var legacyAudio = Path.Join(_root, "TypeWhisper", "Audio");
+        var recoveryRoot = Path.Join(_root, "TypeWhisper-Recovered");
         Directory.CreateDirectory(legacyAudio);
-        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "wav");
+        File.WriteAllText(Path.Join(legacyAudio, "recording.wav"), "wav");
         var recycle = new FakeRecycleBinOperation(_ => false);
         var protector = new UninstallUserDataProtector(
             recycle,
@@ -44,20 +44,20 @@ public sealed class UninstallUserDataProtectorTests : IDisposable
 
         protector.ProtectLegacyAudioDirectory(legacyAudio, recoveryRoot);
 
-        var recoveredAudio = Path.Combine(recoveryRoot, "Audio-20260708-123045");
+        var recoveredAudio = Path.Join(recoveryRoot, "Audio-20260708-123045");
         Assert.Equal([legacyAudio], recycle.Paths);
         Assert.False(Directory.Exists(legacyAudio));
-        Assert.Equal("wav", File.ReadAllText(Path.Combine(recoveredAudio, "recording.wav")));
+        Assert.Equal("wav", File.ReadAllText(Path.Join(recoveredAudio, "recording.wav")));
     }
 
     [Fact]
     public void ProtectLegacyAudioDirectory_DoesNothingWhenLegacyAudioDirectoryIsMissing()
     {
-        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
+        var legacyAudio = Path.Join(_root, "TypeWhisper", "Audio");
         var recycle = new FakeRecycleBinOperation(_ => throw new InvalidOperationException("Should not be called."));
         var protector = new UninstallUserDataProtector(recycle, () => DateTimeOffset.UtcNow);
 
-        protector.ProtectLegacyAudioDirectory(legacyAudio, Path.Combine(_root, "recovery"));
+        protector.ProtectLegacyAudioDirectory(legacyAudio, Path.Join(_root, "recovery"));
 
         Assert.Empty(recycle.Paths);
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
@@ -5,50 +5,50 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class UserAudioMigrationServiceTests : IDisposable
 {
-    private readonly string _root = Path.Combine(Path.GetTempPath(), $"tw_audio_migration_{Guid.NewGuid():N}");
+    private readonly string _root = Path.Join(Path.GetTempPath(), $"tw_audio_migration_{Guid.NewGuid():N}");
 
     [Fact]
     public void MigrateLegacyAudioIfNeeded_MovesLegacyAudioContentsToUserDataAudioPath()
     {
-        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
-        var userAudio = Path.Combine(_root, "TypeWhisper-UserData", "Audio");
-        Directory.CreateDirectory(Path.Combine(legacyAudio, "nested"));
-        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "wav");
-        File.WriteAllText(Path.Combine(legacyAudio, "transcript.txt"), "txt");
-        File.WriteAllText(Path.Combine(legacyAudio, "nested", "clip.m4a"), "m4a");
+        var legacyAudio = Path.Join(_root, "TypeWhisper", "Audio");
+        var userAudio = Path.Join(_root, "TypeWhisper-UserData", "Audio");
+        Directory.CreateDirectory(Path.Join(legacyAudio, "nested"));
+        File.WriteAllText(Path.Join(legacyAudio, "recording.wav"), "wav");
+        File.WriteAllText(Path.Join(legacyAudio, "transcript.txt"), "txt");
+        File.WriteAllText(Path.Join(legacyAudio, "nested", "clip.m4a"), "m4a");
 
         UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
-        Assert.Equal("wav", File.ReadAllText(Path.Combine(userAudio, "recording.wav")));
-        Assert.Equal("txt", File.ReadAllText(Path.Combine(userAudio, "transcript.txt")));
-        Assert.Equal("m4a", File.ReadAllText(Path.Combine(userAudio, "nested", "clip.m4a")));
+        Assert.Equal("wav", File.ReadAllText(Path.Join(userAudio, "recording.wav")));
+        Assert.Equal("txt", File.ReadAllText(Path.Join(userAudio, "transcript.txt")));
+        Assert.Equal("m4a", File.ReadAllText(Path.Join(userAudio, "nested", "clip.m4a")));
         Assert.False(Directory.Exists(legacyAudio));
     }
 
     [Fact]
     public void MigrateLegacyAudioIfNeeded_PreservesConflictingTargetFilesWithStableSuffix()
     {
-        var legacyAudio = Path.Combine(_root, "legacy");
-        var userAudio = Path.Combine(_root, "user");
+        var legacyAudio = Path.Join(_root, "legacy");
+        var userAudio = Path.Join(_root, "user");
         Directory.CreateDirectory(legacyAudio);
         Directory.CreateDirectory(userAudio);
-        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "legacy");
-        File.WriteAllText(Path.Combine(userAudio, "recording.wav"), "existing");
-        File.WriteAllText(Path.Combine(userAudio, "recording-1.wav"), "existing-one");
+        File.WriteAllText(Path.Join(legacyAudio, "recording.wav"), "legacy");
+        File.WriteAllText(Path.Join(userAudio, "recording.wav"), "existing");
+        File.WriteAllText(Path.Join(userAudio, "recording-1.wav"), "existing-one");
 
         UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
-        Assert.Equal("existing", File.ReadAllText(Path.Combine(userAudio, "recording.wav")));
-        Assert.Equal("existing-one", File.ReadAllText(Path.Combine(userAudio, "recording-1.wav")));
-        Assert.Equal("legacy", File.ReadAllText(Path.Combine(userAudio, "recording-2.wav")));
-        Assert.False(File.Exists(Path.Combine(legacyAudio, "recording.wav")));
+        Assert.Equal("existing", File.ReadAllText(Path.Join(userAudio, "recording.wav")));
+        Assert.Equal("existing-one", File.ReadAllText(Path.Join(userAudio, "recording-1.wav")));
+        Assert.Equal("legacy", File.ReadAllText(Path.Join(userAudio, "recording-2.wav")));
+        Assert.False(File.Exists(Path.Join(legacyAudio, "recording.wav")));
     }
 
     [Fact]
     public void MigrateLegacyAudioIfNeeded_DoesNothingWhenLegacyAudioPathIsMissing()
     {
-        var legacyAudio = Path.Combine(_root, "missing");
-        var userAudio = Path.Combine(_root, "user");
+        var legacyAudio = Path.Join(_root, "missing");
+        var userAudio = Path.Join(_root, "user");
 
         UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
@@ -58,8 +58,8 @@ public sealed class UserAudioMigrationServiceTests : IDisposable
     [Fact]
     public void MigrateLegacyAudioIfNeeded_RemovesEmptyLegacyAudioDirectory()
     {
-        var legacyAudio = Path.Combine(_root, "empty");
-        var userAudio = Path.Combine(_root, "user");
+        var legacyAudio = Path.Join(_root, "empty");
+        var userAudio = Path.Join(_root, "user");
         Directory.CreateDirectory(legacyAudio);
 
         UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);

--- a/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class UserAudioMigrationServiceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"tw_audio_migration_{Guid.NewGuid():N}");
+
+    [Fact]
+    public void MigrateLegacyAudioIfNeeded_MovesLegacyAudioContentsToUserDataAudioPath()
+    {
+        var legacyAudio = Path.Combine(_root, "TypeWhisper", "Audio");
+        var userAudio = Path.Combine(_root, "TypeWhisper-UserData", "Audio");
+        Directory.CreateDirectory(Path.Combine(legacyAudio, "nested"));
+        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "wav");
+        File.WriteAllText(Path.Combine(legacyAudio, "transcript.txt"), "txt");
+        File.WriteAllText(Path.Combine(legacyAudio, "nested", "clip.m4a"), "m4a");
+
+        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+
+        Assert.Equal("wav", File.ReadAllText(Path.Combine(userAudio, "recording.wav")));
+        Assert.Equal("txt", File.ReadAllText(Path.Combine(userAudio, "transcript.txt")));
+        Assert.Equal("m4a", File.ReadAllText(Path.Combine(userAudio, "nested", "clip.m4a")));
+        Assert.False(Directory.Exists(legacyAudio));
+    }
+
+    [Fact]
+    public void MigrateLegacyAudioIfNeeded_PreservesConflictingTargetFilesWithStableSuffix()
+    {
+        var legacyAudio = Path.Combine(_root, "legacy");
+        var userAudio = Path.Combine(_root, "user");
+        Directory.CreateDirectory(legacyAudio);
+        Directory.CreateDirectory(userAudio);
+        File.WriteAllText(Path.Combine(legacyAudio, "recording.wav"), "legacy");
+        File.WriteAllText(Path.Combine(userAudio, "recording.wav"), "existing");
+        File.WriteAllText(Path.Combine(userAudio, "recording-1.wav"), "existing-one");
+
+        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+
+        Assert.Equal("existing", File.ReadAllText(Path.Combine(userAudio, "recording.wav")));
+        Assert.Equal("existing-one", File.ReadAllText(Path.Combine(userAudio, "recording-1.wav")));
+        Assert.Equal("legacy", File.ReadAllText(Path.Combine(userAudio, "recording-2.wav")));
+        Assert.False(File.Exists(Path.Combine(legacyAudio, "recording.wav")));
+    }
+
+    [Fact]
+    public void MigrateLegacyAudioIfNeeded_DoesNothingWhenLegacyAudioPathIsMissing()
+    {
+        var legacyAudio = Path.Combine(_root, "missing");
+        var userAudio = Path.Combine(_root, "user");
+
+        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+
+        Assert.False(Directory.Exists(userAudio));
+    }
+
+    [Fact]
+    public void MigrateLegacyAudioIfNeeded_RemovesEmptyLegacyAudioDirectory()
+    {
+        var legacyAudio = Path.Combine(_root, "empty");
+        var userAudio = Path.Combine(_root, "user");
+        Directory.CreateDirectory(legacyAudio);
+
+        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+
+        Assert.False(Directory.Exists(legacyAudio));
+        Assert.False(Directory.Exists(userAudio));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
@@ -70,6 +70,22 @@ public sealed class UserAudioMigrationServiceTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_root, recursive: true); } catch { }
+        try
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            Console.Error.WriteLine($"Test cleanup skipped missing directory '{_root}': {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            Console.Error.WriteLine($"Test cleanup could not delete '{_root}': {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Console.Error.WriteLine($"Test cleanup could not access '{_root}': {ex.Message}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Move future recordings to `%LocalAppData%\TypeWhisper-UserData\Audio` (`TypeWhisper-DevUserData` for debug builds) so they live outside the Velopack install root.
- Migrate any legacy `Audio` directory on normal app startup while preserving conflicts with stable suffixes.
- Register a Velopack before-uninstall hook that sends the legacy `Audio` directory to the Recycle Bin, with a timestamped recovery fallback if needed.

Fixes #269

## Validation
- `dotnet restore TypeWhisper.slnx`
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj --no-restore`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore`
- `dotnet test TypeWhisper.slnx --no-restore`
- `dotnet restore src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -r win-x64`
- `dotnet publish src\TypeWhisper.Windows\TypeWhisper.Windows.csproj -c Release -r win-x64 --no-restore -o <temp>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated user data location for app files, with audio stored outside the install folder.
  * Kept support for the previous audio location.
  * Automatically migrates legacy audio to the new location on startup.
  * Protects legacy audio during uninstall by sending it to the Recycle Bin or recovering it if needed.
* **Bug Fixes**
  * Improved migration behavior for missing folders, empty legacy folders, and filename/path conflicts.
* **Tests**
  * Added coverage for environment path rules, migration scenarios, and uninstall protection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->