### PR TITLE
Publish plugin package hashes in registry

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -195,10 +195,12 @@ jobs:
           $zipName = "$pluginId-$env:PLUGIN_VERSION.zip"
           Compress-Archive -Path "$stagingDir/*" -DestinationPath $zipName -Force
           $zipSize = (Get-Item $zipName).Length
+          $zipSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $zipName).Hash.ToLowerInvariant()
           echo "ZIP_NAME=$zipName" >> $env:GITHUB_ENV
           echo "ZIP_SIZE=$zipSize" >> $env:GITHUB_ENV
+          echo "PLUGIN_SHA256=$zipSha256" >> $env:GITHUB_ENV
           echo "PLUGIN_ID=$pluginId" >> $env:GITHUB_ENV
-          echo "Created $zipName ($zipSize bytes)"
+          echo "Created $zipName ($zipSize bytes, SHA-256 $zipSha256)"
 
       - name: Create GitHub Release
         env:
@@ -282,6 +284,7 @@ jobs:
                   Set-RegistryProperty $registry[$j] 'categories' $categories
                   Set-RegistryProperty $registry[$j] 'size' ([long]$env:ZIP_SIZE)
                   Set-RegistryProperty $registry[$j] 'downloadUrl' $downloadUrl
+                  Set-RegistryProperty $registry[$j] 'sha256' $env:PLUGIN_SHA256
                   Set-RegistryProperty $registry[$j] 'iconSystemName' $manifest.iconSystemName
                   Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]($manifest.requiresApiKey))
                   Set-RegistryProperty $registry[$j] 'descriptions' $manifest.descriptions
@@ -306,6 +309,7 @@ jobs:
                   categories = $categories
                   size = [long]$env:ZIP_SIZE
                   downloadUrl = $downloadUrl
+                  sha256 = $env:PLUGIN_SHA256
                   iconSystemName = $manifest.iconSystemName
                   requiresApiKey = [bool]($manifest.requiresApiKey)
                   descriptions = $manifest.descriptions

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -217,8 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
         run: |
-          $tag = "${{ github.ref_name }}"
-          $downloadUrl = "https://github.com/TypeWhisper/typewhisper-win/releases/download/$tag/$env:ZIP_NAME"
+          $downloadUrl = "https://typewhisper.github.io/typewhisper-win/plugins/$env:ZIP_NAME"
 
           git fetch origin gh-pages
           git worktree add -B gh-pages gh-pages-work origin/gh-pages

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -48,6 +48,7 @@ public sealed class PluginPackagingWorkflowTests
 
         Assert.Contains("Get-FileHash -Algorithm SHA256", workflow, StringComparison.Ordinal);
         Assert.Contains("PLUGIN_SHA256=$zipSha256", workflow, StringComparison.Ordinal);
+        Assert.Contains("https://typewhisper.github.io/typewhisper-win/plugins/$env:ZIP_NAME", workflow, StringComparison.Ordinal);
         Assert.Contains("Set-RegistryProperty $registry[$j] 'sha256' $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
         Assert.Contains("sha256 = $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -40,4 +40,15 @@ public sealed class PluginPackagingWorkflowTests
         Assert.Contains("TypeWhisper-$RuntimeIdentifier-*.msix", script, StringComparison.Ordinal);
         Assert.Contains("must be in the range 0-65535", script, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void PluginReleaseWorkflow_PublishesPackageHashInRegistry()
+    {
+        var workflow = TestFile.ReadProjectFile(".github", "workflows", "publish-plugins.yml");
+
+        Assert.Contains("Get-FileHash -Algorithm SHA256", workflow, StringComparison.Ordinal);
+        Assert.Contains("PLUGIN_SHA256=$zipSha256", workflow, StringComparison.Ordinal);
+        Assert.Contains("Set-RegistryProperty $registry[$j] 'sha256' $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
+        Assert.Contains("sha256 = $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary
- calculate the SHA-256 digest for each published plugin ZIP
- write the digest to new and existing `plugins.json` registry entries
- serve registry downloads from the same GitHub Pages origin as the registry
- add regression coverage for the plugin release workflow

## Root cause
Microsoft Store builds require each downloadable plugin package to have a trusted SHA-256 digest. The Store package added that verification, but the plugin publishing workflow never populated the `sha256` registry field, so Store installs always failed after downloading the package. Plugin URLs also redirected from the reachable registry origin to `release-assets.githubusercontent.com`, adding a second network boundary during certification.

## Validation
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter FullyQualifiedName~PluginPackagingWorkflowTests`
- live registry backfill verified separately for all 34 current plugin packages
- all 34 Pages ZIP archives opened successfully and matched their published SHA-256 digest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin downloads now use a dedicated hosting URL.
  * Published plugins include a SHA-256 integrity hash in the plugin registry.

* **Tests**
  * Added coverage to verify plugin packages publish correctly with download URLs and integrity hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->