### PR TITLE
Prefer compressed Soniox uploads with WAV fallback

### DIFF
--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -1,8 +1,13 @@
+using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Windows.Controls;
+using NAudio.MediaFoundation;
+using NAudio.Wave;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
 
@@ -19,6 +24,10 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     private const string RegionSettingKey = "region";
     private const string ApiKeySecretName = "api-key";
     private const string SonioxAsyncModelId = "stt-async-v5";
+    private const string InvalidAudioFileErrorType = "invalid_audio_file";
+    private const string ErrorTypeDataKey = "TypeWhisper.Soniox.ErrorType";
+    private const string IsFileUploadDataKey = "TypeWhisper.Soniox.IsFileUpload";
+    private const int TranscriptionUploadBitRate = 48_000;
     private const int DefaultMaxPollAttempts = 3600;
     private const int MaxSubtitleSegmentCharacters = 84;
     private const int MinSentenceSegmentCharacters = 20;
@@ -58,6 +67,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     private readonly TimeSpan _initialPollDelay;
     private readonly TimeSpan _maxPollDelay;
     private readonly int _maxPollAttempts;
+    private readonly Func<byte[], SonioxTranscriptionUpload> _compressedUploadFactory;
     private readonly SemaphoreSlim _apiKeyWriteLock = new(1, 1);
 
     private IPluginHostServices? _host;
@@ -77,7 +87,8 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     internal SonioxPlugin(
         HttpClient httpClient,
         TimeSpan? pollDelay = null,
-        int maxPollAttempts = DefaultMaxPollAttempts)
+        int maxPollAttempts = DefaultMaxPollAttempts,
+        Func<byte[], SonioxTranscriptionUpload>? compressedUploadFactory = null)
     {
         if (maxPollAttempts <= 0)
             throw new ArgumentOutOfRangeException(nameof(maxPollAttempts), "Poll attempts must be positive.");
@@ -88,6 +99,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         _initialPollDelay = pollDelay ?? DefaultInitialPollDelay;
         _maxPollDelay = pollDelay ?? DefaultMaxPollDelay;
         _maxPollAttempts = maxPollAttempts;
+        _compressedUploadFactory = compressedUploadFactory ?? CreateCompressedUpload;
     }
 
     private string BaseUrl => ResolveRegion(_region).BaseUrl;
@@ -105,7 +117,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.4";
+    public string PluginVersion => "1.1.0";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.
@@ -207,32 +219,63 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         if (string.IsNullOrEmpty(apiKey))
             throw new InvalidOperationException("Plugin not configured. API key required.");
 
+        var normalizedLanguageHints = languageHints
+            .Select(NormalizeLanguage)
+            .Where(static language => language is not null)
+            .Select(static language => language!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var context = new SonioxTranscriptionContext(
+            BaseUrl,
+            apiKey,
+            SonioxAsyncModelId,
+            normalizedLanguageHints);
+        var preferredUpload = CreatePreferredUpload(wavAudio, ct);
+
+        try
+        {
+            return await TranscribeUploadAsync(preferredUpload, context, ct);
+        }
+        catch (Exception ex) when (
+            preferredUpload.Format == SonioxUploadFormat.M4a
+            && ShouldRetryWithWav(ex))
+        {
+            ct.ThrowIfCancellationRequested();
+            _host?.Log(
+                PluginLogLevel.Warning,
+                $"Soniox rejected the M4A upload; retrying the complete transaction with WAV: {ex.Message}");
+            return await TranscribeUploadAsync(CreateWavUpload(wavAudio), context, ct);
+        }
+    }
+
+    private async Task<PluginTranscriptionResult> TranscribeUploadAsync(
+        SonioxTranscriptionUpload upload,
+        SonioxTranscriptionContext context,
+        CancellationToken ct)
+    {
         string? fileId = null;
         string? transcriptionId = null;
 
         try
         {
-            fileId = await UploadFileAsync(wavAudio, apiKey, ct);
-            var normalizedLanguageHints = languageHints
-                .Select(NormalizeLanguage)
-                .Where(static language => language is not null)
-                .Select(static language => language!)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            transcriptionId = await CreateTranscriptionAsync(fileId, normalizedLanguageHints, apiKey, ct);
-            var completedDetails = await WaitUntilCompletedAsync(transcriptionId, apiKey, ct);
-            var transcriptJson = await FetchTranscriptAsync(transcriptionId, apiKey, ct);
-            var result = ParseTranscript(transcriptJson, completedDetails, normalizedLanguageHints.FirstOrDefault());
+            fileId = await UploadFileAsync(upload, context, ct);
+            transcriptionId = await CreateTranscriptionAsync(fileId, context, ct);
+            var completedDetails = await WaitUntilCompletedAsync(transcriptionId, context, ct);
+            var transcriptJson = await FetchTranscriptAsync(transcriptionId, context, ct);
+            var result = ParseTranscript(
+                transcriptJson,
+                completedDetails,
+                context.LanguageHints.FirstOrDefault());
 
             // Deleting the uploaded file and the transcription is best-effort housekeeping the
             // caller does not need to wait for. Run it off the critical path so the two extra
             // round-trips do not add to perceived dictation latency.
-            _lastCleanupTask = CleanupInBackgroundAsync(transcriptionId, fileId, apiKey);
+            _lastCleanupTask = CleanupInBackgroundAsync(transcriptionId, fileId, context);
             return result;
         }
         catch
         {
-            await CleanupAsync(transcriptionId, fileId, apiKey);
+            await CleanupAfterFailureAsync(transcriptionId, fileId, context);
             throw;
         }
     }
@@ -370,18 +413,89 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         }
     }
 
-    private async Task<string> UploadFileAsync(byte[] wavAudio, string apiKey, CancellationToken ct)
+    private SonioxTranscriptionUpload CreatePreferredUpload(byte[] wavAudio, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        try
+        {
+            return _compressedUploadFactory(wavAudio);
+        }
+        catch (Exception ex) when (IsExpectedCompressionFailure(ex))
+        {
+            _host?.Log(
+                PluginLogLevel.Warning,
+                $"Soniox M4A encoding failed; falling back to WAV: {ex.Message}");
+            return CreateWavUpload(wavAudio);
+        }
+    }
+
+    private static bool IsExpectedCompressionFailure(Exception ex) =>
+        ex is InvalidDataException
+        or IOException
+        or InvalidOperationException
+        or COMException
+        or NotSupportedException;
+
+    internal static SonioxTranscriptionUpload CreateCompressedUpload(byte[] wavAudio)
+    {
+        ArgumentNullException.ThrowIfNull(wavAudio);
+
+        using var input = new MemoryStream(wavAudio, writable: false);
+        using var reader = new WaveFileReader(input);
+        using var output = new MemoryStream();
+        MediaFoundationEncoder.EncodeToAac(reader, output, TranscriptionUploadBitRate);
+
+        var bytes = output.ToArray();
+        if (bytes.Length == 0)
+            throw new InvalidOperationException("Media Foundation produced an empty AAC upload.");
+
+        return new SonioxTranscriptionUpload(
+            bytes,
+            "audio.m4a",
+            "audio/mp4",
+            SonioxUploadFormat.M4a);
+    }
+
+    private static SonioxTranscriptionUpload CreateWavUpload(byte[] wavAudio) =>
+        new(wavAudio, "audio.wav", "audio/wav", SonioxUploadFormat.Wav);
+
+    private static bool ShouldRetryWithWav(Exception ex) =>
+        ex switch
+        {
+            HttpRequestException httpException
+                when IsFileUploadException(httpException)
+                && (httpException.StatusCode == HttpStatusCode.UnsupportedMediaType
+                    || IsInvalidAudioFile(GetErrorType(httpException))) => true,
+            InvalidOperationException jobException
+                when IsInvalidAudioFile(GetErrorType(jobException)) => true,
+            _ => false
+        };
+
+    private static bool IsFileUploadException(Exception ex) =>
+        ex.Data[IsFileUploadDataKey] is true;
+
+    private static string? GetErrorType(Exception ex) =>
+        ex.Data[ErrorTypeDataKey] as string;
+
+    private static bool IsInvalidAudioFile(string? errorType) =>
+        string.Equals(errorType, InvalidAudioFileErrorType, StringComparison.OrdinalIgnoreCase);
+
+    private async Task<string> UploadFileAsync(
+        SonioxTranscriptionUpload upload,
+        SonioxTranscriptionContext context,
+        CancellationToken ct)
     {
         using var form = new MultipartFormDataContent();
-        var fileContent = new ByteArrayContent(wavAudio);
-        fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
-        form.Add(fileContent, "file", "audio.wav");
+        var fileContent = new ByteArrayContent(upload.Data);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(upload.ContentType);
+        form.Add(fileContent, "file", upload.FileName);
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/files");
-        AddAuthorization(request, apiKey);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{context.BaseUrl}/v1/files");
+        AddAuthorization(request, context.ApiKey);
         request.Content = form;
 
-        var json = await SendJsonAsync(request, "Soniox file upload", ct);
+        var json = await SendJsonAsync(request, "Soniox file upload", ct, isFileUpload: true);
         using var doc = JsonDocument.Parse(json);
         return GetString(doc.RootElement, "id")
             ?? throw new InvalidOperationException("Soniox file upload response did not include a file id.");
@@ -389,21 +503,20 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
     private async Task<string> CreateTranscriptionAsync(
         string fileId,
-        IReadOnlyList<string> languageHints,
-        string apiKey,
+        SonioxTranscriptionContext context,
         CancellationToken ct)
     {
         var payload = new Dictionary<string, object?>
         {
-            ["model"] = SonioxAsyncModelId,
+            ["model"] = context.ModelId,
             ["file_id"] = fileId,
         };
 
-        if (languageHints.Count > 0)
-            payload["language_hints"] = languageHints;
+        if (context.LanguageHints.Count > 0)
+            payload["language_hints"] = context.LanguageHints;
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/v1/transcriptions");
-        AddAuthorization(request, apiKey);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{context.BaseUrl}/v1/transcriptions");
+        AddAuthorization(request, context.ApiKey);
         request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
         var json = await SendJsonAsync(request, "Soniox transcription creation", ct);
@@ -412,15 +525,20 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             ?? throw new InvalidOperationException("Soniox transcription response did not include a transcription id.");
     }
 
-    private async Task<JsonElement> WaitUntilCompletedAsync(string transcriptionId, string apiKey, CancellationToken ct)
+    private async Task<JsonElement> WaitUntilCompletedAsync(
+        string transcriptionId,
+        SonioxTranscriptionContext context,
+        CancellationToken ct)
     {
         var delay = _initialPollDelay;
         for (var attempt = 0; attempt < _maxPollAttempts; attempt++)
         {
             ct.ThrowIfCancellationRequested();
 
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/transcriptions/{transcriptionId}");
-            AddAuthorization(request, apiKey);
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"{context.BaseUrl}/v1/transcriptions/{transcriptionId}");
+            AddAuthorization(request, context.ApiKey);
 
             var json = await SendJsonAsync(request, "Soniox transcription status", ct);
             using var doc = JsonDocument.Parse(json);
@@ -430,8 +548,16 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             if (string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase))
                 return root.Clone();
 
-            if (string.Equals(status, "error", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException($"Soniox transcription failed: {ExtractApiError(root)}");
+            if (string.Equals(status, "error", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(status, "failed", StringComparison.OrdinalIgnoreCase))
+            {
+                var error = ExtractApiErrorDetails(root);
+                var exception = new InvalidOperationException(
+                    $"Soniox transcription failed: {FormatApiError(error)}");
+                if (!string.IsNullOrWhiteSpace(error.ErrorType))
+                    exception.Data[ErrorTypeDataKey] = error.ErrorType;
+                throw exception;
+            }
 
             if (attempt < _maxPollAttempts - 1 && delay > TimeSpan.Zero)
             {
@@ -446,47 +572,88 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             $"Soniox transcription {transcriptionId} did not complete within the configured polling window.");
     }
 
-    private async Task<string> FetchTranscriptAsync(string transcriptionId, string apiKey, CancellationToken ct)
+    private async Task<string> FetchTranscriptAsync(
+        string transcriptionId,
+        SonioxTranscriptionContext context,
+        CancellationToken ct)
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"{BaseUrl}/v1/transcriptions/{transcriptionId}/transcript");
-        AddAuthorization(request, apiKey);
+            $"{context.BaseUrl}/v1/transcriptions/{transcriptionId}/transcript");
+        AddAuthorization(request, context.ApiKey);
 
         return await SendJsonAsync(request, "Soniox transcript retrieval", ct);
     }
 
-    private async Task<string> SendJsonAsync(HttpRequestMessage request, string operation, CancellationToken ct)
+    private async Task<string> SendJsonAsync(
+        HttpRequestMessage request,
+        string operation,
+        CancellationToken ct,
+        bool isFileUpload = false)
     {
         using var response = await _httpClient.SendAsync(request, ct);
         var json = await response.Content.ReadAsStringAsync(ct);
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new HttpRequestException(
-                $"{operation} error {(int)response.StatusCode}: {ExtractApiError(json)}");
+            var error = ExtractApiErrorDetails(json);
+            var exception = new HttpRequestException(
+                $"{operation} error {(int)response.StatusCode}: {FormatApiError(error)}",
+                inner: null,
+                response.StatusCode);
+            if (!string.IsNullOrWhiteSpace(error.ErrorType))
+                exception.Data[ErrorTypeDataKey] = error.ErrorType;
+            if (isFileUpload)
+                exception.Data[IsFileUploadDataKey] = true;
+            throw exception;
         }
 
         return json;
     }
 
-    private async Task CleanupAsync(string? transcriptionId, string? fileId, string apiKey)
+    private async Task CleanupAsync(
+        string? transcriptionId,
+        string? fileId,
+        SonioxTranscriptionContext context)
     {
         if (transcriptionId is not null)
-            await DeleteBestEffortAsync($"{BaseUrl}/v1/transcriptions/{transcriptionId}", "transcription", apiKey);
+        {
+            await DeleteBestEffortAsync(
+                $"{context.BaseUrl}/v1/transcriptions/{transcriptionId}",
+                "transcription",
+                context.ApiKey);
+        }
 
         if (fileId is not null)
-            await DeleteBestEffortAsync($"{BaseUrl}/v1/files/{fileId}", "file", apiKey);
+            await DeleteBestEffortAsync($"{context.BaseUrl}/v1/files/{fileId}", "file", context.ApiKey);
     }
 
-    private async Task CleanupInBackgroundAsync(string? transcriptionId, string? fileId, string apiKey)
+    private async Task CleanupAfterFailureAsync(
+        string? transcriptionId,
+        string? fileId,
+        SonioxTranscriptionContext context)
+    {
+        try
+        {
+            await CleanupAsync(transcriptionId, fileId, context);
+        }
+        catch (Exception ex)
+        {
+            _host?.Log(PluginLogLevel.Warning, $"Soniox failure cleanup failed: {ex.Message}");
+        }
+    }
+
+    private async Task CleanupInBackgroundAsync(
+        string? transcriptionId,
+        string? fileId,
+        SonioxTranscriptionContext context)
     {
         // Yield so the transcript is returned to the caller before cleanup round-trips run.
         await Task.Yield();
 
         try
         {
-            await CleanupAsync(transcriptionId, fileId, apiKey);
+            await CleanupAsync(transcriptionId, fileId, context);
         }
         catch (Exception ex)
         {
@@ -712,19 +879,28 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
 
     private static string ExtractApiError(string json)
+        => FormatApiError(ExtractApiErrorDetails(json));
+
+    private static SonioxErrorDetails ExtractApiErrorDetails(string json)
     {
         try
         {
             using var doc = JsonDocument.Parse(json);
-            return ExtractApiError(doc.RootElement);
+            return ExtractApiErrorDetails(doc.RootElement);
         }
         catch (JsonException)
         {
-            return string.IsNullOrWhiteSpace(json) ? "Unknown error" : json;
+            return new SonioxErrorDetails(
+                ErrorType: null,
+                Message: string.IsNullOrWhiteSpace(json) ? "Unknown error" : json,
+                RequestId: null);
         }
     }
 
     private static string ExtractApiError(JsonElement root)
+        => FormatApiError(ExtractApiErrorDetails(root));
+
+    private static SonioxErrorDetails ExtractApiErrorDetails(JsonElement root)
     {
         var errorType = GetString(root, "error_type");
         var message = GetString(root, "error_message")
@@ -732,15 +908,19 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             ?? GetNestedErrorMessage(root)
             ?? "Unknown error";
         var requestId = GetString(root, "request_id");
+        return new SonioxErrorDetails(errorType, message, requestId);
+    }
 
+    private static string FormatApiError(SonioxErrorDetails error)
+    {
         var sb = new StringBuilder();
-        if (!string.IsNullOrWhiteSpace(errorType))
-            sb.Append(errorType).Append(": ");
+        if (!string.IsNullOrWhiteSpace(error.ErrorType))
+            sb.Append(error.ErrorType).Append(": ");
 
-        sb.Append(message);
+        sb.Append(error.Message);
 
-        if (!string.IsNullOrWhiteSpace(requestId))
-            sb.Append(" (request_id: ").Append(requestId).Append(')');
+        if (!string.IsNullOrWhiteSpace(error.RequestId))
+            sb.Append(" (request_id: ").Append(error.RequestId).Append(')');
 
         return sb.ToString();
     }
@@ -798,6 +978,14 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
 
     private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromMinutes(5) };
 
+    private sealed record SonioxTranscriptionContext(
+        string BaseUrl,
+        string ApiKey,
+        string ModelId,
+        IReadOnlyList<string> LanguageHints);
+
+    private sealed record SonioxErrorDetails(string? ErrorType, string Message, string? RequestId);
+
     private sealed record SonioxTimedToken(string Text, double Start, double End);
 
     /// <summary>A Soniox data-residency region and its REST base URL.</summary>
@@ -812,3 +1000,15 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
         _apiKeyWriteLock.Dispose();
     }
 }
+
+internal enum SonioxUploadFormat
+{
+    Wav,
+    M4a
+}
+
+internal sealed record SonioxTranscriptionUpload(
+    byte[] Data,
+    string FileName,
+    string ContentType,
+    SonioxUploadFormat Format);

--- a/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Soniox/SonioxPlugin.cs
@@ -230,7 +230,7 @@ public sealed class SonioxPlugin : ITranscriptionEnginePlugin
             apiKey,
             SonioxAsyncModelId,
             normalizedLanguageHints);
-        var preferredUpload = CreatePreferredUpload(wavAudio, ct);
+        var preferredUpload = await Task.Run(() => CreatePreferredUpload(wavAudio, ct), ct);
 
         try
         {

--- a/plugins/TypeWhisper.Plugin.Soniox/TypeWhisper.Plugin.Soniox.csproj
+++ b/plugins/TypeWhisper.Plugin.Soniox/TypeWhisper.Plugin.Soniox.csproj
@@ -6,11 +6,13 @@
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <RootNamespace>TypeWhisper.Plugin.Soniox</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.2.1" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -23,9 +25,15 @@
       <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
       <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.soniox\</PluginOutputDir>
     </PropertyGroup>
+    <RemoveDir Directories="$(PluginOutputDir)" Condition="Exists('$(PluginOutputDir)')" />
     <MakeDir Directories="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_DependencyFiles Include="$(TargetDir)*.dll"
+                        Exclude="$(TargetPath);$(TargetDir)TypeWhisper.PluginSDK.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_DependencyFiles)" DestinationFolder="$(PluginOutputDir)" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.Soniox/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Soniox/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.soniox",
   "name": "Soniox",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": "TypeWhisper",
   "description": "Soniox speech-to-text transcription engine",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SonioxPluginTests.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using TypeWhisper.Core.Audio;
 using TypeWhisper.Plugin.Soniox;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
@@ -26,8 +28,25 @@ public class SonioxPluginTests
         var manifest = LoadManifest();
         var sut = new SonioxPlugin();
 
-        Assert.Equal("1.0.4", manifest.GetProperty("version").GetString());
-        Assert.Equal("1.0.4", sut.PluginVersion);
+        Assert.Equal("1.1.0", manifest.GetProperty("version").GetString());
+        Assert.Equal("1.1.0", sut.PluginVersion);
+    }
+
+    [Fact]
+    public void CreateCompressedUpload_ProducesM4aMetadataAndContainer()
+    {
+        var samples = Enumerable.Range(0, 32_000)
+            .Select(index => (float)(Math.Sin(index * 2 * Math.PI * 440 / 16_000) * 0.25))
+            .ToArray();
+        var wavAudio = WavEncoder.Encode(samples);
+
+        var upload = SonioxPlugin.CreateCompressedUpload(wavAudio);
+
+        Assert.Equal("audio.m4a", upload.FileName);
+        Assert.Equal("audio/mp4", upload.ContentType);
+        Assert.Equal(SonioxUploadFormat.M4a, upload.Format);
+        Assert.True(upload.Data.AsSpan().IndexOf("ftyp"u8) >= 0);
+        Assert.True(upload.Data.Length < wavAudio.Length);
     }
 
     [Fact]
@@ -226,8 +245,8 @@ public class SonioxPluginTests
                 Assert.NotNull(body);
                 var multipartBody = Encoding.UTF8.GetString(body);
                 Assert.Contains("name=file", multipartBody);
-                Assert.Contains("filename=audio.wav", multipartBody);
-                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753", "filename": "audio.wav", "size": 3 }""", HttpStatusCode.Created);
+                AssertMultipartUpload(multipartBody, "audio.m4a", "audio/mp4");
+                return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753", "filename": "audio.m4a", "size": 3 }""", HttpStatusCode.Created);
             }
 
             if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
@@ -272,7 +291,15 @@ public class SonioxPluginTests
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "soniox-key";
         using var httpClient = new HttpClient(handler);
-        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 3);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 3,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [1, 2, 3],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
         await sut.ActivateAsync(host);
 
         var result = await sut.TranscribeWithLanguageHintsAsync(
@@ -285,6 +312,485 @@ public class SonioxPluginTests
         Assert.Equal(["Hallo Welt"], result.Segments.Select(s => s.Text).ToArray());
         Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/73d4357d-cad2-4338-a60d-ec6f2044f721", seen);
         Assert.Contains("DELETE https://api.soniox.com/v1/files/84c32fc6-4fb5-4e7a-b656-b5ec70493753", seen);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_EncoderFailureFallsBackToWavBeforeRequest()
+    {
+        string? uploadBody = null;
+        var handler = new SonioxFlowHandler(
+            inspectCreateBody: _ => { },
+            inspectUploadBody: body => uploadBody = body);
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => throw new COMException("encoder unavailable"));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(
+            [1, 2, 3],
+            "en",
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+        await sut.LastCleanupTask;
+
+        Assert.Equal("Hello", result.Text);
+        Assert.NotNull(uploadBody);
+        AssertMultipartUpload(uploadBody, "audio.wav", "audio/wav");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.UnsupportedMediaType, "invalid_request")]
+    [InlineData(HttpStatusCode.BadRequest, "invalid_audio_file")]
+    public async Task TranscribeAsync_RetriesUploadRejectionOnceWithWav(
+        HttpStatusCode firstStatusCode,
+        string firstErrorType)
+    {
+        var uploadBodies = new List<string>();
+        var createCount = 0;
+        var handler = new CapturingHandler((request, body) =>
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadBodies.Add(Encoding.UTF8.GetString(body ?? []));
+                if (uploadBodies.Count == 1)
+                {
+                    return JsonResponse(
+                        JsonSerializer.Serialize(new
+                        {
+                            status_code = (int)firstStatusCode,
+                            error_type = firstErrorType,
+                            message = "Compressed audio rejected"
+                        }),
+                        firstStatusCode);
+                }
+
+                return JsonResponse("""{ "id": "file-wav" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                createCount++;
+                return JsonResponse("""{ "id": "job-wav", "status": "queued" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-wav")
+                return JsonResponse("""{ "status": "completed", "audio_duration_ms": 1000 }""");
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-wav/transcript")
+                return JsonResponse("""{ "text": "WAV fallback", "tokens": [] }""");
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(
+            [1, 2, 3],
+            "en",
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+        await sut.LastCleanupTask;
+
+        Assert.Equal("WAV fallback", result.Text);
+        Assert.Equal(2, uploadBodies.Count);
+        AssertMultipartUpload(uploadBodies[0], "audio.m4a", "audio/mp4");
+        AssertMultipartUpload(uploadBodies[1], "audio.wav", "audio/wav");
+        Assert.Equal(1, createCount);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, "unauthenticated")]
+    [InlineData(HttpStatusCode.TooManyRequests, "rate_limit_exceeded")]
+    public async Task TranscribeAsync_DoesNotRetryNonAudioUploadFailures(
+        HttpStatusCode statusCode,
+        string errorType)
+    {
+        var uploadCount = 0;
+        var handler = new CapturingHandler((request, _) =>
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadCount++;
+                return JsonResponse(
+                    JsonSerializer.Serialize(new
+                    {
+                        status_code = (int)statusCode,
+                        error_type = errorType,
+                        message = "Do not retry"
+                    }),
+                    statusCode);
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
+
+        Assert.Equal(statusCode, ex.StatusCode);
+        Assert.Contains(errorType, ex.Message);
+        Assert.Equal(1, uploadCount);
+    }
+
+    [Theory]
+    [InlineData("organization_balance_exhausted")]
+    [InlineData("invalid_audio")]
+    public async Task TranscribeAsync_DoesNotRetryOtherTerminalJobErrors(string errorType)
+    {
+        var uploadCount = 0;
+        var createCount = 0;
+        var handler = new CapturingHandler((request, _) =>
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadCount++;
+                return JsonResponse("""{ "id": "file-m4a" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                createCount++;
+                return JsonResponse("""{ "id": "job-m4a", "status": "queued" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-m4a")
+            {
+                return JsonResponse(
+                    JsonSerializer.Serialize(new
+                    {
+                        status = "failed",
+                        error_type = errorType,
+                        error_message = "Do not retry"
+                    }));
+            }
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
+
+        Assert.Contains(errorType, ex.Message);
+        Assert.Equal(1, uploadCount);
+        Assert.Equal(1, createCount);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_AsyncInvalidAudioRetriesWholeTransactionWithSnapshotParameters()
+    {
+        var seen = new List<string>();
+        var uploadBodies = new List<string>();
+        var createBodies = new List<string>();
+        var uploadCount = 0;
+        var createCount = 0;
+        SonioxPlugin? sut = null;
+        var handler = new AsyncCapturingHandler(async (request, body, _) =>
+        {
+            seen.Add($"{request.Method} {request.RequestUri}");
+            Assert.Equal("api.soniox.com", request.RequestUri?.Host);
+            Assert.Equal("Bearer initial-key", request.Headers.Authorization?.ToString());
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadCount++;
+                uploadBodies.Add(Encoding.UTF8.GetString(body ?? []));
+                return uploadCount == 1
+                    ? JsonResponse("""{ "id": "file-m4a" }""", HttpStatusCode.Created)
+                    : JsonResponse("""{ "id": "file-wav" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                createCount++;
+                createBodies.Add(Encoding.UTF8.GetString(body ?? []));
+                return createCount == 1
+                    ? JsonResponse("""{ "id": "job-m4a", "status": "queued" }""", HttpStatusCode.Created)
+                    : JsonResponse("""{ "id": "job-wav", "status": "queued" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-m4a")
+            {
+                sut!.SetRegion("eu");
+                await sut.SetApiKeyAsync("replacement-key");
+                return JsonResponse("""
+                    {
+                      "status": "failed",
+                      "error_type": "invalid_audio_file",
+                      "error_message": "Cannot decode M4A",
+                      "request_id": "req-m4a"
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-wav")
+                return JsonResponse("""{ "status": "completed", "audio_duration_ms": 1000 }""");
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-wav/transcript")
+                return JsonResponse("""{ "text": "Recovered transcript", "tokens": [] }""");
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "initial-key";
+        using var httpClient = new HttpClient(handler);
+        sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeWithLanguageHintsAsync(
+            [1, 2, 3],
+            [" de ", "en", "DE"],
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+        await sut.LastCleanupTask;
+
+        Assert.Equal("Recovered transcript", result.Text);
+        Assert.Equal(2, uploadBodies.Count);
+        AssertMultipartUpload(uploadBodies[0], "audio.m4a", "audio/mp4");
+        AssertMultipartUpload(uploadBodies[1], "audio.wav", "audio/wav");
+        Assert.Equal(2, createBodies.Count);
+
+        using var firstCreate = JsonDocument.Parse(createBodies[0]);
+        using var secondCreate = JsonDocument.Parse(createBodies[1]);
+        Assert.Equal("stt-async-v5", firstCreate.RootElement.GetProperty("model").GetString());
+        Assert.Equal("stt-async-v5", secondCreate.RootElement.GetProperty("model").GetString());
+        Assert.Equal(["de", "en"], firstCreate.RootElement.GetProperty("language_hints").EnumerateArray().Select(e => e.GetString()!).ToArray());
+        Assert.Equal(["de", "en"], secondCreate.RootElement.GetProperty("language_hints").EnumerateArray().Select(e => e.GetString()!).ToArray());
+        Assert.Equal("file-m4a", firstCreate.RootElement.GetProperty("file_id").GetString());
+        Assert.Equal("file-wav", secondCreate.RootElement.GetProperty("file_id").GetString());
+
+        Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/job-m4a", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/files/file-m4a", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/job-wav", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/files/file-wav", seen);
+        Assert.Equal("eu", sut.RegionId);
+        Assert.Equal("replacement-key", sut.ApiKey);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_WavAttemptFailureSurfacesSecondErrorWithoutThirdAttempt()
+    {
+        var seen = new List<string>();
+        var uploadCount = 0;
+        var createCount = 0;
+        var handler = new CapturingHandler((request, _) =>
+        {
+            seen.Add($"{request.Method} {request.RequestUri}");
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadCount++;
+                return uploadCount == 1
+                    ? JsonResponse("""{ "id": "file-m4a" }""", HttpStatusCode.Created)
+                    : JsonResponse("""{ "id": "file-wav" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                createCount++;
+                return createCount == 1
+                    ? JsonResponse("""{ "id": "job-m4a", "status": "queued" }""", HttpStatusCode.Created)
+                    : JsonResponse("""{ "id": "job-wav", "status": "queued" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-m4a")
+            {
+                return JsonResponse("""
+                    {
+                      "status": "error",
+                      "error_type": "invalid_audio_file",
+                      "error_message": "first-attempt-error",
+                      "request_id": "req-first"
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-wav")
+            {
+                return JsonResponse("""
+                    {
+                      "status": "failed",
+                      "error_type": "organization_balance_exhausted",
+                      "error_message": "second-attempt-error",
+                      "request_id": "req-second"
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
+        await sut.ActivateAsync(host);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
+
+        Assert.Contains("organization_balance_exhausted", ex.Message);
+        Assert.Contains("second-attempt-error", ex.Message);
+        Assert.Contains("req-second", ex.Message);
+        Assert.DoesNotContain("first-attempt-error", ex.Message);
+        Assert.Equal(2, uploadCount);
+        Assert.Equal(2, createCount);
+        Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/job-m4a", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/files/file-m4a", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/transcriptions/job-wav", seen);
+        Assert.Contains("DELETE https://api.soniox.com/v1/files/file-wav", seen);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_CanceledBeforeCompressionSkipsEncoderAndRequests()
+    {
+        var encoderCalled = false;
+        var handler = new CapturingHandler((request, _) =>
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}"));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            compressedUploadFactory: _ =>
+            {
+                encoderCalled = true;
+                return new SonioxTranscriptionUpload(
+                    [9, 8, 7],
+                    "audio.m4a",
+                    "audio/mp4",
+                    SonioxUploadFormat.M4a);
+            });
+        await sut.ActivateAsync(host);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, cts.Token));
+
+        Assert.False(encoderCalled);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_CancellationDuringPollingDoesNotRetry()
+    {
+        var uploadCount = 0;
+        using var cts = new CancellationTokenSource();
+        var handler = new CapturingHandler((request, _) =>
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadCount++;
+                return JsonResponse("""{ "id": "file-m4a" }""", HttpStatusCode.Created);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+                return JsonResponse("""{ "id": "job-m4a", "status": "queued" }""", HttpStatusCode.Created);
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/v1/transcriptions/job-m4a")
+            {
+                cts.Cancel();
+                return JsonResponse("""{ "status": "processing" }""");
+            }
+
+            if (request.Method == HttpMethod.Delete)
+                return JsonResponse("""{}""");
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "soniox-key";
+        using var httpClient = new HttpClient(handler);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
+        await sut.ActivateAsync(host);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, cts.Token));
+
+        Assert.Equal(1, uploadCount);
     }
 
     [Fact]
@@ -556,13 +1062,21 @@ public class SonioxPluginTests
     [Fact]
     public async Task TranscribeAsync_PollTimeoutThrowsTimeoutException()
     {
+        var uploadCount = 0;
+        var createCount = 0;
         var handler = new CapturingHandler((request, _) =>
         {
             if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                uploadCount++;
                 return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753" }""", HttpStatusCode.Created);
+            }
 
             if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
+            {
+                createCount++;
                 return JsonResponse("""{ "id": "73d4357d-cad2-4338-a60d-ec6f2044f721", "status": "queued" }""", HttpStatusCode.Created);
+            }
 
             if (request.Method == HttpMethod.Get)
                 return JsonResponse("""{ "status": "processing" }""");
@@ -573,13 +1087,23 @@ public class SonioxPluginTests
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "soniox-key";
         using var httpClient = new HttpClient(handler);
-        var sut = new SonioxPlugin(httpClient, pollDelay: TimeSpan.Zero, maxPollAttempts: 2);
+        var sut = new SonioxPlugin(
+            httpClient,
+            pollDelay: TimeSpan.Zero,
+            maxPollAttempts: 2,
+            compressedUploadFactory: _ => new SonioxTranscriptionUpload(
+                [9, 8, 7],
+                "audio.m4a",
+                "audio/mp4",
+                SonioxUploadFormat.M4a));
         await sut.ActivateAsync(host);
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
             sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None));
 
         Assert.Contains("did not complete", ex.Message);
+        Assert.Equal(1, uploadCount);
+        Assert.Equal(1, createCount);
     }
 
     private static JsonElement LoadManifest()
@@ -599,14 +1123,33 @@ public class SonioxPluginTests
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
 
-    private sealed class SonioxFlowHandler(Action<string> inspectCreateBody) : HttpMessageHandler
+    private static void AssertMultipartUpload(string body, string fileName, string contentType)
+    {
+        Assert.True(
+            body.Contains($"filename={fileName}", StringComparison.Ordinal)
+            || body.Contains($"filename=\"{fileName}\"", StringComparison.Ordinal),
+            $"Multipart body did not contain filename {fileName}.");
+        Assert.Contains($"Content-Type: {contentType}", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class SonioxFlowHandler(
+        Action<string> inspectCreateBody,
+        Action<string>? inspectUploadBody = null) : HttpMessageHandler
     {
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/files")
+            {
+                if (inspectUploadBody is not null)
+                {
+                    var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+                    inspectUploadBody(body);
+                }
+
                 return JsonResponse("""{ "id": "84c32fc6-4fb5-4e7a-b656-b5ec70493753" }""", HttpStatusCode.Created);
+            }
 
             if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/v1/transcriptions")
             {


### PR DESCRIPTION
## Summary

- encode Soniox uploads as 48 kbit/s M4A on Windows and fall back to the original WAV when Media Foundation compression is unavailable
- retry the complete upload, job creation, polling, and transcript retrieval transaction exactly once with WAV when Soniox rejects M4A with HTTP 415 or `invalid_audio_file`
- preserve the selected region, API key, async model, and normalized ordered language hints across the retry, with best-effort cleanup for both attempts
- package the required NAudio dependencies and bump the Soniox plugin to 1.1.0

## Validation

- 36 focused Soniox plugin tests, including a Windows Media Foundation M4A container test and deterministic retry/no-retry coverage
- full PluginSystem suite: 1,364 tests passed
- Soniox Release build completed with 0 warnings and 0 errors
- local dev installation discovered `com.typewhisper.soniox` 1.1.0 with its NAudio dependencies
- real Soniox transcription completed successfully in the dev app

Related origin: TypeWhisper/typewhisper-mac#1011. This PR intentionally does not close the macOS issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compressed M4A audio uploads for transcription to reduce payload size and speed up requests.
  * Improved transcription setup by normalizing and de-duplicating language hints per request.

* **Bug Fixes**
  * Improved reliability with expanded retry and fallback behavior (including WAV fallback when M4A fails or is rejected).
  * Enhanced error reporting for upload and transcription job failures, plus safer cleanup.
  * Strengthened cancellation handling during both upload and polling.

* **Release**
  * Updated the Soniox plugin to version 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->