### PR TITLE
Clarify Parakeet plugin updates

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -213,6 +213,31 @@ public partial class WelcomeViewModel : ObservableObject
     /// </summary>
     public bool IsLocalRecommendationInstalled => LocalEngine is not null;
     /// <summary>
+    /// Gets whether an update is available for the recommended local plugin.
+    /// </summary>
+    public bool IsLocalRecommendationUpdateAvailable =>
+        RecommendedLocalPlugin?.InstallState == PluginInstallState.UpdateAvailable;
+    /// <summary>
+    /// Gets whether the recommended local plugin update is waiting for restart.
+    /// </summary>
+    public bool IsLocalRecommendationPendingRestart =>
+        RecommendedLocalPlugin?.InstallState == PluginInstallState.PendingRestart;
+    /// <summary>
+    /// Gets whether the recommended local plugin can be installed.
+    /// </summary>
+    public bool CanInstallLocalRecommendation =>
+        RecommendedLocalPlugin is not null
+        && !IsLocalRecommendationInstalled
+        && !IsLocalRecommendationUpdateAvailable
+        && !IsLocalRecommendationPendingRestart;
+    /// <summary>
+    /// Gets whether the recommended local plugin can be selected.
+    /// </summary>
+    public bool CanUseLocalRecommendation =>
+        IsLocalRecommendationInstalled
+        && !IsLocalRecommendationUpdateAvailable
+        && !IsLocalRecommendationPendingRestart;
+    /// <summary>
     /// Gets whether is cloud recommendation installed.
     /// </summary>
     public bool IsCloudRecommendationInstalled => CloudEngine is not null;
@@ -450,7 +475,11 @@ public partial class WelcomeViewModel : ObservableObject
         if (plugin is null)
             return;
 
-        await plugin.InstallCommand.ExecuteAsync(null);
+        if (plugin.InstallState == PluginInstallState.UpdateAvailable)
+            await plugin.UpdateCommand.ExecuteAsync(null);
+        else
+            await plugin.InstallCommand.ExecuteAsync(null);
+
         plugin.RefreshInstallState();
         NotifyRecommendationProperties();
         RefreshModels();
@@ -758,6 +787,10 @@ public partial class WelcomeViewModel : ObservableObject
         OnPropertyChanged(nameof(RecommendedLocalPlugin));
         OnPropertyChanged(nameof(RecommendedCloudPlugin));
         OnPropertyChanged(nameof(IsLocalRecommendationInstalled));
+        OnPropertyChanged(nameof(IsLocalRecommendationUpdateAvailable));
+        OnPropertyChanged(nameof(IsLocalRecommendationPendingRestart));
+        OnPropertyChanged(nameof(CanInstallLocalRecommendation));
+        OnPropertyChanged(nameof(CanUseLocalRecommendation));
         OnPropertyChanged(nameof(IsCloudRecommendationInstalled));
         OnPropertyChanged(nameof(IsCloudRecommendationConfigured));
         OnPropertyChanged(nameof(IsLocalRecommendationSelected));

--- a/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml
@@ -386,9 +386,14 @@
                                                            Command="{Binding InstallCommand}"
                                                            IsEnabled="{Binding IsWorking, Converter={StaticResource InvertBool}}"
                                                            Visibility="{Binding InstallState, Converter={StaticResource InstallStateToVis}, ConverterParameter=NotInstalled}"/>
+                                                <ui:Button Appearance="Primary"
+                                                           Content="{loc:Str Plugins.Update}"
+                                                           Command="{Binding UpdateCommand}"
+                                                           IsEnabled="{Binding IsWorking, Converter={StaticResource InvertBool}}"
+                                                           Visibility="{Binding InstallState, Converter={StaticResource InstallStateToVis}, ConverterParameter=UpdateAvailable}"/>
                                                 <TextBlock Foreground="{StaticResource ActiveIndicatorBrush}"
                                                            FontSize="12"
-                                                           Visibility="{Binding IsInstalledOrUpdateAvailable, Converter={StaticResource BoolToVis}}">
+                                                           Visibility="{Binding InstallState, Converter={StaticResource InstallStateToVis}, ConverterParameter=Installed}">
                                                     <Run Text="&#x2705; "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.InstalledBadge], Mode=OneWay}"/>
                                                 </TextBlock>
                                                 <TextBlock Foreground="{StaticResource WarningBrush}"

--- a/src/TypeWhisper.Windows/Views/WelcomeWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/WelcomeWindow.xaml
@@ -200,36 +200,32 @@
                                                         Command="{Binding InstallRecommendedLocalCommand}"
                                                         Padding="12,6"
                                                         IsEnabled="{Binding RecommendedLocalPlugin.IsWorking, Converter={StaticResource InvertBool}}"
-                                                        Margin="0,0,8,0">
-                                                    <Button.Style>
-                                                        <Style TargetType="Button" BasedOn="{StaticResource SecondaryButtonStyle}">
-                                                            <Setter Property="Visibility" Value="Visible"/>
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding IsLocalRecommendationInstalled}" Value="True">
-                                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                                </DataTrigger>
-                                                                <DataTrigger Binding="{Binding RecommendedLocalPlugin}" Value="{x:Null}">
-                                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </Button.Style>
-                                                </Button>
+                                                        Margin="0,0,8,0"
+                                                        Visibility="{Binding CanInstallLocalRecommendation, Converter={StaticResource BoolToVis}}"/>
+
+                                                <Button Content="{loc:Str Plugins.Update}"
+                                                        Command="{Binding InstallRecommendedLocalCommand}"
+                                                        Padding="12,6"
+                                                        IsEnabled="{Binding RecommendedLocalPlugin.IsWorking, Converter={StaticResource InvertBool}}"
+                                                        Margin="0,0,8,0"
+                                                        Visibility="{Binding IsLocalRecommendationUpdateAvailable, Converter={StaticResource BoolToVis}}"/>
 
                                                 <Button Content="{loc:Str Welcome.UseParakeet}"
                                                         Command="{Binding SelectRecommendedLocalCommand}"
-                                                        Padding="12,6">
-                                                    <Button.Style>
-                                                        <Style TargetType="Button" BasedOn="{StaticResource SecondaryButtonStyle}">
-                                                            <Setter Property="Visibility" Value="Visible"/>
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding IsLocalRecommendationInstalled}" Value="False">
-                                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </Button.Style>
-                                                </Button>
+                                                        Padding="12,6"
+                                                        Visibility="{Binding CanUseLocalRecommendation, Converter={StaticResource BoolToVis}}"/>
+
+                                                <Border Background="#16F2A93B"
+                                                        BorderBrush="#33F2A93B"
+                                                        BorderThickness="1"
+                                                        CornerRadius="999"
+                                                        Padding="10,5"
+                                                        Visibility="{Binding IsLocalRecommendationPendingRestart, Converter={StaticResource BoolToVis}}">
+                                                    <TextBlock Text="{loc:Str Welcome.RestartRequired}"
+                                                               Foreground="{StaticResource WarningBrush}"
+                                                               FontSize="11"
+                                                               FontWeight="SemiBold"/>
+                                                </Border>
                                             </StackPanel>
 
                                             <ProgressBar Grid.Row="1"
@@ -566,6 +562,14 @@
                                                                     MinWidth="84"
                                                                     IsEnabled="{Binding IsWorking, Converter={StaticResource InvertBool}}"
                                                                     Visibility="{Binding InstallState, Converter={StaticResource InstallStateToVis}, ConverterParameter=NotInstalled}"/>
+                                                            <Button Content="{loc:Str Plugins.Update}"
+                                                                    Command="{Binding UpdateCommand}"
+                                                                    Style="{StaticResource PrimaryButtonStyle}"
+                                                                    FontSize="11"
+                                                                    Padding="12,6"
+                                                                    MinWidth="84"
+                                                                    IsEnabled="{Binding IsWorking, Converter={StaticResource InvertBool}}"
+                                                                    Visibility="{Binding InstallState, Converter={StaticResource InstallStateToVis}, ConverterParameter=UpdateAvailable}"/>
                                                             <Border Background="#1239B980"
                                                                     BorderBrush="#2239B980"
                                                                     BorderThickness="1"

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -285,6 +285,17 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetInstallState_UpdateAvailable_WhenOnlyDiskManifestIsOlderThanRegistry()
+    {
+        var manager = CreateManager();
+        var service = new PluginRegistryService(manager, _loader, _settings.Object, pluginsPath: _pluginsRoot);
+        var registryPlugin = CreateRegistryPlugin("com.test.disk-update", "1.0.3");
+        WritePluginManifest(Path.Combine(_pluginsRoot, registryPlugin.Id), registryPlugin.Id, "1.0.2");
+
+        Assert.Equal(PluginInstallState.UpdateAvailable, service.GetInstallState(registryPlugin));
+    }
+
+    [Fact]
     public void GetInstallState_PendingRestart_WhenPendingUpdateMatchesRegistryVersion()
     {
         var manager = CreateManager();

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginsSectionLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginsSectionLayoutTests.cs
@@ -34,7 +34,7 @@ public sealed class PluginsSectionLayoutTests
     }
 
     [Fact]
-    public void PluginsSection_DoesNotOfferMarketplaceUpdates()
+    public void PluginsSection_OffersMarketplaceUpdates()
     {
         var xaml = TestFile.ReadProjectFile(
             "src",
@@ -43,6 +43,7 @@ public sealed class PluginsSectionLayoutTests
             "Sections",
             "PluginsSection.xaml");
 
-        Assert.DoesNotContain("ConverterParameter=UpdateAvailable", xaml);
+        Assert.Contains("Command=\"{Binding UpdateCommand}\"", xaml);
+        Assert.Contains("ConverterParameter=UpdateAvailable", xaml);
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/WelcomeWindowLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WelcomeWindowLayoutTests.cs
@@ -43,4 +43,19 @@ public sealed class WelcomeWindowLayoutTests
         Assert.Contains("ConverterParameter=PendingRestart", xaml);
         Assert.Contains("Welcome.RestartRequired", xaml);
     }
+
+    [Fact]
+    public void WelcomeWindow_ShowsUpdateActionsForRecommendedAndMarketplacePlugins()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "WelcomeWindow.xaml");
+
+        Assert.Contains("IsLocalRecommendationUpdateAvailable", xaml);
+        Assert.Contains("InstallRecommendedLocalCommand", xaml);
+        Assert.Contains("Command=\"{Binding UpdateCommand}\"", xaml);
+        Assert.Contains("ConverterParameter=UpdateAvailable", xaml);
+    }
 }


### PR DESCRIPTION
## Summary
- show an explicit Update action for stale marketplace plugins in the setup wizard and Integrations
- route the Parakeet recommendation through the plugin update command when a newer registry version is available
- show the pending-restart state and cover the stale on-disk manifest path with regression tests

## Root cause
The registry correctly classified an older on-disk plugin manifest as `UpdateAvailable`, but marketplace cards only exposed Install for `NotInstalled` and otherwise presented the plugin as installed. A broken sherpa-onnx 1.0.2 plugin could therefore be detected but had no clear update path.

## User impact
Users with the stale Parakeet plugin can update to the official 1.0.3 package directly from the wizard or Integrations, without manual file cleanup.

## Validation
- `dotnet test TypeWhisper.slnx --no-restore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added update actions for recommended and marketplace plugins.
  * Added clear indicators for installed, update available, and restart-required states.
  * Recommended plugins can now be installed, updated, or selected based on their current status.

* **Bug Fixes**
  * Correctly detects available plugin updates when the installed version is outdated.

* **Tests**
  * Added coverage for plugin update detection and update-related interface actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->