### PR TITLE
Support explicit workflow dictation in the local API

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -505,6 +505,7 @@ public partial class App : Application
         services.AddSingleton<AudioRecorderViewModel>();
         services.AddSingleton<IRecorderApiController>(sp => sp.GetRequiredService<AudioRecorderViewModel>());
         services.AddSingleton<DictationViewModel>();
+        services.AddSingleton<IDictationApiController>(sp => sp.GetRequiredService<DictationViewModel>());
         services.AddSingleton<RecordingOverlayViewModel>();
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<ModelManagerViewModel>();

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -30,7 +30,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
     private readonly IVocabularyBoostingService _vocabularyBoosting;
     private readonly IPostProcessingPipeline _pipeline;
     private readonly ITranslationService _translation;
-    private readonly DictationViewModel _dictation;
+    private readonly IDictationApiController _dictation;
     private readonly IWorkflowService _workflows;
     private readonly IRecorderApiController? _recorder;
     private readonly IDictationAutomationController? _automation;
@@ -68,7 +68,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         IVocabularyBoostingService vocabularyBoosting,
         IPostProcessingPipeline pipeline,
         ITranslationService translation,
-        DictationViewModel dictation,
+        IDictationApiController dictation,
         IWorkflowService workflows,
         Func<string>? apiTokenProvider = null,
         IRecorderApiController? recorder = null,
@@ -248,7 +248,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                 ("/v1/transcribe/local-file", "POST") => await HandleTranscribeLocalFile(request, ct),
                 ("/v1/history", "GET") => HandleHistorySearch(request),
                 ("/v1/history", "DELETE") => HandleHistoryDelete(request),
-                ("/v1/dictation/start", "POST") => await HandleDictationStart(),
+                ("/v1/dictation/start", "POST") => await HandleDictationStart(request),
                 ("/v1/dictation/stop", "POST") => await HandleDictationStop(),
                 ("/v1/dictation/status", "GET") => HandleDictationStatus(),
                 ("/v1/dictation/transcription", "GET") => HandleDictationTranscription(request),
@@ -306,7 +306,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             engine = activePlugin?.ProviderId,
             model = activeModel,
             active_model = _modelManager.ActiveModelId,
-            api_version = "1.0",
+            api_version = "1.1",
+            supports_workflow_dictation = true,
             supports_streaming = activePlugin?.SupportsStreaming ?? false,
             supports_translation = activePlugin?.SupportsTranslation ?? false,
             acceleration = activePlugin is null || accelerationStatus is null
@@ -545,17 +546,54 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         return Json(new { deleted = true, id });
     }
 
-    private async Task<HttpApiResponse> HandleDictationStart()
+    private async Task<HttpApiResponse> HandleDictationStart(HttpApiRequest request)
     {
         if (_dictation.IsRecording)
             return Error(409, "Already recording");
 
-        var id = await InvokeOnDispatcherAsync(() => _dictation.StartRecordingForApiAsync());
+        DictationStartRequest? payload = null;
+        if (request.Body.Length > 0)
+        {
+            try
+            {
+                payload = JsonSerializer.Deserialize<DictationStartRequest>(request.Body, JsonOptions);
+            }
+            catch (JsonException)
+            {
+                return Error(400, "Invalid JSON body");
+            }
+
+            if (payload is null)
+                return Error(400, "Invalid JSON body");
+        }
+
+        Workflow? workflow = null;
+        if (payload?.WorkflowId is { } requestedWorkflowId)
+        {
+            if (string.IsNullOrWhiteSpace(requestedWorkflowId))
+                return Error(400, "Missing or invalid 'workflow_id'");
+
+            workflow = _workflows.GetWorkflow(requestedWorkflowId)
+                ?? _workflows.Workflows.FirstOrDefault(candidate =>
+                    string.Equals(candidate.Id, requestedWorkflowId, StringComparison.Ordinal));
+            if (workflow is null)
+                return Error(404, "Workflow not found");
+            if (!workflow.IsEnabled)
+                return Error(409, "Workflow is disabled");
+        }
+
+        var id = await InvokeOnDispatcherAsync(() => _dictation.StartRecordingForApiAsync(workflow?.Id));
         var session = _dictation.GetApiDictationSession(id);
         if (session?.Status == ApiDictationSessionStatus.Failed)
             return Error(409, session.Error ?? "Failed to start dictation");
 
-        return Json(new { id, status = "recording" });
+        return Json(new
+        {
+            id,
+            status = "recording",
+            workflow_id = workflow?.Id,
+            workflow_name = workflow?.Name
+        });
     }
 
     private async Task<HttpApiResponse> HandleDictationStop()
@@ -577,7 +615,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             state = _dictation.State.ToString().ToLowerInvariant(),
             is_recording = _dictation.IsRecording,
             active_model = _modelManager.ActiveModelId,
-            active_workflow = _dictation.ActiveWorkflowName
+            active_workflow = _dictation.ActiveWorkflowName,
+            active_workflow_id = _dictation.ActiveWorkflowId
         });
     }
 
@@ -1250,6 +1289,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         string Mode,
         string? InputLanguage,
         IReadOnlyList<string> Hints);
+
+    private sealed record DictationStartRequest(string? WorkflowId);
 
     private sealed record DictionaryCorrectionDto(
         [property: JsonPropertyName("original")] string Original,

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -82,9 +82,36 @@ public enum ApiDictationSessionStatus
 }
 
 /// <summary>
+/// API-facing dictation control surface.
+/// </summary>
+public interface IDictationApiController
+{
+    /// <summary>Gets whether dictation recording is active.</summary>
+    bool IsRecording { get; }
+
+    /// <summary>Gets the current dictation state.</summary>
+    DictationState State { get; }
+
+    /// <summary>Gets the active workflow name, when applicable.</summary>
+    string? ActiveWorkflowName { get; }
+
+    /// <summary>Gets the active workflow id, when applicable.</summary>
+    string? ActiveWorkflowId { get; }
+
+    /// <summary>Starts an API dictation session, optionally forcing a workflow.</summary>
+    Task<Guid> StartRecordingForApiAsync(string? workflowId = null);
+
+    /// <summary>Stops the active API dictation session.</summary>
+    Task<Guid?> StopRecordingForApiAsync();
+
+    /// <summary>Returns an API dictation session by id.</summary>
+    ApiDictationSessionSnapshot? GetApiDictationSession(Guid id);
+}
+
+/// <summary>
 /// Provides dictation view model behavior.
 /// </summary>
-public partial class DictationViewModel : ObservableObject, IDisposable, IDictationAutomationController
+public partial class DictationViewModel : ObservableObject, IDisposable, IDictationApiController, IDictationAutomationController
 {
     private readonly ISettingsService _settings;
     private readonly ModelManagerService _modelManager;
@@ -480,10 +507,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     /// <summary>Whether the service is currently recording.</summary>
     public bool IsRecording => _isRecording;
 
+    /// <summary>Gets the active workflow id for API status responses.</summary>
+    public string? ActiveWorkflowId => _activeWorkflow?.Id;
+
     /// <summary>
     /// Starts recording for api asynchronously.
     /// </summary>
-    public async Task<Guid> StartRecordingForApiAsync()
+    public async Task<Guid> StartRecordingForApiAsync(string? workflowId = null)
     {
         var sessionId = Guid.NewGuid();
         _activeApiDictationSessionId = sessionId;
@@ -493,6 +523,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             null,
             null));
 
+        _workflowHotkeyOverrideId = workflowId;
         await StartRecording();
 
         if (!_isRecording)

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -516,6 +516,17 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     public async Task<Guid> StartRecordingForApiAsync(string? workflowId = null)
     {
         var sessionId = Guid.NewGuid();
+
+        if (_isRecording || _isStoppingRecording)
+        {
+            StoreApiDictationSession(new ApiDictationSessionSnapshot(
+                sessionId,
+                ApiDictationSessionStatus.Failed,
+                null,
+                "Already recording"));
+            return sessionId;
+        }
+
         _activeApiDictationSessionId = sessionId;
         StoreApiDictationSession(new ApiDictationSessionSnapshot(
             sessionId,

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -918,6 +918,30 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task DictationStart_ReturnsConflictWhenConcurrentAdmissionIsRejected()
+    {
+        var dictation = new ConcurrentAdmissionDictationApiController();
+        var service = CreateService(dictation: dictation);
+        var request = new HttpApiRequest(
+            "POST",
+            "/v1/dictation/start",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []);
+
+        var firstStart = service.HandleRequestAsync(request, CancellationToken.None);
+        await dictation.FirstStartEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var secondResponse = await service.HandleRequestAsync(request, CancellationToken.None);
+        dictation.ReleaseFirstStart.TrySetResult();
+        var firstResponse = await firstStart;
+
+        Assert.Equal(200, firstResponse.StatusCode);
+        Assert.Equal(409, secondResponse.StatusCode);
+        Assert.Equal("Already recording", ErrorMessage(secondResponse));
+    }
+
+    [Fact]
     public async Task DictationStart_RejectsUnknownDisabledAndMalformedWorkflows()
     {
         var disabled = new Workflow
@@ -1018,7 +1042,7 @@ public class HttpApiServiceTests : IDisposable
         {
             SelectedModelId = selectedModel,
             SaveToHistoryEnabled = true
-        }, null, null, false, null, plugins).Service;
+        }, null, null, false, null, null, plugins).Service;
     }
 
     private HttpApiService CreateService(
@@ -1027,6 +1051,7 @@ public class HttpApiServiceTests : IDisposable
         IRecorderApiController? recorder = null,
         bool automationEnabled = false,
         IDictationAutomationController? automationController = null,
+        IDictationApiController? dictation = null,
         params ITranscriptionEnginePlugin[] plugins)
     {
         var selectedModel = plugins.Length > 0
@@ -1037,13 +1062,13 @@ public class HttpApiServiceTests : IDisposable
         {
             SelectedModelId = selectedModel,
             SaveToHistoryEnabled = true
-        }, apiTokenProvider, recorder, automationEnabled, automationController, plugins).Service;
+        }, apiTokenProvider, recorder, automationEnabled, automationController, dictation, plugins).Service;
     }
 
     private (HttpApiService Service, ModelManagerService ModelManager) CreateServiceWithModelManager(
         AppSettings settings,
         params ITranscriptionEnginePlugin[] plugins)
-        => CreateServiceWithModelManager(settings, null, null, false, null, plugins);
+        => CreateServiceWithModelManager(settings, null, null, false, null, null, plugins);
 
     private (HttpApiService Service, ModelManagerService ModelManager) CreateServiceWithModelManager(
         AppSettings settings,
@@ -1051,6 +1076,7 @@ public class HttpApiServiceTests : IDisposable
         IRecorderApiController? recorder,
         bool automationEnabled,
         IDictationAutomationController? automationController,
+        IDictationApiController? dictation,
         params ITranscriptionEnginePlugin[] plugins)
     {
         _settings.Setup(s => s.Current).Returns(settings);
@@ -1081,7 +1107,7 @@ public class HttpApiServiceTests : IDisposable
             vocabulary.Object,
             new PostProcessingPipeline(),
             translation.Object,
-            _dictation,
+            dictation ?? _dictation,
             _workflows.Object,
             apiTokenProvider ?? (() => "test-token"),
             recorder,
@@ -1245,6 +1271,48 @@ public class HttpApiServiceTests : IDisposable
                     null,
                     null)
                 : null;
+    }
+
+    private sealed class ConcurrentAdmissionDictationApiController : IDictationApiController
+    {
+        private readonly Dictionary<Guid, ApiDictationSessionSnapshot> _sessions = [];
+        private int _startCount;
+
+        public TaskCompletionSource FirstStartEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseFirstStart { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool IsRecording { get; private set; }
+        public DictationState State => IsRecording ? DictationState.Recording : DictationState.Idle;
+        public string? ActiveWorkflowName => null;
+        public string? ActiveWorkflowId => null;
+
+        public async Task<Guid> StartRecordingForApiAsync(string? workflowId = null)
+        {
+            var sessionId = Guid.NewGuid();
+            if (Interlocked.Increment(ref _startCount) > 1)
+            {
+                _sessions[sessionId] = new ApiDictationSessionSnapshot(
+                    sessionId,
+                    ApiDictationSessionStatus.Failed,
+                    null,
+                    "Already recording");
+                return sessionId;
+            }
+
+            FirstStartEntered.TrySetResult();
+            await ReleaseFirstStart.Task;
+            IsRecording = true;
+            _sessions[sessionId] = new ApiDictationSessionSnapshot(
+                sessionId,
+                ApiDictationSessionStatus.Recording,
+                null,
+                null);
+            return sessionId;
+        }
+
+        public Task<Guid?> StopRecordingForApiAsync() => Task.FromResult<Guid?>(null);
+
+        public ApiDictationSessionSnapshot? GetApiDictationSession(Guid id) =>
+            _sessions.GetValueOrDefault(id);
     }
 
     private sealed class FakeDictationAutomationController : IDictationAutomationController

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -23,6 +23,7 @@ public class HttpApiServiceTests : IDisposable
     private readonly Mock<IWorkflowService> _workflows = new();
     private readonly Mock<ISettingsService> _settings = new();
     private readonly Mock<IHistoryService> _history = new();
+    private readonly FakeDictationApiController _dictation = new();
     private readonly PluginEventBus _eventBus = new();
     private readonly PluginLoader _loader = new();
 
@@ -872,6 +873,110 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Status_AdvertisesWorkflowDictationCapability()
+    {
+        var response = JsonObject(await CreateService().HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/status",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+
+        Assert.Equal("1.1", response["api_version"].GetString());
+        Assert.True(response["supports_workflow_dictation"].GetBoolean());
+    }
+
+    [Fact]
+    public async Task DictationStart_PreservesBodylessBehaviorAndAcceptsEnabledWorkflow()
+    {
+        var workflow = new Workflow
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Meeting notes",
+            Template = WorkflowTemplate.Custom,
+            Trigger = new WorkflowTrigger { Kind = WorkflowTriggerKind.Manual }
+        };
+        _workflows.Setup(w => w.Workflows).Returns([workflow]);
+        var service = CreateService();
+
+        var bodyless = JsonObject(await service.HandleRequestAsync(new HttpApiRequest(
+            "POST",
+            "/v1/dictation/start",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+        _dictation.IsRecording = false;
+        var withWorkflow = JsonObject(await service.HandleRequestAsync(JsonRequest(
+            "POST",
+            "/v1/dictation/start",
+            JsonSerializer.Serialize(new { workflow_id = workflow.Id })), CancellationToken.None));
+
+        Assert.Equal([null, workflow.Id], _dictation.StartWorkflowIds);
+        Assert.Equal(JsonValueKind.Null, bodyless["workflow_id"].ValueKind);
+        Assert.Equal(workflow.Id, withWorkflow["workflow_id"].GetString());
+        Assert.Equal("Meeting notes", withWorkflow["workflow_name"].GetString());
+    }
+
+    [Fact]
+    public async Task DictationStart_RejectsUnknownDisabledAndMalformedWorkflows()
+    {
+        var disabled = new Workflow
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Disabled",
+            IsEnabled = false,
+            Template = WorkflowTemplate.Custom,
+            Trigger = new WorkflowTrigger { Kind = WorkflowTriggerKind.Manual }
+        };
+        _workflows.Setup(w => w.Workflows).Returns([disabled]);
+        var service = CreateService();
+
+        var unknown = await service.HandleRequestAsync(JsonRequest(
+            "POST",
+            "/v1/dictation/start",
+            """{"workflow_id":"missing"}"""), CancellationToken.None);
+        var disabledResponse = await service.HandleRequestAsync(JsonRequest(
+            "POST",
+            "/v1/dictation/start",
+            JsonSerializer.Serialize(new { workflow_id = disabled.Id })), CancellationToken.None);
+        var empty = await service.HandleRequestAsync(JsonRequest(
+            "POST",
+            "/v1/dictation/start",
+            """{"workflow_id":" "}"""), CancellationToken.None);
+        var malformed = await service.HandleRequestAsync(JsonRequest(
+            "POST",
+            "/v1/dictation/start",
+            "{"), CancellationToken.None);
+
+        Assert.Equal(404, unknown.StatusCode);
+        Assert.Equal(409, disabledResponse.StatusCode);
+        Assert.Equal(400, empty.StatusCode);
+        Assert.Equal(400, malformed.StatusCode);
+        Assert.Empty(_dictation.StartWorkflowIds);
+    }
+
+    [Fact]
+    public async Task DictationStatus_IncludesActiveWorkflowIdentity()
+    {
+        _dictation.IsRecording = true;
+        _dictation.State = DictationState.Recording;
+        _dictation.ActiveWorkflowId = "workflow-id";
+        _dictation.ActiveWorkflowName = "Meeting notes";
+
+        var response = JsonObject(await CreateService().HandleRequestAsync(new HttpApiRequest(
+            "GET",
+            "/v1/dictation/status",
+            new NameValueCollection(),
+            new Dictionary<string, string>(),
+            []), CancellationToken.None));
+
+        Assert.True(response["is_recording"].GetBoolean());
+        Assert.Equal("recording", response["state"].GetString());
+        Assert.Equal("workflow-id", response["active_workflow_id"].GetString());
+        Assert.Equal("Meeting notes", response["active_workflow"].GetString());
+    }
+
+    [Fact]
     public async Task TranscribeLocalFileEndpoint_RejectsMissingAndUnsupportedFiles()
     {
         var service = CreateService();
@@ -976,7 +1081,7 @@ public class HttpApiServiceTests : IDisposable
             vocabulary.Object,
             new PostProcessingPipeline(),
             translation.Object,
-            null!,
+            _dictation,
             _workflows.Object,
             apiTokenProvider ?? (() => "test-token"),
             recorder,
@@ -1106,6 +1211,40 @@ public class HttpApiServiceTests : IDisposable
 
         public RecorderApiSessionSnapshot? GetRecorderApiSession(Guid id) =>
             Session is not null && Session.Id == id ? Session : null;
+    }
+
+    private sealed class FakeDictationApiController : IDictationApiController
+    {
+        public bool IsRecording { get; set; }
+        public DictationState State { get; set; } = DictationState.Idle;
+        public string? ActiveWorkflowName { get; set; }
+        public string? ActiveWorkflowId { get; set; }
+        public List<string?> StartWorkflowIds { get; } = [];
+        public Guid SessionId { get; } = Guid.NewGuid();
+
+        public Task<Guid> StartRecordingForApiAsync(string? workflowId = null)
+        {
+            StartWorkflowIds.Add(workflowId);
+            IsRecording = true;
+            State = DictationState.Recording;
+            return Task.FromResult(SessionId);
+        }
+
+        public Task<Guid?> StopRecordingForApiAsync()
+        {
+            IsRecording = false;
+            State = DictationState.Idle;
+            return Task.FromResult<Guid?>(SessionId);
+        }
+
+        public ApiDictationSessionSnapshot? GetApiDictationSession(Guid id) =>
+            id == SessionId
+                ? new ApiDictationSessionSnapshot(
+                    SessionId,
+                    ApiDictationSessionStatus.Recording,
+                    null,
+                    null)
+                : null;
     }
 
     private sealed class FakeDictationAutomationController : IDictationAutomationController


### PR DESCRIPTION
## Summary
- accept an optional `workflow_id` when starting dictation through the local API
- reject unknown and disabled workflows without falling back to normal dictation
- expose workflow capability and active workflow identity in status responses
- preserve existing bodyless dictation starts

## User impact
Authenticated local integrations such as the Stream Deck plugin can start a specific enabled workflow safely while older clients remain compatible.

## Validation
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter FullyQualifiedName~HttpApiServiceTests` (32 tests)
- Debug app built and launched from the branch
- live API checks for 404 unknown workflow, bodyless start/stop, explicit workflow start/stop, and status identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflow-aware dictation controls through the HTTP API.
  - Dictation can now start with an optional workflow selection and returns workflow details.
  - Dictation status includes the active workflow.
  - API status now reports version 1.1 and workflow dictation support.

- **Bug Fixes**
  - Added validation for unknown, disabled, blank, or malformed workflow selections.
  - Preserved existing behavior when starting dictation without a request body.

- **Tests**
  - Added coverage for workflow dictation, validation, status reporting, and session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->