### PR TITLE
Fix wizard lifetime when settings close

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
@@ -5,14 +5,12 @@ using System.Windows.Controls;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Extensions.DependencyInjection;
 using TypeWhisper.Core;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.Core.Services;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
-using TypeWhisper.Windows.Views;
 
 namespace TypeWhisper.Windows.ViewModels;
 
@@ -22,6 +20,11 @@ namespace TypeWhisper.Windows.ViewModels;
 public sealed partial class SettingsWindowViewModel : ObservableObject
 {
     private static SettingsRoute _lastOpenedRoute = SettingsRoute.Dashboard;
+
+    /// <summary>
+    /// Raised when the settings shell should open the setup wizard.
+    /// </summary>
+    public event EventHandler? SetupWizardRequested;
 
     /// <summary>
     /// Gets the settings.
@@ -431,8 +434,7 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenSetupWizard()
     {
-        var window = App.Services.GetRequiredService<WelcomeWindow>();
-        window.Show();
+        SetupWizardRequested?.Invoke(this, EventArgs.Empty);
     }
 
     [RelayCommand(CanExecute = nameof(CanClearAndSeedDevelopmentData))]

--- a/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using TypeWhisper.Windows.ViewModels;
 using TypeWhisper.Windows.Views.Sections;
 using Wpf.Ui.Controls;
@@ -9,12 +10,16 @@ namespace TypeWhisper.Windows.Views;
 /// </summary>
 public partial class SettingsWindow : FluentWindow
 {
+    private readonly SettingsWindowViewModel _viewModel;
+    private WelcomeWindow? _setupWizard;
+
     /// <summary>
     /// Initializes a new instance of the SettingsWindow class.
     /// </summary>
     public SettingsWindow(SettingsWindowViewModel viewModel)
     {
         InitializeComponent();
+        _viewModel = viewModel;
         DataContext = viewModel;
 
         viewModel.RegisterSection(SettingsRoute.Dashboard, () => new DashboardSection { DataContext = viewModel });
@@ -36,6 +41,40 @@ public partial class SettingsWindow : FluentWindow
 
         viewModel.NavigateToDefault();
 
-        Closing += (_, _) => viewModel.Settings.StopMicrophonePreview();
+        _viewModel.SetupWizardRequested += OnSetupWizardRequested;
+        Closing += OnClosing;
+        Closed += OnClosed;
+    }
+
+    private void OnSetupWizardRequested(object? sender, EventArgs e)
+    {
+        if (_setupWizard is { IsLoaded: true })
+        {
+            _setupWizard.Activate();
+            return;
+        }
+
+        var wizard = App.Services.GetRequiredService<WelcomeWindow>();
+        wizard.Owner = this;
+        wizard.Closed += OnSetupWizardClosed;
+        _setupWizard = wizard;
+        wizard.Show();
+    }
+
+    private void OnSetupWizardClosed(object? sender, EventArgs e)
+    {
+        if (ReferenceEquals(sender, _setupWizard))
+            _setupWizard = null;
+    }
+
+    private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        _viewModel.Settings.StopMicrophonePreview();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        _viewModel.SetupWizardRequested -= OnSetupWizardRequested;
+        _setupWizard = null;
     }
 }

--- a/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
@@ -63,6 +63,9 @@ public partial class SettingsWindow : FluentWindow
 
     private void OnSetupWizardClosed(object? sender, EventArgs e)
     {
+        if (sender is WelcomeWindow wizard)
+            wizard.Closed -= OnSetupWizardClosed;
+
         if (ReferenceEquals(sender, _setupWizard))
             _setupWizard = null;
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
@@ -31,6 +31,7 @@ public sealed class SettingsWindowWizardLifetimeTests
         Assert.Contains("if (_setupWizard is { IsLoaded: true })", source);
         Assert.Contains("_setupWizard.Activate();", source);
         Assert.Contains("wizard.Closed += OnSetupWizardClosed;", source);
+        Assert.Contains("wizard.Closed -= OnSetupWizardClosed;", source);
         Assert.Contains("_viewModel.SetupWizardRequested -= OnSetupWizardRequested;", source);
 
         var ownerIndex = source.IndexOf("wizard.Owner = this;", StringComparison.Ordinal);

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
@@ -1,0 +1,40 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class SettingsWindowWizardLifetimeTests
+{
+    [Fact]
+    public void SettingsWindowViewModel_RequestsWizardWithoutCreatingAnUnownedWindow()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "SettingsWindowViewModel.cs");
+        var command = TestFile.ExtractBlock(source, "private void OpenSetupWizard()");
+
+        Assert.Contains("public event EventHandler? SetupWizardRequested;", source);
+        Assert.Contains("SetupWizardRequested?.Invoke(this, EventArgs.Empty);", command);
+        Assert.DoesNotContain("GetRequiredService<WelcomeWindow>", command);
+    }
+
+    [Fact]
+    public void SettingsWindow_OwnsReusesAndReleasesItsSetupWizard()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "SettingsWindow.xaml.cs");
+
+        Assert.Contains("private WelcomeWindow? _setupWizard;", source);
+        Assert.Contains("_viewModel.SetupWizardRequested += OnSetupWizardRequested;", source);
+        Assert.Contains("if (_setupWizard is { IsLoaded: true })", source);
+        Assert.Contains("_setupWizard.Activate();", source);
+        Assert.Contains("wizard.Closed += OnSetupWizardClosed;", source);
+        Assert.Contains("_viewModel.SetupWizardRequested -= OnSetupWizardRequested;", source);
+
+        var ownerIndex = source.IndexOf("wizard.Owner = this;", StringComparison.Ordinal);
+        var showIndex = source.IndexOf("wizard.Show();", StringComparison.Ordinal);
+        Assert.True(ownerIndex >= 0 && ownerIndex < showIndex, "The wizard owner must be set before it is shown.");
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TrayIntegrationTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TrayIntegrationTests.cs
@@ -3,6 +3,22 @@ namespace TypeWhisper.PluginSystem.Tests;
 public sealed class TrayIntegrationTests
 {
     [Fact]
+    public void App_RemainsRunningInTrayUntilExplicitExit()
+    {
+        var appXaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml");
+        var appCode = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+
+        Assert.Contains("ShutdownMode=\"OnExplicitShutdown\"", appXaml);
+        Assert.Contains("_trayIcon.ExitRequested += (_, _) => Shutdown();", appCode);
+    }
+
+    [Fact]
     public void App_DispatchesTrayViewModelActionsToUiThread()
     {
         var code = TestFile.ReadProjectFile(


### PR DESCRIPTION
## Summary

- make the settings window own the active setup wizard
- close the wizard with its settings owner while keeping TypeWhisper running in the tray
- add regression coverage for wizard lifetime and explicit tray exit behavior

## Root cause

The settings view model created a transient `WelcomeWindow` without an owner, so closing the settings window left the wizard as an independent window.

## Testing

- `dotnet test TypeWhisper.slnx --no-restore`
- launched the Debug dev app from `F:\typewhisper\dev-output\typewhisper-win\Build\TypeWhisper.exe`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup wizard behavior from the Settings window.
  * Reuses an already-open wizard and ensures it is properly owned and closed with the Settings window.
  * Prevents unintended application shutdown while running in the system tray; the app now exits explicitly through the tray exit action.

* **Tests**
  * Added coverage for setup wizard lifetime, ownership, reuse, cleanup, and tray-based application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->