### PR TITLE
Add privacy-friendly Polar attribution

### DIFF
--- a/src/TypeWhisper.Windows/Services/LicenseService.cs
+++ b/src/TypeWhisper.Windows/Services/LicenseService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -44,6 +45,8 @@ public sealed partial class LicenseService : ObservableObject
     private readonly HttpClient _http;
     private readonly string _credentialPath;
     private readonly string _legacyCredentialPath;
+    private readonly AppDistributionKind _distributionKind;
+    private readonly string _appVersion;
 
     private bool _suppressPersistence;
     private string? _commercialLicenseKey;
@@ -134,11 +137,17 @@ public sealed partial class LicenseService : ObservableObject
     {
     }
 
-    internal LicenseService(HttpClient http, string dataPath)
+    internal LicenseService(
+        HttpClient http,
+        string dataPath,
+        AppDistributionKind? distributionKind = null,
+        string? appVersion = null)
     {
         _http = http;
         _credentialPath = ResolveDataFilePath(dataPath, CredentialStoreFileName);
         _legacyCredentialPath = ResolveDataFilePath(dataPath, LegacyCredentialFileName);
+        _distributionKind = distributionKind ?? AppDistribution.Current;
+        _appVersion = appVersion ?? GetAppVersion();
         LoadStore();
     }
 
@@ -834,7 +843,18 @@ public sealed partial class LicenseService : ObservableObject
 
     private async Task<PolarActivationResponse> ActivateCoreAsync(string key, CancellationToken ct)
     {
-        var body = new { key, organization_id = OrganizationId, label = Environment.MachineName };
+        var body = new
+        {
+            key,
+            organization_id = OrganizationId,
+            label = Environment.MachineName,
+            meta = new
+            {
+                platform = "windows",
+                app_version = _appVersion,
+                distribution = _distributionKind == AppDistributionKind.Store ? "store" : "direct"
+            }
+        };
         var response = await _http.PostAsJsonAsync($"{BaseUrl}/activate", body, ct);
         var json = await response.Content.ReadAsStringAsync(ct);
 
@@ -856,6 +876,14 @@ public sealed partial class LicenseService : ObservableObject
 
         return JsonSerializer.Deserialize<PolarValidationResponse>(json)
             ?? throw new InvalidOperationException("Validation failed: Polar returned an empty response.");
+    }
+
+    private static string GetAppVersion()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
     }
 
     private async Task DeactivateCoreAsync(string key, string activationId, CancellationToken ct)

--- a/src/TypeWhisper.Windows/Services/PolarCheckoutUrlBuilder.cs
+++ b/src/TypeWhisper.Windows/Services/PolarCheckoutUrlBuilder.cs
@@ -1,0 +1,24 @@
+namespace TypeWhisper.Windows.Services;
+
+/// <summary>
+/// Adds TypeWhisper purchase attribution to Polar checkout links.
+/// </summary>
+public static class PolarCheckoutUrlBuilder
+{
+    /// <summary>
+    /// Builds a Polar checkout URL attributed to the Windows app.
+    /// </summary>
+    public static string BuildAppCheckoutUrl(string baseUrl, string content)
+    {
+        var builder = new UriBuilder(baseUrl);
+        var parameters = new List<string>();
+        if (!string.IsNullOrWhiteSpace(builder.Query))
+            parameters.Add(builder.Query.TrimStart('?'));
+
+        parameters.Add("utm_source=typewhisper_windows");
+        parameters.Add("utm_medium=app");
+        parameters.Add($"utm_content={Uri.EscapeDataString($"windows_{content}")}");
+        builder.Query = string.Join("&", parameters);
+        return builder.Uri.AbsoluteUri;
+    }
+}

--- a/src/TypeWhisper.Windows/ViewModels/LicenseSectionViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/LicenseSectionViewModel.cs
@@ -37,23 +37,23 @@ public sealed partial class LicenseSectionViewModel : ObservableObject
 
         MonthlyCommercialOptions =
         [
-            new LicensePurchaseOption("Individual", "5 EUR/mo", Loc.Instance["License.TierIndividualHint"], CheckoutUrlIndividual),
-            new LicensePurchaseOption("Team", "19 EUR/mo", Loc.Instance["License.TierTeamHint"], CheckoutUrlTeam),
-            new LicensePurchaseOption("Enterprise", "99 EUR/mo", Loc.Instance["License.TierEnterpriseHint"], CheckoutUrlEnterprise),
+            new LicensePurchaseOption("Individual", "5 EUR/mo", Loc.Instance["License.TierIndividualHint"], AttributedCheckoutUrl(CheckoutUrlIndividual, "settings_individual_monthly")),
+            new LicensePurchaseOption("Team", "19 EUR/mo", Loc.Instance["License.TierTeamHint"], AttributedCheckoutUrl(CheckoutUrlTeam, "settings_team_monthly")),
+            new LicensePurchaseOption("Enterprise", "99 EUR/mo", Loc.Instance["License.TierEnterpriseHint"], AttributedCheckoutUrl(CheckoutUrlEnterprise, "settings_enterprise_monthly")),
         ];
 
         LifetimeCommercialOptions =
         [
-            new LicensePurchaseOption("Individual", "99 EUR", Loc.Instance["License.TierIndividualHint"], CheckoutUrlIndividualLifetime),
-            new LicensePurchaseOption("Team", "299 EUR", Loc.Instance["License.TierTeamHint"], CheckoutUrlTeamLifetime),
-            new LicensePurchaseOption("Enterprise", "999 EUR", Loc.Instance["License.TierEnterpriseHint"], CheckoutUrlEnterpriseLifetime),
+            new LicensePurchaseOption("Individual", "99 EUR", Loc.Instance["License.TierIndividualHint"], AttributedCheckoutUrl(CheckoutUrlIndividualLifetime, "settings_individual_lifetime")),
+            new LicensePurchaseOption("Team", "299 EUR", Loc.Instance["License.TierTeamHint"], AttributedCheckoutUrl(CheckoutUrlTeamLifetime, "settings_team_lifetime")),
+            new LicensePurchaseOption("Enterprise", "999 EUR", Loc.Instance["License.TierEnterpriseHint"], AttributedCheckoutUrl(CheckoutUrlEnterpriseLifetime, "settings_enterprise_lifetime")),
         ];
 
         SupporterOptions =
         [
-            new LicensePurchaseOption("Bronze", "10 EUR", Loc.Instance["License.SupporterBronzeHint"], CheckoutUrlSupporterBronze),
-            new LicensePurchaseOption("Silver", "25 EUR", Loc.Instance["License.SupporterSilverHint"], CheckoutUrlSupporterSilver),
-            new LicensePurchaseOption("Gold", "50 EUR", Loc.Instance["License.SupporterGoldHint"], CheckoutUrlSupporterGold),
+            new LicensePurchaseOption("Bronze", "10 EUR", Loc.Instance["License.SupporterBronzeHint"], AttributedCheckoutUrl(CheckoutUrlSupporterBronze, "settings_bronze_one_time")),
+            new LicensePurchaseOption("Silver", "25 EUR", Loc.Instance["License.SupporterSilverHint"], AttributedCheckoutUrl(CheckoutUrlSupporterSilver, "settings_silver_one_time")),
+            new LicensePurchaseOption("Gold", "50 EUR", Loc.Instance["License.SupporterGoldHint"], AttributedCheckoutUrl(CheckoutUrlSupporterGold, "settings_gold_one_time")),
         ];
 
         SelectPrivateUserCommand = new RelayCommand(() => License.SetUserType(LicenseUserType.PrivateUser));
@@ -74,6 +74,9 @@ public sealed partial class LicenseSectionViewModel : ObservableObject
         License.PropertyChanged += OnServicePropertyChanged;
         Discord.PropertyChanged += OnServicePropertyChanged;
     }
+
+    private static string AttributedCheckoutUrl(string baseUrl, string content) =>
+        PolarCheckoutUrlBuilder.BuildAppCheckoutUrl(baseUrl, content);
 
     /// <summary>
     /// Gets the license.

--- a/tests/TypeWhisper.PluginSystem.Tests/LicenseServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/LicenseServiceTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.ViewModels;
 
@@ -52,6 +53,52 @@ public sealed class LicenseServiceTests : IDisposable
         Assert.Equal(SupporterTier.Bronze, LicenseService.DetectSupporterTier("legacy", "Bronze supporter"));
         Assert.Equal(SupporterTier.Silver, LicenseService.DetectSupporterTier("legacy", "Silver supporter"));
         Assert.Equal(SupporterTier.Gold, LicenseService.DetectSupporterTier("legacy", "Gold supporter"));
+    }
+
+    [Fact]
+    public void CheckoutUrlBuilder_AddsWindowsPolarAttribution()
+    {
+        var url = new Uri(PolarCheckoutUrlBuilder.BuildAppCheckoutUrl(
+            "https://buy.polar.sh/example",
+            "settings_individual_monthly"));
+
+        Assert.Contains("utm_source=typewhisper_windows", url.Query);
+        Assert.Contains("utm_medium=app", url.Query);
+        Assert.Contains("utm_content=windows_settings_individual_monthly", url.Query);
+    }
+
+    [Theory]
+    [InlineData(AppDistributionKind.Direct, "direct")]
+    [InlineData(AppDistributionKind.Store, "store")]
+    public async Task ActivationPayload_IncludesPlatformVersionAndDistribution(
+        AppDistributionKind distributionKind,
+        string expectedDistribution)
+    {
+        string? activationBody = null;
+        var service = CreateService(
+            (request, body) =>
+            {
+                if (request.RequestUri?.AbsolutePath == "/v1/customer-portal/license-keys/activate")
+                    activationBody = body;
+
+                return request.RequestUri?.AbsolutePath switch
+                {
+                    "/v1/customer-portal/license-keys/activate" => Json(HttpStatusCode.OK, """{"id":"activation-123"}"""),
+                    "/v1/customer-portal/license-keys/validate" => Json(HttpStatusCode.OK, """{"id":"activation-123","status":"granted","expires_at":null,"benefit_id":"40b82917-f74e-4cc3-8165-937f1f47b294"}"""),
+                    _ => Json(HttpStatusCode.InternalServerError, """{"detail":"unexpected"}"""),
+                };
+            },
+            distributionKind,
+            "9.8.7-test");
+
+        await service.ActivateAnyLicenseKeyAsync("TYPEWHISPER-COM-123");
+
+        using var payload = JsonDocument.Parse(Assert.IsType<string>(activationBody));
+        var root = payload.RootElement;
+        Assert.Equal(Environment.MachineName, root.GetProperty("label").GetString());
+        Assert.Equal("windows", root.GetProperty("meta").GetProperty("platform").GetString());
+        Assert.Equal("9.8.7-test", root.GetProperty("meta").GetProperty("app_version").GetString());
+        Assert.Equal(expectedDistribution, root.GetProperty("meta").GetProperty("distribution").GetString());
     }
 
     [Fact]
@@ -466,13 +513,18 @@ public sealed class LicenseServiceTests : IDisposable
         }
     }
 
-    private LicenseService CreateService(Func<HttpRequestMessage, string, HttpResponseMessage> responder)
+    private LicenseService CreateService(
+        Func<HttpRequestMessage, string, HttpResponseMessage> responder,
+        AppDistributionKind? distributionKind = null,
+        string? appVersion = null)
     {
         var tempDir = CreateTempDir();
 
         return new LicenseService(
             new HttpClient(new CapturingHandler(responder)) { Timeout = TimeSpan.FromSeconds(5) },
-            tempDir);
+            tempDir,
+            distributionKind,
+            appVersion);
     }
 
     private SupporterDiscordService CreateDiscordService(Func<HttpRequestMessage, string, HttpResponseMessage>? responder = null)


### PR DESCRIPTION
## Context

TypeWhisper needs aggregate attribution from Windows in-app checkout clicks through purchases and license activations without creating persistent user identifiers.

## Changes

- Route all commercial and supporter purchase links through a shared Polar URL builder.
- Tag Windows checkout traffic with utm_source=typewhisper_windows and utm_medium=app.
- Attach platform, app version, and detected store or direct distribution metadata to license activations.
- Retain the readable machine name as the activation label.
- Add coverage for checkout parameters and both distribution payloads.

## User impact

Purchases started in the Windows app can be attributed in Polar, and activations identify the platform, version, and distribution channel.

## Test plan

- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --filter FullyQualifiedName~LicenseServiceTests

The project and test assembly compile successfully on macOS. The testhost cannot execute the net10.0-windows suite locally because Microsoft.WindowsDesktop.App 10.0 is unavailable on macOS; Windows CI provides the executable validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows app version, platform, and distribution details to license activation requests.
  * Added attribution parameters to checkout links for improved purchase tracking.
  * Preserved existing checkout URL parameters when adding attribution data.

* **Tests**
  * Added coverage for checkout attribution and activation metadata across distribution types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->