### PR TITLE
Require double Escape to cancel dictation

### DIFF
--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -684,6 +684,8 @@
   "Status.Done": "Fertig",
   "Status.ActionFormat": "{0} wird ausgeführt...",
   "Status.Cancelled": "Abgebrochen",
+  "Status.CancelRecordingConfirm": "Drücke Esc erneut, um die Aufnahme abzubrechen",
+  "Status.CancelTranscriptionConfirm": "Drücke Esc erneut, um die Transkription abzubrechen",
   "Status.NoMicrophone": "Kein Mikrofon angeschlossen",
   "Status.MicrophoneRestored": "Mikrofon verbunden",
   "Status.ErrorFormat": "Fehler: {0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -684,6 +684,8 @@
   "Status.Done": "Done",
   "Status.ActionFormat": "Running {0}...",
   "Status.Cancelled": "Cancelled",
+  "Status.CancelRecordingConfirm": "Press Esc again to cancel recording",
+  "Status.CancelTranscriptionConfirm": "Press Esc again to cancel transcription",
   "Status.NoMicrophone": "No microphone connected",
   "Status.MicrophoneRestored": "Microphone connected",
   "Status.ErrorFormat": "Error: {0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -671,6 +671,8 @@
   "Status.Done": "完了",
   "Status.ActionFormat": "{0}を実行中...",
   "Status.Cancelled": "キャンセルしました",
+  "Status.CancelRecordingConfirm": "Escを再度押して録音をキャンセル",
+  "Status.CancelTranscriptionConfirm": "Escを再度押して文字起こしをキャンセル",
   "Status.NoMicrophone": "マイクが接続されていません",
   "Status.MicrophoneRestored": "マイクが接続されました",
   "Status.ErrorFormat": "エラー: {0}",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -671,6 +671,8 @@
   "Status.Done": "Готово",
   "Status.ActionFormat": "Выполняется {0}…",
   "Status.Cancelled": "Отменено",
+  "Status.CancelRecordingConfirm": "Нажмите Esc ещё раз, чтобы отменить запись",
+  "Status.CancelTranscriptionConfirm": "Нажмите Esc ещё раз, чтобы отменить расшифровку",
   "Status.NoMicrophone": "Микрофон не подключён",
   "Status.MicrophoneRestored": "Микрофон подключён",
   "Status.ErrorFormat": "Ошибка: {0}",

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -122,6 +122,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     private int _feedbackAutoHideMilliseconds = 2000;
     private bool _isRecording;
     private bool _isStoppingRecording;
+    private DictationState? _cancelConfirmationState;
     private int _pendingJobCount;
     private const int MaxTrackedApiDictationSessions = 50;
     private const string ExternalLiveTranscriptPluginId = "com.typewhisper.live-transcript";
@@ -176,6 +177,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     [ObservableProperty] private string? _feedbackActionText;
     [ObservableProperty] private string? _lastTranscribedText;
     [ObservableProperty] private string? _lastTranscriptionLanguage;
+    [ObservableProperty] private string? _cancelWarningText;
 
     /// <summary>
     /// Returns whether read back last transcription.
@@ -300,8 +302,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             }
         });
 
-        _hotkey.CancelRequested += (_, _) => Application.Current?.Dispatcher.InvokeAsync(async () =>
-            await AbortActiveOperation());
+        _hotkey.CancelRequested += (_, _) => Application.Current?.Dispatcher.InvokeAsync(HandleCancelRequested);
         _hotkey.RecentTranscriptionsRequested += (_, _) => Application.Current?.Dispatcher.InvokeAsync(ShowRecentTranscriptionsPalette);
         _hotkey.CopyLastTranscriptionRequested += (_, _) => Application.Current?.Dispatcher.InvokeAsync(async () =>
             await CopyLastTranscriptionToClipboardAsync());
@@ -1226,6 +1227,50 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         }
 
         return Task.CompletedTask;
+    }
+
+    internal async Task HandleCancelRequested()
+    {
+        if (State is not (DictationState.Recording or DictationState.Processing))
+            return;
+
+        if (ConfirmCancel(State, ref _cancelConfirmationState))
+        {
+            CancelWarningText = null;
+            await AbortActiveOperation();
+            return;
+        }
+
+        CancelWarningText = State == DictationState.Recording
+            ? Loc.Instance["Status.CancelRecordingConfirm"]
+            : Loc.Instance["Status.CancelTranscriptionConfirm"];
+    }
+
+    partial void OnStateChanged(DictationState value)
+    {
+        ResetCancelConfirmation(value, ref _cancelConfirmationState);
+        if (_cancelConfirmationState is null)
+            CancelWarningText = null;
+    }
+
+    internal static bool ConfirmCancel(DictationState state, ref DictationState? confirmationState)
+    {
+        if (confirmationState != state)
+        {
+            confirmationState = state;
+            return false;
+        }
+
+        confirmationState = null;
+        return true;
+    }
+
+    internal static void ResetCancelConfirmation(
+        DictationState state,
+        ref DictationState? confirmationState)
+    {
+        if (confirmationState != state)
+            confirmationState = null;
     }
 
     private async Task ProcessJobsAsync(CancellationToken ct)

--- a/src/TypeWhisper.Windows/ViewModels/RecordingOverlayViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/RecordingOverlayViewModel.cs
@@ -92,7 +92,9 @@ public sealed class RecordingOverlayViewModel : ObservableObject
     /// <summary>
     /// Gets the status text.
     /// </summary>
-    public string StatusText => UseDictation ? _dictation.StatusText : _recorder.StatusText;
+    public string StatusText => UseDictation
+        ? _dictation.CancelWarningText ?? _dictation.StatusText
+        : _recorder.StatusText;
     /// <summary>
     /// Gets the partial text.
     /// </summary>

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationCancelShortcutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationCancelShortcutTests.cs
@@ -27,4 +27,35 @@ public class DictationCancelShortcutTests
             isRecording: false,
             pendingJobCount: 0));
     }
+
+    [Theory]
+    [InlineData(DictationState.Recording)]
+    [InlineData(DictationState.Processing)]
+    public void CancelConfirmation_RequiresTwoPressesInSameState(DictationState state)
+    {
+        DictationState? confirmationState = null;
+
+        Assert.False(DictationViewModel.ConfirmCancel(state, ref confirmationState));
+        Assert.Equal(state, confirmationState);
+        Assert.True(DictationViewModel.ConfirmCancel(state, ref confirmationState));
+        Assert.Null(confirmationState);
+    }
+
+    [Fact]
+    public void CancelConfirmation_StateChangeRequiresTwoNewPresses()
+    {
+        DictationState? confirmationState = null;
+        Assert.False(DictationViewModel.ConfirmCancel(
+            DictationState.Recording,
+            ref confirmationState));
+
+        DictationViewModel.ResetCancelConfirmation(
+            DictationState.Processing,
+            ref confirmationState);
+
+        Assert.Null(confirmationState);
+        Assert.False(DictationViewModel.ConfirmCancel(
+            DictationState.Processing,
+            ref confirmationState));
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -534,7 +534,7 @@ public class ModelManagerViewModelTests
     }
 
     [Fact]
-    public async Task DictationAbortActiveOperation_WhileRecording_PublishesTerminalPluginEvents()
+    public async Task DictationCancel_WhileRecording_RequiresConfirmationAndPublishesTerminalPluginEvents()
     {
         const string pluginId = "com.typewhisper.sherpa-onnx";
         const string modelId = "parakeet";
@@ -639,7 +639,16 @@ public class ModelManagerViewModelTests
         lock (startedEvents)
             recordingId = Assert.Single(startedEvents).RecordingId;
 
-        await InvokeAbortActiveOperationAsync(sut);
+        await sut.HandleCancelRequested();
+
+        Assert.True(sut.IsRecording);
+        Assert.Equal(Loc.Instance["Status.CancelRecordingConfirm"], sut.CancelWarningText);
+        lock (stoppedEvents)
+            Assert.Empty(stoppedEvents);
+        lock (failedEvents)
+            Assert.Empty(failedEvents);
+
+        await sut.HandleCancelRequested();
 
         Assert.True(await WaitForConditionAsync(
             () =>
@@ -924,16 +933,6 @@ public class ModelManagerViewModelTests
         var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
         field.SetValue(target, value);
-    }
-
-    private static Task InvokeAbortActiveOperationAsync(DictationViewModel target)
-    {
-        var method = typeof(DictationViewModel).GetMethod(
-            "AbortActiveOperation",
-            BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new MissingMethodException(nameof(DictationViewModel), "AbortActiveOperation");
-
-        return (Task)method.Invoke(target, null)!;
     }
 
     private static async Task<bool> WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)


### PR DESCRIPTION
## Summary

- require a second Escape press before cancelling an active recording or transcription
- show a localized confirmation warning in the dictation overlay after the first press
- reset confirmation when the dictation state changes

## Root cause

Escape was wired directly to the active-operation abort path, so dismissing common Windows UI such as the Start menu also discarded the current recording.

## User impact

The first Escape press can dismiss the foreground Windows UI without losing dictation audio. A second Escape press in the same dictation state still cancels intentionally.

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --no-build` (1232 passed)
- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj --no-restore` (298 passed)
- local Debug dev build launched successfully

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-step confirmation when cancelling an active recording or transcription.
  * The first Esc press displays a warning; pressing Esc again confirms cancellation.
  * Confirmation prompts are localized in English, German, Japanese, and Russian.

* **Bug Fixes**
  * Cancellation confirmations reset when the dictation state changes.

* **Tests**
  * Added coverage for repeated cancellation presses and state-change behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->