### PR TITLE
Group dictionary correction variants by replacement

### DIFF
--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -390,6 +390,7 @@
   "Dictionary.Term": "Begriff",
   "Dictionary.ReplacementPlaceholder": "Ersetzung (optional)",
   "Dictionary.Add": "Hinzuf\u00fcgen",
+  "Dictionary.AddAlias": "Alias hinzuf\u00fcgen",
   "Dictionary.UsageCount": "{0}x verwendet",
   "Dictionary.PackTerms": "Begriffe",
   "Dictionary.EditEntry": "Eintrag bearbeiten",

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -391,6 +391,7 @@
   "Dictionary.ReplacementPlaceholder": "Ersetzung (optional)",
   "Dictionary.Add": "Hinzuf\u00fcgen",
   "Dictionary.AddAlias": "Alias hinzuf\u00fcgen",
+  "Dictionary.ToggleAliases": "Aliase ein- oder ausklappen",
   "Dictionary.UsageCount": "{0}x verwendet",
   "Dictionary.PackTerms": "Begriffe",
   "Dictionary.EditEntry": "Eintrag bearbeiten",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -390,6 +390,7 @@
   "Dictionary.Term": "Term",
   "Dictionary.ReplacementPlaceholder": "Replacement (optional)",
   "Dictionary.Add": "Add",
+  "Dictionary.AddAlias": "Add alias",
   "Dictionary.UsageCount": "{0}x used",
   "Dictionary.PackTerms": "Terms",
   "Dictionary.EditEntry": "Edit Entry",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -391,6 +391,7 @@
   "Dictionary.ReplacementPlaceholder": "Replacement (optional)",
   "Dictionary.Add": "Add",
   "Dictionary.AddAlias": "Add alias",
+  "Dictionary.ToggleAliases": "Expand or collapse aliases",
   "Dictionary.UsageCount": "{0}x used",
   "Dictionary.PackTerms": "Terms",
   "Dictionary.EditEntry": "Edit Entry",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -382,6 +382,7 @@
   "Dictionary.Term": "用語",
   "Dictionary.ReplacementPlaceholder": "置換（オプション）",
   "Dictionary.Add": "追加",
+  "Dictionary.AddAlias": "別表記を追加",
   "Dictionary.UsageCount": "{0}回使用",
   "Dictionary.PackTerms": "用語",
   "Dictionary.EditEntry": "エントリを編集",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -383,6 +383,7 @@
   "Dictionary.ReplacementPlaceholder": "置換（オプション）",
   "Dictionary.Add": "追加",
   "Dictionary.AddAlias": "別表記を追加",
+  "Dictionary.ToggleAliases": "別表記を展開または折りたたむ",
   "Dictionary.UsageCount": "{0}回使用",
   "Dictionary.PackTerms": "用語",
   "Dictionary.EditEntry": "エントリを編集",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -383,6 +383,7 @@
   "Dictionary.ReplacementPlaceholder": "Замена (необязательно)",
   "Dictionary.Add": "Добавить",
   "Dictionary.AddAlias": "Добавить вариант",
+  "Dictionary.ToggleAliases": "Развернуть или свернуть варианты",
   "Dictionary.UsageCount": "{0}× использовано",
   "Dictionary.PackTerms": "Термины",
   "Dictionary.EditEntry": "Изменить запись",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -382,6 +382,7 @@
   "Dictionary.Term": "Термин",
   "Dictionary.ReplacementPlaceholder": "Замена (необязательно)",
   "Dictionary.Add": "Добавить",
+  "Dictionary.AddAlias": "Добавить вариант",
   "Dictionary.UsageCount": "{0}× использовано",
   "Dictionary.PackTerms": "Термины",
   "Dictionary.EditEntry": "Изменить запись",

--- a/src/TypeWhisper.Windows/ViewModels/DictionaryViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictionaryViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows;
-using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TypeWhisper.Core.Interfaces;
@@ -78,7 +77,7 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
     /// <summary>
     /// Performs entry count.
     /// </summary>
-    public int EntryCount => FilteredEntries.Cast<object>().Count();
+    public int EntryCount => _visibleEntries.Sum(item => item.Entries.Count);
     /// <summary>
     /// Performs active boosting term count.
     /// </summary>
@@ -96,9 +95,11 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
     /// </summary>
     public ObservableCollection<DictionaryEntry> Entries { get; } = [];
     /// <summary>
-    /// Gets the filtered entries.
+    /// Gets the visible dictionary presentation items.
     /// </summary>
-    public ICollectionView FilteredEntries { get; }
+    public System.Collections.IEnumerable VisibleEntries => _visibleEntries;
+    internal ObservableCollection<DictionaryDisplayItem> VisibleDisplayItems => _visibleEntries;
+    private readonly ObservableCollection<DictionaryDisplayItem> _visibleEntries = [];
     /// <summary>
     /// Gets the packs.
     /// </summary>
@@ -126,9 +127,6 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
         _vocabularyBoostingEnabled = _settings.Current.VocabularyBoostingEnabled;
         _selectedIndustryPresetId = IndustryPreset.Resolve(_settings.Current.SelectedIndustryPresetId).Id;
 
-        FilteredEntries = CollectionViewSource.GetDefaultView(Entries);
-        FilteredEntries.Filter = FilterByTab;
-
         _dictionary.EntriesChanged += RefreshEntries;
         if (_license is not null)
             _license.PropertyChanged += OnLicenseChanged;
@@ -153,15 +151,13 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
 
     partial void OnSelectedTabChanged(int value)
     {
-        FilteredEntries.Refresh();
-        OnPropertyChanged(nameof(EntryCount));
+        RefreshVisibleEntries();
     }
 
     partial void OnSearchTextChanged(string value)
     {
         OnPropertyChanged(nameof(HasSearchText));
-        FilteredEntries.Refresh();
-        OnPropertyChanged(nameof(EntryCount));
+        RefreshVisibleEntries();
     }
 
     partial void OnVocabularyBoostingEnabledChanged(bool value)
@@ -184,28 +180,51 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void ClearSearch() => SearchText = "";
 
-    private bool FilterByTab(object obj)
+    private bool MatchesSelectedTab(DictionaryEntry entry)
     {
-        if (obj is not DictionaryEntry entry) return false;
-
-        // Tab filter
-        var tabMatch = SelectedTab switch
+        return SelectedTab switch
         {
             1 => entry.EntryType == DictionaryEntryType.Term,
             2 => entry.EntryType == DictionaryEntryType.Correction,
             _ => true // 0=Alle, 3=Packs (entries hidden, packs shown)
         };
-        if (!tabMatch) return false;
+    }
 
-        // Search filter
-        if (!string.IsNullOrWhiteSpace(SearchText))
+    private void RefreshVisibleEntries()
+    {
+        var candidates = Entries.Where(MatchesSelectedTab).ToArray();
+        var correctionGroups = candidates
+            .Where(entry => entry.EntryType == DictionaryEntryType.Correction &&
+                entry.Replacement is { Length: > 0 })
+            .GroupBy(entry => entry.Replacement!, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        var emittedReplacements = new HashSet<string>(StringComparer.Ordinal);
+        var search = SearchText.Trim();
+
+        _visibleEntries.Clear();
+        foreach (var entry in candidates)
         {
-            var search = SearchText.Trim();
-            return entry.Original.Contains(search, StringComparison.OrdinalIgnoreCase)
-                || (entry.Replacement?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false);
+            IReadOnlyList<DictionaryEntry> entries = [entry];
+            if (entry.EntryType == DictionaryEntryType.Correction &&
+                entry.Replacement is { Length: > 0 } replacement)
+            {
+                if (!emittedReplacements.Add(replacement))
+                    continue;
+
+                entries = correctionGroups[replacement];
+            }
+
+            var replacementMatch = search.Length > 0 &&
+                entries[0].Replacement?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+            var aliasMatch = search.Length > 0 &&
+                entries.Any(candidate => candidate.Original.Contains(search, StringComparison.OrdinalIgnoreCase));
+            if (search.Length > 0 && !replacementMatch && !aliasMatch)
+                continue;
+
+            _visibleEntries.Add(new DictionaryDisplayItem(entries, aliasMatch && entries.Count > 1));
         }
 
-        return true;
+        OnPropertyChanged(nameof(EntryCount));
     }
 
     [RelayCommand]
@@ -224,6 +243,18 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
 
         NewOriginal = "";
         NewReplacement = "";
+        NewCaseSensitive = false;
+    }
+
+    [RelayCommand]
+    private void PrepareAlias(string? replacement)
+    {
+        if (replacement is not { Length: > 0 })
+            return;
+
+        NewEntryType = DictionaryEntryType.Correction;
+        NewOriginal = "";
+        NewReplacement = replacement;
         NewCaseSensitive = false;
     }
 
@@ -482,10 +513,24 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
         Entries.Clear();
         foreach (var e in _dictionary.Entries)
             Entries.Add(e);
-        FilteredEntries.Refresh();
-        OnPropertyChanged(nameof(EntryCount));
+        RefreshVisibleEntries();
         OnPropertyChanged(nameof(ActiveBoostingTermCount));
         OnPropertyChanged(nameof(VocabularyBoostingStatusText));
+    }
+}
+
+internal sealed class DictionaryDisplayItem
+{
+    public IReadOnlyList<DictionaryEntry> Entries { get; }
+    public DictionaryEntry PrimaryEntry => Entries[0];
+    public string? Replacement => PrimaryEntry.Replacement;
+    public bool IsGroupedCorrection => Entries.Count > 1;
+    public bool IsExpanded { get; set; }
+
+    public DictionaryDisplayItem(IReadOnlyList<DictionaryEntry> entries, bool isExpanded = false)
+    {
+        Entries = entries;
+        IsExpanded = isExpanded;
     }
 }
 

--- a/src/TypeWhisper.Windows/ViewModels/DictionaryViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictionaryViewModel.cs
@@ -519,19 +519,22 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
     }
 }
 
-internal sealed class DictionaryDisplayItem
+internal sealed partial class DictionaryDisplayItem : ObservableObject
 {
     public IReadOnlyList<DictionaryEntry> Entries { get; }
     public DictionaryEntry PrimaryEntry => Entries[0];
     public string? Replacement => PrimaryEntry.Replacement;
     public bool IsGroupedCorrection => Entries.Count > 1;
-    public bool IsExpanded { get; set; }
+    [ObservableProperty] private bool _isExpanded;
 
     public DictionaryDisplayItem(IReadOnlyList<DictionaryEntry> entries, bool isExpanded = false)
     {
         Entries = entries;
-        IsExpanded = isExpanded;
+        _isExpanded = isExpanded;
     }
+
+    [RelayCommand]
+    private void Toggle() => IsExpanded = !IsExpanded;
 }
 
 /// <summary>

--- a/src/TypeWhisper.Windows/ViewModels/DictionaryViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictionaryViewModel.cs
@@ -215,7 +215,7 @@ public partial class DictionaryViewModel : ObservableObject, IDisposable
             }
 
             var replacementMatch = search.Length > 0 &&
-                entries[0].Replacement?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+                entries[0].Replacement?.Contains(search, StringComparison.OrdinalIgnoreCase) is true;
             var aliasMatch = search.Length > 0 &&
                 entries.Any(candidate => candidate.Original.Contains(search, StringComparison.OrdinalIgnoreCase));
             if (search.Length > 0 && !replacementMatch && !aliasMatch)

--- a/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
@@ -617,6 +617,8 @@
                                                         <TextBlock Text="&#xE710;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
                                                     </Button>
                                                     <Button Grid.Column="4" Style="{StaticResource IconButtonStyle}"
+                                                            ToolTip="{loc:Str Dictionary.ToggleAliases}"
+                                                            AutomationProperties.Name="{loc:Str Dictionary.ToggleAliases}"
                                                             Command="{Binding ToggleCommand}">
                                                         <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="12">
                                                             <TextBlock.Style>

--- a/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
@@ -366,7 +366,7 @@
                             <Style TargetType="StackPanel">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Dictionary.FilteredEntries.IsEmpty}" Value="True">
+                                    <DataTrigger Binding="{Binding Dictionary.EntryCount}" Value="0">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -440,173 +440,242 @@
                     </StackPanel>
 
                     <!-- Entry Cards -->
-                    <ItemsControl ItemsSource="{Binding Dictionary.FilteredEntries}">
+                    <ItemsControl ItemsSource="{Binding Dictionary.VisibleEntries}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- Outer wrapper for opacity on disabled -->
-                                <Border Margin="0,0,0,6">
-                                    <Border.Style>
-                                        <Style TargetType="Border">
-                                            <Setter Property="Opacity" Value="1"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsEnabled}" Value="False">
-                                                    <Setter Property="Opacity" Value="0.5"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Border.Style>
-
-                                    <!-- Card with accent stripe -->
-                                    <Border Background="{StaticResource InputBackgroundBrush}"
-                                            BorderBrush="{StaticResource BorderBrush}"
-                                            BorderThickness="1" CornerRadius="8"
-                                            ClipToBounds="True">
-                                        <Border.Style>
-                                            <Style TargetType="Border">
-                                                <Style.Triggers>
-                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="BorderBrush" Value="#555555"/>
-                                                        <Setter Property="Background" Value="#333333"/>
-                                                    </Trigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Border.Style>
-
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="3"/>
-                                                <ColumnDefinition Width="*"/>
-                                            </Grid.ColumnDefinitions>
-
-                                            <!-- Accent stripe -->
-                                            <Border Grid.Column="0" CornerRadius="8,0,0,8">
-                                                <Border.Style>
-                                                    <Style TargetType="Border">
-                                                        <Setter Property="Background" Value="#5B9BD5"/>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding EntryType}" Value="Correction">
-                                                                <Setter Property="Background" Value="#D4915B"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Border.Style>
-                                            </Border>
-
-                                            <!-- Card content -->
-                                            <Grid Grid.Column="1" Margin="12,10">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
-
-                                                <!-- Left: Type badge + content -->
-                                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                                                    <StackPanel Orientation="Horizontal">
-                                                        <!-- Type Badge -->
-                                                        <Border CornerRadius="4" Padding="6,2" Margin="0,0,8,0"
-                                                                VerticalAlignment="Center">
-                                                            <Border.Style>
-                                                                <Style TargetType="Border">
-                                                                    <Setter Property="Background" Value="#2A3A5A"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding EntryType}" Value="Correction">
-                                                                            <Setter Property="Background" Value="#3A2A1A"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </Border.Style>
-                                                            <TextBlock FontSize="11" FontWeight="Medium">
+                                <Grid Margin="0,0,0,6">
+                                    <!-- Terms, empty corrections, and single-alias corrections stay lightweight. -->
+                                    <Border Visibility="{Binding IsGroupedCorrection, Converter={StaticResource InverseBoolToVis}}">
+                                        <Border DataContext="{Binding PrimaryEntry}">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Opacity" Value="1"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                            <Setter Property="Opacity" Value="0.5"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                                    BorderBrush="{StaticResource BorderBrush}"
+                                                    BorderThickness="1" CornerRadius="8" ClipToBounds="True">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="3"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Border Grid.Column="0" CornerRadius="8,0,0,8">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Background" Value="#5B9BD5"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding EntryType}" Value="Correction">
+                                                                        <Setter Property="Background" Value="#D4915B"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
+                                                    </Border>
+                                                    <Grid Grid.Column="1" Margin="12,10">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <Border CornerRadius="4" Padding="6,2" Margin="0,0,8,0"
+                                                                        VerticalAlignment="Center">
+                                                                    <Border.Style>
+                                                                        <Style TargetType="Border">
+                                                                            <Setter Property="Background" Value="#2A3A5A"/>
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding EntryType}" Value="Correction">
+                                                                                    <Setter Property="Background" Value="#3A2A1A"/>
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </Border.Style>
+                                                                    <TextBlock FontSize="11" FontWeight="Medium">
+                                                                        <TextBlock.Style>
+                                                                            <Style TargetType="TextBlock">
+                                                                                <Setter Property="Foreground" Value="#5B9BD5"/>
+                                                                                <Setter Property="Text" Value="{loc:Str Dictionary.Term}"/>
+                                                                                <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding EntryType}" Value="Correction">
+                                                                                        <Setter Property="Foreground" Value="#D4915B"/>
+                                                                                        <Setter Property="Text" Value="{loc:Str Dictionary.Correction}"/>
+                                                                                    </DataTrigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </TextBlock.Style>
+                                                                    </TextBlock>
+                                                                </Border>
+                                                                <TextBlock Text="{Binding Original}" Foreground="{StaticResource TextBrush}"
+                                                                           FontSize="13" VerticalAlignment="Center"/>
+                                                                <StackPanel Orientation="Horizontal" Margin="6,0,0,0"
+                                                                            VerticalAlignment="Center"
+                                                                            Visibility="{Binding Replacement, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
+                                                                    <TextBlock Text="→" Foreground="#D4915B" FontSize="13" FontWeight="Medium"/>
+                                                                    <TextBlock Text="{Binding Replacement}" Foreground="{StaticResource TextBrush}"
+                                                                               FontSize="13" FontWeight="Medium" Margin="4,0,0,0"/>
+                                                                </StackPanel>
+                                                                <Border CornerRadius="3" Padding="4,1" Margin="8,0,0,0"
+                                                                        Background="#333333" VerticalAlignment="Center"
+                                                                        Visibility="{Binding CaseSensitive, Converter={StaticResource BoolToVis}}">
+                                                                    <TextBlock Text="Aa" FontSize="10" Foreground="{StaticResource HintBrush}"
+                                                                               ToolTip="{loc:Str Dictionary.CaseSensitive}"/>
+                                                                </Border>
+                                                            </StackPanel>
+                                                            <TextBlock FontSize="11" Foreground="{StaticResource HintBrush}" Margin="0,2,0,0">
                                                                 <TextBlock.Style>
                                                                     <Style TargetType="TextBlock">
-                                                                        <Setter Property="Foreground" Value="#5B9BD5"/>
-                                                                        <Setter Property="Text" Value="{loc:Str Dictionary.Term}"/>
+                                                                        <Setter Property="Visibility" Value="Visible"/>
                                                                         <Style.Triggers>
-                                                                            <DataTrigger Binding="{Binding EntryType}" Value="Correction">
-                                                                                <Setter Property="Foreground" Value="#D4915B"/>
-                                                                                <Setter Property="Text" Value="{loc:Str Dictionary.Correction}"/>
+                                                                            <DataTrigger Binding="{Binding UsageCount}" Value="0">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
                                                                             </DataTrigger>
                                                                         </Style.Triggers>
                                                                     </Style>
                                                                 </TextBlock.Style>
+                                                                <TextBlock.Text>
+                                                                    <MultiBinding Converter="{StaticResource LocalizedFormat}">
+                                                                        <Binding Source="{x:Static loc:Loc.Instance}" Path="[Dictionary.UsageCount]"/>
+                                                                        <Binding Path="UsageCount"/>
+                                                                    </MultiBinding>
+                                                                </TextBlock.Text>
                                                             </TextBlock>
-                                                        </Border>
-
-                                                        <!-- Original text -->
-                                                        <TextBlock Text="{Binding Original}"
-                                                                   Foreground="{StaticResource TextBrush}"
-                                                                   FontSize="13" VerticalAlignment="Center"/>
-
-                                                        <!-- Arrow + Replacement (for corrections) -->
-                                                        <StackPanel Orientation="Horizontal" Margin="6,0,0,0"
-                                                                    VerticalAlignment="Center"
-                                                                    Visibility="{Binding Replacement, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
-                                                            <TextBlock Text="→" Foreground="#D4915B" FontSize="13"
-                                                                       FontWeight="Medium"/>
-                                                            <TextBlock Text="{Binding Replacement}"
-                                                                       Foreground="{StaticResource TextBrush}"
-                                                                       FontSize="13" FontWeight="Medium" Margin="4,0,0,0"/>
                                                         </StackPanel>
+                                                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                                            <Button Style="{StaticResource IconButtonStyle}"
+                                                                    ToolTip="{loc:Str Dictionary.AddAlias}"
+                                                                    Visibility="{Binding Replacement, Converter={StaticResource BoolToVis}}"
+                                                                    Command="{Binding DataContext.Dictionary.PrepareAliasCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                    CommandParameter="{Binding Replacement}"
+                                                                    Click="PrepareAlias_Click">
+                                                                <TextBlock Text="&#xE710;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
+                                                            </Button>
+                                                            <Button Style="{StaticResource IconButtonStyle}" ToolTip="{loc:Str Dictionary.Edit}"
+                                                                    Command="{Binding DataContext.Dictionary.StartEditCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                    CommandParameter="{Binding}">
+                                                                <TextBlock Text="&#xE70F;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
+                                                            </Button>
+                                                            <ui:ToggleSwitch IsChecked="{Binding IsEnabled, Mode=OneWay}" Margin="4,0"
+                                                                             Command="{Binding DataContext.Dictionary.ToggleEnabledCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                             CommandParameter="{Binding}"/>
+                                                            <Button Style="{StaticResource IconButtonStyle}" ToolTip="{loc:Str Dictionary.Delete}"
+                                                                    Command="{Binding DataContext.Dictionary.DeleteEntryCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                    CommandParameter="{Binding}">
+                                                                <TextBlock Text="&#xE74D;" FontFamily="Segoe MDL2 Assets" FontSize="13"
+                                                                           Foreground="{StaticResource DangerBrush}"/>
+                                                            </Button>
+                                                        </StackPanel>
+                                                    </Grid>
+                                                </Grid>
+                                            </Border>
+                                        </Border>
+                                    </Border>
 
-                                                        <!-- Case-sensitive indicator -->
-                                                        <Border CornerRadius="3" Padding="4,1" Margin="8,0,0,0"
-                                                                Background="#333333" VerticalAlignment="Center"
-                                                                Visibility="{Binding CaseSensitive, Converter={StaticResource BoolToVis}}">
-                                                            <TextBlock Text="Aa" FontSize="10"
-                                                                       Foreground="{StaticResource HintBrush}"
-                                                                       ToolTip="{loc:Str Dictionary.CaseSensitive}"/>
-                                                        </Border>
-                                                    </StackPanel>
-
-                                                    <!-- Usage count if > 0 -->
-                                                    <TextBlock FontSize="11" Foreground="{StaticResource HintBrush}"
-                                                               Margin="0,2,0,0">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Visibility" Value="Visible"/>
+                                    <!-- Multi-alias corrections share one replacement heading. -->
+                                    <ui:CardExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
+                                                     Visibility="{Binding IsGroupedCorrection, Converter={StaticResource BoolToVis}}">
+                                        <ui:CardExpander.Header>
+                                            <Grid Margin="0,4">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" Background="#3A2A1A" CornerRadius="4"
+                                                        Padding="6,2" Margin="0,0,8,0">
+                                                    <TextBlock Text="{loc:Str Dictionary.Correction}" Foreground="#D4915B"
+                                                               FontSize="11" FontWeight="Medium"/>
+                                                </Border>
+                                                <TextBlock Grid.Column="1" Text="{Binding Replacement}"
+                                                           Foreground="{StaticResource TextBrush}" FontSize="13"
+                                                           FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <Button Grid.Column="2" Style="{StaticResource IconButtonStyle}"
+                                                        ToolTip="{loc:Str Dictionary.AddAlias}"
+                                                        Command="{Binding DataContext.Dictionary.PrepareAliasCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                        CommandParameter="{Binding Replacement}"
+                                                        Click="PrepareAlias_Click">
+                                                    <TextBlock Text="&#xE710;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
+                                                </Button>
+                                            </Grid>
+                                        </ui:CardExpander.Header>
+                                        <ItemsControl ItemsSource="{Binding Entries}" Margin="10,0,10,8">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border BorderBrush="{StaticResource BorderBrush}" BorderThickness="0,1,0,0"
+                                                            Padding="4,8">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Opacity" Value="1"/>
                                                                 <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding UsageCount}" Value="0">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                                        <Setter Property="Opacity" Value="0.5"/>
                                                                     </DataTrigger>
                                                                 </Style.Triggers>
                                                             </Style>
-                                                        </TextBlock.Style>
-                                                        <TextBlock.Text>
-                                                            <MultiBinding Converter="{StaticResource LocalizedFormat}">
-                                                                <Binding Source="{x:Static loc:Loc.Instance}" Path="[Dictionary.UsageCount]"/>
-                                                                <Binding Path="UsageCount"/>
-                                                            </MultiBinding>
-                                                        </TextBlock.Text>
-                                                    </TextBlock>
-                                                </StackPanel>
-
-                                                <!-- Right: Actions -->
-                                                <StackPanel Grid.Column="1" Orientation="Horizontal"
-                                                            VerticalAlignment="Center">
-                                                    <!-- Edit -->
-                                                    <Button Style="{StaticResource IconButtonStyle}"
-                                                            ToolTip="{loc:Str Dictionary.Edit}"
-                                                            Command="{Binding DataContext.Dictionary.StartEditCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                            CommandParameter="{Binding}">
-                                                        <TextBlock Text="&#xE70F;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
-                                                    </Button>
-                                                    <!-- Toggle -->
-                                                    <ui:ToggleSwitch IsChecked="{Binding IsEnabled, Mode=OneWay}"
-                                                              Margin="4,0"
-                                                              Command="{Binding DataContext.Dictionary.ToggleEnabledCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                              CommandParameter="{Binding}"/>
-                                                    <!-- Delete -->
-                                                    <Button Style="{StaticResource IconButtonStyle}"
-                                                            ToolTip="{loc:Str Dictionary.Delete}"
-                                                            Command="{Binding DataContext.Dictionary.DeleteEntryCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                            CommandParameter="{Binding}">
-                                                        <TextBlock Text="&#xE74D;" FontFamily="Segoe MDL2 Assets" FontSize="13"
-                                                                   Foreground="{StaticResource DangerBrush}"/>
-                                                    </Button>
-                                                </StackPanel>
-                                            </Grid>
-                                        </Grid>
-                                    </Border>
-                                </Border>
+                                                        </Border.Style>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                                                <StackPanel Orientation="Horizontal">
+                                                                    <TextBlock Text="{Binding Original}" Foreground="{StaticResource TextBrush}"
+                                                                               FontSize="13" VerticalAlignment="Center"/>
+                                                                    <Border CornerRadius="3" Padding="4,1" Margin="8,0,0,0"
+                                                                            Background="#333333" VerticalAlignment="Center"
+                                                                            Visibility="{Binding CaseSensitive, Converter={StaticResource BoolToVis}}">
+                                                                        <TextBlock Text="Aa" FontSize="10" Foreground="{StaticResource HintBrush}"
+                                                                                   ToolTip="{loc:Str Dictionary.CaseSensitive}"/>
+                                                                    </Border>
+                                                                </StackPanel>
+                                                                <TextBlock FontSize="11" Foreground="{StaticResource HintBrush}" Margin="0,2,0,0">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding UsageCount}" Value="0">
+                                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                    <TextBlock.Text>
+                                                                        <MultiBinding Converter="{StaticResource LocalizedFormat}">
+                                                                            <Binding Source="{x:Static loc:Loc.Instance}" Path="[Dictionary.UsageCount]"/>
+                                                                            <Binding Path="UsageCount"/>
+                                                                        </MultiBinding>
+                                                                    </TextBlock.Text>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                                                <Button Style="{StaticResource IconButtonStyle}" ToolTip="{loc:Str Dictionary.Edit}"
+                                                                        Command="{Binding DataContext.Dictionary.StartEditCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}">
+                                                                    <TextBlock Text="&#xE70F;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
+                                                                </Button>
+                                                                <ui:ToggleSwitch IsChecked="{Binding IsEnabled, Mode=OneWay}" Margin="4,0"
+                                                                                 Command="{Binding DataContext.Dictionary.ToggleEnabledCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                                 CommandParameter="{Binding}"/>
+                                                                <Button Style="{StaticResource IconButtonStyle}" ToolTip="{loc:Str Dictionary.Delete}"
+                                                                        Command="{Binding DataContext.Dictionary.DeleteEntryCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}">
+                                                                    <TextBlock Text="&#xE74D;" FontFamily="Segoe MDL2 Assets" FontSize="13"
+                                                                               Foreground="{StaticResource DangerBrush}"/>
+                                                                </Button>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </ui:CardExpander>
+                                </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml
@@ -576,38 +576,68 @@
                                         </Border>
                                     </Border>
 
-                                    <!-- Multi-alias corrections share one replacement heading. -->
-                                    <ui:CardExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
-                                                     Visibility="{Binding IsGroupedCorrection, Converter={StaticResource BoolToVis}}">
-                                        <ui:CardExpander.Header>
-                                            <Grid Margin="0,4">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
-                                                <Border Grid.Column="0" Background="#3A2A1A" CornerRadius="4"
-                                                        Padding="6,2" Margin="0,0,8,0">
-                                                    <TextBlock Text="{loc:Str Dictionary.Correction}" Foreground="#D4915B"
-                                                               FontSize="11" FontWeight="Medium"/>
-                                                </Border>
-                                                <TextBlock Grid.Column="1" Text="{Binding Replacement}"
-                                                           Foreground="{StaticResource TextBrush}" FontSize="13"
-                                                           FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                                <Button Grid.Column="2" Style="{StaticResource IconButtonStyle}"
-                                                        ToolTip="{loc:Str Dictionary.AddAlias}"
-                                                        Command="{Binding DataContext.Dictionary.PrepareAliasCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                        CommandParameter="{Binding Replacement}"
-                                                        Click="PrepareAlias_Click">
-                                                    <TextBlock Text="&#xE710;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
-                                                </Button>
-                                            </Grid>
-                                        </ui:CardExpander.Header>
-                                        <ItemsControl ItemsSource="{Binding Entries}" Margin="10,0,10,8">
+                                    <!-- Multi-alias corrections use the same compact card shape as single entries. -->
+                                    <Border Background="{StaticResource InputBackgroundBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1" CornerRadius="8" ClipToBounds="True"
+                                            Visibility="{Binding IsGroupedCorrection, Converter={StaticResource BoolToVis}}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="3"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Border Grid.Column="0" Background="#D4915B" CornerRadius="8,0,0,8"/>
+                                            <StackPanel Grid.Column="1">
+                                                <Grid Margin="12,8">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Border Grid.Column="0" Background="#3A2A1A" CornerRadius="4"
+                                                            Padding="6,2" Margin="0,0,8,0" VerticalAlignment="Center">
+                                                        <TextBlock Text="{loc:Str Dictionary.Correction}" Foreground="#D4915B"
+                                                                   FontSize="11" FontWeight="Medium"/>
+                                                    </Border>
+                                                    <TextBlock Grid.Column="1" Text="{Binding Replacement}"
+                                                               Foreground="{StaticResource TextBrush}" FontSize="13"
+                                                               FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                    <Border Grid.Column="2" Background="#252B33" CornerRadius="10"
+                                                            Padding="7,2" Margin="8,0,4,0" VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding Entries.Count}" Foreground="{StaticResource HintBrush}"
+                                                                   FontSize="10" FontWeight="SemiBold"/>
+                                                    </Border>
+                                                    <Button Grid.Column="3" Style="{StaticResource IconButtonStyle}"
+                                                            ToolTip="{loc:Str Dictionary.AddAlias}"
+                                                            Command="{Binding DataContext.Dictionary.PrepareAliasCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding Replacement}"
+                                                            Click="PrepareAlias_Click">
+                                                        <TextBlock Text="&#xE710;" FontFamily="Segoe MDL2 Assets" FontSize="13"/>
+                                                    </Button>
+                                                    <Button Grid.Column="4" Style="{StaticResource IconButtonStyle}"
+                                                            Command="{Binding ToggleCommand}">
+                                                        <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="12">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Text" Value="&#xE70D;"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsExpanded}" Value="True">
+                                                                            <Setter Property="Text" Value="&#xE70E;"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Button>
+                                                </Grid>
+                                                <ItemsControl ItemsSource="{Binding Entries}"
+                                                              Visibility="{Binding IsExpanded, Converter={StaticResource BoolToVis}}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
                                                     <Border BorderBrush="{StaticResource BorderBrush}" BorderThickness="0,1,0,0"
-                                                            Padding="4,8">
+                                                            Padding="12,8">
                                                         <Border.Style>
                                                             <Style TargetType="Border">
                                                                 <Setter Property="Opacity" Value="1"/>
@@ -674,7 +704,9 @@
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
-                                    </ui:CardExpander>
+                                            </StackPanel>
+                                        </Grid>
+                                    </Border>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/Sections/DictionarySection.xaml.cs
@@ -24,6 +24,12 @@ public partial class DictionarySection : UserControl
         }
     }
 
+    private void PrepareAlias_Click(object sender, RoutedEventArgs e)
+    {
+        OriginalBox.Focus();
+        e.Handled = true;
+    }
+
     private void EditOverlay_MouseDown(object sender, MouseButtonEventArgs e)
     {
         if (DataContext is SettingsWindowViewModel vm)

--- a/tests/TypeWhisper.PluginSystem.Tests/DictionaryViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictionaryViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json;
 using Moq;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
@@ -9,6 +10,162 @@ namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class DictionaryViewModelTests
 {
+    [Fact]
+    public void Corrections_WithExactReplacement_AreGroupedInSourceOrder()
+    {
+        var first = Correction("1", "recieve", "receive");
+        var term = Term("2", "TypeWhisper");
+        var second = Correction("3", "receeve", "receive", isEnabled: false, caseSensitive: true);
+        var viewModel = CreateViewModel(CreateDictionaryMock([first, term, second]).Object);
+
+        Assert.Equal(2, viewModel.VisibleDisplayItems.Count);
+        var group = viewModel.VisibleDisplayItems[0];
+        Assert.True(group.IsGroupedCorrection);
+        Assert.Equal([first, second], group.Entries);
+        Assert.Same(term, viewModel.VisibleDisplayItems[1].PrimaryEntry);
+        Assert.Equal(3, viewModel.EntryCount);
+        Assert.False(group.IsExpanded);
+        Assert.False(group.Entries[1].IsEnabled);
+        Assert.True(group.Entries[1].CaseSensitive);
+    }
+
+    [Fact]
+    public void Corrections_WithDifferentReplacementCasing_OrEmptyReplacement_StaySeparate()
+    {
+        var entries = new[]
+        {
+            Correction("1", "type whisper", "TypeWhisper"),
+            Correction("2", "typewhisper", "typewhisper"),
+            Correction("3", "empty-one", ""),
+            Correction("4", "empty-two", "")
+        };
+        var viewModel = CreateViewModel(CreateDictionaryMock(entries).Object);
+
+        Assert.Equal(4, viewModel.VisibleDisplayItems.Count);
+        Assert.All(viewModel.VisibleDisplayItems, item => Assert.False(item.IsGroupedCorrection));
+    }
+
+    [Fact]
+    public void SearchByAlias_ShowsAndExpandsTheCompleteGroup()
+    {
+        var first = Correction("1", "recieve", "receive");
+        var second = Correction("2", "receeve", "receive");
+        var unrelated = Correction("3", "teh", "the");
+        var viewModel = CreateViewModel(CreateDictionaryMock([first, second, unrelated]).Object);
+
+        viewModel.SearchText = "recieve";
+
+        var group = Assert.Single(viewModel.VisibleDisplayItems);
+        Assert.Equal([first, second], group.Entries);
+        Assert.True(group.IsExpanded);
+        Assert.Equal(2, viewModel.EntryCount);
+
+        viewModel.SearchText = "receive";
+
+        group = Assert.Single(viewModel.VisibleDisplayItems);
+        Assert.False(group.IsExpanded);
+    }
+
+    [Fact]
+    public void Tabs_FilterTermsAndCorrectionGroups()
+    {
+        var term = Term("1", "TypeWhisper");
+        var first = Correction("2", "recieve", "receive");
+        var second = Correction("3", "receeve", "receive");
+        var viewModel = CreateViewModel(CreateDictionaryMock([term, first, second]).Object);
+
+        viewModel.SelectedTab = 1;
+        Assert.Same(term, Assert.Single(viewModel.VisibleDisplayItems).PrimaryEntry);
+
+        viewModel.SelectedTab = 2;
+        var group = Assert.Single(viewModel.VisibleDisplayItems);
+        Assert.Equal([first, second], group.Entries);
+    }
+
+    [Fact]
+    public void PrepareAlias_ReusesTheExistingAddFlow()
+    {
+        var existing = Correction("1", "recieve", "receive");
+        DictionaryEntry? added = null;
+        var dictionary = CreateDictionaryMock([existing]);
+        dictionary
+            .Setup(service => service.AddEntry(It.IsAny<DictionaryEntry>()))
+            .Callback<DictionaryEntry>(entry => added = entry);
+        var viewModel = CreateViewModel(dictionary.Object);
+
+        viewModel.NewOriginal = "old";
+        viewModel.NewCaseSensitive = true;
+        viewModel.PrepareAliasCommand.Execute(viewModel.VisibleDisplayItems[0].Replacement);
+
+        Assert.Equal(DictionaryEntryType.Correction, viewModel.NewEntryType);
+        Assert.Equal("", viewModel.NewOriginal);
+        Assert.Equal("receive", viewModel.NewReplacement);
+        Assert.False(viewModel.NewCaseSensitive);
+
+        viewModel.NewOriginal = "receeve";
+        viewModel.AddEntryCommand.Execute(null);
+
+        Assert.NotNull(added);
+        Assert.Equal("receeve", added.Original);
+        Assert.Equal("receive", added.Replacement);
+    }
+
+    [Fact]
+    public void AliasActions_TargetOnlyTheSelectedEntry()
+    {
+        var first = Correction("1", "recieve", "receive");
+        var second = Correction("2", "receeve", "receive", isEnabled: false);
+        var dictionary = CreateDictionaryMock([first, second]);
+        var viewModel = CreateViewModel(dictionary.Object);
+
+        viewModel.StartEditCommand.Execute(second);
+        viewModel.ToggleEnabledCommand.Execute(second);
+        viewModel.DeleteEntryCommand.Execute(second);
+
+        Assert.Same(second, viewModel.EditEntry);
+        dictionary.Verify(service => service.UpdateEntry(
+            It.Is<DictionaryEntry>(entry => entry.Id == second.Id && entry.IsEnabled)), Times.Once);
+        dictionary.Verify(service => service.DeleteEntry(second.Id), Times.Once);
+        dictionary.Verify(service => service.DeleteEntry(first.Id), Times.Never);
+    }
+
+    [Fact]
+    public void DictionarySection_RendersGroupedAndSingleCorrections()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "DictionarySection.xaml");
+
+        Assert.Contains("ItemsSource=\"{Binding Dictionary.VisibleEntries}\"", xaml);
+        Assert.Contains("IsExpanded=\"{Binding IsExpanded, Mode=TwoWay}\"", xaml);
+        Assert.Contains("ItemsSource=\"{Binding Entries}\"", xaml);
+        Assert.Contains("Command=\"{Binding DataContext.Dictionary.PrepareAliasCommand", xaml);
+        Assert.Contains("Click=\"PrepareAlias_Click\"", xaml);
+        Assert.Contains("DataContext=\"{Binding PrimaryEntry}\"", xaml);
+        Assert.DoesNotContain("Dictionary.FilteredEntries", xaml);
+    }
+
+    [Fact]
+    public void AddAlias_IsLocalizedInEverySupportedLanguage()
+    {
+        foreach (var language in new[] { "en", "de", "ja", "ru" })
+        {
+            var json = TestFile.ReadProjectFile(
+                "src",
+                "TypeWhisper.Windows",
+                "Resources",
+                "Localization",
+                $"{language}.json");
+            using var document = JsonDocument.Parse(json);
+
+            Assert.False(string.IsNullOrWhiteSpace(
+                document.RootElement.GetProperty("Dictionary.AddAlias").GetString()));
+        }
+    }
+
     [Fact]
     public void AddEntry_PreservesEmptyCorrectionReplacement()
     {
@@ -86,6 +243,28 @@ public sealed class DictionaryViewModelTests
             .Returns(entries ?? Array.Empty<DictionaryEntry>());
         return dictionary;
     }
+
+    private static DictionaryEntry Correction(
+        string id,
+        string original,
+        string replacement,
+        bool isEnabled = true,
+        bool caseSensitive = false) => new()
+        {
+            Id = id,
+            EntryType = DictionaryEntryType.Correction,
+            Original = original,
+            Replacement = replacement,
+            IsEnabled = isEnabled,
+            CaseSensitive = caseSensitive
+        };
+
+    private static DictionaryEntry Term(string id, string original) => new()
+    {
+        Id = id,
+        EntryType = DictionaryEntryType.Term,
+        Original = original
+    };
 
     private static IReadOnlyList<Delegate> GetLanguageChangedSubscribers()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/DictionaryViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictionaryViewModelTests.cs
@@ -140,11 +140,13 @@ public sealed class DictionaryViewModelTests
             "DictionarySection.xaml");
 
         Assert.Contains("ItemsSource=\"{Binding Dictionary.VisibleEntries}\"", xaml);
-        Assert.Contains("IsExpanded=\"{Binding IsExpanded, Mode=TwoWay}\"", xaml);
+        Assert.Contains("Command=\"{Binding ToggleCommand}\"", xaml);
+        Assert.Contains("Visibility=\"{Binding IsExpanded, Converter={StaticResource BoolToVis}}\"", xaml);
         Assert.Contains("ItemsSource=\"{Binding Entries}\"", xaml);
         Assert.Contains("Command=\"{Binding DataContext.Dictionary.PrepareAliasCommand", xaml);
         Assert.Contains("Click=\"PrepareAlias_Click\"", xaml);
         Assert.Contains("DataContext=\"{Binding PrimaryEntry}\"", xaml);
+        Assert.DoesNotContain("<ui:CardExpander", xaml);
         Assert.DoesNotContain("Dictionary.FilteredEntries", xaml);
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/DictionaryViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictionaryViewModelTests.cs
@@ -141,6 +141,7 @@ public sealed class DictionaryViewModelTests
 
         Assert.Contains("ItemsSource=\"{Binding Dictionary.VisibleEntries}\"", xaml);
         Assert.Contains("Command=\"{Binding ToggleCommand}\"", xaml);
+        Assert.Contains("AutomationProperties.Name=\"{loc:Str Dictionary.ToggleAliases}\"", xaml);
         Assert.Contains("Visibility=\"{Binding IsExpanded, Converter={StaticResource BoolToVis}}\"", xaml);
         Assert.Contains("ItemsSource=\"{Binding Entries}\"", xaml);
         Assert.Contains("Command=\"{Binding DataContext.Dictionary.PrepareAliasCommand", xaml);
@@ -165,6 +166,8 @@ public sealed class DictionaryViewModelTests
 
             Assert.False(string.IsNullOrWhiteSpace(
                 document.RootElement.GetProperty("Dictionary.AddAlias").GetString()));
+            Assert.False(string.IsNullOrWhiteSpace(
+                document.RootElement.GetProperty("Dictionary.ToggleAliases").GetString()));
         }
     }
 


### PR DESCRIPTION
## Summary

- derive correction groups in the Windows dictionary view model while keeping stored entries flat
- show multi-alias replacements as expandable cards with per-alias edit, toggle, and delete actions
- support search by replacement or alias and reuse the existing add form for new aliases
- localize the new alias action in English, German, Japanese, and Russian

## Compatibility

Dictionary JSON, Cloud Folder Sync, import/export, CLI, HTTP API, and `IDictionaryService` remain unchanged.

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~DictionaryViewModelTests"` (11 passed)
- `dotnet test TypeWhisper.slnx --no-restore`
- `dotnet build TypeWhisper.slnx -c Release --no-restore`
- `git diff --check`
- stable development build launched from `F:\typewhisper\dev-output\typewhisper-win\Build\TypeWhisper.exe`

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added alias creation from dictionary entries, with a dedicated “prepare alias” action.
  - Reworked dictionary display to use expandable cards for grouped corrections, including expand/collapse controls.
  - Improved search and tab filtering so matching aliases/groups are shown and expanded appropriately.
- **UI/UX Improvements**
  - Empty-state visibility now reflects the actual number of visible dictionary entries.
- **Localization**
  - Added new labels for “Add alias” and “Expand or collapse aliases” in English, German, Japanese, and Russian.
- **Tests**
  - Expanded automated coverage for grouping, filtering, alias actions, UI bindings, and localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->