### PR TITLE
Restore hybrid hold behavior for modifier-only hotkeys

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -42,7 +42,7 @@ public sealed class KeyboardHook : IDisposable
     /// <summary>
     /// Sets hotkey.
     /// </summary>
-    public void SetHotkey(string hotkeyString)
+    public void SetHotkey(string hotkeyString, bool activateModifierOnlyOnKeyDown = false)
     {
         _stateMachine.Reset();
         _mouseStateMachine.Reset();
@@ -53,7 +53,7 @@ public sealed class KeyboardHook : IDisposable
             if (parsed.Kind == HotkeyTargetKind.Mouse)
                 _mouseStateMachine.SetHotkey(parsed.Modifiers, parsed.MouseButton);
             else
-                _stateMachine.SetHotkey(parsed.Modifiers, parsed.Code);
+                _stateMachine.SetHotkey(parsed.Modifiers, parsed.Code, activateModifierOnlyOnKeyDown);
         }
     }
 
@@ -386,6 +386,7 @@ internal sealed class HotkeyMatchStateMachine
     private uint _pendingSuppressedWinKey;
     private uint _targetModifiers;
     private uint _targetVk;
+    private bool _activateModifierOnlyOnKeyDown;
     private bool _isPressed;
     private bool _winPassThroughActive;
     private bool _modifierOnlyReady;
@@ -399,10 +400,11 @@ internal sealed class HotkeyMatchStateMachine
     /// <summary>
     /// Sets hotkey.
     /// </summary>
-    public void SetHotkey(uint modifiers, uint vk)
+    public void SetHotkey(uint modifiers, uint vk, bool activateModifierOnlyOnKeyDown = false)
     {
         _targetModifiers = modifiers;
         _targetVk = vk;
+        _activateModifierOnlyOnKeyDown = activateModifierOnlyOnKeyDown;
         ResetRuntimeState();
     }
 
@@ -413,6 +415,7 @@ internal sealed class HotkeyMatchStateMachine
     {
         _targetModifiers = 0;
         _targetVk = 0;
+        _activateModifierOnlyOnKeyDown = false;
         ResetRuntimeState();
     }
 
@@ -424,7 +427,7 @@ internal sealed class HotkeyMatchStateMachine
         if (!HasHotkey || (!isKeyDown && !isKeyUp))
             return default;
 
-        if (IsModifierOnly)
+        if (IsModifierOnly && !_activateModifierOnlyOnKeyDown)
             return ProcessModifierOnlyKeyEvent(vkCode, isKeyDown, isKeyUp);
 
         var swallow = false;

--- a/src/TypeWhisper.Windows/Services/HotkeyService.cs
+++ b/src/TypeWhisper.Windows/Services/HotkeyService.cs
@@ -133,7 +133,9 @@ public sealed class HotkeyService : IDisposable
         {
             var hook = new KeyboardHook();
             AttachAppHotkeyHandler(hook, binding.Action);
-            hook.SetHotkey(binding.Hotkey);
+            hook.SetHotkey(
+                binding.Hotkey,
+                activateModifierOnlyOnKeyDown: binding.Action == AppHotkeyAction.MainDictation);
             hook.Start();
             _appHotkeyHooks.Add(hook);
         }

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -193,6 +193,22 @@ public class HotkeyInputTests
     }
 
     [Fact]
+    public void ModifierOnly_CtrlShift_CanTriggerOnPressForHybridBehavior()
+    {
+        var sut = CreateStateMachine(
+            NativeMethods.MOD_CONTROL | NativeMethods.MOD_SHIFT,
+            activateModifierOnlyOnKeyDown: true);
+
+        _ = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
+
+        var shiftDown = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false);
+        Assert.True(shiftDown.RaiseKeyDown);
+
+        var shiftUp = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true);
+        Assert.True(shiftUp.RaiseKeyUp);
+    }
+
+    [Fact]
     public void ModifierOnly_CtrlWin_WhenCtrlIsPressedFirst_SuppressesWinActivationKey()
     {
         var sut = CreateStateMachine(NativeMethods.MOD_WIN | NativeMethods.MOD_CONTROL);
@@ -664,10 +680,13 @@ public class HotkeyInputTests
         Assert.False(rightCtrlUp.Swallow);
     }
 
-    private static HotkeyMatchStateMachine CreateStateMachine(uint modifiers, uint vk = 0)
+    private static HotkeyMatchStateMachine CreateStateMachine(
+        uint modifiers,
+        uint vk = 0,
+        bool activateModifierOnlyOnKeyDown = false)
     {
         var sut = new HotkeyMatchStateMachine();
-        sut.SetHotkey(modifiers, vk);
+        sut.SetHotkey(modifiers, vk, activateModifierOnlyOnKeyDown);
         return sut;
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -199,13 +199,16 @@ public class HotkeyInputTests
             NativeMethods.MOD_CONTROL | NativeMethods.MOD_SHIFT,
             activateModifierOnlyOnKeyDown: true);
 
-        _ = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
+        var ctrlDown = sut.ProcessKeyEvent(NativeMethods.VK_LCONTROL, isKeyDown: true, isKeyUp: false);
+        Assert.Equal(default, ctrlDown);
 
         var shiftDown = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: true, isKeyUp: false);
         Assert.True(shiftDown.RaiseKeyDown);
+        Assert.True(shiftDown.Swallow);
 
         var shiftUp = sut.ProcessKeyEvent(NativeMethods.VK_LSHIFT, isKeyDown: false, isKeyUp: true);
         Assert.True(shiftUp.RaiseKeyUp);
+        Assert.True(shiftUp.Swallow);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Restore immediate press and release events for modifier-only main dictation hotkeys.
- Keep release-only matching for other modifier-only shortcuts.
- Add regression coverage for `Ctrl+Shift` hybrid behavior.

## Root cause

The refined modifier-only matcher delayed both hotkey events until the first modifier was released. Hybrid mode therefore measured no hold duration and always switched to toggle mode.

## Impact

Long-press push-to-talk works again for hybrid modifier-only shortcuts such as `Ctrl+Shift`, while short presses still toggle recording.

## Testing

- `dotnet test TypeWhisper.slnx --no-restore` (1,528 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Main dictation hotkeys using only modifier keys can now activate when the keys are pressed, while retaining release-based activation behavior.

* **Bug Fixes**
  * Improved modifier-only hotkey handling for more responsive dictation activation.

* **Tests**
  * Added coverage for modifier-only hotkeys triggering on both key press and release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->