### PR TITLE
Protect user data during release channel changes

### DIFF
--- a/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
+++ b/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
@@ -22,11 +22,11 @@ public static class TypeWhisperEnvironment
 
     private static readonly string _localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-    private static readonly string _basePath = Path.Join(
+    private static readonly string _legacyBasePath = Path.Join(
         _localAppDataPath,
         IsDevelopmentBuild ? "TypeWhisper-Dev" : "TypeWhisper");
 
-    private static readonly string _userDataBasePath = Path.Join(
+    private static readonly string _basePath = Path.Join(
         _localAppDataPath,
         IsDevelopmentBuild ? "TypeWhisper-DevUserData" : "TypeWhisper-UserData");
 
@@ -35,9 +35,13 @@ public static class TypeWhisperEnvironment
     /// </summary>
     public static string BasePath => _basePath;
     /// <summary>
+    /// Gets the previous base path inside the Velopack install root.
+    /// </summary>
+    public static string LegacyBasePath => _legacyBasePath;
+    /// <summary>
     /// Gets the base path for user-created data that must survive Velopack uninstall cleanup.
     /// </summary>
-    public static string UserDataBasePath => _userDataBasePath;
+    public static string UserDataBasePath => _basePath;
     /// <summary>
     /// Gets the models path.
     /// </summary>
@@ -57,11 +61,11 @@ public static class TypeWhisperEnvironment
     /// <summary>
     /// Gets the audio path.
     /// </summary>
-    public static string AudioPath => Path.Join(_userDataBasePath, "Audio");
+    public static string AudioPath => Path.Join(_basePath, "Audio");
     /// <summary>
     /// Gets the previous audio path inside the Velopack install root.
     /// </summary>
-    public static string LegacyAudioPath => Path.Join(_basePath, "Audio");
+    public static string LegacyAudioPath => Path.Join(_legacyBasePath, "Audio");
     /// <summary>
     /// Gets the plugin data path.
     /// </summary>

--- a/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
+++ b/src/TypeWhisper.Core/TypeWhisperEnvironment.cs
@@ -31,7 +31,7 @@ public static class TypeWhisperEnvironment
         IsDevelopmentBuild ? "TypeWhisper-DevUserData" : "TypeWhisper-UserData");
 
     /// <summary>
-    /// Gets the base path.
+    /// Gets the canonical base path for persistent user data.
     /// </summary>
     public static string BasePath => _basePath;
     /// <summary>

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -51,29 +51,25 @@ public static class Program
 #endif
 
         StartMinimized = args.Contains("--minimized", StringComparer.OrdinalIgnoreCase);
-        try
-        {
-            UserDataMigrationService.MigrateLegacyDataIfNeeded();
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            System.Windows.MessageBox.Show(
-                $"TypeWhisper could not move its user data outside the application directory. No data was deleted.\n\n{ex.Message}",
-                "TypeWhisper",
-                System.Windows.MessageBoxButton.OK,
-                System.Windows.MessageBoxImage.Error);
-            return;
-        }
-
-        TypeWhisperEnvironment.EnsureDirectories();
         var callbackArg = args.FirstOrDefault(SupporterDiscordService.CanHandleCallbackUri);
 
         // Single instance check
         _singleInstanceMutex = new Mutex(true, "TypeWhisper-SingleInstance", out var createdNew);
         if (!createdNew)
         {
-            if (!string.IsNullOrWhiteSpace(callbackArg))
-                File.WriteAllText(CallbackInboxPath, callbackArg);
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(callbackArg))
+                {
+                    Directory.CreateDirectory(TypeWhisperEnvironment.DataPath);
+                    File.WriteAllText(CallbackInboxPath, callbackArg);
+                }
+            }
+            finally
+            {
+                _singleInstanceMutex.Dispose();
+                _singleInstanceMutex = null;
+            }
 
             // Another instance is already running
             return;
@@ -81,6 +77,21 @@ public static class Program
 
         try
         {
+            try
+            {
+                UserDataMigrationService.MigrateLegacyDataIfNeeded();
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                System.Windows.MessageBox.Show(
+                    $"TypeWhisper could not move its user data outside the application directory. No data was deleted.\n\n{ex.Message}",
+                    "TypeWhisper",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+                return;
+            }
+
+            TypeWhisperEnvironment.EnsureDirectories();
             var app = new App();
             app.InitializeComponent();
             app.Run();

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -51,6 +51,20 @@ public static class Program
 #endif
 
         StartMinimized = args.Contains("--minimized", StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            UserDataMigrationService.MigrateLegacyDataIfNeeded();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            System.Windows.MessageBox.Show(
+                $"TypeWhisper could not move its user data outside the application directory. No data was deleted.\n\n{ex.Message}",
+                "TypeWhisper",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+            return;
+        }
+
         TypeWhisperEnvironment.EnsureDirectories();
         var callbackArg = args.FirstOrDefault(SupporterDiscordService.CanHandleCallbackUri);
 
@@ -67,8 +81,6 @@ public static class Program
 
         try
         {
-            UserAudioMigrationService.MigrateLegacyAudioIfNeeded();
-
             var app = new App();
             app.InitializeComponent();
             app.Run();

--- a/src/TypeWhisper.Windows/Services/UserDataMigrationService.cs
+++ b/src/TypeWhisper.Windows/Services/UserDataMigrationService.cs
@@ -4,18 +4,65 @@ using TypeWhisper.Core;
 
 namespace TypeWhisper.Windows.Services;
 
-internal static class UserAudioMigrationService
+internal static class UserDataMigrationService
 {
-    public static void MigrateLegacyAudioIfNeeded()
+    private static readonly string[] DirectoryNames = ["Data", "Logs", "Models", "Plugins", "PluginData"];
+    private static readonly string[] FileNames = ["settings.json", "settings.json.bak", "api-token"];
+
+    public static void MigrateLegacyDataIfNeeded() =>
+        MigrateLegacyData(TypeWhisperEnvironment.LegacyBasePath, TypeWhisperEnvironment.BasePath);
+
+    internal static void MigrateLegacyData(string legacyBasePath, string userDataBasePath)
     {
-        try
+        var legacyRoot = Normalize(legacyBasePath);
+        var userDataRoot = Normalize(userDataBasePath);
+
+        if (PathsEqual(legacyRoot, userDataRoot) || !Directory.Exists(legacyRoot))
+            return;
+
+        Directory.CreateDirectory(userDataRoot);
+
+        foreach (var name in DirectoryNames)
+            MoveWithoutOverwrite(Path.Join(legacyRoot, name), Path.Join(userDataRoot, name));
+
+        foreach (var name in FileNames)
+            MoveWithoutOverwrite(Path.Join(legacyRoot, name), Path.Join(userDataRoot, name));
+
+        MigrateLegacyAudio(Path.Join(legacyRoot, "Audio"), Path.Join(userDataRoot, "Audio"));
+    }
+
+    private static void MoveWithoutOverwrite(string source, string target)
+    {
+        if (File.Exists(source))
         {
-            MigrateLegacyAudio(TypeWhisperEnvironment.LegacyAudioPath, TypeWhisperEnvironment.AudioPath);
+            if (!File.Exists(target) && !Directory.Exists(target))
+                File.Move(source, target);
+
+            return;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+
+        if (!Directory.Exists(source) || File.Exists(target))
+            return;
+
+        if (!Directory.Exists(target))
         {
-            Trace.TraceWarning("Could not migrate legacy audio directory: {0}", ex.Message);
+            Directory.Move(source, target);
+            return;
         }
+
+        foreach (var entry in Directory.GetFileSystemEntries(source))
+        {
+            var destination = GetSafeChildPath(target, entry);
+            if (File.Exists(destination) || Directory.Exists(destination))
+                continue;
+
+            if (Directory.Exists(entry))
+                Directory.Move(entry, destination);
+            else
+                File.Move(entry, destination);
+        }
+
+        TryDeleteDirectoryIfEmpty(source);
     }
 
     internal static void MigrateLegacyAudio(string legacyAudioPath, string audioPath)
@@ -85,7 +132,7 @@ internal static class UserAudioMigrationService
     {
         var safeName = Path.GetFileName(value.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
         if (string.IsNullOrWhiteSpace(safeName) || safeName is "." or "..")
-            throw new InvalidOperationException("Invalid audio path segment.");
+            throw new InvalidOperationException("Invalid user data path segment.");
 
         return safeName;
     }
@@ -105,7 +152,7 @@ internal static class UserAudioMigrationService
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            Trace.TraceWarning("Could not delete empty legacy audio directory '{0}': {1}", path, ex.Message);
+            Trace.TraceWarning("Could not delete empty legacy user data directory '{0}': {1}", path, ex.Message);
         }
     }
 }

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -879,12 +879,18 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         CurrentHotkeyMode = null;
     }
 
-    private void ApplyModelLoadFailureFeedback(Exception ex)
+    private void ApplyModelUnavailableFeedback(string? modelId, Exception? error = null)
     {
         _isRecording = false;
-        ApplyTransientIdleFeedback(
-            Loc.Instance.GetString("Status.ModelErrorFormat", ex.Message),
-            feedbackIsError: true);
+        var feedback = error is null
+            ? Loc.Instance["Status.NoModelLoaded"]
+            : Loc.Instance.GetString("Status.ModelErrorFormat", error.Message);
+        var diagnostic = string.IsNullOrWhiteSpace(modelId)
+            ? feedback
+            : $"{feedback} ({modelId})";
+
+        _errorLog.AddEntry(diagnostic, ErrorCategory.Transcription);
+        ApplyTransientIdleFeedback(feedback, feedbackIsError: true);
     }
 
     private async Task StartRecording()
@@ -915,8 +921,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         var desiredModelId = EffectiveModelId ?? _settings.Current.SelectedModelId;
         if (string.IsNullOrWhiteSpace(desiredModelId))
         {
-            StatusText = Loc.Instance["Status.NoModelLoaded"];
-            _isRecording = false;
+            ApplyModelUnavailableFeedback(desiredModelId);
             return;
         }
 
@@ -924,8 +929,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         {
             if (!await _modelManager.EnsureModelLoadedAsync(desiredModelId))
             {
-                StatusText = Loc.Instance["Status.NoModelLoaded"];
-                _isRecording = false;
+                ApplyModelUnavailableFeedback(desiredModelId);
                 return;
             }
         }
@@ -936,29 +940,28 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         }
         catch (InvalidOperationException ex)
         {
-            ApplyModelLoadFailureFeedback(ex);
+            ApplyModelUnavailableFeedback(desiredModelId, ex);
             return;
         }
         catch (IOException ex)
         {
-            ApplyModelLoadFailureFeedback(ex);
+            ApplyModelUnavailableFeedback(desiredModelId, ex);
             return;
         }
         catch (ArgumentException ex)
         {
-            ApplyModelLoadFailureFeedback(ex);
+            ApplyModelUnavailableFeedback(desiredModelId, ex);
             return;
         }
         catch (UnauthorizedAccessException ex)
         {
-            ApplyModelLoadFailureFeedback(ex);
+            ApplyModelUnavailableFeedback(desiredModelId, ex);
             return;
         }
 
         if (!_modelManager.Engine.IsModelLoaded)
         {
-            _isRecording = false;
-            ApplyTransientIdleFeedback(Loc.Instance["Status.NoModelLoaded"], feedbackIsError: true);
+            ApplyModelUnavailableFeedback(desiredModelId);
             return;
         }
 

--- a/tests/TypeWhisper.Core.Tests/TypeWhisperEnvironmentTests.cs
+++ b/tests/TypeWhisper.Core.Tests/TypeWhisperEnvironmentTests.cs
@@ -5,19 +5,31 @@ namespace TypeWhisper.Core.Tests;
 public class TypeWhisperEnvironmentTests
 {
     [Fact]
-    public void AudioPath_IsOutsideVelopackInstallRoot()
+    public void PersistentPaths_AreOutsideVelopackInstallRoot()
     {
         var basePath = Normalize(TypeWhisperEnvironment.BasePath);
+        var legacyBasePath = Normalize(TypeWhisperEnvironment.LegacyBasePath);
         var audioPath = Normalize(TypeWhisperEnvironment.AudioPath);
         var legacyAudioPath = Normalize(TypeWhisperEnvironment.LegacyAudioPath);
         var userDataDirectoryName = TypeWhisperEnvironment.IsDevelopmentBuild
             ? "TypeWhisper-DevUserData"
             : "TypeWhisper-UserData";
 
-        Assert.StartsWith(basePath, legacyAudioPath, StringComparison.OrdinalIgnoreCase);
-        Assert.False(
-            IsUnderDirectory(audioPath, basePath),
-            $"AudioPath '{audioPath}' must not live under Velopack install root '{basePath}'.");
+        Assert.StartsWith(legacyBasePath, legacyAudioPath, StringComparison.OrdinalIgnoreCase);
+        Assert.False(IsUnderDirectory(basePath, legacyBasePath));
+        Assert.All(
+            new[]
+            {
+                TypeWhisperEnvironment.SettingsFilePath,
+                TypeWhisperEnvironment.DataPath,
+                TypeWhisperEnvironment.ModelsPath,
+                TypeWhisperEnvironment.PluginsPath,
+                TypeWhisperEnvironment.PluginDataPath,
+                TypeWhisperEnvironment.LogsPath,
+                TypeWhisperEnvironment.AudioPath,
+                TypeWhisperEnvironment.ApiTokenFilePath
+            },
+            path => Assert.True(IsUnderDirectory(path, basePath), $"'{path}' must live under '{basePath}'."));
         Assert.EndsWith(
             $"{userDataDirectoryName}{Path.DirectorySeparatorChar}Audio",
             audioPath,

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
@@ -82,7 +82,9 @@ public class DictationOverlayPresentationTests
         Assert.Contains("_errorLog.AddEntry(diagnostic, ErrorCategory.Transcription);", helper, StringComparison.Ordinal);
         Assert.Contains("ApplyTransientIdleFeedback(feedback, feedbackIsError: true);", helper, StringComparison.Ordinal);
         Assert.Contains("ApplyModelUnavailableFeedback(desiredModelId);", startRecording, StringComparison.Ordinal);
-        Assert.Contains("ApplyModelUnavailableFeedback(desiredModelId, ex);", startRecording, StringComparison.Ordinal);
+        Assert.Equal(4, TestFile.CountOccurrences(
+            startRecording,
+            "ApplyModelUnavailableFeedback(desiredModelId, ex);"));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
@@ -66,6 +66,26 @@ public class DictationOverlayPresentationTests
     }
 
     [Fact]
+    public void MissingModel_UsesVisibleLoggedFeedbackPath()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+        var helper = TestFile.ExtractBlock(
+            source,
+            "private void ApplyModelUnavailableFeedback(string? modelId, Exception? error = null)",
+            900);
+        var startRecording = TestFile.ExtractBlock(source, "private async Task StartRecording()", 4200);
+
+        Assert.Contains("_errorLog.AddEntry(diagnostic, ErrorCategory.Transcription);", helper, StringComparison.Ordinal);
+        Assert.Contains("ApplyTransientIdleFeedback(feedback, feedbackIsError: true);", helper, StringComparison.Ordinal);
+        Assert.Contains("ApplyModelUnavailableFeedback(desiredModelId);", startRecording, StringComparison.Ordinal);
+        Assert.Contains("ApplyModelUnavailableFeedback(desiredModelId, ex);", startRecording, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuiltInPartialPreview_ShowsWhenExternalPreviewIsInactive()
     {
         Assert.True(DictationOverlayPresentation.ShowBuiltInPartialPreview(

--- a/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
@@ -71,6 +71,18 @@ public sealed class UninstallUserDataProtectorTests : IDisposable
         Assert.Contains("UninstallUserDataProtector.ProtectLegacyAudioDirectory()", source);
     }
 
+    [Fact]
+    public void Program_AcquiresSingleInstanceBeforeMigratingUserData()
+    {
+        var source = TestFile.ReadProjectFile("src", "TypeWhisper.Windows", "Program.cs");
+
+        var mutexIndex = source.IndexOf("new Mutex(true, \"TypeWhisper-SingleInstance\"", StringComparison.Ordinal);
+        var migrationIndex = source.IndexOf("UserDataMigrationService.MigrateLegacyDataIfNeeded()", StringComparison.Ordinal);
+
+        Assert.True(mutexIndex >= 0);
+        Assert.True(migrationIndex > mutexIndex);
+    }
+
     public void Dispose()
     {
         try

--- a/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UserAudioMigrationServiceTests.cs
@@ -3,7 +3,7 @@ using TypeWhisper.Windows.Services;
 
 namespace TypeWhisper.PluginSystem.Tests;
 
-public sealed class UserAudioMigrationServiceTests : IDisposable
+public sealed class UserDataMigrationServiceTests : IDisposable
 {
     private readonly string _root = Path.Join(Path.GetTempPath(), $"tw_audio_migration_{Guid.NewGuid():N}");
 
@@ -17,7 +17,7 @@ public sealed class UserAudioMigrationServiceTests : IDisposable
         File.WriteAllText(Path.Join(legacyAudio, "transcript.txt"), "txt");
         File.WriteAllText(Path.Join(legacyAudio, "nested", "clip.m4a"), "m4a");
 
-        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+        UserDataMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
         Assert.Equal("wav", File.ReadAllText(Path.Join(userAudio, "recording.wav")));
         Assert.Equal("txt", File.ReadAllText(Path.Join(userAudio, "transcript.txt")));
@@ -36,7 +36,7 @@ public sealed class UserAudioMigrationServiceTests : IDisposable
         File.WriteAllText(Path.Join(userAudio, "recording.wav"), "existing");
         File.WriteAllText(Path.Join(userAudio, "recording-1.wav"), "existing-one");
 
-        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+        UserDataMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
         Assert.Equal("existing", File.ReadAllText(Path.Join(userAudio, "recording.wav")));
         Assert.Equal("existing-one", File.ReadAllText(Path.Join(userAudio, "recording-1.wav")));
@@ -50,7 +50,7 @@ public sealed class UserAudioMigrationServiceTests : IDisposable
         var legacyAudio = Path.Join(_root, "missing");
         var userAudio = Path.Join(_root, "user");
 
-        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+        UserDataMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
         Assert.False(Directory.Exists(userAudio));
     }
@@ -62,10 +62,50 @@ public sealed class UserAudioMigrationServiceTests : IDisposable
         var userAudio = Path.Join(_root, "user");
         Directory.CreateDirectory(legacyAudio);
 
-        UserAudioMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
+        UserDataMigrationService.MigrateLegacyAudio(legacyAudio, userAudio);
 
         Assert.False(Directory.Exists(legacyAudio));
         Assert.False(Directory.Exists(userAudio));
+    }
+
+    [Fact]
+    public void MigrateLegacyData_MovesPersistentFilesAndDirectories()
+    {
+        var legacy = Path.Join(_root, "TypeWhisper");
+        var userData = Path.Join(_root, "TypeWhisper-UserData");
+        Directory.CreateDirectory(Path.Join(legacy, "Plugins", "com.test.plugin"));
+        Directory.CreateDirectory(Path.Join(legacy, "Data"));
+        File.WriteAllText(Path.Join(legacy, "settings.json"), "settings");
+        File.WriteAllText(Path.Join(legacy, "api-token"), "token");
+        File.WriteAllText(Path.Join(legacy, "Plugins", "com.test.plugin", "manifest.json"), "plugin");
+        File.WriteAllText(Path.Join(legacy, "Data", "typewhisper.db"), "database");
+
+        UserDataMigrationService.MigrateLegacyData(legacy, userData);
+
+        Assert.Equal("settings", File.ReadAllText(Path.Join(userData, "settings.json")));
+        Assert.Equal("token", File.ReadAllText(Path.Join(userData, "api-token")));
+        Assert.Equal("plugin", File.ReadAllText(Path.Join(userData, "Plugins", "com.test.plugin", "manifest.json")));
+        Assert.Equal("database", File.ReadAllText(Path.Join(userData, "Data", "typewhisper.db")));
+    }
+
+    [Fact]
+    public void MigrateLegacyData_DoesNotOverwriteCanonicalData()
+    {
+        var legacy = Path.Join(_root, "TypeWhisper");
+        var userData = Path.Join(_root, "TypeWhisper-UserData");
+        Directory.CreateDirectory(Path.Join(legacy, "Plugins", "com.legacy.plugin"));
+        Directory.CreateDirectory(Path.Join(userData, "Plugins", "com.current.plugin"));
+        File.WriteAllText(Path.Join(legacy, "settings.json"), "legacy");
+        File.WriteAllText(Path.Join(userData, "settings.json"), "current");
+        File.WriteAllText(Path.Join(legacy, "Plugins", "com.legacy.plugin", "manifest.json"), "legacy-plugin");
+        File.WriteAllText(Path.Join(userData, "Plugins", "com.current.plugin", "manifest.json"), "current-plugin");
+
+        UserDataMigrationService.MigrateLegacyData(legacy, userData);
+
+        Assert.Equal("current", File.ReadAllText(Path.Join(userData, "settings.json")));
+        Assert.Equal("legacy", File.ReadAllText(Path.Join(legacy, "settings.json")));
+        Assert.Equal("current-plugin", File.ReadAllText(Path.Join(userData, "Plugins", "com.current.plugin", "manifest.json")));
+        Assert.Equal("legacy-plugin", File.ReadAllText(Path.Join(userData, "Plugins", "com.legacy.plugin", "manifest.json")));
     }
 
     public void Dispose()

--- a/tests/TypeWhisper.PluginSystem.Tests/UserDataMigrationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UserDataMigrationServiceTests.cs
@@ -5,7 +5,7 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class UserDataMigrationServiceTests : IDisposable
 {
-    private readonly string _root = Path.Join(Path.GetTempPath(), $"tw_audio_migration_{Guid.NewGuid():N}");
+    private readonly string _root = Path.Join(Path.GetTempPath(), $"tw_user_data_migration_{Guid.NewGuid():N}");
 
     [Fact]
     public void MigrateLegacyAudioIfNeeded_MovesLegacyAudioContentsToUserDataAudioPath()


### PR DESCRIPTION
## Summary
- move persistent settings, plugins, models, logs, and app data outside the Velopack-managed install directory
- migrate existing user data without overwriting data already present in the protected location
- show visible feedback and add a transcription log entry when the configured model or provider is unavailable

## Root cause
TypeWhisper stored persistent integrations and settings under the same `%LocalAppData%\TypeWhisper` directory managed by Velopack. Switching release channels can clean that install directory and remove user-managed integrations.

## User impact
Future release channel changes preserve integrations and configuration. Existing data is migrated on startup, and an unavailable transcription provider no longer fails silently.

## Validation
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-restore` (294 passed)
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release --no-restore` (1168 passed)
- targeted `dotnet format --verify-no-changes`
- `git diff --check`

Closes #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic migration of legacy settings, models, plugins, audio, and other persistent data to the current user-data location.
  * Preserves existing current data without overwriting it.
  * Added clearer visible feedback and error logging when a dictation model is unavailable or fails to load.

* **Bug Fixes**
  * Improved startup handling when data migration fails, including a user-facing error message.
  * Improved cleanup when another application instance is already running.

* **Tests**
  * Expanded coverage for data-path migration, preservation behavior, startup ordering, and missing-model feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->