### PR TITLE
Fix portable user data migration across volumes

### DIFF
--- a/.github/workflows/package-dry-run.yml
+++ b/.github/workflows/package-dry-run.yml
@@ -102,6 +102,12 @@ jobs:
             --channel ${{ steps.meta.outputs.velopack_channel }} `
             --outputDir "releases/${{ steps.meta.outputs.velopack_channel }}"
 
+      - name: Validate portable package
+        shell: pwsh
+        run: |
+          ./eng/Test-PortablePackage.ps1 `
+            -ReleaseDirectory "releases/${{ steps.meta.outputs.velopack_channel }}"
+
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,12 @@ jobs:
             --channel $env:VELOPACK_CHANNEL `
             --outputDir "releases/$env:VELOPACK_CHANNEL"
 
+      - name: Validate portable package
+        shell: pwsh
+        run: |
+          ./eng/Test-PortablePackage.ps1 `
+            -ReleaseDirectory "releases/$env:VELOPACK_CHANNEL"
+
       - uses: actions/upload-artifact@v7
         with:
           name: release-${{ env.VELOPACK_CHANNEL }}

--- a/eng/Test-PortablePackage.ps1
+++ b/eng/Test-PortablePackage.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ReleaseDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$resolvedReleaseDirectory = Resolve-Path -LiteralPath $ReleaseDirectory
+$portableArchives = @(
+    Get-ChildItem -LiteralPath $resolvedReleaseDirectory.Path -File -Filter "*-Portable.zip"
+)
+
+if ($portableArchives.Count -ne 1) {
+    $archiveNames = @($portableArchives | Select-Object -ExpandProperty Name) -join ", "
+    throw "Expected exactly one portable ZIP in '$($resolvedReleaseDirectory.Path)', found $($portableArchives.Count): $archiveNames"
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$requiredEntries = @(
+    ".portable"
+    "TypeWhisper.exe"
+    "Update.exe"
+    "current/TypeWhisper.exe"
+)
+$portableArchive = $portableArchives[0]
+$archive = [System.IO.Compression.ZipFile]::OpenRead($portableArchive.FullName)
+
+try {
+    $entryNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($entry in $archive.Entries) {
+        $normalizedName = $entry.FullName.Replace('\', '/').TrimStart([char]'/')
+        $null = $entryNames.Add($normalizedName)
+    }
+
+    $missingEntries = @($requiredEntries | Where-Object { -not $entryNames.Contains($_) })
+    if ($missingEntries.Count -gt 0) {
+        throw "Portable ZIP '$($portableArchive.Name)' is missing required entries: $($missingEntries -join ', ')"
+    }
+}
+finally {
+    $archive.Dispose()
+}
+
+Write-Host "Validated portable package '$($portableArchive.Name)'."

--- a/src/TypeWhisper.Windows/Services/UserDataMigrationService.cs
+++ b/src/TypeWhisper.Windows/Services/UserDataMigrationService.cs
@@ -6,14 +6,29 @@ namespace TypeWhisper.Windows.Services;
 
 internal static class UserDataMigrationService
 {
+    private const string MigrationTempSuffix = ".typewhisper-migration.tmp";
     private static readonly string[] DirectoryNames = ["Data", "Logs", "Models", "Plugins", "PluginData"];
     private static readonly string[] FileNames = ["settings.json", "settings.json.bak", "api-token"];
 
     public static void MigrateLegacyDataIfNeeded() =>
         MigrateLegacyData(TypeWhisperEnvironment.LegacyBasePath, TypeWhisperEnvironment.BasePath);
 
-    internal static void MigrateLegacyData(string legacyBasePath, string userDataBasePath)
+    internal static void MigrateLegacyData(string legacyBasePath, string userDataBasePath) =>
+        MigrateLegacyData(
+            legacyBasePath,
+            userDataBasePath,
+            Directory.Move,
+            static (source, target) => File.Copy(source, target));
+
+    internal static void MigrateLegacyData(
+        string legacyBasePath,
+        string userDataBasePath,
+        Action<string, string> moveDirectory,
+        Action<string, string> copyFile)
     {
+        ArgumentNullException.ThrowIfNull(moveDirectory);
+        ArgumentNullException.ThrowIfNull(copyFile);
+
         var legacyRoot = Normalize(legacyBasePath);
         var userDataRoot = Normalize(userDataBasePath);
 
@@ -23,20 +38,32 @@ internal static class UserDataMigrationService
         Directory.CreateDirectory(userDataRoot);
 
         foreach (var name in DirectoryNames)
-            MoveWithoutOverwrite(Path.Join(legacyRoot, name), Path.Join(userDataRoot, name));
+            MoveWithoutOverwrite(
+                Path.Join(legacyRoot, name),
+                Path.Join(userDataRoot, name),
+                moveDirectory,
+                copyFile);
 
         foreach (var name in FileNames)
-            MoveWithoutOverwrite(Path.Join(legacyRoot, name), Path.Join(userDataRoot, name));
+            MoveWithoutOverwrite(
+                Path.Join(legacyRoot, name),
+                Path.Join(userDataRoot, name),
+                moveDirectory,
+                copyFile);
 
         MigrateLegacyAudio(Path.Join(legacyRoot, "Audio"), Path.Join(userDataRoot, "Audio"));
     }
 
-    private static void MoveWithoutOverwrite(string source, string target)
+    private static void MoveWithoutOverwrite(
+        string source,
+        string target,
+        Action<string, string> moveDirectory,
+        Action<string, string> copyFile)
     {
         if (File.Exists(source))
         {
             if (!File.Exists(target) && !Directory.Exists(target))
-                File.Move(source, target);
+                CopyFileWithoutOverwrite(source, target, copyFile);
 
             return;
         }
@@ -46,23 +73,66 @@ internal static class UserDataMigrationService
 
         if (!Directory.Exists(target))
         {
-            Directory.Move(source, target);
-            return;
+            try
+            {
+                moveDirectory(source, target);
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                if (!Directory.Exists(source))
+                {
+                    if (Directory.Exists(target))
+                        return;
+
+                    throw;
+                }
+            }
         }
 
+        if (File.Exists(target))
+            return;
+
+        Directory.CreateDirectory(target);
         foreach (var entry in Directory.GetFileSystemEntries(source))
         {
             var destination = GetSafeChildPath(target, entry);
-            if (File.Exists(destination) || Directory.Exists(destination))
-                continue;
-
-            if (Directory.Exists(entry))
-                Directory.Move(entry, destination);
-            else
-                File.Move(entry, destination);
+            MoveWithoutOverwrite(entry, destination, moveDirectory, copyFile);
         }
 
         TryDeleteDirectoryIfEmpty(source);
+    }
+
+    private static void CopyFileWithoutOverwrite(
+        string source,
+        string target,
+        Action<string, string> copyFile)
+    {
+        if (File.Exists(target) || Directory.Exists(target))
+            return;
+
+        var targetDirectory = Path.GetDirectoryName(target)
+            ?? throw new InvalidOperationException("User data target has no parent directory.");
+        Directory.CreateDirectory(targetDirectory);
+
+        var temporaryTarget = target + MigrationTempSuffix;
+        if (Directory.Exists(temporaryTarget))
+            throw new IOException($"Migration temporary path is a directory: '{temporaryTarget}'.");
+
+        if (File.Exists(temporaryTarget))
+            File.Delete(temporaryTarget);
+
+        try
+        {
+            copyFile(source, temporaryTarget);
+            File.Move(temporaryTarget, target);
+            File.Delete(source);
+        }
+        catch
+        {
+            TryDeleteMigrationTempFile(temporaryTarget);
+            throw;
+        }
     }
 
     internal static void MigrateLegacyAudio(string legacyAudioPath, string audioPath)
@@ -153,6 +223,19 @@ internal static class UserDataMigrationService
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             Trace.TraceWarning("Could not delete empty legacy user data directory '{0}': {1}", path, ex.Message);
+        }
+    }
+
+    private static void TryDeleteMigrationTempFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Trace.TraceWarning("Could not delete user data migration temporary file '{0}': {1}", path, ex.Message);
         }
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -171,14 +171,28 @@ public sealed class PluginPackagingWorkflowTests
         using var process = new Process { StartInfo = startInfo };
         Assert.True(process.Start(), "Expected PowerShell validator process to start.");
 
-        var standardOutput = process.StandardOutput.ReadToEndAsync();
-        var standardError = process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var standardOutput = process.StandardOutput.ReadToEndAsync(timeout.Token);
+        var standardError = process.StandardError.ReadToEndAsync(timeout.Token);
 
-        return new PowerShellResult(
-            process.ExitCode,
-            await standardOutput,
-            await standardError);
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+
+            return new PowerShellResult(
+                process.ExitCode,
+                await standardOutput,
+                await standardError);
+        }
+        catch (OperationCanceledException exception) when (timeout.IsCancellationRequested)
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+
+            throw new TimeoutException(
+                "Portable package validator did not finish within 30 seconds.",
+                exception);
+        }
     }
 
     private static void AssertPortableValidationFailed(PowerShellResult result, string expectedMessage)

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -1,7 +1,19 @@
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+
 namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class PluginPackagingWorkflowTests
 {
+    private static readonly string[] RequiredPortableEntries =
+    [
+        ".portable",
+        "TypeWhisper.exe",
+        "Update.exe",
+        "current/TypeWhisper.exe"
+    ];
+
     [Theory]
     [InlineData(".github", "workflows", "release.yml")]
     [InlineData(".github", "workflows", "package-dry-run.yml")]
@@ -15,25 +27,76 @@ public sealed class PluginPackagingWorkflowTests
     }
 
     [Theory]
-    [InlineData(".github", "workflows", "release.yml")]
-    [InlineData(".github", "workflows", "package-dry-run.yml")]
-    public void InstallerWorkflows_ValidatePortablePackage(params string[] workflowPath)
+    [InlineData("releases/$env:VELOPACK_CHANNEL", ".github", "workflows", "release.yml")]
+    [InlineData("releases/${{ steps.meta.outputs.velopack_channel }}", ".github", "workflows", "package-dry-run.yml")]
+    public void InstallerWorkflows_ValidatePortablePackage(
+        string expectedReleaseDirectory,
+        params string[] workflowPath)
     {
-        var workflow = TestFile.ReadProjectFile(workflowPath);
+        var workflow = TestFile.ReadProjectFile(workflowPath).ReplaceLineEndings("\n");
+        var expectedInvocation =
+            "        shell: pwsh\n" +
+            "        run: |\n" +
+            "          ./eng/Test-PortablePackage.ps1 `\n" +
+            $"            -ReleaseDirectory \"{expectedReleaseDirectory}\"";
 
-        Assert.Contains("eng/Test-PortablePackage.ps1", workflow, StringComparison.Ordinal);
+        Assert.Contains(expectedInvocation, workflow, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void PortablePackageValidator_RequiresVelopackRuntimeLayout()
+    public async Task PortablePackageValidator_AcceptsValidArchive()
     {
-        var script = TestFile.ReadProjectFile("eng", "Test-PortablePackage.ps1");
+        using var releaseDirectory = new TemporaryReleaseDirectory();
+        CreatePortableArchive(
+            releaseDirectory.Path,
+            "TypeWhisper-win-x64-1.0.0-Portable.zip",
+            RequiredPortableEntries);
 
-        Assert.Contains("*-Portable.zip", script, StringComparison.Ordinal);
-        Assert.Contains(".portable", script, StringComparison.Ordinal);
-        Assert.Contains("TypeWhisper.exe", script, StringComparison.Ordinal);
-        Assert.Contains("Update.exe", script, StringComparison.Ordinal);
-        Assert.Contains("current/TypeWhisper.exe", script, StringComparison.Ordinal);
+        var result = await RunPortablePackageValidatorAsync(releaseDirectory.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Validated portable package", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PortablePackageValidator_RejectsArchiveWithMissingRequiredEntry()
+    {
+        using var releaseDirectory = new TemporaryReleaseDirectory();
+        CreatePortableArchive(
+            releaseDirectory.Path,
+            "TypeWhisper-win-x64-1.0.0-Portable.zip",
+            RequiredPortableEntries.Where(entry => entry != "Update.exe").ToArray());
+
+        var result = await RunPortablePackageValidatorAsync(releaseDirectory.Path);
+
+        AssertPortableValidationFailed(result, "missing required entries: Update.exe");
+    }
+
+    [Fact]
+    public async Task PortablePackageValidator_RejectsZeroOrMultiplePortableArchives()
+    {
+        using (var emptyReleaseDirectory = new TemporaryReleaseDirectory())
+        {
+            var result = await RunPortablePackageValidatorAsync(emptyReleaseDirectory.Path);
+
+            AssertPortableValidationFailed(result, "found 0");
+        }
+
+        using (var multipleReleaseDirectory = new TemporaryReleaseDirectory())
+        {
+            CreatePortableArchive(
+                multipleReleaseDirectory.Path,
+                "TypeWhisper-win-x64-1.0.0-Portable.zip",
+                RequiredPortableEntries);
+            CreatePortableArchive(
+                multipleReleaseDirectory.Path,
+                "TypeWhisper-win-arm64-1.0.0-Portable.zip",
+                RequiredPortableEntries);
+
+            var result = await RunPortablePackageValidatorAsync(multipleReleaseDirectory.Path);
+
+            AssertPortableValidationFailed(result, "found 2");
+        }
     }
 
     [Fact]
@@ -73,5 +136,81 @@ public sealed class PluginPackagingWorkflowTests
         Assert.Contains("https://typewhisper.github.io/typewhisper-win/plugins/$env:ZIP_NAME", workflow, StringComparison.Ordinal);
         Assert.Contains("Set-RegistryProperty $registry[$j] 'sha256' $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
         Assert.Contains("sha256 = $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
+    }
+
+    private static void CreatePortableArchive(
+        string releaseDirectory,
+        string fileName,
+        params string[] entries)
+    {
+        var archivePath = Path.Join(releaseDirectory, fileName);
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+
+        foreach (var entry in entries)
+            archive.CreateEntry(entry);
+    }
+
+    private static async Task<PowerShellResult> RunPortablePackageValidatorAsync(string releaseDirectory)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(TestFile.ProjectFile("eng", "Test-PortablePackage.ps1"));
+        startInfo.ArgumentList.Add("-ReleaseDirectory");
+        startInfo.ArgumentList.Add(releaseDirectory);
+
+        using var process = new Process { StartInfo = startInfo };
+        Assert.True(process.Start(), "Expected PowerShell validator process to start.");
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return new PowerShellResult(
+            process.ExitCode,
+            await standardOutput,
+            await standardError);
+    }
+
+    private static void AssertPortableValidationFailed(PowerShellResult result, string expectedMessage)
+    {
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(
+            expectedMessage,
+            result.StandardOutput + result.StandardError,
+            StringComparison.Ordinal);
+    }
+
+    private sealed record PowerShellResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError);
+
+    private sealed class TemporaryReleaseDirectory : IDisposable
+    {
+        public TemporaryReleaseDirectory()
+        {
+            Path = System.IO.Path.Join(
+                System.IO.Path.GetTempPath(),
+                $"tw_portable_package_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -14,6 +14,28 @@ public sealed class PluginPackagingWorkflowTests
         Assert.DoesNotContain("publish/${{ matrix.rid }}/Plugins", workflow, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(".github", "workflows", "release.yml")]
+    [InlineData(".github", "workflows", "package-dry-run.yml")]
+    public void InstallerWorkflows_ValidatePortablePackage(params string[] workflowPath)
+    {
+        var workflow = TestFile.ReadProjectFile(workflowPath);
+
+        Assert.Contains("eng/Test-PortablePackage.ps1", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PortablePackageValidator_RequiresVelopackRuntimeLayout()
+    {
+        var script = TestFile.ReadProjectFile("eng", "Test-PortablePackage.ps1");
+
+        Assert.Contains("*-Portable.zip", script, StringComparison.Ordinal);
+        Assert.Contains(".portable", script, StringComparison.Ordinal);
+        Assert.Contains("TypeWhisper.exe", script, StringComparison.Ordinal);
+        Assert.Contains("Update.exe", script, StringComparison.Ordinal);
+        Assert.Contains("current/TypeWhisper.exe", script, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void StorePackageWorkflow_DoesNotBuildBundledPlugins()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/UserDataMigrationServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UserDataMigrationServiceTests.cs
@@ -89,16 +89,64 @@ public sealed class UserDataMigrationServiceTests : IDisposable
     }
 
     [Fact]
+    public void MigrateLegacyData_DoesNothingWhenLegacyPathIsMissing()
+    {
+        var legacy = Path.Join(_root, "missing");
+        var userData = Path.Join(_root, "TypeWhisper-UserData");
+
+        UserDataMigrationService.MigrateLegacyData(legacy, userData);
+
+        Assert.False(Directory.Exists(userData));
+    }
+
+    [Fact]
+    public void MigrateLegacyData_DoesNothingWhenPathsAreEqual()
+    {
+        var sharedRoot = Path.Join(_root, "TypeWhisper");
+        Directory.CreateDirectory(Path.Join(sharedRoot, "Data"));
+        File.WriteAllText(Path.Join(sharedRoot, "Data", "typewhisper.db"), "database");
+
+        UserDataMigrationService.MigrateLegacyData(sharedRoot, sharedRoot);
+
+        Assert.Equal("database", File.ReadAllText(Path.Join(sharedRoot, "Data", "typewhisper.db")));
+    }
+
+    [Fact]
+    public void MigrateLegacyData_FallsBackToRecursiveCopyWhenDirectoryMoveFails()
+    {
+        var legacy = Path.Join(_root, "TypeWhisper");
+        var userData = Path.Join(_root, "TypeWhisper-UserData");
+        Directory.CreateDirectory(Path.Join(legacy, "Data", "nested"));
+        File.WriteAllText(Path.Join(legacy, "Data", "typewhisper.db"), "database");
+        File.WriteAllText(Path.Join(legacy, "Data", "nested", "metadata.json"), "metadata");
+
+        UserDataMigrationService.MigrateLegacyData(
+            legacy,
+            userData,
+            moveDirectory: (_, _) => throw new IOException("Simulated cross-volume directory move."),
+            copyFile: (source, target) => File.Copy(source, target));
+
+        Assert.Equal("database", File.ReadAllText(Path.Join(userData, "Data", "typewhisper.db")));
+        Assert.Equal("metadata", File.ReadAllText(Path.Join(userData, "Data", "nested", "metadata.json")));
+        Assert.False(Directory.Exists(Path.Join(legacy, "Data")));
+    }
+
+    [Fact]
     public void MigrateLegacyData_DoesNotOverwriteCanonicalData()
     {
         var legacy = Path.Join(_root, "TypeWhisper");
         var userData = Path.Join(_root, "TypeWhisper-UserData");
         Directory.CreateDirectory(Path.Join(legacy, "Plugins", "com.legacy.plugin"));
+        Directory.CreateDirectory(Path.Join(legacy, "Plugins", "com.shared.plugin"));
         Directory.CreateDirectory(Path.Join(userData, "Plugins", "com.current.plugin"));
+        Directory.CreateDirectory(Path.Join(userData, "Plugins", "com.shared.plugin"));
         File.WriteAllText(Path.Join(legacy, "settings.json"), "legacy");
         File.WriteAllText(Path.Join(userData, "settings.json"), "current");
         File.WriteAllText(Path.Join(legacy, "Plugins", "com.legacy.plugin", "manifest.json"), "legacy-plugin");
+        File.WriteAllText(Path.Join(legacy, "Plugins", "com.shared.plugin", "manifest.json"), "legacy-shared");
+        File.WriteAllText(Path.Join(legacy, "Plugins", "com.shared.plugin", "legacy-only.json"), "legacy-only");
         File.WriteAllText(Path.Join(userData, "Plugins", "com.current.plugin", "manifest.json"), "current-plugin");
+        File.WriteAllText(Path.Join(userData, "Plugins", "com.shared.plugin", "manifest.json"), "current-shared");
 
         UserDataMigrationService.MigrateLegacyData(legacy, userData);
 
@@ -106,6 +154,48 @@ public sealed class UserDataMigrationServiceTests : IDisposable
         Assert.Equal("legacy", File.ReadAllText(Path.Join(legacy, "settings.json")));
         Assert.Equal("current-plugin", File.ReadAllText(Path.Join(userData, "Plugins", "com.current.plugin", "manifest.json")));
         Assert.Equal("legacy-plugin", File.ReadAllText(Path.Join(userData, "Plugins", "com.legacy.plugin", "manifest.json")));
+        Assert.Equal("current-shared", File.ReadAllText(Path.Join(userData, "Plugins", "com.shared.plugin", "manifest.json")));
+        Assert.Equal("legacy-only", File.ReadAllText(Path.Join(userData, "Plugins", "com.shared.plugin", "legacy-only.json")));
+        Assert.Equal("legacy-shared", File.ReadAllText(Path.Join(legacy, "Plugins", "com.shared.plugin", "manifest.json")));
+    }
+
+    [Fact]
+    public void MigrateLegacyData_PartialCopyFailureKeepsSourceAndCanRetry()
+    {
+        var legacy = Path.Join(_root, "TypeWhisper");
+        var userData = Path.Join(_root, "TypeWhisper-UserData");
+        var legacyData = Path.Join(legacy, "Data");
+        var userDataData = Path.Join(userData, "Data");
+        Directory.CreateDirectory(legacyData);
+        File.WriteAllText(Path.Join(legacyData, "first.db"), "first");
+        File.WriteAllText(Path.Join(legacyData, "second.db"), "second");
+        File.WriteAllText(Path.Join(legacyData, "third.db"), "third");
+        var copyCount = 0;
+
+        Assert.Throws<IOException>(() => UserDataMigrationService.MigrateLegacyData(
+            legacy,
+            userData,
+            moveDirectory: (_, _) => throw new IOException("Simulated cross-volume directory move."),
+            copyFile: (source, target) =>
+            {
+                File.Copy(source, target);
+                copyCount++;
+                if (copyCount == 2)
+                    throw new IOException("Simulated interrupted copy.");
+            }));
+
+        Assert.Single(Directory.GetFiles(userDataData, "*.db"));
+        Assert.Equal(2, Directory.GetFiles(legacyData, "*.db").Length);
+        Assert.Empty(Directory.GetFiles(userDataData, "*.typewhisper-migration.tmp"));
+
+        UserDataMigrationService.MigrateLegacyData(
+            legacy,
+            userData,
+            moveDirectory: (_, _) => throw new IOException("Simulated cross-volume directory move."),
+            copyFile: (source, target) => File.Copy(source, target));
+
+        Assert.Equal(3, Directory.GetFiles(userDataData, "*.db").Length);
+        Assert.False(Directory.Exists(legacyData));
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- fall back to a staged recursive copy when a legacy directory cannot be moved across volumes
- preserve canonical data and keep interrupted migrations safe to retry
- validate the generated portable runtime layout in dry-run and release packaging for x64 and ARM64

## Root cause
The migration used `Directory.Move()` whenever the canonical child directory did not exist. A legacy `%LOCALAPPDATA%\TypeWhisper` symlink or junction targeting another volume therefore made portable startup fail before the app could initialize.

## User impact
Portable upgrades can migrate legacy data across volume boundaries without overwriting existing canonical data. Genuine copy or access failures still stop startup with the existing error dialog, while the source remains available for a later retry.

## Validation
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release --no-build` (1,338 passed)
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release --no-restore` (302 passed)
- targeted migration and packaging tests (18 passed)
- targeted `dotnet format --verify-no-changes`
- local x64 and ARM64 `dotnet publish` + `vpk pack` + portable archive validation
- published v1.0.4 x64 portable archive validation
- `git diff --check`

Refs #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legacy user-data migration reliability with safer move/copy behavior, reduced risk of temporary leftovers, and correct handling of cross-volume move failures.
  - Added protection against overwriting canonical data and improved recoverability after partial copy interruptions.

- **Quality Improvements**
  - Added release-time portable package validation to confirm the ZIP contains the expected runtime layout before artifacts are uploaded.
  - Expanded automated tests to invoke the portable package validator and cover additional user-data migration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->