### PR TITLE
Release microphone capture between dictations

### DIFF
--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -184,7 +184,8 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     {
         AudioCaptureDiagnostics.Log(
             $"WarmUp enter warmed={_isWarmedUp} disposed={_disposed} deviceCount={SafeDeviceCount()} sync={SynchronizationContext.Current?.GetType().FullName ?? "<null>"}");
-        if (_isWarmedUp || _disposed) return _isWarmedUp;
+        if (_disposed) return false;
+        if (_isWarmedUp && _waveIn is not null) return true;
 
         if (_deviceProvider.DeviceCount == 0)
         {
@@ -213,12 +214,11 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
             _waveIn.DataAvailable += OnDataAvailable;
             _waveIn.RecordingStopped += OnRecordingStopped;
-            _waveIn.StartRecording();
 
             SetActiveDeviceIdentity(_activeDeviceNumber);
             _isWarmedUp = true;
             AudioCaptureDiagnostics.Log(
-                $"WarmUp success active={_activeDeviceNumber}:{_activeDeviceName ?? "<unknown>"} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
+                $"WarmUp prepared active={_activeDeviceNumber}:{_activeDeviceName ?? "<unknown>"} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
         }
         catch (Exception ex) when (IsNonFatalAudioException(ex))
         {
@@ -264,7 +264,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         if (_isPreviewing)
             StopPreview();
 
-        if (!_isWarmedUp && !WarmUp())
+        if ((!_isWarmedUp || _waveIn is null) && !WarmUp())
         {
             AudioCaptureDiagnostics.Log("StartRecording warmup failed");
             return;
@@ -288,8 +288,20 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         _recordingStartTime = DateTime.UtcNow;
         _isRecording = true;
         _diagnosticDataAvailableCount = 0;
-        AudioCaptureDiagnostics.Log(
-            $"StartRecording active isRecording={_isRecording} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
+
+        try
+        {
+            _waveIn.StartRecording();
+            AudioCaptureDiagnostics.Log(
+                $"StartRecording active isRecording={_isRecording} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
+        }
+        catch (Exception ex) when (IsNonFatalAudioException(ex))
+        {
+            AudioCaptureDiagnostics.Log($"StartRecording failed {ex.GetType().Name}: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"StartRecording failed: {ex.Message}");
+            ClearRecordingState();
+            DisposeWaveIn();
+        }
     }
 
     /// <summary>
@@ -326,6 +338,8 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             samples = _sampleBuffer?.ToArray();
             _sampleBuffer = null;
         }
+
+        DisposeWaveIn(resetWarmUp: false);
 
         if (samples is null || samples.Length == 0)
         {
@@ -1097,12 +1111,14 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         RaisePreviewLevelChanged(peak, rms);
     }
 
-    private void DisposeWaveIn(bool stopRecording = true)
+    private void DisposeWaveIn(bool stopRecording = true, bool resetWarmUp = true)
     {
         if (_waveIn is not null)
         {
             var waveIn = _waveIn;
             _waveIn = null;
+            AudioCaptureDiagnostics.Log(
+                $"DisposeWaveIn release stopRecording={stopRecording} resetWarmUp={resetWarmUp}");
             waveIn.DataAvailable -= OnDataAvailable;
             waveIn.RecordingStopped -= OnRecordingStopped;
             if (stopRecording)
@@ -1111,6 +1127,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             }
             waveIn.Dispose();
         }
+
+        if (!resetWarmUp)
+            return;
+
         _isWarmedUp = false;
         _activeDeviceNumber = -1;
         _activeDeviceId = null;

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -144,6 +144,78 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
+    public void WarmUp_DoesNotStartMicrophoneCapture()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+
+        Assert.True(sut.WarmUp());
+
+        var capture = Assert.Single(captures.Created);
+        Assert.False(capture.Started);
+    }
+
+    [Fact]
+    public void StopRecording_StopsAndDisposesMicrophoneCapture_WhenNoAudioWasReceived()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        Assert.True(sut.WarmUp());
+        sut.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        var samples = sut.StopRecording();
+
+        Assert.Null(samples);
+        Assert.True(capture.Stopped);
+        Assert.True(capture.Disposed);
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_ReleasesMicrophoneCapture_WhenCancellationIsRequested()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        sut.StartRecording();
+        var capture = Assert.Single(captures.Created);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var samples = await sut.StopRecordingAsync(cancellation.Token);
+
+        Assert.Null(samples);
+        Assert.True(capture.Stopped);
+        Assert.True(capture.Disposed);
+    }
+
+    [Fact]
+    public void ConsecutiveRecordings_UseFreshMicrophoneCaptures()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        var bytes = new byte[sizeof(short) * 2];
+
+        sut.StartRecording();
+        var firstCapture = Assert.Single(captures.Created);
+        firstCapture.RaiseData(bytes, bytes.Length);
+        Assert.NotNull(sut.StopRecording());
+
+        sut.StartRecording();
+        var secondCapture = Assert.Single(captures.Created.Skip(1));
+        secondCapture.RaiseData(bytes, bytes.Length);
+        Assert.NotNull(sut.StopRecording());
+
+        Assert.True(firstCapture.Stopped);
+        Assert.True(firstCapture.Disposed);
+        Assert.True(secondCapture.Stopped);
+        Assert.True(secondCapture.Disposed);
+    }
+
+    [Fact]
     public void RecordingStopped_WithoutException_DoesNotRaiseDeviceLost_WhenCaptureStopsCleanly()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -201,11 +201,14 @@ public sealed class AudioRecordingServiceDeviceChangeTests
 
         sut.StartRecording();
         var firstCapture = Assert.Single(captures.Created);
+        Assert.True(firstCapture.Started);
         firstCapture.RaiseData(bytes, bytes.Length);
         Assert.NotNull(sut.StopRecording());
 
         sut.StartRecording();
         var secondCapture = Assert.Single(captures.Created.Skip(1));
+        Assert.NotSame(firstCapture, secondCapture);
+        Assert.True(secondCapture.Started);
         secondCapture.RaiseData(bytes, bytes.Length);
         Assert.NotNull(sut.StopRecording());
 


### PR DESCRIPTION
## Summary

- prepare the selected input device during warm-up without starting microphone capture
- create a fresh capture for each dictation and stop/dispose it on every stop path
- preserve the selected device identity so default-device recovery keeps working between recordings
- add regression coverage for warm-up, empty/cancelled stops, and consecutive recordings

## Root cause

`AudioRecordingService.WarmUp()` started the NAudio capture immediately, while the normal stop path only stopped collecting samples. The capture therefore stayed open for the lifetime of the app and could leave later dictations stuck.

## User impact

Windows can release the microphone between dictations, and every new dictation starts with a fresh capture instance.

## Validation

- `dotnet test TypeWhisper.slnx --no-restore -m:1` (1,633 passed)
- two consecutive 50% speaker-to-microphone TTS recordings on a HyperX QuadCast 2; both WAV files contained audio
- Windows microphone capability state reported a completed start/stop pair after the smoke test
- normal dev relaunch confirmed the automation-only endpoint is disabled (`404`)

Closes #321


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved microphone recording startup and shutdown reliability.
  - Preparing the microphone no longer starts recording prematurely.
  - Recording sessions now release microphone resources correctly when stopped, cancelled, or no audio is captured.
  - Consecutive recordings use a fresh microphone capture, helping prevent stale recording state.
  - Startup failures are handled gracefully without leaving recording active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->