### PR TITLE
Update GraniteSpeech PyTorch dependency

### DIFF
--- a/plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt
+++ b/plugins/TypeWhisper.Plugin.GraniteSpeech/Scripts/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.12.1
+torch==2.13.0
 torchaudio==2.11.0
 transformers==5.8.1
 soundfile==0.13.1


### PR DESCRIPTION
## Summary

- update GraniteSpeech from PyTorch 2.12.1 to 2.13.0
- allow dependency resolution to select the fixed setuptools 83.0.0 release

## Root cause

PyTorch 2.12.1 constrained setuptools to versions below 82, so the dependency audit resolved vulnerable setuptools 81.0.0 and failed on PYSEC-2026-3447.

## Validation

- verified the dependency resolver selects setuptools 83.0.0
- ran the repository's pip-audit command with its existing documented exceptions: no known vulnerabilities found