### PR TITLE
Fix Script Runner editor persistence

### DIFF
--- a/plugins/TypeWhisper.Plugin.Script/ScriptSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Script/ScriptSettingsView.xaml
@@ -48,6 +48,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Name:" VerticalAlignment="Center" Margin="0,0,0,6" />
@@ -68,6 +69,14 @@
                 <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Foreground="Gray" FontSize="11"
                            TextWrapping="Wrap"
                            Text="The transcribed text is passed via stdin. The script's stdout becomes the new text. Environment variables: TYPEWHISPER_APP_NAME, TYPEWHISPER_LANGUAGE, TYPEWHISPER_PROFILE" />
+
+                <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                            Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                    <Button x:Name="CancelButton" Content="Cancel" Click="OnCancelEdit"
+                            IsEnabled="False" Padding="12,6" Margin="0,0,8,0" />
+                    <Button x:Name="SaveButton" Content="Save" Click="OnSaveEdit"
+                            IsEnabled="False" Padding="12,6" />
+                </StackPanel>
             </Grid>
         </Border>
     </StackPanel>

--- a/plugins/TypeWhisper.Plugin.Script/ScriptSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Script/ScriptSettingsView.xaml.cs
@@ -104,6 +104,7 @@ public partial class ScriptSettingsView : UserControl
         {
             NameBox.Text = script.Name;
             CommandBox.Text = script.Command;
+            ShellCombo.SelectedIndex = -1;
 
             // Select matching shell in ComboBox
             for (var i = 0; i < ShellCombo.Items.Count; i++)
@@ -153,7 +154,7 @@ public partial class ScriptSettingsView : UserControl
         {
             Name = NameBox.Text,
             Command = CommandBox.Text,
-            Shell = (ShellCombo.SelectedItem as ComboBoxItem)?.Content as string ?? "cmd"
+            Shell = (ShellCombo.SelectedItem as ComboBoxItem)?.Content as string ?? script.Shell
         };
     }
 

--- a/plugins/TypeWhisper.Plugin.Script/ScriptSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Script/ScriptSettingsView.xaml.cs
@@ -10,7 +10,9 @@ namespace TypeWhisper.Plugin.Script;
 public partial class ScriptSettingsView : UserControl
 {
     private readonly ScriptPlugin _plugin;
+    private ScriptEntry? _editingScript;
     private bool _suppressEditEvents;
+    private bool _suppressSelectionEvents;
 
     /// <summary>
     /// Initializes a new instance of the ScriptSettingsView class.
@@ -81,24 +83,34 @@ public partial class ScriptSettingsView : UserControl
 
     private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        if (_suppressSelectionEvents) return;
+
         if (ScriptList.SelectedItem is not ScriptEntry selected)
         {
+            _editingScript = null;
             EditPanel.Visibility = Visibility.Collapsed;
+            UpdateEditButtons();
             return;
         }
 
+        LoadEditor(selected);
+    }
+
+    private void LoadEditor(ScriptEntry script)
+    {
+        _editingScript = script;
         _suppressEditEvents = true;
         try
         {
-            NameBox.Text = selected.Name;
-            CommandBox.Text = selected.Command;
+            NameBox.Text = script.Name;
+            CommandBox.Text = script.Command;
 
             // Select matching shell in ComboBox
             for (var i = 0; i < ShellCombo.Items.Count; i++)
             {
                 if (ShellCombo.Items[i] is ComboBoxItem item
                     && item.Content is string shell
-                    && shell.Equals(selected.Shell, StringComparison.OrdinalIgnoreCase))
+                    && shell.Equals(script.Shell, StringComparison.OrdinalIgnoreCase))
                 {
                     ShellCombo.SelectedIndex = i;
                     break;
@@ -111,21 +123,62 @@ public partial class ScriptSettingsView : UserControl
         {
             _suppressEditEvents = false;
         }
+
+        UpdateEditButtons();
     }
 
     private void OnEditFieldChanged(object sender, RoutedEventArgs e)
     {
         if (_suppressEditEvents) return;
-        if (ScriptList.SelectedItem is not ScriptEntry selected) return;
+        UpdateEditButtons();
+    }
 
-        var shell = (ShellCombo.SelectedItem as ComboBoxItem)?.Content as string ?? "cmd";
+    private void OnSaveEdit(object sender, RoutedEventArgs e)
+    {
+        if (CreateEditedScript() is not { } updated || updated == _editingScript) return;
+        UpdateScriptAndKeepSelection(updated);
+        UpdateEditButtons();
+    }
 
-        _plugin.Service?.UpdateScript(selected with
+    private void OnCancelEdit(object sender, RoutedEventArgs e)
+    {
+        if (_editingScript is { } script) LoadEditor(script);
+    }
+
+    private ScriptEntry? CreateEditedScript()
+    {
+        if (_editingScript is not { } script) return null;
+
+        return script with
         {
             Name = NameBox.Text,
             Command = CommandBox.Text,
-            Shell = shell
-        });
+            Shell = (ShellCombo.SelectedItem as ComboBoxItem)?.Content as string ?? "cmd"
+        };
+    }
+
+    private void UpdateEditButtons()
+    {
+        var hasChanges = CreateEditedScript() is { } edited && edited != _editingScript;
+        SaveButton.IsEnabled = hasChanges;
+        CancelButton.IsEnabled = hasChanges;
+    }
+
+    private void UpdateScriptAndKeepSelection(ScriptEntry updated)
+    {
+        if (_plugin.Service is not { } service) return;
+
+        _suppressSelectionEvents = true;
+        try
+        {
+            service.UpdateScript(updated);
+            ScriptList.SelectedItem = updated;
+            _editingScript = updated;
+        }
+        finally
+        {
+            _suppressSelectionEvents = false;
+        }
     }
 
     private void OnToggleChanged(object sender, RoutedEventArgs e)
@@ -134,6 +187,15 @@ public partial class ScriptSettingsView : UserControl
         var existing = _plugin.Service?.Scripts.FirstOrDefault(s => s.Id == id);
         if (existing is null) return;
 
-        _plugin.Service?.UpdateScript(existing with { IsEnabled = isChecked == true });
+        var updated = existing with { IsEnabled = isChecked == true };
+        if (_editingScript?.Id == id)
+        {
+            UpdateScriptAndKeepSelection(updated);
+            UpdateEditButtons();
+        }
+        else
+        {
+            _plugin.Service?.UpdateScript(updated);
+        }
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/ScriptPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ScriptPluginTests.cs
@@ -1,0 +1,101 @@
+namespace TypeWhisper.PluginSystem.Tests;
+
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using Moq;
+using TypeWhisper.Plugin.Script;
+using TypeWhisper.PluginSDK;
+
+public sealed class ScriptPluginTests
+{
+    [Fact]
+    public void SettingsView_StagesEditsUntilSaveAndSupportsCancel()
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            var dataDirectory = Path.Join(Path.GetTempPath(), $"typewhisper-script-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dataDirectory);
+
+            try
+            {
+                var host = new Mock<IPluginHostServices>();
+                host.SetupGet(x => x.PluginDataDirectory).Returns(dataDirectory);
+
+                var plugin = new ScriptPlugin();
+                plugin.ActivateAsync(host.Object).GetAwaiter().GetResult();
+
+                var original = new ScriptEntry { Name = "Original", Command = "echo original" };
+                var other = new ScriptEntry { Name = "Other" };
+                plugin.Service!.AddScript(original);
+                plugin.Service.AddScript(other);
+
+                var view = Assert.IsType<ScriptSettingsView>(plugin.CreateSettingsView());
+                var list = Assert.IsType<ListBox>(view.FindName("ScriptList"));
+                var panel = Assert.IsType<Border>(view.FindName("EditPanel"));
+                var name = Assert.IsType<TextBox>(view.FindName("NameBox"));
+                var command = Assert.IsType<TextBox>(view.FindName("CommandBox"));
+                var shell = Assert.IsType<ComboBox>(view.FindName("ShellCombo"));
+                var save = Assert.IsType<Button>(view.FindName("SaveButton"));
+                var cancel = Assert.IsType<Button>(view.FindName("CancelButton"));
+
+                list.SelectedItem = original;
+                name.Text = "Edited Script";
+                command.Text = "echo edited";
+                shell.SelectedIndex = 1;
+
+                Assert.Equal(Visibility.Visible, panel.Visibility);
+                Assert.Same(original, list.SelectedItem);
+                Assert.Equal("Original", plugin.Service.Scripts[0].Name);
+                Assert.True(save.IsEnabled);
+                Assert.True(cancel.IsEnabled);
+
+                save.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+                var saved = plugin.Service.Scripts[0];
+                Assert.Equal("Edited Script", saved.Name);
+                Assert.Equal("echo edited", saved.Command);
+                Assert.Equal("powershell", saved.Shell);
+                Assert.Same(saved, list.SelectedItem);
+                Assert.Equal(Visibility.Visible, panel.Visibility);
+                Assert.False(save.IsEnabled);
+                Assert.False(cancel.IsEnabled);
+
+                var reloaded = new ScriptService(host.Object);
+                Assert.Equal(saved, reloaded.Scripts.Single(script => script.Id == saved.Id));
+
+                name.Text = "Discarded";
+                Assert.True(save.IsEnabled);
+                Assert.True(cancel.IsEnabled);
+                cancel.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+                Assert.Equal("Edited Script", name.Text);
+                Assert.Equal("Edited Script", plugin.Service.Scripts[0].Name);
+                Assert.False(save.IsEnabled);
+                Assert.False(cancel.IsEnabled);
+
+                name.Text = "Also discarded";
+                list.SelectedItem = other;
+                list.SelectedItem = saved;
+                Assert.Equal("Edited Script", name.Text);
+                Assert.Equal(Visibility.Visible, panel.Visibility);
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                try { Directory.Delete(dataDirectory, recursive: true); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "Script settings test did not finish.");
+        Assert.Null(failure);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/ScriptPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ScriptPluginTests.cs
@@ -13,7 +13,7 @@ public sealed class ScriptPluginTests
     public void SettingsView_StagesEditsUntilSaveAndSupportsCancel()
     {
         Exception? failure = null;
-        var thread = new Thread(() =>
+        var thread = new Thread(() => failure = Record.Exception(() =>
         {
             var dataDirectory = Path.Join(Path.GetTempPath(), $"typewhisper-script-{Guid.NewGuid():N}");
             Directory.CreateDirectory(dataDirectory);
@@ -28,8 +28,10 @@ public sealed class ScriptPluginTests
 
                 var original = new ScriptEntry { Name = "Original", Command = "echo original" };
                 var other = new ScriptEntry { Name = "Other" };
+                var customShell = new ScriptEntry { Name = "Custom", Shell = "custom-shell" };
                 plugin.Service!.AddScript(original);
                 plugin.Service.AddScript(other);
+                plugin.Service.AddScript(customShell);
 
                 var view = Assert.IsType<ScriptSettingsView>(plugin.CreateSettingsView());
                 var list = Assert.IsType<ListBox>(view.FindName("ScriptList"));
@@ -80,10 +82,15 @@ public sealed class ScriptPluginTests
                 list.SelectedItem = saved;
                 Assert.Equal("Edited Script", name.Text);
                 Assert.Equal(Visibility.Visible, panel.Visibility);
-            }
-            catch (Exception ex)
-            {
-                failure = ex;
+
+                list.SelectedItem = customShell;
+                Assert.Equal(-1, shell.SelectedIndex);
+                Assert.False(save.IsEnabled);
+                name.Text = "Custom edited";
+                save.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Assert.Equal(
+                    "custom-shell",
+                    plugin.Service.Scripts.Single(script => script.Id == customShell.Id).Shell);
             }
             finally
             {
@@ -91,8 +98,9 @@ public sealed class ScriptPluginTests
                 catch (IOException) { }
                 catch (UnauthorizedAccessException) { }
             }
-        });
+        }));
 
+        thread.IsBackground = true;
         thread.SetApartmentState(ApartmentState.STA);
         thread.Start();
         Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "Script settings test did not finish.");

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.GraniteSpeech\TypeWhisper.Plugin.GraniteSpeech.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Script\TypeWhisper.Plugin.Script.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SmallestAi\TypeWhisper.Plugin.SmallestAi.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Cli\TypeWhisper.Cli.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />


### PR DESCRIPTION
## Summary

- stage Script Runner name, command, and shell edits until Save
- add dirty-state-aware Save and Cancel actions while keeping the selected script open
- preserve selection when persisted entries are replaced
- add STA WPF regression coverage for save, cancel, persistence, and selection changes

## Root cause

Each field change immediately replaced the selected `ScriptEntry` in the observable collection. WPF then cleared the `ListBox` selection, which collapsed the details pane after every input action.

## Validation

- `dotnet build plugins\TypeWhisper.Plugin.Script\TypeWhisper.Plugin.Script.csproj -c Release --no-restore`
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore` (1,322 passed)

Closes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-aligned **Save** and **Cancel** controls to the script editor panel.
  * Script edits are now **staged** and only persisted when **Save** is clicked.
  * **Cancel** restores the last saved script values and disables Save/Cancel again.
  * Save/Cancel enablement updates based on whether the selected script has unsaved changes (including shell selection behavior).
* **Tests**
  * Added a UI-driven test covering staging, Save/Cancel, persistence reload by ID, and shell-related selection updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->