### PR TITLE
Prepare Live Transcript plugin 1.0.3

### DIFF
--- a/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/LiveTranscriptPlugin.cs
@@ -48,7 +48,7 @@ public sealed class LiveTranscriptPlugin : ITypeWhisperPlugin
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.2";
+    public string PluginVersion => "1.0.3";
 
     /// <summary>
     /// Gets whether uses host appearance.

--- a/plugins/TypeWhisper.Plugin.LiveTranscript/manifest.json
+++ b/plugins/TypeWhisper.Plugin.LiveTranscript/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.live-transcript",
   "name": "Live Transcript",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "TypeWhisper",
   "description": "Floating window showing real-time transcription",
   "assemblyName": "TypeWhisper.Plugin.LiveTranscript.dll",


### PR DESCRIPTION
## Summary

- bump the Live Transcript manifest version to 1.0.3
- keep the runtime-reported plugin version aligned with the release manifest
- prepare the merged overlay and transcript refinements for marketplace publication

## Validation

- 38 Live Transcript plugin tests
- Release plugin build