### PR TITLE
Handle stalled plugin downloads

### DIFF
--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -23,6 +23,7 @@ public sealed class PluginRegistryService
     private const string StagingDirectoryName = ".staging";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan UpdateCheckInterval = TimeSpan.FromHours(24);
+    private static readonly TimeSpan DefaultDownloadInactivityTimeout = TimeSpan.FromSeconds(30);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -40,6 +41,7 @@ public sealed class PluginRegistryService
     private readonly Func<string, string, CancellationToken, Task> _replaceActiveDirectoryAsync;
     private readonly Func<string, CancellationToken, Task> _deleteActiveDirectoryAsync;
     private readonly AppDistributionKind _distributionKind;
+    private readonly TimeSpan _downloadInactivityTimeout;
 
     private List<RegistryPlugin>? _cachedRegistry;
     private DateTime _cacheTimestamp;
@@ -57,13 +59,15 @@ public sealed class PluginRegistryService
         Func<string, string, CancellationToken, Task>? replaceActiveDirectoryAsync = null,
         Func<string, CancellationToken, Task>? deleteActiveDirectoryAsync = null,
         string? bundledPluginsPath = null,
-        AppDistributionKind? distributionKind = null)
+        AppDistributionKind? distributionKind = null,
+        TimeSpan? downloadInactivityTimeout = null)
     {
         _pluginManager = pluginManager;
         _pluginLoader = pluginLoader;
         _settings = settings;
-        _httpClient = httpClient ?? new HttpClient();
+        _httpClient = httpClient ?? new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
         _distributionKind = distributionKind ?? AppDistribution.Current;
+        _downloadInactivityTimeout = downloadInactivityTimeout ?? DefaultDownloadInactivityTimeout;
         _pluginsPath = Path.GetFullPath(pluginsPath ?? TypeWhisperEnvironment.PluginsPath);
         _bundledPluginsPath = Path.GetFullPath(bundledPluginsPath ?? Path.Join(AppContext.BaseDirectory, "Plugins"));
         _pendingUpdatesPath = GetValidatedChildDirectory(_pluginsPath, PendingUpdatesDirectoryName, "pending updates directory");
@@ -160,26 +164,40 @@ public sealed class PluginRegistryService
         {
             Directory.CreateDirectory(stagingRoot);
 
-            using (var response = await _httpClient.GetAsync(
-                       registryPlugin.DownloadUrl,
-                       HttpCompletionOption.ResponseHeadersRead,
-                       ct))
+            using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            downloadCts.CancelAfter(_downloadInactivityTimeout);
+            try
             {
+                using var response = await _httpClient.GetAsync(
+                    registryPlugin.DownloadUrl,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    downloadCts.Token);
                 response.EnsureSuccessStatusCode();
 
                 var totalBytes = response.Content.Headers.ContentLength ?? registryPlugin.Size;
-                await using var contentStream = await response.Content.ReadAsStreamAsync(ct);
+                await using var contentStream = await response.Content.ReadAsStreamAsync(downloadCts.Token);
                 await using var fileStream = File.Create(tempZip);
 
                 var buffer = new byte[8192];
                 long bytesRead = 0;
                 int read;
-                while ((read = await contentStream.ReadAsync(buffer, ct)) > 0)
+                while (true)
                 {
+                    downloadCts.CancelAfter(_downloadInactivityTimeout);
+                    read = await contentStream.ReadAsync(buffer, downloadCts.Token);
+                    if (read == 0)
+                        break;
+
                     await fileStream.WriteAsync(buffer.AsMemory(0, read), ct);
                     bytesRead += read;
                     progress?.Report(totalBytes > 0 ? (double)bytesRead / totalBytes : 0);
                 }
+            }
+            catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    "Plugin download timed out because no data was received. Check your internet connection and try again.",
+                    ex);
             }
 
             VerifyDownloadedPackage(registryPlugin, tempZip);

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginRegistryService.cs
@@ -193,7 +193,7 @@ public sealed class PluginRegistryService
                     progress?.Report(totalBytes > 0 ? (double)bytesRead / totalBytes : 0);
                 }
             }
-            catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (!ct.IsCancellationRequested && downloadCts.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     "Plugin download timed out because no data was received. Check your internet connection and try again.",

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -530,6 +530,28 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallPluginAsync_StalledDownloadTimesOut()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.stalled-download", "1.0.2");
+        var httpClient = TrackDisposable(new HttpClient(new StalledHttpMessageHandler())
+        {
+            Timeout = Timeout.InfiniteTimeSpan
+        });
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            httpClient,
+            _pluginsRoot,
+            downloadInactivityTimeout: TimeSpan.FromMilliseconds(50));
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => service.InstallPluginAsync(registryPlugin));
+
+        Assert.Contains("download timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task InstallPluginAsync_DownloadFailure_LeavesExistingPluginDirectoryUntouched()
     {
         var manager = CreateManager();
@@ -1231,5 +1253,16 @@ public class PluginRegistryServiceTests : IDisposable
         }
 
         return stream.ToArray();
+    }
+
+    private sealed class StalledHttpMessageHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginRegistryServiceTests.cs
@@ -552,6 +552,26 @@ public class PluginRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallPluginAsync_HttpClientTimeoutIsNotReportedAsInactivity()
+    {
+        var manager = CreateManager();
+        var registryPlugin = CreateRegistryPlugin("com.test.http-timeout", "1.0.2");
+        var httpClient = TrackDisposable(new HttpClient(new StalledHttpMessageHandler())
+        {
+            Timeout = TimeSpan.FromMilliseconds(50)
+        });
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            httpClient,
+            _pluginsRoot,
+            downloadInactivityTimeout: TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.InstallPluginAsync(registryPlugin));
+    }
+
+    [Fact]
     public async Task InstallPluginAsync_DownloadFailure_LeavesExistingPluginDirectoryUntouched()
     {
         var manager = CreateManager();


### PR DESCRIPTION
## Summary
- stop plugin installation after 30 seconds without download activity
- keep slow but active downloads uncapped
- show a clear network error instead of leaving onboarding on `Installing...`
- preserve externally configured `HttpClient` timeout behavior

## Root cause
The Store package already declares `internetClient`, but a package request that produces no data can leave certification testers waiting indefinitely in the installation state.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj -c Release --no-restore` (1243 passed)
- built and inspected the x64 Store MSIX as version `1.0.3.0`
- verified zero bundled `Plugins/*` entries and the expected `internetClient`, `runFullTrust`, and `microphone` capabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin marketplace downloads now detect stalled transfers and stop after a configurable period of inactivity.
  * Download activity resets the inactivity timer, allowing longer transfers to complete normally.
  * Stalled downloads now provide a clear timeout error instead of waiting indefinitely.

* **Tests**
  * Added coverage for stalled downloads and for distinguishing inactivity timeouts from standard HTTP client timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->