### PR TITLE
Fix bare modifier main dictation hotkeys

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -629,7 +629,9 @@ internal sealed class HotkeyMatchStateMachine
             return false;
 
         if (_targetVk != 0)
-            return vkCode == _targetVk && GetPressedModifiers() == _targetModifiers;
+            return vkCode == _targetVk
+                && GetPressedModifiers(HotkeyKeyClassifier.IsModifierKey(_targetVk) ? _targetVk : 0)
+                    == _targetModifiers;
 
         return HotkeyKeyClassifier.IsModifierKey(vkCode)
             && IsRequiredModifier(vkCode)
@@ -719,13 +721,13 @@ internal sealed class HotkeyMatchStateMachine
     private bool HasAnyModifierOnlyTargetPressed() =>
         _pressedKeys.Any(IsModifierOnlyTargetKey);
 
-    private uint GetPressedModifiers()
+    private uint GetPressedModifiers(uint excludedVkCode = 0)
     {
         var modifiers = 0u;
-        if (AnyPressed(HotkeyModifier.Control)) modifiers |= NativeMethods.MOD_CONTROL;
-        if (AnyPressed(HotkeyModifier.Shift)) modifiers |= NativeMethods.MOD_SHIFT;
-        if (AnyPressed(HotkeyModifier.Alt)) modifiers |= NativeMethods.MOD_ALT;
-        if (AnyPressed(HotkeyModifier.Win)) modifiers |= NativeMethods.MOD_WIN;
+        if (AnyPressed(HotkeyModifier.Control, excludedVkCode)) modifiers |= NativeMethods.MOD_CONTROL;
+        if (AnyPressed(HotkeyModifier.Shift, excludedVkCode)) modifiers |= NativeMethods.MOD_SHIFT;
+        if (AnyPressed(HotkeyModifier.Alt, excludedVkCode)) modifiers |= NativeMethods.MOD_ALT;
+        if (AnyPressed(HotkeyModifier.Win, excludedVkCode)) modifiers |= NativeMethods.MOD_WIN;
         return modifiers;
     }
 
@@ -786,8 +788,9 @@ internal sealed class HotkeyMatchStateMachine
         return false;
     }
 
-    private bool AnyPressed(HotkeyModifier modifier) =>
-        _pressedKeys.Any(vkCode => HotkeyKeyClassifier.MatchesModifier(vkCode, modifier));
+    private bool AnyPressed(HotkeyModifier modifier, uint excludedVkCode = 0) =>
+        _pressedKeys.Any(vkCode =>
+            vkCode != excludedVkCode && HotkeyKeyClassifier.MatchesModifier(vkCode, modifier));
 
     private bool WouldModifierRemainPressedAfterRelease(HotkeyModifier modifier, uint releasedVkCode) =>
         _pressedKeys.Any(vkCode => vkCode != releasedVkCode && HotkeyKeyClassifier.MatchesModifier(vkCode, modifier));

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -683,6 +683,38 @@ public class HotkeyInputTests
         Assert.False(rightCtrlUp.Swallow);
     }
 
+    [Theory]
+    [InlineData(NativeMethods.VK_RMENU, NativeMethods.VK_LMENU)]
+    [InlineData(NativeMethods.VK_RCONTROL, NativeMethods.VK_LCONTROL)]
+    public void SideSpecificSingleModifier_HybridActivatesOnMatchingPress(uint targetVk, uint otherSideVk)
+    {
+        var sut = CreateStateMachine(0, targetVk, activateModifierOnlyOnKeyDown: true);
+
+        Assert.Equal(default, sut.ProcessKeyEvent(otherSideVk, isKeyDown: true, isKeyUp: false));
+        Assert.Equal(default, sut.ProcessKeyEvent(otherSideVk, isKeyDown: false, isKeyUp: true));
+
+        var targetDown = sut.ProcessKeyEvent(targetVk, isKeyDown: true, isKeyUp: false);
+        Assert.True(targetDown.RaiseKeyDown);
+        Assert.True(targetDown.Swallow);
+
+        var targetUp = sut.ProcessKeyEvent(targetVk, isKeyDown: false, isKeyUp: true);
+        Assert.True(targetUp.RaiseKeyUp);
+        Assert.True(targetUp.Swallow);
+    }
+
+    [Theory]
+    [InlineData(NativeMethods.VK_RMENU, NativeMethods.VK_LMENU)]
+    [InlineData(NativeMethods.VK_RMENU, NativeMethods.VK_LCONTROL)]
+    [InlineData(NativeMethods.VK_RCONTROL, NativeMethods.VK_LCONTROL)]
+    [InlineData(NativeMethods.VK_RCONTROL, NativeMethods.VK_LMENU)]
+    public void SideSpecificSingleModifier_HybridRejectsAdditionalModifiers(uint targetVk, uint additionalVk)
+    {
+        var sut = CreateStateMachine(0, targetVk, activateModifierOnlyOnKeyDown: true);
+        _ = sut.ProcessKeyEvent(additionalVk, isKeyDown: true, isKeyUp: false);
+
+        Assert.Equal(default, sut.ProcessKeyEvent(targetVk, isKeyDown: true, isKeyUp: false));
+    }
+
     private static HotkeyMatchStateMachine CreateStateMachine(
         uint modifiers,
         uint vk = 0,


### PR DESCRIPTION
## Summary

- restore press-time activation for side-specific bare-modifier main dictation hotkeys such as Right Alt and Right Ctrl
- keep exact modifier matching by excluding only the target key itself from the pressed-modifier calculation
- cover matching-side activation, wrong-side input, and additional modifiers with regression tests

## Root cause

Main dictation opts modifier-only hotkeys into press-time activation. For a side-specific bare modifier, the matcher counted the target key as a pressed modifier and compared that value against the parsed binding's zero modifier mask, so the hotkey could never activate.

## User impact

Users can again use a single side-specific modifier as the main dictation hotkey without falling back to the toggle-only slot. Existing exact-match behavior for other hotkeys remains unchanged.

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~HotkeyInputTests|FullyQualifiedName~HotkeyServiceTests"` (212 passed)
- `dotnet test TypeWhisper.slnx --no-restore` (1,623 passed)
- stable dev build launched from `F:\typewhisper\dev-output\typewhisper-win\Build\TypeWhisper.exe`

Closes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved side-specific modifier hotkeys so activation correctly ignores the modifier key currently being evaluated.
  * Prevented activation when additional modifier keys are pressed.
  * Ensured opposite-side modifier presses and releases do not incorrectly trigger or interfere with the configured hotkey.

* **Tests**
  * Added coverage for modifier-only hotkeys and hybrid key-down behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->