### PR TITLE
Move plugin settings into accessible modal windows

### DIFF
--- a/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
@@ -122,17 +122,12 @@ public partial class PluginsViewModel : ObservableObject
 
     private void RefreshPlugins()
     {
-        // Preserve expanded state across refresh
-        var expandedIds = Plugins.Where(p => p.IsExpanded).Select(p => p.Id).ToHashSet();
-
         Plugins.Clear();
         foreach (var plugin in _pluginManager.AllPlugins)
         {
             var isEnabled = _pluginManager.IsEnabled(plugin.Manifest.Id);
             var vm = new PluginItemViewModel(plugin, isEnabled, _pluginManager, _registryService);
             vm.RegistryPlugin = FindRegistryPlugin(vm.Id);
-            if (expandedIds.Contains(vm.Id))
-                vm.IsExpanded = true;
             Plugins.Add(vm);
         }
 
@@ -247,8 +242,6 @@ public partial class PluginsViewModel : ObservableObject
             return false;
 
         IsMarketplaceSelected = false;
-        foreach (var plugin in Plugins)
-            plugin.IsExpanded = ReferenceEquals(plugin, selected);
         return true;
     }
 
@@ -461,7 +454,16 @@ public partial class PluginItemViewModel : ObservableObject
 
     [ObservableProperty] private bool _isEnabled;
     [ObservableProperty] private UserControl? _settingsView;
-    [ObservableProperty] private bool _isExpanded;
+
+    /// <summary>
+    /// Gets whether the plugin exposes settings.
+    /// </summary>
+    public bool HasSettings => SettingsView is not null;
+
+    /// <summary>
+    /// Gets the accessible label for the plugin settings action.
+    /// </summary>
+    public string SettingsAutomationName => $"{Loc.Instance["Settings.WindowTitle"]}: {Name}";
 
     private IReadOnlyList<PluginMarketplaceCategoryDescriptor>? _categoryDescriptors;
 
@@ -569,11 +571,9 @@ public partial class PluginItemViewModel : ObservableObject
         OnPropertyChanged(nameof(StatusLabel));
     }
 
-    partial void OnIsExpandedChanged(bool value)
+    partial void OnSettingsViewChanged(UserControl? value)
     {
-        // Lazy-load settings view when first expanded
-        if (value && SettingsView is null && IsEnabled)
-            SettingsView = _plugin.Instance.CreateSettingsView();
+        OnPropertyChanged(nameof(HasSettings));
     }
 
     [RelayCommand]
@@ -659,6 +659,7 @@ public partial class PluginItemViewModel : ObservableObject
         OnPropertyChanged(nameof(CategoryDescriptors));
         OnPropertyChanged(nameof(Category));
         OnPropertyChanged(nameof(LocationBadge));
+        OnPropertyChanged(nameof(SettingsAutomationName));
         NotifyUpdateStateChanged();
     }
 }

--- a/src/TypeWhisper.Windows/Views/PluginSettingsWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/PluginSettingsWindow.xaml
@@ -1,0 +1,48 @@
+<ui:FluentWindow x:Class="TypeWhisper.Windows.Views.PluginSettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+        Width="640"
+        Height="560"
+        MinWidth="520"
+        MinHeight="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip"
+        ShowInTaskbar="False"
+        ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="None"
+        Background="#0E131B"
+        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+        AutomationProperties.AutomationId="PluginSettingsWindow"
+        AutomationProperties.Name="{Binding RelativeSource={RelativeSource Self}, Path=Title}">
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/TypeWhisper;component/Styles/UnifiedSettingsStyles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Background="{StaticResource BackgroundBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <ui:TitleBar Grid.Row="0"
+                     Title="{Binding Title, RelativeSource={RelativeSource AncestorType={x:Type ui:FluentWindow}}}"
+                     ShowMinimize="False"
+                     ShowMaximize="False"
+                     Margin="18,8,18,0"/>
+
+        <Border Grid.Row="1" Style="{StaticResource WizardShellStyle}">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <ContentControl x:Name="SettingsContent"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Top"/>
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</ui:FluentWindow>

--- a/src/TypeWhisper.Windows/Views/PluginSettingsWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/PluginSettingsWindow.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows.Controls;
+using TypeWhisper.Windows.Services.Localization;
+using Wpf.Ui.Controls;
+
+namespace TypeWhisper.Windows.Views;
+
+/// <summary>
+/// Hosts a plugin-provided settings view in a modal window.
+/// </summary>
+public partial class PluginSettingsWindow : FluentWindow
+{
+    /// <summary>
+    /// Initializes a new instance of the PluginSettingsWindow class.
+    /// </summary>
+    public PluginSettingsWindow(string pluginName, UserControl settingsView)
+    {
+        InitializeComponent();
+        Title = $"{Loc.Instance["Settings.WindowTitle"]} – {pluginName}";
+        SettingsContent.Content = settingsView;
+        Closed += OnClosed;
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        SettingsContent.Content = null;
+        Closed -= OnClosed;
+    }
+}

--- a/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml
@@ -138,11 +138,11 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="{x:Type vm:PluginItemViewModel}">
-                                <ui:CardExpander AutomationProperties.AutomationId="{Binding Id, StringFormat=IntegrationsPlugin.{0}}"
-                                                 IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
-                                                 Margin="0,0,0,10">
-                                    <ui:CardExpander.Header>
-                                        <Grid Margin="0,6">
+                                <Border AutomationProperties.AutomationId="{Binding Id, StringFormat=IntegrationsPlugin.{0}}"
+                                        Style="{StaticResource SettingsGroupPanelStyle}"
+                                        Padding="14"
+                                        Margin="0,0,0,10">
+                                    <Grid Margin="0,6">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="*"/>
@@ -220,6 +220,13 @@
                                                            Visibility="{Binding HasUpdateAvailable, Converter={StaticResource BoolToVis}}"
                                                            Margin="0,0,8,0"/>
                                                 <ui:Button Appearance="Secondary"
+                                                           AutomationProperties.AutomationId="{Binding Id, StringFormat=IntegrationsSettings.{0}}"
+                                                           AutomationProperties.Name="{Binding SettingsAutomationName}"
+                                                           Content="{loc:Str Settings.WindowTitle}"
+                                                           Click="OnPluginSettingsClick"
+                                                           Visibility="{Binding HasSettings, Converter={StaticResource BoolToVis}}"
+                                                           Margin="0,0,8,0"/>
+                                                <ui:Button Appearance="Secondary"
                                                            AutomationProperties.AutomationId="{Binding Id, StringFormat=IntegrationsUninstall.{0}}"
                                                            AutomationProperties.Name="{loc:Str Plugins.Uninstall}"
                                                            ToolTip="{loc:Str Plugins.Uninstall}"
@@ -232,31 +239,8 @@
                                                                  AutomationProperties.AutomationId="{Binding Id, StringFormat=IntegrationsEnabled.{0}}"
                                                                  AutomationProperties.Name="{Binding Name}"/>
                                             </StackPanel>
-                                        </Grid>
-                                    </ui:CardExpander.Header>
-
-                                    <StackPanel Margin="0,8,0,0">
-                                        <TextBlock Text="{Binding Description}" Foreground="{StaticResource HintBrush}" FontSize="12" TextWrapping="Wrap" Visibility="{Binding Description, Converter={StaticResource NonEmptyToVis}}"/>
-                                        <WrapPanel Margin="0,8,0,0">
-                                            <Border Style="{StaticResource BadgeStyle}" Visibility="{Binding IsTranscriptionProvider, Converter={StaticResource BoolToVis}}" Margin="0,0,6,6">
-                                                <TextBlock Foreground="#D6DEE9" FontSize="10"><Run Text="&#x1F3A4; "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.Transcription], Mode=OneWay}"/></TextBlock>
-                                            </Border>
-                                            <Border Style="{StaticResource BadgeStyle}" Visibility="{Binding IsLlmProvider, Converter={StaticResource BoolToVis}}" Margin="0,0,6,6">
-                                                <TextBlock Foreground="#D6DEE9" FontSize="10"><Run Text="&#x1F916; "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.Llm], Mode=OneWay}"/></TextBlock>
-                                            </Border>
-                                            <Border Style="{StaticResource BadgeStyle}" Visibility="{Binding IsTtsProvider, Converter={StaticResource BoolToVis}}" Margin="0,0,6,6">
-                                                <TextBlock Foreground="#D6DEE9" FontSize="10"><Run Text="&#x1F50A; "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.Tts], Mode=OneWay}"/></TextBlock>
-                                            </Border>
-                                            <Border Style="{StaticResource BadgeStyle}" Visibility="{Binding IsPostProcessor, Converter={StaticResource BoolToVis}}" Margin="0,0,6,6">
-                                                <TextBlock Foreground="#D6DEE9" FontSize="10"><Run Text="&#x2699; "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.PostProcessing], Mode=OneWay}"/></TextBlock>
-                                            </Border>
-                                            <Border Style="{StaticResource BadgeStyle}" Visibility="{Binding IsActionProvider, Converter={StaticResource BoolToVis}}" Margin="0,0,6,6">
-                                                <TextBlock Foreground="#D6DEE9" FontSize="10"><Run Text="&#x26A1; "/><Run Text="{Binding Source={x:Static loc:Loc.Instance}, Path=[Plugins.Action], Mode=OneWay}"/></TextBlock>
-                                            </Border>
-                                        </WrapPanel>
-                                        <ContentControl Content="{Binding SettingsView}" Margin="0,10,0,0" Visibility="{Binding IsEnabled, Converter={StaticResource BoolToVis}}"/>
-                                    </StackPanel>
-                                </ui:CardExpander>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
@@ -400,7 +384,7 @@
                                                 <ui:Button Appearance="Primary"
                                                            AutomationProperties.AutomationId="{Binding Id, StringFormat=IntegrationsInstall.{0}}"
                                                            Content="{loc:Str Plugins.Install}"
-                                                           Command="{Binding InstallCommand}"
+                                                           Click="OnInstallPluginClick"
                                                            IsEnabled="{Binding IsWorking, Converter={StaticResource InvertBool}}"
                                                            Visibility="{Binding InstallState, Converter={StaticResource InstallStateToVis}, ConverterParameter=NotInstalled}"/>
                                                 <ui:Button Appearance="Primary"

--- a/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/Sections/PluginsSection.xaml.cs
@@ -2,7 +2,9 @@ using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using TypeWhisper.Windows.Services.Plugins;
 using TypeWhisper.Windows.ViewModels;
+using TypeWhisper.Windows.Views;
 
 namespace TypeWhisper.Windows.Views.Sections;
 
@@ -80,6 +82,44 @@ public partial class PluginsSection : UserControl
             vm.Plugins.IsMarketplaceSelected = true;
         else
             ApplyTabSelection(true);
+    }
+
+    private async void OnInstallPluginClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { DataContext: RegistryPluginItemViewModel plugin })
+            return;
+
+        await plugin.InstallCommand.ExecuteAsync(null);
+
+        if (plugin.InstallState != PluginInstallState.Installed
+            || _pluginsViewModel?.FocusInstalledPlugin(plugin.Id) != true)
+        {
+            return;
+        }
+
+        var installedPlugin = _pluginsViewModel.Plugins.FirstOrDefault(item =>
+            string.Equals(item.Id, plugin.Id, StringComparison.OrdinalIgnoreCase));
+        if (installedPlugin is not null)
+            OpenPluginSettings(installedPlugin);
+    }
+
+    private void OnPluginSettingsClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: PluginItemViewModel plugin })
+            OpenPluginSettings(plugin);
+    }
+
+    private void OpenPluginSettings(PluginItemViewModel plugin)
+    {
+        var owner = Window.GetWindow(this);
+        if (owner is null || plugin.SettingsView is null)
+            return;
+
+        var dialog = new PluginSettingsWindow(plugin.Name, plugin.SettingsView)
+        {
+            Owner = owner
+        };
+        dialog.ShowDialog();
     }
 
     private void ApplyTabSelection(bool marketplaceSelected)

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginSettingsWindowLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginSettingsWindowLifetimeTests.cs
@@ -11,7 +11,7 @@ public sealed class PluginSettingsWindowLifetimeTests
         Exception? failure = null;
         var thread = new Thread(() =>
         {
-            try
+            failure = Record.Exception(() =>
             {
                 var settingsView = new UserControl();
                 var dialog = new PluginSettingsWindow("Test Plugin", settingsView);
@@ -26,11 +26,7 @@ public sealed class PluginSettingsWindowLifetimeTests
                 reopenedDialog.Show();
                 reopenedDialog.Close();
                 Assert.Null(reopenedDialog.SettingsContent.Content);
-            }
-            catch (Exception ex)
-            {
-                failure = ex;
-            }
+            });
         });
         thread.SetApartmentState(ApartmentState.STA);
         thread.Start();

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginSettingsWindowLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginSettingsWindowLifetimeTests.cs
@@ -1,0 +1,104 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+using System.Windows.Controls;
+using TypeWhisper.Windows.Views;
+
+public sealed class PluginSettingsWindowLifetimeTests
+{
+    [Fact]
+    public void PluginSettingsWindow_CanBeCreatedAndReleasesHostedViewWhenClosed()
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var settingsView = new UserControl();
+                var dialog = new PluginSettingsWindow("Test Plugin", settingsView);
+
+                Assert.Same(settingsView, dialog.SettingsContent.Content);
+                dialog.Show();
+                dialog.Close();
+                Assert.Null(dialog.SettingsContent.Content);
+
+                var reopenedDialog = new PluginSettingsWindow("Test Plugin", settingsView);
+                Assert.Same(settingsView, reopenedDialog.SettingsContent.Content);
+                reopenedDialog.Show();
+                reopenedDialog.Close();
+                Assert.Null(reopenedDialog.SettingsContent.Content);
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "Plugin settings window did not close.");
+
+        Assert.Null(failure);
+    }
+
+    [Fact]
+    public void PluginSettingsWindow_IsResizableScrollableAndOwnedModal()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "PluginSettingsWindow.xaml");
+        var section = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "PluginsSection.xaml.cs");
+        var dialog = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "PluginSettingsWindow.xaml.cs");
+
+        Assert.Contains("Width=\"640\"", xaml);
+        Assert.Contains("Height=\"560\"", xaml);
+        Assert.Contains("WindowStartupLocation=\"CenterOwner\"", xaml);
+        Assert.Contains("ResizeMode=\"CanResizeWithGrip\"", xaml);
+        Assert.Contains("ShowInTaskbar=\"False\"", xaml);
+        Assert.Contains("<ui:FluentWindow", xaml);
+        Assert.Contains("ExtendsContentIntoTitleBar=\"True\"", xaml);
+        Assert.Contains("WindowBackdropType=\"None\"", xaml);
+        Assert.Contains("Style=\"{StaticResource WizardShellStyle}\"", xaml);
+        Assert.Contains("<ui:TitleBar", xaml);
+        Assert.Contains("Title=\"{Binding Title, RelativeSource={RelativeSource AncestorType={x:Type ui:FluentWindow}}}\"", xaml);
+        Assert.Contains("ShowMinimize=\"False\"", xaml);
+        Assert.Contains("ShowMaximize=\"False\"", xaml);
+        Assert.Contains("Foreground=\"{DynamicResource TextFillColorPrimaryBrush}\"", xaml);
+        Assert.Contains("AutomationProperties.Name=\"{Binding RelativeSource={RelativeSource Self}, Path=Title}\"", xaml);
+        Assert.DoesNotContain("x:Name=\"PluginNameText\"", xaml);
+        Assert.Contains("<ScrollViewer", xaml);
+        Assert.Contains("plugin.SettingsView is null", section);
+        Assert.Contains("Owner = owner", section);
+        Assert.Contains("dialog.ShowDialog();", section);
+        Assert.Contains("Title = $\"{Loc.Instance[\"Settings.WindowTitle\"]} – {pluginName}\";", dialog);
+        Assert.Contains("SettingsContent.Content = null;", dialog);
+    }
+
+    [Fact]
+    public void SuccessfulFreshInstall_FocusesPluginBeforeOpeningSettings()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "PluginsSection.xaml.cs");
+        var handler = TestFile.ExtractBlock(source, "private async void OnInstallPluginClick");
+
+        Assert.Contains("plugin.InstallState != PluginInstallState.Installed", handler);
+        Assert.Contains("FocusInstalledPlugin(plugin.Id)", handler);
+        Assert.Contains("OpenPluginSettings(installedPlugin);", handler);
+        Assert.True(
+            handler.IndexOf("FocusInstalledPlugin(plugin.Id)", StringComparison.Ordinal)
+            < handler.IndexOf("OpenPluginSettings(installedPlugin);", StringComparison.Ordinal));
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginsSectionLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginsSectionLayoutTests.cs
@@ -46,4 +46,23 @@ public sealed class PluginsSectionLayoutTests
         Assert.Contains("Command=\"{Binding UpdateCommand}\"", xaml);
         Assert.Contains("ConverterParameter=UpdateAvailable", xaml);
     }
+
+    [Fact]
+    public void PluginsSection_OpensPluginSettingsInModalInsteadOfInline()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "PluginsSection.xaml");
+
+        Assert.Contains("Click=\"OnInstallPluginClick\"", xaml);
+        Assert.Contains("Click=\"OnPluginSettingsClick\"", xaml);
+        Assert.Contains("Visibility=\"{Binding HasSettings", xaml);
+        Assert.Contains("AutomationProperties.Name=\"{Binding SettingsAutomationName}\"", xaml);
+        Assert.DoesNotContain("<ContentControl Content=\"{Binding SettingsView}\"", xaml);
+        Assert.DoesNotContain("<ui:CardExpander", xaml);
+        Assert.DoesNotContain("IsExpanded=\"{Binding IsExpanded", xaml);
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
@@ -118,6 +118,19 @@ public class PluginsViewModelMarketplaceFilterTests : IDisposable
         Assert.True(installedPlugin.UpdateRegistryPluginCommand.CanExecute(null));
     }
 
+    [Fact]
+    public async Task FocusInstalledPlugin_SelectsInstalledTab()
+    {
+        var first = CreateLoadedPlugin("com.typewhisper.openai", "OpenAI", "1.0.0");
+        var second = CreateLoadedPlugin("com.typewhisper.groq", "Groq", "1.0.0");
+        var viewModel = await CreateViewModelAsync(null, "1.0.0", [first, second]);
+        viewModel.IsMarketplaceSelected = true;
+
+        Assert.True(viewModel.FocusInstalledPlugin("com.typewhisper.groq"));
+
+        Assert.False(viewModel.IsMarketplaceSelected);
+    }
+
     private async Task<PluginsViewModel> CreateViewModelAsync()
         => await CreateViewModelAsync(null, "1.0.0");
 


### PR DESCRIPTION
## Summary

- open plugin settings in an owned modal window after successful fresh installs
- replace inline expandable settings with static installed-plugin cards and explicit Settings actions
- use Wizard-style window chrome with the plugin name in the title bar
- expose localized automation names and preserve the existing `CreateSettingsView()` SDK contract

## Why

Plugin settings were hosted inline inside expandable cards, which made installation flow unclear and left redundant card expansion UI after settings moved out of the page. The host now owns the modal lifecycle while plugins continue supplying their existing settings view unchanged.

## User impact

Configurable plugins open their settings modal after installation and from the installed card. Plugins without settings never show an empty modal. The dialog is resizable, scrollable, screen-reader named, and can be reopened safely.

## Validation

- `dotnet test TypeWhisper.slnx --no-restore` (1617 passed)
- stable dev build and UI smoke test
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated Settings windows for installed plugins, opened from a per-plugin Settings button.
  - Plugin settings now appear in a resizable, scrollable dialog.
  - After a successful install, newly installed plugins can open their settings immediately.

- **Improvements**
  - Installed plugin items no longer use inline expandable settings UI; the Settings button appears only when settings are available and labels update with localization.
  - Plugin expansion state is no longer preserved across refreshes.
  - Focusing an installed plugin correctly returns to the Installed tab.

- **Tests**
  - Added tests for settings window lifetime and modal opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->