### PR TITLE
Hide Groq Qwen reasoning output

### DIFF
--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -81,7 +81,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.3";
+    public string PluginVersion => "1.0.4";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.
@@ -247,7 +247,8 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
 
         var modelId = ResolveLlmModelId(string.IsNullOrWhiteSpace(model) ? null : model);
         return await OpenAiChatHelper.SendChatCompletionAsync(
-            _httpClient, BaseUrl, _apiKey!, modelId, systemPrompt, userText, ct);
+            _httpClient, BaseUrl, _apiKey!, modelId, systemPrompt, userText, ct,
+            reasoningFormat: modelId.StartsWith("qwen", StringComparison.OrdinalIgnoreCase) ? "hidden" : null);
     }
 
     // API key management (for settings view)

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -248,6 +248,10 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin
         var modelId = ResolveLlmModelId(string.IsNullOrWhiteSpace(model) ? null : model);
         return await OpenAiChatHelper.SendChatCompletionAsync(
             _httpClient, BaseUrl, _apiKey!, modelId, systemPrompt, userText, ct,
+            maxOutputTokens: 2048,
+            maxOutputTokenParameter: "max_tokens",
+            reasoningEffort: null,
+            temperature: 0.1,
             reasoningFormat: modelId.StartsWith("qwen", StringComparison.OrdinalIgnoreCase) ? "hidden" : null);
     }
 

--- a/plugins/TypeWhisper.Plugin.Groq/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Groq/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.groq",
   "name": "Groq",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "TypeWhisper",
   "description": "Groq Whisper transcription and Llama translation",
   "category": "transcription",

--- a/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
@@ -52,16 +52,42 @@ public static class OpenAiChatHelper
     /// <param name="maxOutputTokenParameter">Provider-specific token cap parameter name.</param>
     /// <param name="reasoningEffort">Optional reasoning effort value for providers that support it.</param>
     /// <param name="temperature">Optional sampling temperature.</param>
-    /// <param name="reasoningFormat">Optional reasoning output format for providers that support it.</param>
     /// <returns>The assistant's response content text.</returns>
-    public static async Task<string> SendChatCompletionAsync(
+    public static Task<string> SendChatCompletionAsync(
         HttpClient httpClient, string baseUrl, string apiKey,
         string model, string systemPrompt, string userText, CancellationToken ct,
         int? maxOutputTokens = 2048,
         string maxOutputTokenParameter = "max_tokens",
         string? reasoningEffort = null,
-        double? temperature = 0.1,
-        string? reasoningFormat = null)
+        double? temperature = 0.1) =>
+        SendChatCompletionAsync(
+            httpClient, baseUrl, apiKey, model, systemPrompt, userText, ct,
+            maxOutputTokens, maxOutputTokenParameter, reasoningEffort, temperature, null);
+
+    /// <summary>
+    /// Sends a chat completion request with an explicit reasoning output format.
+    /// </summary>
+    /// <param name="httpClient">HTTP client to use for the request.</param>
+    /// <param name="baseUrl">API base URL.</param>
+    /// <param name="apiKey">Bearer token for authentication.</param>
+    /// <param name="model">Model identifier.</param>
+    /// <param name="systemPrompt">System prompt text.</param>
+    /// <param name="userText">User message text.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="maxOutputTokens">Optional response token cap.</param>
+    /// <param name="maxOutputTokenParameter">Provider-specific token cap parameter name.</param>
+    /// <param name="reasoningEffort">Optional reasoning effort value.</param>
+    /// <param name="temperature">Optional sampling temperature.</param>
+    /// <param name="reasoningFormat">Optional reasoning output format.</param>
+    /// <returns>The assistant's response content text.</returns>
+    public static async Task<string> SendChatCompletionAsync(
+        HttpClient httpClient, string baseUrl, string apiKey,
+        string model, string systemPrompt, string userText, CancellationToken ct,
+        int? maxOutputTokens,
+        string maxOutputTokenParameter,
+        string? reasoningEffort,
+        double? temperature,
+        string? reasoningFormat)
     {
         var body = new Dictionary<string, object?>
         {

--- a/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
@@ -52,6 +52,7 @@ public static class OpenAiChatHelper
     /// <param name="maxOutputTokenParameter">Provider-specific token cap parameter name.</param>
     /// <param name="reasoningEffort">Optional reasoning effort value for providers that support it.</param>
     /// <param name="temperature">Optional sampling temperature.</param>
+    /// <param name="reasoningFormat">Optional reasoning output format for providers that support it.</param>
     /// <returns>The assistant's response content text.</returns>
     public static async Task<string> SendChatCompletionAsync(
         HttpClient httpClient, string baseUrl, string apiKey,
@@ -59,7 +60,8 @@ public static class OpenAiChatHelper
         int? maxOutputTokens = 2048,
         string maxOutputTokenParameter = "max_tokens",
         string? reasoningEffort = null,
-        double? temperature = 0.1)
+        double? temperature = 0.1,
+        string? reasoningFormat = null)
     {
         var body = new Dictionary<string, object?>
         {
@@ -79,6 +81,9 @@ public static class OpenAiChatHelper
 
         if (!string.IsNullOrWhiteSpace(reasoningEffort))
             body["reasoning_effort"] = reasoningEffort;
+
+        if (!string.IsNullOrWhiteSpace(reasoningFormat))
+            body["reasoning_format"] = reasoningFormat;
 
         var requestBody = JsonSerializer.Serialize(body);
 

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -257,10 +257,11 @@ public class GroqPluginTests
     [Fact]
     public async Task ProcessAsync_UsesSelectedLlmModelWhenCallerDoesNotOverride()
     {
-        var handler = new CapturingHandler((_, body) =>
+        var handler = new CapturingHandler((request, body) =>
         {
             using var doc = JsonDocument.Parse(body ?? throw new InvalidOperationException("Missing request body."));
             Assert.Equal("openai/gpt-oss-120b", doc.RootElement.GetProperty("model").GetString());
+            Assert.False(doc.RootElement.TryGetProperty("reasoning_format", out _));
 
             return JsonResponse("""
                 {
@@ -286,6 +287,39 @@ public class GroqPluginTests
         var result = await sut.ProcessAsync("system", "user", "", CancellationToken.None);
 
         Assert.Equal("done", result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_HidesReasoningForQwenModels()
+    {
+        var handler = new CapturingHandler((_, body) =>
+        {
+            using var doc = JsonDocument.Parse(body ?? throw new InvalidOperationException("Missing request body."));
+            Assert.Equal("hidden", doc.RootElement.GetProperty("reasoning_format").GetString());
+
+            return JsonResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "final answer"
+                      }
+                    }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new GroqPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.ProcessAsync("system", "user", "qwen/qwen3.6-27b", CancellationToken.None);
+
+        Assert.Equal("final answer", result);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
@@ -30,4 +30,33 @@ public sealed class OpenAiChatHelperTests
         Assert.NotNull(method);
         Assert.Equal(typeof(Task<string>), method!.ReturnType);
     }
+
+    [Fact]
+    public void SendChatCompletionAsync_PreservesLegacyElevenParameterOverload()
+    {
+        var parameterTypes = new[]
+        {
+            typeof(HttpClient),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(CancellationToken),
+            typeof(int?),
+            typeof(string),
+            typeof(string),
+            typeof(double?)
+        };
+
+        var method = typeof(OpenAiChatHelper).GetMethod(
+            nameof(OpenAiChatHelper.SendChatCompletionAsync),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: parameterTypes,
+            modifiers: null);
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(Task<string>), method!.ReturnType);
+    }
 }


### PR DESCRIPTION
## Summary
- request hidden reasoning output for Groq-hosted Qwen models
- keep non-Qwen Groq models and other OpenAI-compatible providers unchanged
- bump the Groq plugin to 1.0.4

## Root cause
Groq defaults supported Qwen reasoning models to raw reasoning output, which places `<think>` blocks in `message.content`. TypeWhisper forwarded that content unchanged into workflow output.

## Validation
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~GroqPluginTests|FullyQualifiedName~OpenAiChatHelperTests" --no-restore` (26 passed)
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore` (1,309 passed)
- `dotnet build TypeWhisper.slnx`
- `dotnet build plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj -c Release --no-restore`
- installed Groq 1.0.4 into the stable Windows dev app and relaunched it successfully

Fixes #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hidden reasoning output when using Qwen models.
  * Requests for other models continue without the reasoning format setting.
* **Bug Fixes**
  * Improved compatibility with provider-specific reasoning configuration.
* **Tests**
  * Added coverage confirming reasoning is hidden for Qwen models and omitted for other models.
* **Chores**
  * Updated the Groq plugin version to 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->