### PR TITLE
Improve Windows startup and recording performance

### DIFF
--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeProbe.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeProbe.cs
@@ -103,6 +103,9 @@ internal sealed class SherpaCudaRuntimeProbe(
             if (process is null)
                 return new CudaRuntimeProbeResult(false, "CUDA safety probe process could not be started.");
 
+            // Drain stderr while the child is running. Waiting first can
+            // deadlock when a failed native load fills the redirected pipe.
+            var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeout.CancelAfter(ProbeTimeout);
             try
@@ -122,7 +125,7 @@ internal sealed class SherpaCudaRuntimeProbe(
                 throw;
             }
 
-            var standardError = await process.StandardError.ReadToEndAsync(cancellationToken);
+            var standardError = await standardErrorTask;
             if (process.ExitCode == 0)
             {
                 RecordCachedSuccess(successCachePath, fingerprint);

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeProbe.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeProbe.cs
@@ -1,0 +1,271 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TypeWhisper.Plugin.SherpaOnnx;
+
+internal sealed record CudaRuntimeProbeResult(bool Success, string? ErrorMessage);
+
+internal interface ISherpaCudaRuntimeProbe
+{
+    Task<CudaRuntimeProbeResult> ProbeAsync(
+        string modelId,
+        string modelDirectory,
+        string runtimeDirectory,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class SherpaCudaRuntimeProbe(
+    string hostExecutablePath,
+    string pluginDirectory,
+    string pluginAssetDirectory) : ISherpaCudaRuntimeProbe
+{
+    internal const string ProbeEnvironmentVariable = "TYPEWHISPER_NATIVE_MODEL_PROBE";
+    internal const string ProbeArgument = "--native-model-probe";
+    internal const string PluginDirectoryArgument = "--plugin-directory";
+    internal const string PluginAssetDirectoryArgument = "--plugin-asset-directory";
+    internal const string ModelIdArgument = "--model-id";
+    internal const string RuntimeDirectoryArgument = "--runtime-directory";
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromMinutes(2);
+    private const string SuccessCacheFileName = ".typewhisper-cuda-probe-success";
+
+    public async Task<CudaRuntimeProbeResult> ProbeAsync(
+        string modelId,
+        string modelDirectory,
+        string runtimeDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(hostExecutablePath) || !File.Exists(hostExecutablePath))
+        {
+            return new CudaRuntimeProbeResult(
+                false,
+                "CUDA safety probe could not find the TypeWhisper executable.");
+        }
+
+        if (!Directory.Exists(pluginDirectory)
+            || !Directory.Exists(pluginAssetDirectory)
+            || !Directory.Exists(modelDirectory)
+            || !Directory.Exists(runtimeDirectory))
+        {
+            return new CudaRuntimeProbeResult(
+                false,
+                "CUDA safety probe could not find the plugin, model, or runtime directory.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        string fingerprint;
+        try
+        {
+            fingerprint = BuildCacheFingerprint(
+                modelId,
+                hostExecutablePath,
+                pluginDirectory,
+                modelDirectory,
+                runtimeDirectory);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ArgumentException)
+        {
+            return new CudaRuntimeProbeResult(
+                false,
+                $"CUDA safety probe could not fingerprint the native runtime: {ex.Message}");
+        }
+
+        var successCachePath = Path.Join(runtimeDirectory, SuccessCacheFileName);
+        if (IsCachedSuccess(successCachePath, fingerprint))
+            return new CudaRuntimeProbeResult(true, null);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = hostExecutablePath,
+            WorkingDirectory = Path.GetDirectoryName(hostExecutablePath) ?? AppContext.BaseDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            RedirectStandardError = true,
+        };
+        startInfo.Environment[ProbeEnvironmentVariable] = "1";
+        AddArgument(startInfo, ProbeArgument);
+        AddArgument(startInfo, PluginDirectoryArgument, pluginDirectory);
+        AddArgument(startInfo, PluginAssetDirectoryArgument, pluginAssetDirectory);
+        AddArgument(startInfo, ModelIdArgument, modelId);
+        AddArgument(startInfo, RuntimeDirectoryArgument, runtimeDirectory);
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process is null)
+                return new CudaRuntimeProbeResult(false, "CUDA safety probe process could not be started.");
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(ProbeTimeout);
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                TryTerminate(process);
+                return new CudaRuntimeProbeResult(
+                    false,
+                    $"CUDA safety probe did not finish within {ProbeTimeout.TotalSeconds:0} seconds.");
+            }
+            catch (OperationCanceledException)
+            {
+                TryTerminate(process);
+                throw;
+            }
+
+            var standardError = await process.StandardError.ReadToEndAsync(cancellationToken);
+            if (process.ExitCode == 0)
+            {
+                RecordCachedSuccess(successCachePath, fingerprint);
+                return new CudaRuntimeProbeResult(true, null);
+            }
+
+            var unsignedExitCode = unchecked((uint)process.ExitCode);
+            var detail = string.IsNullOrWhiteSpace(standardError)
+                ? $"Native CUDA probe exited with code 0x{unsignedExitCode:X8}."
+                : $"Native CUDA probe exited with code 0x{unsignedExitCode:X8}: {standardError.Trim()}";
+            return new CudaRuntimeProbeResult(false, detail);
+        }
+        catch (Exception ex) when (
+            ex is Win32Exception
+                or InvalidOperationException
+                or IOException
+                or UnauthorizedAccessException)
+        {
+            return new CudaRuntimeProbeResult(false, $"CUDA safety probe failed: {ex.Message}");
+        }
+    }
+
+    internal static bool IsProbeProcess =>
+        string.Equals(
+            Environment.GetEnvironmentVariable(ProbeEnvironmentVariable),
+            "1",
+            StringComparison.Ordinal);
+
+    internal static string BuildCacheFingerprint(
+        string modelId,
+        string executablePath,
+        string pluginPath,
+        string modelPath,
+        string runtimePath)
+    {
+        var fingerprint = new StringBuilder();
+        fingerprint.AppendLine(modelId);
+        fingerprint.AppendLine(Environment.OSVersion.VersionString);
+        fingerprint.AppendLine(RuntimeInformation.OSArchitecture.ToString());
+        fingerprint.AppendLine(RuntimeInformation.ProcessArchitecture.ToString());
+        AppendFileFingerprint(fingerprint, executablePath);
+        AppendDirectoryFingerprint(fingerprint, pluginPath, "*.dll", SearchOption.TopDirectoryOnly);
+        AppendDirectoryFingerprint(fingerprint, modelPath, "*", SearchOption.AllDirectories);
+        AppendDirectoryFingerprint(fingerprint, runtimePath, "*.dll", SearchOption.TopDirectoryOnly);
+        AppendFileFingerprint(
+            fingerprint,
+            Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.System), "nvcuda.dll"));
+
+        return Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(fingerprint.ToString())));
+    }
+
+    internal static bool IsCachedSuccess(string cachePath, string fingerprint)
+    {
+        try
+        {
+            return File.Exists(cachePath)
+                && string.Equals(
+                    File.ReadAllText(cachePath).Trim(),
+                    fingerprint,
+                    StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    internal static void RecordCachedSuccess(string cachePath, string fingerprint)
+    {
+        try
+        {
+            File.WriteAllText(cachePath, fingerprint);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ArgumentException)
+        {
+            // A read-only runtime remains usable; it only loses the fast path.
+        }
+    }
+
+    private static void AppendDirectoryFingerprint(
+        StringBuilder fingerprint,
+        string directory,
+        string searchPattern,
+        SearchOption searchOption)
+    {
+        fingerprint.AppendLine(Path.GetFullPath(directory));
+        foreach (var file in Directory
+                     .EnumerateFiles(directory, searchPattern, searchOption)
+                     .Order(StringComparer.OrdinalIgnoreCase))
+        {
+            AppendFileFingerprint(fingerprint, file);
+        }
+    }
+
+    private static void AppendFileFingerprint(StringBuilder fingerprint, string path)
+    {
+        var resolvedPath = Path.GetFullPath(path);
+        fingerprint.Append(resolvedPath);
+        if (File.Exists(resolvedPath))
+        {
+            var info = new FileInfo(resolvedPath);
+            fingerprint
+                .Append('|')
+                .Append(info.Length)
+                .Append('|')
+                .Append(info.LastWriteTimeUtc.Ticks);
+        }
+        else
+        {
+            fingerprint.Append("|missing");
+        }
+
+        fingerprint.AppendLine();
+    }
+
+    private static void AddArgument(ProcessStartInfo startInfo, string name, string? value = null)
+    {
+        startInfo.ArgumentList.Add(name);
+        if (value is not null)
+            startInfo.ArgumentList.Add(value);
+    }
+
+    private static void TryTerminate(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (Win32Exception)
+        {
+        }
+    }
+}

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
@@ -41,6 +41,15 @@ internal static class SherpaOnnxNativeRuntime
         }
     }
 
+    public static void ConfigureBundledRuntime()
+    {
+        lock (Sync)
+        {
+            RegisterResolverUnsafe();
+            _cudaRuntimeDirectory = null;
+        }
+    }
+
     private static void RegisterResolverUnsafe()
     {
         _bundledRuntimeDirectory ??= ResolveBundledRuntimeDirectory(

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -41,6 +41,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     private readonly HttpClient _httpClient = new();
     private readonly Func<string, string, string, OfflineRecognizer>? _recognizerFactory;
     private ISherpaCudaRuntimeInstaller? _cudaRuntimeInstaller;
+    private ISherpaCudaRuntimeProbe? _cudaRuntimeProbe;
     private IPluginHostServices? _host;
     private OfflineRecognizer? _recognizer;
     private string? _loadedModelId;
@@ -67,9 +68,18 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     internal SherpaOnnxPlugin(
         ISherpaCudaRuntimeInstaller cudaRuntimeInstaller,
         Func<string, string, string, OfflineRecognizer>? recognizerFactory)
+        : this(cudaRuntimeInstaller, recognizerFactory, cudaRuntimeProbe: null)
+    {
+    }
+
+    internal SherpaOnnxPlugin(
+        ISherpaCudaRuntimeInstaller cudaRuntimeInstaller,
+        Func<string, string, string, OfflineRecognizer>? recognizerFactory,
+        ISherpaCudaRuntimeProbe? cudaRuntimeProbe)
     {
         _cudaRuntimeInstaller = cudaRuntimeInstaller;
         _recognizerFactory = recognizerFactory;
+        _cudaRuntimeProbe = cudaRuntimeProbe;
     }
 
     // Canary-specific state
@@ -157,6 +167,15 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     {
         _host = host;
         _cudaRuntimeInstaller ??= new SherpaCudaRuntimeInstaller(host.PluginAssetDirectory, _httpClient);
+        if (_cudaRuntimeProbe is null
+            && Environment.ProcessPath is { } hostExecutablePath
+            && Path.GetDirectoryName(typeof(SherpaOnnxPlugin).Assembly.Location) is { } pluginDirectory)
+        {
+            _cudaRuntimeProbe = new SherpaCudaRuntimeProbe(
+                hostExecutablePath,
+                pluginDirectory,
+                host.PluginAssetDirectory);
+        }
         SherpaOnnxNativeRuntime.RegisterResolver();
         MigrateModelFiles();
         return Task.CompletedTask;
@@ -273,6 +292,35 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             throw new FileNotFoundException($"Model files not found for: {modelId}");
 
         var provider = await ResolveProviderForLoadAsync(ct);
+        var providerForLoad = provider;
+        if (string.Equals(provider, "cuda", StringComparison.OrdinalIgnoreCase)
+            && !SherpaCudaRuntimeProbe.IsProbeProcess)
+        {
+            var probeResult = _cudaRuntimeProbe is null
+                ? new CudaRuntimeProbeResult(
+                    false,
+                    "CUDA safety probe is unavailable in this TypeWhisper installation.")
+                : await _cudaRuntimeProbe.ProbeAsync(
+                    modelId,
+                    dir,
+                    _cudaRuntimeInstaller?.RuntimeDirectory ?? string.Empty,
+                    ct);
+
+            if (!probeResult.Success)
+            {
+                var detail = probeResult.ErrorMessage ?? "Native CUDA safety probe failed.";
+                _accelerationStatus = CreateCudaUnavailableStatus(detail);
+                SherpaOnnxNativeRuntime.ConfigureBundledRuntime();
+
+                if (_accelerationPreference != TranscriptionAccelerationPreference.Auto)
+                    throw new InvalidOperationException(detail);
+
+                _host?.Log(
+                    PluginLogLevel.Warning,
+                    $"CUDA safety probe failed for {modelId}; falling back to CPU: {detail}");
+                providerForLoad = "cpu";
+            }
+        }
 
         await Task.Run(() =>
         {
@@ -280,7 +328,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             {
                 UnloadRecognizerUnsafe();
 
-                var activeProvider = provider;
+                var activeProvider = providerForLoad;
                 var accelerationStatus = CreateLoadedAccelerationStatus(activeProvider);
 
                 try

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -293,6 +293,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
 
         var provider = await ResolveProviderForLoadAsync(ct);
         var providerForLoad = provider;
+        string? cudaProbeFallbackDetail = null;
         if (string.Equals(provider, "cuda", StringComparison.OrdinalIgnoreCase)
             && !SherpaCudaRuntimeProbe.IsProbeProcess)
         {
@@ -319,6 +320,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                     PluginLogLevel.Warning,
                     $"CUDA safety probe failed for {modelId}; falling back to CPU: {detail}");
                 providerForLoad = "cpu";
+                cudaProbeFallbackDetail = detail;
             }
         }
 
@@ -329,7 +331,9 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                 UnloadRecognizerUnsafe();
 
                 var activeProvider = providerForLoad;
-                var accelerationStatus = CreateLoadedAccelerationStatus(activeProvider);
+                var accelerationStatus = cudaProbeFallbackDetail is not null
+                    ? CreateCudaUnavailableStatus(cudaProbeFallbackDetail)
+                    : CreateLoadedAccelerationStatus(activeProvider);
 
                 try
                 {

--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -38,7 +38,7 @@ public partial class App : Application
     /// <summary>
     /// Initializes application services, plugin discovery, error handling, and startup windows.
     /// </summary>
-    protected override void OnStartup(StartupEventArgs e)
+    protected override async void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
         AudioCaptureDiagnostics.Reset();
@@ -102,20 +102,69 @@ public partial class App : Application
         Loc.Instance.CurrentLanguage = settings.Current.UiLanguage
             ?? Loc.Instance.DetectSystemLanguage();
 
+        // Configure feedback before the overlay graph is created.
+        var soundService = _serviceProvider.GetRequiredService<SoundService>();
+        soundService.IsEnabled = settings.Current.SoundFeedbackEnabled;
+        settings.SettingsChanged += s => soundService.IsEnabled = s.SoundFeedbackEnabled;
+
+        var speechFeedback = _serviceProvider.GetRequiredService<SpeechFeedbackService>();
+        speechFeedback.IsEnabled = settings.Current.SpokenFeedbackEnabled;
+        settings.SettingsChanged += s => speechFeedback.IsEnabled = s.SpokenFeedbackEnabled;
+
+        // Publish the native shell before plugin discovery. The tray is the
+        // primary idle surface, while the transparent overlay creates the
+        // window handle needed by hotkeys later in startup.
+        _trayIcon = _serviceProvider.GetRequiredService<TrayIconService>();
+        _trayIcon.Initialize();
+        _trayIcon.ShowSettingsRequested += (_, _) => RunTrayActionOnUiThread(() => ShowSettingsWindow());
+        _trayIcon.ShowFileTranscriptionRequested += (_, _) => RunTrayActionOnUiThread(() => ShowSettingsWindow(SettingsRoute.FileTranscription, presentFileImporter: true));
+        _trayIcon.ShowRecentTranscriptionsRequested += (_, _) => RunTrayActionOnUiThread(() =>
+            _serviceProvider!.GetRequiredService<DictationViewModel>().ShowRecentTranscriptionsPalette());
+        _trayIcon.CopyLastTranscriptionRequested += (_, _) => RunTrayActionOnUiThread(async () =>
+            await _serviceProvider!.GetRequiredService<DictationViewModel>().CopyLastTranscriptionToClipboardAsync());
+        _trayIcon.ReadBackLastTranscriptionRequested += (_, _) => RunTrayActionOnUiThread(() =>
+            _serviceProvider!.GetRequiredService<DictationViewModel>().ReadBackLastTranscription());
+        _trayIcon.ToggleRecorderRequested += (_, _) => RunTrayActionOnUiThread(() =>
+            _serviceProvider!.GetRequiredService<AudioRecorderViewModel>().ToggleRecordingCommand.Execute(null));
+        _trayIcon.ExitRequested += (_, _) => Shutdown();
+        _trayIcon.UpdateCheckRequested += (_, _) => RunTrayActionOnUiThread(async () =>
+        {
+            var update = _serviceProvider!.GetRequiredService<UpdateService>();
+            await update.CheckForUpdatesAsync();
+            if (!update.IsUpdateAvailable)
+                _trayIcon.ShowBalloon(Loc.Instance["Update.NoUpdate"], Loc.Instance["Update.NoUpdateMessage"]);
+        });
+
+        var mainWindow = _serviceProvider.GetRequiredService<MainWindow>();
+        mainWindow.Show();
+        await Dispatcher.Yield(DispatcherPriority.ContextIdle);
+
         // Apply staged plugin updates before plugin assemblies are loaded.
         var pluginRegistry = _serviceProvider.GetRequiredService<PluginRegistryService>();
         try
         {
-            pluginRegistry.ApplyPendingUpdatesAsync().GetAwaiter().GetResult();
+            await Task.Run(() => pluginRegistry.ApplyPendingUpdatesAsync());
         }
-        catch (Exception ex)
+        catch (Exception ex) when (IsNonFatalStartupException(ex))
         {
             System.Diagnostics.Debug.WriteLine($"[PluginRegistry] Failed to apply pending updates at startup: {ex.Message}");
+            LogCrash(ex);
         }
 
         // Initialize plugins (must happen after settings.Load so enabled state is available)
         var pluginManager = _serviceProvider.GetRequiredService<PluginManager>();
-        pluginManager.InitializeAsync().GetAwaiter().GetResult();
+        try
+        {
+            await Task.Run(() => pluginManager.InitializeAsync());
+        }
+        catch (Exception ex) when (IsNonFatalStartupException(ex))
+        {
+            System.Diagnostics.Debug.WriteLine($"[PluginManager] Failed to initialize plugins at startup: {ex.Message}");
+            LogCrash(ex);
+        }
+
+        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+            return;
 
         // Validate commercial/supporter licensing state in the background.
         var supporterDiscord = _serviceProvider.GetRequiredService<SupporterDiscordService>();
@@ -136,46 +185,8 @@ public partial class App : Application
                     System.Diagnostics.Debug.WriteLine($"Plugin registry check failed: {t.Exception?.Message}");
             });
 
-        // Setup sound service
-        var soundService = _serviceProvider.GetRequiredService<SoundService>();
-        soundService.IsEnabled = settings.Current.SoundFeedbackEnabled;
-        settings.SettingsChanged += s => soundService.IsEnabled = s.SoundFeedbackEnabled;
-
-        // Setup spoken feedback service
-        var speechFeedback = _serviceProvider.GetRequiredService<SpeechFeedbackService>();
-        speechFeedback.IsEnabled = settings.Current.SpokenFeedbackEnabled;
-        settings.SettingsChanged += s => speechFeedback.IsEnabled = s.SpokenFeedbackEnabled;
-
         _historyRetentionCoordinator = _serviceProvider.GetRequiredService<HistoryRetentionCoordinator>();
         _historyRetentionCoordinator.Initialize();
-
-        // Setup tray icon
-        _trayIcon = _serviceProvider.GetRequiredService<TrayIconService>();
-        _trayIcon.Initialize();
-        _trayIcon.ShowSettingsRequested += (_, _) => RunTrayActionOnUiThread(() => ShowSettingsWindow());
-        _trayIcon.ShowFileTranscriptionRequested += (_, _) => RunTrayActionOnUiThread(() => ShowSettingsWindow(SettingsRoute.FileTranscription, presentFileImporter: true));
-        _trayIcon.ShowRecentTranscriptionsRequested += (_, _) => RunTrayActionOnUiThread(() =>
-            _serviceProvider!.GetRequiredService<DictationViewModel>().ShowRecentTranscriptionsPalette());
-        _trayIcon.CopyLastTranscriptionRequested += (_, _) => RunTrayActionOnUiThread(async () =>
-            await _serviceProvider!.GetRequiredService<DictationViewModel>().CopyLastTranscriptionToClipboardAsync());
-        _trayIcon.ReadBackLastTranscriptionRequested += (_, _) => RunTrayActionOnUiThread(() =>
-            _serviceProvider!.GetRequiredService<DictationViewModel>().ReadBackLastTranscription());
-        _trayIcon.ToggleRecorderRequested += (_, _) => RunTrayActionOnUiThread(() =>
-            _serviceProvider!.GetRequiredService<AudioRecorderViewModel>().ToggleRecordingCommand.Execute(null));
-        _trayIcon.ExitRequested += (_, _) => Shutdown();
-
-        // Manual update check from tray menu
-        _trayIcon.UpdateCheckRequested += (_, _) => RunTrayActionOnUiThread(async () =>
-        {
-            var update = _serviceProvider!.GetRequiredService<UpdateService>();
-            await update.CheckForUpdatesAsync();
-            if (!update.IsUpdateAvailable)
-                _trayIcon.ShowBalloon(Loc.Instance["Update.NoUpdate"], Loc.Instance["Update.NoUpdateMessage"]);
-        });
-
-        // Create and show overlay window
-        var mainWindow = _serviceProvider.GetRequiredService<MainWindow>();
-        mainWindow.Show();
 
         // Initialize hotkey service (needs window handle)
         var hotkeyService = _serviceProvider.GetRequiredService<HotkeyService>();
@@ -216,20 +227,6 @@ public partial class App : Application
         var modelManager = _serviceProvider.GetRequiredService<ModelManagerService>();
         modelManager.MigrateSettings();
         MigrateWorkflowModelOverrides(_serviceProvider);
-
-        // Auto-load previously selected model (after plugin initialization)
-        if (!string.IsNullOrEmpty(settings.Current.SelectedModelId))
-        {
-            if (modelManager.IsDownloaded(settings.Current.SelectedModelId))
-            {
-                _ = modelManager.LoadModelAsync(settings.Current.SelectedModelId)
-                    .ContinueWith(t =>
-                    {
-                        if (t.IsFaulted)
-                            System.Diagnostics.Debug.WriteLine($"Auto-load model failed: {t.Exception?.Message}");
-                    });
-            }
-        }
 
         if (settings.Current.WatchFolderAutoStart
             && !string.IsNullOrWhiteSpace(settings.Current.WatchFolderPath))

--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -22,6 +22,8 @@ namespace TypeWhisper.Windows;
 public partial class App : Application
 {
     private ServiceProvider? _serviceProvider;
+    private readonly CancellationTokenSource _startupCancellation = new();
+    private Task? _startupBackgroundTask;
     private HistoryRetentionCoordinator? _historyRetentionCoordinator;
     private TrayIconService? _trayIcon;
     private SettingsWindow? _settingsWindow;
@@ -143,7 +145,12 @@ public partial class App : Application
         var pluginRegistry = _serviceProvider.GetRequiredService<PluginRegistryService>();
         try
         {
-            await Task.Run(() => pluginRegistry.ApplyPendingUpdatesAsync());
+            await RunTrackedStartupWorkAsync(
+                token => pluginRegistry.ApplyPendingUpdatesAsync(token));
+        }
+        catch (OperationCanceledException) when (_startupCancellation.IsCancellationRequested)
+        {
+            return;
         }
         catch (Exception ex) when (IsNonFatalStartupException(ex))
         {
@@ -151,11 +158,23 @@ public partial class App : Application
             LogCrash(ex);
         }
 
+        if (_startupCancellation.IsCancellationRequested
+            || Dispatcher.HasShutdownStarted
+            || Dispatcher.HasShutdownFinished)
+        {
+            return;
+        }
+
         // Initialize plugins (must happen after settings.Load so enabled state is available)
         var pluginManager = _serviceProvider.GetRequiredService<PluginManager>();
         try
         {
-            await Task.Run(() => pluginManager.InitializeAsync());
+            await RunTrackedStartupWorkAsync(
+                token => pluginManager.InitializeAsync(token));
+        }
+        catch (OperationCanceledException) when (_startupCancellation.IsCancellationRequested)
+        {
+            return;
         }
         catch (Exception ex) when (IsNonFatalStartupException(ex))
         {
@@ -239,6 +258,21 @@ public partial class App : Application
         var updateService = _serviceProvider.GetRequiredService<UpdateService>();
         updateService.Initialize();
         _ = updateService.CheckForUpdatesAsync();
+    }
+
+    private async Task RunTrackedStartupWorkAsync(Func<CancellationToken, Task> work)
+    {
+        var token = _startupCancellation.Token;
+        var task = Task.Run(() => work(token), token);
+        Volatile.Write(ref _startupBackgroundTask, task);
+        try
+        {
+            await task;
+        }
+        finally
+        {
+            _ = Interlocked.CompareExchange(ref _startupBackgroundTask, null, task);
+        }
     }
 
     private void RunTrayActionOnUiThread(Action action)
@@ -349,8 +383,12 @@ public partial class App : Application
         if (!SupporterDiscordService.CanHandleCallbackUri(uri))
             return;
 
-        var licenseService = _serviceProvider!.GetRequiredService<LicenseService>();
-        var supporterDiscord = _serviceProvider.GetRequiredService<SupporterDiscordService>();
+        var serviceProvider = Volatile.Read(ref _serviceProvider);
+        if (serviceProvider is null)
+            return;
+
+        var licenseService = serviceProvider.GetRequiredService<LicenseService>();
+        var supporterDiscord = serviceProvider.GetRequiredService<SupporterDiscordService>();
         var handled = await supporterDiscord.HandleCallbackUriAsync(uri, licenseService);
         if (!handled)
             return;
@@ -576,10 +614,31 @@ public partial class App : Application
     /// </summary>
     protected override void OnExit(ExitEventArgs e)
     {
+        _startupCancellation.Cancel();
         _protocolCallbackTimer?.Stop();
         _historyRetentionCoordinator?.HandleShutdown();
         _trayIcon?.Dispose();
-        _serviceProvider?.Dispose();
+
+        var serviceProvider = Interlocked.Exchange(ref _serviceProvider, null);
+        Services = null!;
+        var startupTask = Volatile.Read(ref _startupBackgroundTask);
+        if (serviceProvider is not null)
+        {
+            if (startupTask is { IsCompleted: false })
+            {
+                _ = startupTask.ContinueWith(
+                    static (_, state) => ((ServiceProvider)state!).Dispose(),
+                    serviceProvider,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            else
+            {
+                serviceProvider.Dispose();
+            }
+        }
+
         base.OnExit(e);
     }
 

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO;
 using TypeWhisper.Windows.Services;
+using TypeWhisper.Windows.Services.Plugins;
 using TypeWhisper.Core;
 #if TYPEWHISPER_STORE
 using Windows.ApplicationModel;
@@ -39,6 +40,12 @@ public static class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        if (NativeModelProbe.TryRun(args, out var probeExitCode))
+        {
+            Environment.ExitCode = probeExitCode;
+            return;
+        }
+
         var isStartupActivation = false;
 #if TYPEWHISPER_STORE
         try

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -1497,6 +1497,8 @@ internal sealed class WaveInAudioInputDeviceProvider : IAudioInputDeviceProvider
 
 internal sealed class WasapiAudioInputDeviceChangeNotifier : IAudioInputDeviceChangeNotifier, IMMNotificationClient
 {
+    private readonly object _captureEndpointIdsLock = new();
+    private readonly HashSet<string> _captureEndpointIds = new(StringComparer.OrdinalIgnoreCase);
     private MMDeviceEnumerator? _enumerator;
 
     public event EventHandler? DevicesChanged;
@@ -1510,11 +1512,13 @@ internal sealed class WasapiAudioInputDeviceChangeNotifier : IAudioInputDeviceCh
         try
         {
             enumerator = new MMDeviceEnumerator();
+            RefreshCaptureEndpointIds(enumerator);
             var result = enumerator.RegisterEndpointNotificationCallback(this);
             if (result < 0)
             {
                 AudioCaptureDiagnostics.Log(
                     $"Audio endpoint notification registration failed HRESULT=0x{result:X8}");
+                ClearCaptureEndpointIds();
                 enumerator.Dispose();
                 return false;
             }
@@ -1526,28 +1530,44 @@ internal sealed class WasapiAudioInputDeviceChangeNotifier : IAudioInputDeviceCh
         {
             AudioCaptureDiagnostics.Log(
                 $"Audio endpoint notification registration failed {ex.GetType().Name}: {ex.Message}");
+            ClearCaptureEndpointIds();
             enumerator?.Dispose();
             return false;
         }
     }
 
-    public void OnDeviceStateChanged(string deviceId, DeviceState newState) =>
-        RaiseDevicesChanged();
+    public void OnDeviceStateChanged(string deviceId, DeviceState newState)
+    {
+        if (IsCaptureEndpoint(deviceId))
+            RaiseDevicesChanged();
+    }
 
-    public void OnDeviceAdded(string pwstrDeviceId) =>
-        RaiseDevicesChanged();
+    public void OnDeviceAdded(string pwstrDeviceId)
+    {
+        if (IsCaptureEndpoint(pwstrDeviceId))
+            RaiseDevicesChanged();
+    }
 
-    public void OnDeviceRemoved(string deviceId) =>
-        RaiseDevicesChanged();
+    public void OnDeviceRemoved(string deviceId)
+    {
+        if (ForgetCaptureEndpoint(deviceId))
+            RaiseDevicesChanged();
+    }
 
     public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
     {
         if (flow == DataFlow.Capture)
+        {
+            RememberCaptureEndpoint(defaultDeviceId);
             RaiseDevicesChanged();
+        }
     }
 
-    public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) =>
-        RaiseDevicesChanged();
+    public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key)
+    {
+        if (IsRelevantCaptureProperty(key) && IsCaptureEndpoint(pwstrDeviceId))
+            RaiseDevicesChanged();
+    }
 
     public void Dispose()
     {
@@ -1567,7 +1587,84 @@ internal sealed class WasapiAudioInputDeviceChangeNotifier : IAudioInputDeviceCh
         finally
         {
             enumerator.Dispose();
+            ClearCaptureEndpointIds();
         }
+    }
+
+    internal static bool IsRelevantCaptureProperty(PropertyKey key) =>
+        key.Equals(PropertyKeys.PKEY_Device_FriendlyName)
+        || key.Equals(PropertyKeys.PKEY_DeviceInterface_FriendlyName)
+        || key.Equals(PropertyKeys.PKEY_Device_DeviceDesc)
+        || key.Equals(PropertyKeys.PKEY_AudioEngine_DeviceFormat)
+        || key.Equals(PropertyKeys.PKEY_AudioEngine_OEMFormat);
+
+    private void RefreshCaptureEndpointIds(MMDeviceEnumerator enumerator)
+    {
+        var endpointIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var device in enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.All))
+        {
+            using (device)
+                endpointIds.Add(device.ID);
+        }
+
+        lock (_captureEndpointIdsLock)
+        {
+            _captureEndpointIds.Clear();
+            _captureEndpointIds.UnionWith(endpointIds);
+        }
+    }
+
+    private bool IsCaptureEndpoint(string? deviceId)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return false;
+
+        lock (_captureEndpointIdsLock)
+        {
+            if (_captureEndpointIds.Contains(deviceId))
+                return true;
+        }
+
+        var enumerator = Volatile.Read(ref _enumerator);
+        if (enumerator is null)
+            return false;
+
+        try
+        {
+            using var device = enumerator.GetDevice(deviceId);
+            if (device.DataFlow != DataFlow.Capture)
+                return false;
+
+            RememberCaptureEndpoint(deviceId);
+            return true;
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Audio endpoint classification failed {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+
+    private void RememberCaptureEndpoint(string? deviceId)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return;
+
+        lock (_captureEndpointIdsLock)
+            _captureEndpointIds.Add(deviceId);
+    }
+
+    private bool ForgetCaptureEndpoint(string deviceId)
+    {
+        lock (_captureEndpointIdsLock)
+            return _captureEndpointIds.Remove(deviceId);
+    }
+
+    private void ClearCaptureEndpointIds()
+    {
+        lock (_captureEndpointIdsLock)
+            _captureEndpointIds.Clear();
     }
 
     private void RaiseDevicesChanged() =>
@@ -1838,11 +1935,35 @@ internal sealed class FallbackAudioInputCapture : IAudioInputCapture
         }
 
         _usingFallback = true;
-        _capture = _fallbackFactory.Create(
-            _deviceNumber,
-            _requestedWaveFormat,
-            _bufferMilliseconds);
-        AttachCapture();
+        try
+        {
+            _capture = _fallbackFactory.Create(
+                _deviceNumber,
+                _requestedWaveFormat,
+                _bufferMilliseconds);
+            AttachCapture();
+        }
+        catch
+        {
+            var failedCapture = _capture;
+            _capture = null;
+            _disposed = true;
+            if (failedCapture is not null)
+            {
+                try
+                {
+                    DetachCapture(failedCapture);
+                    failedCapture.Dispose();
+                }
+                catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+                {
+                    AudioCaptureDiagnostics.Log(
+                        $"Fallback microphone capture cleanup failed {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            throw;
+        }
     }
 
     private void AttachCapture()

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -1,5 +1,6 @@
 using NAudio;
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 using NAudio.Wave;
 using TypeWhisper.Core.Models;
 
@@ -19,7 +20,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     private const float AgcMinGain = 1f;
     private const float NormalizationTarget = 0.707f;
     private static readonly TimeSpan StopDrainDuration = TimeSpan.FromMilliseconds(120);
-    private static readonly TimeSpan DefaultDevicePollInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan FallbackDevicePollInterval = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Minimum per-chunk RMS level to consider as containing speech.
@@ -29,7 +30,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private readonly IAudioInputDeviceProvider _deviceProvider;
     private readonly IAudioInputCaptureFactory _captureFactory;
+    private readonly IAudioInputDeviceChangeNotifier? _deviceChangeNotifier;
     private readonly TimeSpan _devicePollInterval;
+    private readonly object _deviceInfoCacheLock = new();
+    private readonly object _deviceChangeCheckLock = new();
     private IAudioInputCapture? _waveIn;
     private IAudioInputCapture? _previewWaveIn;
     private List<float>? _sampleBuffer;
@@ -49,6 +53,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     private float _preGainPeakRms;
     private float _currentRmsLevel;
     private System.Timers.Timer? _devicePollTimer;
+    private IReadOnlyList<AudioInputDeviceInfo> _cachedDeviceInfos = [];
+    private bool _hasDeviceInfoCache;
+    private bool _deviceNotificationsStarted;
+    private int _deviceChangeRefreshQueued;
     private string _lastKnownDeviceSignature = "";
     private bool _lastKnownHasDevices;
     private bool _lastKnownPreferredDeviceAvailable;
@@ -63,7 +71,13 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// Initializes a new instance of the AudioRecordingService class.
     /// </summary>
     public AudioRecordingService()
-        : this(new WaveInAudioInputDeviceProvider(), new WaveInAudioInputCaptureFactory(), DefaultDevicePollInterval)
+        : this(
+            new WaveInAudioInputDeviceProvider(),
+            new FallbackAudioInputCaptureFactory(
+                new WasapiAudioInputCaptureFactory(),
+                new WaveInAudioInputCaptureFactory()),
+            FallbackDevicePollInterval,
+            new WasapiAudioInputDeviceChangeNotifier())
     {
     }
 
@@ -71,10 +85,20 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         IAudioInputDeviceProvider deviceProvider,
         IAudioInputCaptureFactory captureFactory,
         TimeSpan devicePollInterval)
+        : this(deviceProvider, captureFactory, devicePollInterval, deviceChangeNotifier: null)
+    {
+    }
+
+    internal AudioRecordingService(
+        IAudioInputDeviceProvider deviceProvider,
+        IAudioInputCaptureFactory captureFactory,
+        TimeSpan devicePollInterval,
+        IAudioInputDeviceChangeNotifier? deviceChangeNotifier)
     {
         _deviceProvider = deviceProvider;
         _captureFactory = captureFactory;
         _devicePollInterval = devicePollInterval;
+        _deviceChangeNotifier = deviceChangeNotifier;
     }
 
     /// <summary>
@@ -241,13 +265,28 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// Returns available input devices.
     /// </summary>
     public IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableInputDevices() =>
-        GetAvailableDevices(_deviceProvider);
+        TryGetDeviceInfos()
+            .Select(device => (device.DeviceNumber, device.Name))
+            .ToList();
 
     /// <summary>
     /// Returns available input devices with stable ids when available.
     /// </summary>
     internal IReadOnlyList<AudioInputDeviceInfo> GetAvailableInputDeviceInfos() =>
-        GetAvailableDeviceInfos(_deviceProvider);
+        TryGetDeviceInfos();
+
+    internal bool TryGetCachedAvailableInputDeviceInfos(
+        out IReadOnlyList<AudioInputDeviceInfo> deviceInfos)
+    {
+        lock (_deviceInfoCacheLock)
+        {
+            deviceInfos = _cachedDeviceInfos;
+            return _hasDeviceInfoCache;
+        }
+    }
+
+    internal IReadOnlyList<AudioInputDeviceInfo> RefreshAvailableInputDeviceInfos() =>
+        TryGetDeviceInfos(refresh: true);
 
     /// <summary>
     /// Starts recording.
@@ -471,7 +510,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             return;
 
         var captureFailed = e.Exception is not null;
-        var activeDeviceAvailable = IsActiveDeviceAvailable(GetDeviceSnapshot());
+        var activeDeviceAvailable = IsActiveDeviceAvailable(GetDeviceSnapshot(refresh: true));
         AudioCaptureDiagnostics.Log(
             $"RecordingStopped captureFailed={captureFailed} activeAvailable={activeDeviceAvailable} exception={e.Exception?.GetType().Name}:{e.Exception?.Message}");
 
@@ -674,28 +713,32 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private AudioInputDeviceInfo? TryGetDeviceInfo(int deviceNumber)
     {
-        if (deviceNumber < 0 || deviceNumber >= _deviceProvider.DeviceCount)
+        if (deviceNumber < 0)
             return null;
 
-        try
-        {
-            return _deviceProvider.GetDeviceInfo(deviceNumber);
-        }
-        catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException or MmException)
-        {
-            return null;
-        }
+        return TryGetDeviceInfos()
+            .FirstOrDefault(device => device.DeviceNumber == deviceNumber);
     }
 
-    private IReadOnlyList<AudioInputDeviceInfo> TryGetDeviceInfos()
+    private IReadOnlyList<AudioInputDeviceInfo> TryGetDeviceInfos(bool refresh = false)
     {
-        try
+        lock (_deviceInfoCacheLock)
         {
-            return _deviceProvider.GetDeviceInfos();
-        }
-        catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException or MmException)
-        {
-            return [];
+            if (!refresh && _hasDeviceInfoCache)
+                return _cachedDeviceInfos;
+
+            try
+            {
+                _cachedDeviceInfos = [.. _deviceProvider.GetDeviceInfos()];
+                _hasDeviceInfoCache = true;
+            }
+            catch (Exception ex) when (IsNonFatalAudioException(ex))
+            {
+                AudioCaptureDiagnostics.Log(
+                    $"Device info refresh failed {ex.GetType().Name}: {ex.Message}");
+            }
+
+            return _cachedDeviceInfos;
         }
     }
 
@@ -728,9 +771,22 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private void StartDevicePolling()
     {
+        if (_disposed || _deviceNotificationsStarted || _devicePollTimer is not null)
+            return;
+
         UpdateKnownDeviceSnapshot();
-        _devicePollTimer?.Dispose();
-        _devicePollTimer = null;
+
+        if (_deviceChangeNotifier is not null)
+        {
+            _deviceChangeNotifier.DevicesChanged += OnDeviceChangeNotification;
+            if (_deviceChangeNotifier.Start())
+            {
+                _deviceNotificationsStarted = true;
+                return;
+            }
+
+            _deviceChangeNotifier.DevicesChanged -= OnDeviceChangeNotification;
+        }
 
         if (_devicePollInterval == Timeout.InfiniteTimeSpan || _devicePollInterval <= TimeSpan.Zero)
             return;
@@ -739,6 +795,47 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         _devicePollTimer.Elapsed += (_, _) => CheckForDeviceChanges();
         _devicePollTimer.AutoReset = true;
         _devicePollTimer.Start();
+    }
+
+    private void OnDeviceChangeNotification(object? sender, EventArgs e)
+    {
+        if (_disposed)
+            return;
+
+        var previousState = Interlocked.CompareExchange(
+            ref _deviceChangeRefreshQueued,
+            1,
+            0);
+        if (previousState == 0)
+        {
+            ThreadPool.QueueUserWorkItem(
+                static state => ((AudioRecordingService)state!).ProcessDeviceChangeNotification(),
+                this);
+            return;
+        }
+
+        // State 2 records one follow-up pass. Additional endpoint callbacks
+        // arriving before that pass completes are intentionally coalesced.
+        Interlocked.CompareExchange(ref _deviceChangeRefreshQueued, 2, 1);
+    }
+
+    private void ProcessDeviceChangeNotification()
+    {
+        while (!_disposed)
+        {
+            Interlocked.Exchange(ref _deviceChangeRefreshQueued, 1);
+            CheckForDeviceChanges();
+
+            if (Interlocked.CompareExchange(
+                    ref _deviceChangeRefreshQueued,
+                    0,
+                    1) == 1)
+            {
+                return;
+            }
+        }
+
+        Interlocked.Exchange(ref _deviceChangeRefreshQueued, 0);
     }
 
     private void UpdateKnownDeviceSnapshot()
@@ -752,67 +849,70 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     internal void CheckForDeviceChanges()
     {
-        try
+        lock (_deviceChangeCheckLock)
         {
-            var snapshot = GetDeviceSnapshot();
-            var signature = BuildDeviceSignature(snapshot);
-            if (_lastKnownSnapshotInitialized && signature == _lastKnownDeviceSignature)
+            try
             {
-                // The device list is unchanged, but the system default endpoint
-                // may have moved (or a migration was deferred while recording).
-                EnsureActiveDeviceIsPreferred(snapshot);
-                return;
-            }
+                var snapshot = GetDeviceSnapshot(refresh: true);
+                var signature = BuildDeviceSignature(snapshot);
+                if (_lastKnownSnapshotInitialized && signature == _lastKnownDeviceSignature)
+                {
+                    // The device list is unchanged, but the system default endpoint
+                    // may have moved (or a migration was deferred while recording).
+                    EnsureActiveDeviceIsPreferred(snapshot);
+                    return;
+                }
 
-            var previousHadDevices = _lastKnownHasDevices;
-            var previousPreferredDeviceAvailable = _lastKnownPreferredDeviceAvailable;
-            var currentHasDevices = snapshot.Count > 0;
-            var currentPreferredDeviceAvailable = IsPreferredDeviceAvailable(snapshot);
+                var previousHadDevices = _lastKnownHasDevices;
+                var previousPreferredDeviceAvailable = _lastKnownPreferredDeviceAvailable;
+                var currentHasDevices = snapshot.Count > 0;
+                var currentPreferredDeviceAvailable = IsPreferredDeviceAvailable(snapshot);
 
-            _lastKnownDeviceSignature = signature;
-            _lastKnownHasDevices = currentHasDevices;
-            _lastKnownPreferredDeviceAvailable = currentPreferredDeviceAvailable;
-            _lastKnownSnapshotInitialized = true;
+                _lastKnownDeviceSignature = signature;
+                _lastKnownHasDevices = currentHasDevices;
+                _lastKnownPreferredDeviceAvailable = currentPreferredDeviceAvailable;
+                _lastKnownSnapshotInitialized = true;
 
-            DevicesChanged?.Invoke(this, EventArgs.Empty);
+                DevicesChanged?.Invoke(this, EventArgs.Empty);
 
-            if (!currentHasDevices)
-            {
-                if (_isWarmedUp || _waveIn is not null)
+                if (!currentHasDevices)
+                {
+                    if (_isWarmedUp || _waveIn is not null)
+                        HandleDeviceLost();
+                    return;
+                }
+
+                if (_isWarmedUp && !IsActiveDeviceAvailable(snapshot))
+                {
                     HandleDeviceLost();
-                return;
-            }
+                    WarmUp();
+                    if (!previousHadDevices
+                        || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
+                    {
+                        RaiseDeviceAvailableIfDeviceLossWasReported();
+                    }
+                    return;
+                }
 
-            if (_isWarmedUp && !IsActiveDeviceAvailable(snapshot))
-            {
-                HandleDeviceLost();
-                WarmUp();
+                if (_isWarmedUp && currentPreferredDeviceAvailable && !IsActiveDevicePreferred())
+                {
+                    EnsureActiveDeviceIsPreferred(snapshot);
+                }
+                else if (!_isWarmedUp)
+                {
+                    WarmUp();
+                }
+
                 if (!previousHadDevices
                     || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
                 {
                     RaiseDeviceAvailableIfDeviceLossWasReported();
                 }
-                return;
             }
-
-            if (_isWarmedUp && currentPreferredDeviceAvailable && !IsActiveDevicePreferred())
+            catch (Exception ex) when (IsNonFatalAudioException(ex))
             {
-                EnsureActiveDeviceIsPreferred(snapshot);
+                AudioCaptureDiagnostics.Log($"Device change check failed {ex.GetType().Name}: {ex.Message}");
             }
-            else if (!_isWarmedUp)
-            {
-                WarmUp();
-            }
-
-            if (!previousHadDevices
-                || (!previousPreferredDeviceAvailable && currentPreferredDeviceAvailable))
-            {
-                RaiseDeviceAvailableIfDeviceLossWasReported();
-            }
-        }
-        catch (Exception ex) when (IsNonFatalAudioException(ex))
-        {
-            AudioCaptureDiagnostics.Log($"Device change check failed {ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -918,10 +1018,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         }
     }
 
-    private IReadOnlyList<AudioInputDeviceSnapshot> GetDeviceSnapshot()
+    private IReadOnlyList<AudioInputDeviceSnapshot> GetDeviceSnapshot(bool refresh = false)
     {
         var devices = new List<AudioInputDeviceSnapshot>();
-        var deviceInfos = TryGetDeviceInfos();
+        var deviceInfos = TryGetDeviceInfos(refresh);
         if (deviceInfos.Count > 0)
         {
             foreach (var info in deviceInfos)
@@ -1144,11 +1244,18 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     {
         if (!_disposed)
         {
+            _disposed = true;
             _devicePollTimer?.Dispose();
+            _devicePollTimer = null;
+            if (_deviceChangeNotifier is not null)
+            {
+                if (_deviceNotificationsStarted)
+                    _deviceChangeNotifier.DevicesChanged -= OnDeviceChangeNotification;
+                _deviceChangeNotifier.Dispose();
+            }
             _isRecording = false;
             StopPreview();
             DisposeWaveIn();
-            _disposed = true;
         }
     }
 
@@ -1257,6 +1364,12 @@ internal interface IAudioInputDeviceProvider
     /// when it cannot be determined.
     /// </summary>
     string? GetDefaultDeviceName();
+}
+
+internal interface IAudioInputDeviceChangeNotifier : IDisposable
+{
+    event EventHandler? DevicesChanged;
+    bool Start();
 }
 
 internal interface IAudioInputCaptureFactory
@@ -1380,6 +1493,85 @@ internal sealed class WaveInAudioInputDeviceProvider : IAudioInputDeviceProvider
 
         return names;
     }
+}
+
+internal sealed class WasapiAudioInputDeviceChangeNotifier : IAudioInputDeviceChangeNotifier, IMMNotificationClient
+{
+    private MMDeviceEnumerator? _enumerator;
+
+    public event EventHandler? DevicesChanged;
+
+    public bool Start()
+    {
+        if (_enumerator is not null)
+            return true;
+
+        MMDeviceEnumerator? enumerator = null;
+        try
+        {
+            enumerator = new MMDeviceEnumerator();
+            var result = enumerator.RegisterEndpointNotificationCallback(this);
+            if (result < 0)
+            {
+                AudioCaptureDiagnostics.Log(
+                    $"Audio endpoint notification registration failed HRESULT=0x{result:X8}");
+                enumerator.Dispose();
+                return false;
+            }
+
+            _enumerator = enumerator;
+            return true;
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Audio endpoint notification registration failed {ex.GetType().Name}: {ex.Message}");
+            enumerator?.Dispose();
+            return false;
+        }
+    }
+
+    public void OnDeviceStateChanged(string deviceId, DeviceState newState) =>
+        RaiseDevicesChanged();
+
+    public void OnDeviceAdded(string pwstrDeviceId) =>
+        RaiseDevicesChanged();
+
+    public void OnDeviceRemoved(string deviceId) =>
+        RaiseDevicesChanged();
+
+    public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+    {
+        if (flow == DataFlow.Capture)
+            RaiseDevicesChanged();
+    }
+
+    public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) =>
+        RaiseDevicesChanged();
+
+    public void Dispose()
+    {
+        var enumerator = Interlocked.Exchange(ref _enumerator, null);
+        if (enumerator is null)
+            return;
+
+        try
+        {
+            enumerator.UnregisterEndpointNotificationCallback(this);
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Audio endpoint notification unregister failed {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            enumerator.Dispose();
+        }
+    }
+
+    private void RaiseDevicesChanged() =>
+        DevicesChanged?.Invoke(this, EventArgs.Empty);
 }
 
 internal sealed class WaveInAudioInputCaptureFactory : IAudioInputCaptureFactory
@@ -1530,6 +1722,151 @@ internal sealed class WasapiAudioInputCaptureFactory : IAudioInputCaptureFactory
         {
             WasapiAudioInputDeviceResolver.DisposeDevices(devices);
         }
+    }
+}
+
+internal sealed class FallbackAudioInputCaptureFactory(
+    IAudioInputCaptureFactory primaryFactory,
+    IAudioInputCaptureFactory fallbackFactory) : IAudioInputCaptureFactory
+{
+    public IAudioInputCapture Create(
+        int deviceNumber,
+        WaveFormat waveFormat,
+        int bufferMilliseconds) =>
+        new FallbackAudioInputCapture(
+            primaryFactory,
+            fallbackFactory,
+            deviceNumber,
+            waveFormat,
+            bufferMilliseconds);
+}
+
+internal sealed class FallbackAudioInputCapture : IAudioInputCapture
+{
+    private readonly IAudioInputCaptureFactory _fallbackFactory;
+    private readonly int _deviceNumber;
+    private readonly WaveFormat _requestedWaveFormat;
+    private readonly int _bufferMilliseconds;
+    private IAudioInputCapture? _capture;
+    private bool _usingFallback;
+    private bool _disposed;
+
+    public FallbackAudioInputCapture(
+        IAudioInputCaptureFactory primaryFactory,
+        IAudioInputCaptureFactory fallbackFactory,
+        int deviceNumber,
+        WaveFormat waveFormat,
+        int bufferMilliseconds)
+    {
+        _fallbackFactory = fallbackFactory;
+        _deviceNumber = deviceNumber;
+        _requestedWaveFormat = waveFormat;
+        _bufferMilliseconds = bufferMilliseconds;
+
+        try
+        {
+            _capture = primaryFactory.Create(deviceNumber, waveFormat, bufferMilliseconds);
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Primary microphone capture creation failed; using fallback {ex.GetType().Name}: {ex.Message}");
+            _usingFallback = true;
+            _capture = fallbackFactory.Create(deviceNumber, waveFormat, bufferMilliseconds);
+        }
+
+        AttachCapture();
+    }
+
+    public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
+    public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+
+    public WaveFormat WaveFormat =>
+        _capture?.WaveFormat ?? throw new ObjectDisposedException(nameof(FallbackAudioInputCapture));
+
+    public void StartRecording()
+    {
+        ThrowIfDisposed();
+
+        try
+        {
+            _capture!.StartRecording();
+        }
+        catch (Exception ex) when (!_usingFallback && NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Primary microphone capture start failed; using fallback {ex.GetType().Name}: {ex.Message}");
+            SwitchToFallback();
+            _capture!.StartRecording();
+        }
+    }
+
+    public void StopRecording()
+    {
+        ThrowIfDisposed();
+        _capture!.StopRecording();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        var capture = _capture;
+        _capture = null;
+        if (capture is null)
+            return;
+
+        DetachCapture(capture);
+        capture.Dispose();
+    }
+
+    private void SwitchToFallback()
+    {
+        var primaryCapture = _capture!;
+        _capture = null;
+        DetachCapture(primaryCapture);
+        try
+        {
+            primaryCapture.Dispose();
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Primary microphone capture cleanup failed {ex.GetType().Name}: {ex.Message}");
+        }
+
+        _usingFallback = true;
+        _capture = _fallbackFactory.Create(
+            _deviceNumber,
+            _requestedWaveFormat,
+            _bufferMilliseconds);
+        AttachCapture();
+    }
+
+    private void AttachCapture()
+    {
+        _capture!.DataAvailable += OnDataAvailable;
+        _capture.RecordingStopped += OnRecordingStopped;
+    }
+
+    private void DetachCapture(IAudioInputCapture capture)
+    {
+        capture.DataAvailable -= OnDataAvailable;
+        capture.RecordingStopped -= OnRecordingStopped;
+    }
+
+    private void OnDataAvailable(object? sender, AudioInputDataAvailableEventArgs e) =>
+        DataAvailable?.Invoke(this, e);
+
+    private void OnRecordingStopped(object? sender, AudioInputRecordingStoppedEventArgs e) =>
+        RecordingStopped?.Invoke(this, e);
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(FallbackAudioInputCapture));
     }
 }
 

--- a/src/TypeWhisper.Windows/Services/Plugins/NativeModelProbe.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/NativeModelProbe.cs
@@ -1,0 +1,183 @@
+using System.IO;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Windows.Services.Plugins;
+
+internal static class NativeModelProbe
+{
+    private const string ProbeArgument = "--native-model-probe";
+    private const string PluginDirectoryArgument = "--plugin-directory";
+    private const string PluginAssetDirectoryArgument = "--plugin-asset-directory";
+    private const string ModelIdArgument = "--model-id";
+    private const string RuntimeDirectoryArgument = "--runtime-directory";
+    private const string ExpectedPluginId = "com.typewhisper.sherpa-onnx";
+
+    internal static bool TryRun(string[] args, out int exitCode)
+    {
+        if (!args.Contains(ProbeArgument, StringComparer.OrdinalIgnoreCase))
+        {
+            exitCode = 0;
+            return false;
+        }
+
+        exitCode = RunAsync(args).GetAwaiter().GetResult();
+        return true;
+    }
+
+    private static async Task<int> RunAsync(string[] args)
+    {
+        var pluginDirectory = GetArgumentValue(args, PluginDirectoryArgument);
+        var pluginAssetDirectory = GetArgumentValue(args, PluginAssetDirectoryArgument);
+        var modelId = GetArgumentValue(args, ModelIdArgument);
+        var runtimeDirectory = GetArgumentValue(args, RuntimeDirectoryArgument);
+
+        if (!TryResolveDirectory(pluginDirectory, out var resolvedPluginDirectory)
+            || !TryResolveDirectory(pluginAssetDirectory, out var resolvedPluginAssetDirectory)
+            || !TryResolveDirectory(runtimeDirectory, out var resolvedRuntimeDirectory)
+            || string.IsNullOrWhiteSpace(modelId))
+        {
+            Console.Error.WriteLine("Native model probe received invalid arguments.");
+            return 2;
+        }
+
+        var expectedRuntimeRoot = Path.Join(
+            resolvedPluginAssetDirectory,
+            "Runtimes",
+            "sherpa-onnx-cuda");
+        if (!IsPathWithin(resolvedRuntimeDirectory, expectedRuntimeRoot))
+        {
+            Console.Error.WriteLine("Native model probe runtime directory is outside the plugin asset directory.");
+            return 2;
+        }
+
+        LoadedPlugin? loaded = null;
+        try
+        {
+            loaded = new PluginLoader().LoadPlugin(resolvedPluginDirectory);
+            if (loaded is null
+                || !string.Equals(loaded.Manifest.Id, ExpectedPluginId, StringComparison.OrdinalIgnoreCase)
+                || loaded.Instance is not ITranscriptionEnginePlugin engine)
+            {
+                Console.Error.WriteLine("Native model probe could not load the expected transcription plugin.");
+                return 2;
+            }
+
+            var host = new ProbePluginHostServices(resolvedPluginAssetDirectory);
+            await loaded.Instance.ActivateAsync(host);
+            engine.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+            await engine.LoadModelAsync(modelId, CancellationToken.None);
+            await loaded.Instance.DeactivateAsync();
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+            return 1;
+        }
+        finally
+        {
+            if (loaded is not null)
+            {
+                try
+                {
+                    loaded.Instance.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Probe cleanup failed: {ex.Message}");
+                }
+
+                loaded.LoadContext.Unload();
+            }
+        }
+    }
+
+    private static string? GetArgumentValue(IReadOnlyList<string> args, string name)
+    {
+        for (var index = 0; index < args.Count - 1; index++)
+        {
+            if (string.Equals(args[index], name, StringComparison.OrdinalIgnoreCase))
+                return args[index + 1];
+        }
+
+        return null;
+    }
+
+    private static bool TryResolveDirectory(string? path, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        try
+        {
+            resolvedPath = Path.GetFullPath(path);
+            return Directory.Exists(resolvedPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsPathWithin(string path, string parentDirectory)
+    {
+        var resolvedParent = Path.GetFullPath(parentDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        return path.StartsWith(resolvedParent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class ProbePluginHostServices(string pluginAssetDirectory) : IPluginHostServices
+    {
+        public string PluginDataDirectory => pluginAssetDirectory;
+        public string PluginAssetDirectory => pluginAssetDirectory;
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new ProbePluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public IPluginLocalization Localization { get; } = new ProbePluginLocalization();
+
+        public Task StoreSecretAsync(string key, string value) => Task.CompletedTask;
+        public Task<string?> LoadSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+        public T? GetSetting<T>(string key) => default;
+        public void SetSetting<T>(string key, T value)
+        {
+        }
+
+        public void Log(PluginLogLevel level, string message)
+        {
+        }
+
+        public void NotifyCapabilitiesChanged()
+        {
+        }
+    }
+
+    private sealed class ProbePluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent
+        {
+        }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new ProbeDisposable();
+    }
+
+    private sealed class ProbePluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class ProbeDisposable : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
@@ -201,9 +201,52 @@ public sealed class PluginManager : IDisposable
     {
         ct.ThrowIfCancellationRequested();
         var loadedPlugins = _loader.DiscoverAndLoad(_searchDirectories);
-        ct.ThrowIfCancellationRequested();
-        var discovered = PreferLaterSearchDirectoryPlugins(loadedPlugins);
-        UnloadDiscardedSearchDirectoryPlugins(loadedPlugins, discovered);
+        await InitializeLoadedPluginsAsync(loadedPlugins, ct);
+    }
+
+    internal async Task InitializeLoadedPluginsAsync(
+        IReadOnlyList<LoadedPlugin> loadedPlugins,
+        CancellationToken ct)
+    {
+        IReadOnlyList<LoadedPlugin> stagedPlugins = loadedPlugins;
+        var activatedPlugins = new List<LoadedPlugin>();
+        IReadOnlyList<LoadedPlugin> discovered;
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+            discovered = PreferLaterSearchDirectoryPlugins(loadedPlugins);
+            UnloadDiscardedSearchDirectoryPlugins(loadedPlugins, discovered);
+            stagedPlugins = discovered;
+
+            Debug.WriteLine($"[PluginManager] Discovered {discovered.Count} plugin(s)");
+
+            var enabledState = _settings.Current.PluginEnabledState;
+
+            foreach (var plugin in discovered)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                // Default to enabled for marketplace-installed plugins
+                var isEnabled = !enabledState.TryGetValue(plugin.Manifest.Id, out var state) || state;
+
+                if (isEnabled)
+                {
+                    await ActivatePluginAsync(plugin);
+                    lock (_lock)
+                    {
+                        if (_activatedPlugins.Contains(plugin.Manifest.Id))
+                            activatedPlugins.Add(plugin);
+                    }
+                }
+            }
+
+            ct.ThrowIfCancellationRequested();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            await RollbackInitializationAsync(stagedPlugins, activatedPlugins);
+            throw;
+        }
 
         lock (_lock)
         {
@@ -211,24 +254,6 @@ public sealed class PluginManager : IDisposable
             _allPlugins.AddRange(discovered);
         }
 
-        Debug.WriteLine($"[PluginManager] Discovered {discovered.Count} plugin(s)");
-
-        var enabledState = _settings.Current.PluginEnabledState;
-
-        foreach (var plugin in discovered)
-        {
-            ct.ThrowIfCancellationRequested();
-
-            // Default to enabled for marketplace-installed plugins
-            var isEnabled = !enabledState.TryGetValue(plugin.Manifest.Id, out var state) || state;
-
-            if (isEnabled)
-            {
-                await ActivatePluginAsync(plugin);
-            }
-        }
-
-        ct.ThrowIfCancellationRequested();
         RebuildCapabilityIndices();
         MigrateApiKeys();
     }
@@ -344,6 +369,55 @@ public sealed class PluginManager : IDisposable
         catch (Exception ex)
         {
             Debug.WriteLine($"[PluginManager] Failed to deactivate plugin {plugin.Manifest.Id}: {ex.Message}");
+        }
+    }
+
+    private async Task RollbackInitializationAsync(
+        IReadOnlyList<LoadedPlugin> stagedPlugins,
+        IReadOnlyList<LoadedPlugin> activatedPlugins)
+    {
+        foreach (var plugin in activatedPlugins.Reverse())
+        {
+            try
+            {
+                await plugin.Instance.DeactivateAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(
+                    $"[PluginManager] Failed to deactivate cancelled startup plugin {plugin.Manifest.Id}: {ex.Message}");
+            }
+            finally
+            {
+                lock (_lock)
+                {
+                    _hostServices.Remove(plugin.Manifest.Id);
+                    _activatedPlugins.Remove(plugin.Manifest.Id);
+                }
+            }
+        }
+
+        foreach (var plugin in stagedPlugins)
+        {
+            try
+            {
+                plugin.Instance.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(
+                    $"[PluginManager] Failed to dispose cancelled startup plugin {plugin.Manifest.Id}: {ex.Message}");
+            }
+
+            try
+            {
+                plugin.LoadContext.Unload();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(
+                    $"[PluginManager] Failed to unload cancelled startup plugin {plugin.Manifest.Id}: {ex.Message}");
+            }
         }
     }
 

--- a/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
+++ b/src/TypeWhisper.Windows/Services/Plugins/PluginManager.cs
@@ -197,9 +197,11 @@ public sealed class PluginManager : IDisposable
     /// Discovers plugins from the configured search directories, restores enabled
     /// state from settings, and activates all enabled plugins.
     /// </summary>
-    public async Task InitializeAsync()
+    public async Task InitializeAsync(CancellationToken ct = default)
     {
+        ct.ThrowIfCancellationRequested();
         var loadedPlugins = _loader.DiscoverAndLoad(_searchDirectories);
+        ct.ThrowIfCancellationRequested();
         var discovered = PreferLaterSearchDirectoryPlugins(loadedPlugins);
         UnloadDiscardedSearchDirectoryPlugins(loadedPlugins, discovered);
 
@@ -215,6 +217,8 @@ public sealed class PluginManager : IDisposable
 
         foreach (var plugin in discovered)
         {
+            ct.ThrowIfCancellationRequested();
+
             // Default to enabled for marketplace-installed plugins
             var isEnabled = !enabledState.TryGetValue(plugin.Manifest.Id, out var state) || state;
 
@@ -224,6 +228,7 @@ public sealed class PluginManager : IDisposable
             }
         }
 
+        ct.ThrowIfCancellationRequested();
         RebuildCapabilityIndices();
         MigrateApiKeys();
     }

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -425,7 +425,7 @@ public partial class SettingsViewModel : ObservableObject
 
             var availableDevices = await Task.Run(
                 () => _audio.RefreshAvailableInputDeviceInfos());
-            ApplyMicrophones(availableDevices);
+            _dispatchToUi(() => ApplyMicrophones(availableDevices));
             _microphonesInitialized =
                 _audio.TryGetCachedAvailableInputDeviceInfos(out _);
         }

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -31,8 +31,10 @@ public partial class SettingsViewModel : ObservableObject
     private readonly SpeechFeedbackService _speechFeedback;
     private readonly Action<Action> _dispatchToUi;
     private readonly object _previewLevelLock = new();
+    private readonly SemaphoreSlim _microphoneRefreshGate = new(1, 1);
     private float _pendingPreviewLevel;
     private bool _previewLevelDispatchQueued;
+    private bool _microphonesInitialized;
 
     [ObservableProperty] private string _toggleHotkey = "";
     [ObservableProperty] private string _pushToTalkHotkey = "";
@@ -366,7 +368,7 @@ public partial class SettingsViewModel : ObservableObject
         LoadFromSettings(_settings.Current);
         RefreshSpokenFeedbackProviders();
         AutostartEnabled = StartupService.IsEnabled;
-        RefreshMicrophones();
+        RefreshMicrophonesFromCache();
         RefreshApiServerStatus();
         RefreshCliState();
         RefreshApiExamples();
@@ -400,13 +402,56 @@ public partial class SettingsViewModel : ObservableObject
         };
     }
 
+    /// <summary>
+    /// Loads microphone devices once the settings window has rendered.
+    /// </summary>
+    public Task EnsureMicrophonesLoadedAsync() =>
+        RefreshMicrophonesAsync(skipIfInitialized: true);
+
     [RelayCommand]
-    private void RefreshMicrophones()
+    private Task RefreshMicrophonesAsync() =>
+        RefreshMicrophonesAsync(skipIfInitialized: false);
+
+    private async Task RefreshMicrophonesAsync(bool skipIfInitialized)
+    {
+        if (skipIfInitialized && _microphonesInitialized)
+            return;
+
+        await _microphoneRefreshGate.WaitAsync();
+        try
+        {
+            if (skipIfInitialized && _microphonesInitialized)
+                return;
+
+            var availableDevices = await Task.Run(
+                () => _audio.RefreshAvailableInputDeviceInfos());
+            ApplyMicrophones(availableDevices);
+            _microphonesInitialized =
+                _audio.TryGetCachedAvailableInputDeviceInfos(out _);
+        }
+        finally
+        {
+            _microphoneRefreshGate.Release();
+        }
+    }
+
+    private void RefreshMicrophonesFromCache()
+    {
+        if (_audio.TryGetCachedAvailableInputDeviceInfos(out var availableDevices))
+        {
+            ApplyMicrophones(availableDevices);
+            _microphonesInitialized = true;
+            return;
+        }
+
+        ApplyMicrophones([]);
+    }
+
+    private void ApplyMicrophones(IReadOnlyList<AudioInputDeviceInfo> availableDevices)
     {
         var selectedDevice = SelectedMicrophoneDevice;
         Microphones.Clear();
         Microphones.Add(new MicrophoneItem(null, Loc.Instance["Microphone.Default"]));
-        var availableDevices = _audio.GetAvailableInputDeviceInfos();
         foreach (var device in availableDevices)
         {
             Microphones.Add(new MicrophoneItem(device.DeviceNumber, device.Name, device.Id));
@@ -1119,7 +1164,7 @@ public partial class SettingsViewModel : ObservableObject
         ReplaceCollection(HistoryRetentionOptions, BuildHistoryRetentionOptions());
         ReplaceCollection(WidgetOptions, BuildWidgetOptions());
         if (refreshMicrophones)
-            RefreshMicrophones();
+            RefreshMicrophonesFromCache();
     }
 
     private string? ResolveLastTranslationTarget()
@@ -1212,7 +1257,7 @@ public partial class SettingsViewModel : ObservableObject
     {
         var wasPreviewing = _audio.IsPreviewing;
         StopMicrophonePreview();
-        RefreshMicrophones();
+        RefreshMicrophonesFromCache();
         _audio.SetMicrophonePriorityList(_microphonePriorityList);
         _audio.SetMicrophoneDevice(SelectedMicrophoneDevice);
         if (wasPreviewing)

--- a/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
@@ -85,6 +85,7 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
     private readonly DispatcherTimer _indicatorPreviewTimer = new(DispatcherPriority.Background);
     private readonly DateTime _indicatorPreviewStartedAt = DateTime.UtcNow;
     private bool _isSyncingUpdateChannel;
+    private bool _isWindowLoaded;
     private double _indicatorPreviewPhase;
 
     [ObservableProperty] private UserControl? _currentSection;
@@ -549,7 +550,7 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
         CurrentSection = section;
         CurrentRoute = route;
         _lastOpenedRoute = route;
-        UpdateMicrophonePreviewForRoute(Settings, previousRoute, route);
+        UpdateMicrophonePreviewForRoute(Settings, previousRoute, route, _isWindowLoaded);
 
         if (route is SettingsRoute.Dictation or SettingsRoute.Integrations)
             ModelManager.RefreshPluginAvailability();
@@ -558,13 +559,37 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
     internal static void UpdateMicrophonePreviewForRoute(
         SettingsViewModel settings,
         SettingsRoute previousRoute,
-        SettingsRoute route)
+        SettingsRoute route,
+        bool canStartPreview = true)
     {
         if (previousRoute == SettingsRoute.Dictation && route != SettingsRoute.Dictation)
             settings.StopMicrophonePreview();
 
-        if (route == SettingsRoute.Dictation)
+        if (canStartPreview && route == SettingsRoute.Dictation)
             settings.StartMicrophonePreview();
+    }
+
+    /// <summary>
+    /// Starts work that should only run while the settings window is visible.
+    /// </summary>
+    public void OnWindowLoaded()
+    {
+        _isWindowLoaded = true;
+        UpdateMicrophonePreviewForRoute(Settings, CurrentRoute, CurrentRoute);
+        SyncIndicatorPreviewTimer(CurrentRoute);
+    }
+
+    /// <summary>
+    /// Stops window-scoped work and releases cached section controls.
+    /// </summary>
+    public void OnWindowClosed()
+    {
+        _isWindowLoaded = false;
+        Settings.StopMicrophonePreview();
+        SyncIndicatorPreviewTimer(CurrentRoute);
+        CurrentSection = null;
+        _sectionCache.Clear();
+        _sectionFactories.Clear();
     }
 
     internal bool FocusInstalledPlugin(string pluginId)
@@ -669,7 +694,7 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
 
     private void SyncIndicatorPreviewTimer(SettingsRoute route)
     {
-        if (route == SettingsRoute.Appearance)
+        if (_isWindowLoaded && route == SettingsRoute.Appearance)
         {
             if (!_indicatorPreviewTimer.IsEnabled)
                 _indicatorPreviewTimer.Start();

--- a/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsWindowViewModel.cs
@@ -589,7 +589,6 @@ public sealed partial class SettingsWindowViewModel : ObservableObject
         SyncIndicatorPreviewTimer(CurrentRoute);
         CurrentSection = null;
         _sectionCache.Clear();
-        _sectionFactories.Clear();
     }
 
     internal bool FocusInstalledPlugin(string pluginId)

--- a/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using System.Windows;
 using System.Windows.Threading;
+using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.ViewModels;
 using TypeWhisper.Windows.Views.Sections;
 using Wpf.Ui.Controls;
@@ -52,18 +53,26 @@ public partial class SettingsWindow : FluentWindow
     {
         Loaded -= OnLoaded;
 
-        // Let WPF render the settings shell before constructing the selected
-        // section or enumerating audio hardware.
-        await Dispatcher.Yield(DispatcherPriority.ContextIdle);
-        if (_isClosed)
-            return;
+        try
+        {
+            // Let WPF render the settings shell before constructing the selected
+            // section or enumerating audio hardware.
+            await Dispatcher.Yield(DispatcherPriority.ContextIdle);
+            if (_isClosed)
+                return;
 
-        if (_viewModel.CurrentSection is null)
-            _viewModel.NavigateToDefault();
+            if (_viewModel.CurrentSection is null)
+                _viewModel.NavigateToDefault();
 
-        await _viewModel.Settings.EnsureMicrophonesLoadedAsync();
-        if (!_isClosed)
-            _viewModel.OnWindowLoaded();
+            await _viewModel.Settings.EnsureMicrophonesLoadedAsync();
+            if (!_isClosed)
+                _viewModel.OnWindowLoaded();
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"Deferred settings initialization failed: {ex}");
+        }
     }
 
     private void OnSetupWizardRequested(object? sender, EventArgs e)

--- a/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/SettingsWindow.xaml.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using System.Windows;
+using System.Windows.Threading;
 using TypeWhisper.Windows.ViewModels;
 using TypeWhisper.Windows.Views.Sections;
 using Wpf.Ui.Controls;
@@ -12,6 +14,7 @@ public partial class SettingsWindow : FluentWindow
 {
     private readonly SettingsWindowViewModel _viewModel;
     private WelcomeWindow? _setupWizard;
+    private bool _isClosed;
 
     /// <summary>
     /// Initializes a new instance of the SettingsWindow class.
@@ -39,11 +42,28 @@ public partial class SettingsWindow : FluentWindow
         viewModel.RegisterSection(SettingsRoute.License, () => new LicenseSection { DataContext = viewModel });
         viewModel.RegisterSection(SettingsRoute.About, () => new InfoSection { DataContext = viewModel });
 
-        viewModel.NavigateToDefault();
-
         _viewModel.SetupWizardRequested += OnSetupWizardRequested;
+        Loaded += OnLoaded;
         Closing += OnClosing;
         Closed += OnClosed;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoaded;
+
+        // Let WPF render the settings shell before constructing the selected
+        // section or enumerating audio hardware.
+        await Dispatcher.Yield(DispatcherPriority.ContextIdle);
+        if (_isClosed)
+            return;
+
+        if (_viewModel.CurrentSection is null)
+            _viewModel.NavigateToDefault();
+
+        await _viewModel.Settings.EnsureMicrophonesLoadedAsync();
+        if (!_isClosed)
+            _viewModel.OnWindowLoaded();
     }
 
     private void OnSetupWizardRequested(object? sender, EventArgs e)
@@ -77,7 +97,10 @@ public partial class SettingsWindow : FluentWindow
 
     private void OnClosed(object? sender, EventArgs e)
     {
+        _isClosed = true;
+        Loaded -= OnLoaded;
         _viewModel.SetupWizardRequested -= OnSetupWizardRequested;
+        _viewModel.OnWindowClosed();
         _setupWizard = null;
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
@@ -40,7 +40,8 @@ public sealed class AppStartupPerformanceTests
 
         Assert.Contains("protected override async void OnStartup", startup);
         Assert.Contains("await Dispatcher.Yield(DispatcherPriority.ContextIdle);", startup);
-        Assert.Contains("await Task.Run(() => pluginManager.InitializeAsync());", startup);
+        Assert.Contains("await RunTrackedStartupWorkAsync(", startup);
+        Assert.Contains("token => pluginManager.InitializeAsync(token)", startup);
         Assert.DoesNotContain("InitializeAsync().GetAwaiter().GetResult()", startup);
 
         var trayIndex = startup.IndexOf("_trayIcon.Initialize();", StringComparison.Ordinal);
@@ -49,7 +50,7 @@ public sealed class AppStartupPerformanceTests
             "await Dispatcher.Yield(DispatcherPriority.ContextIdle);",
             StringComparison.Ordinal);
         var pluginsIndex = startup.IndexOf(
-            "await Task.Run(() => pluginManager.InitializeAsync());",
+            "token => pluginManager.InitializeAsync(token)",
             StringComparison.Ordinal);
 
         Assert.True(
@@ -58,6 +59,21 @@ public sealed class AppStartupPerformanceTests
             && windowIndex < yieldIndex
             && yieldIndex < pluginsIndex,
             "The tray and overlay shell must render before plugin discovery starts.");
+    }
+
+    [Fact]
+    public void OnExit_CancelsAndDrainsTrackedStartupWorkBeforeServiceDisposal()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var onExit = TestFile.ExtractBlock(source, "protected override void OnExit", 2200);
+
+        Assert.Contains("_startupCancellation.Cancel();", onExit);
+        Assert.Contains("startupTask is { IsCompleted: false }", onExit);
+        Assert.Contains("startupTask.ContinueWith(", onExit);
+        Assert.Contains("((ServiceProvider)state!).Dispose()", onExit);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
@@ -16,6 +16,71 @@ public sealed class AppStartupPerformanceTests
     }
 
     [Fact]
+    public void OnStartup_DoesNotEagerLoadTheSelectedLocalModel()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var startup = TestFile.ExtractBlock(source, "protected override", 16000);
+
+        Assert.DoesNotContain("Auto-load previously selected model", startup);
+        Assert.DoesNotContain("modelManager.LoadModelAsync(settings.Current.SelectedModelId)", startup);
+        Assert.Contains("modelManager.MigrateSettings()", startup);
+    }
+
+    [Fact]
+    public void OnStartup_RendersTheAppShellBeforePluginDiscovery()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var startup = TestFile.ExtractBlock(source, "protected override", 16000);
+
+        Assert.Contains("protected override async void OnStartup", startup);
+        Assert.Contains("await Dispatcher.Yield(DispatcherPriority.ContextIdle);", startup);
+        Assert.Contains("await Task.Run(() => pluginManager.InitializeAsync());", startup);
+        Assert.DoesNotContain("InitializeAsync().GetAwaiter().GetResult()", startup);
+
+        var trayIndex = startup.IndexOf("_trayIcon.Initialize();", StringComparison.Ordinal);
+        var windowIndex = startup.IndexOf("mainWindow.Show();", StringComparison.Ordinal);
+        var yieldIndex = startup.IndexOf(
+            "await Dispatcher.Yield(DispatcherPriority.ContextIdle);",
+            StringComparison.Ordinal);
+        var pluginsIndex = startup.IndexOf(
+            "await Task.Run(() => pluginManager.InitializeAsync());",
+            StringComparison.Ordinal);
+
+        Assert.True(
+            trayIndex >= 0
+            && trayIndex < windowIndex
+            && windowIndex < yieldIndex
+            && yieldIndex < pluginsIndex,
+            "The tray and overlay shell must render before plugin discovery starts.");
+    }
+
+    [Fact]
+    public void SettingsWindow_DefersMicrophoneRefreshAndPreviewUntilLoaded()
+    {
+        var window = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "SettingsWindow.xaml.cs");
+        var settings = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "SettingsViewModel.cs");
+        var constructor = TestFile.ExtractBlock(settings, "public SettingsViewModel(", 2600);
+
+        Assert.Contains("Loaded += OnLoaded;", window);
+        Assert.Contains("EnsureMicrophonesLoadedAsync", window);
+        Assert.DoesNotContain("RefreshMicrophones();", constructor);
+    }
+
+    [Fact]
     public void NonFatalStartupAndAudioFilters_UseSharedFatalExceptionFilter()
     {
         var appSource = TestFile.ReadProjectFile(

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using NAudio.CoreAudioApi;
 using NAudio.Wave;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
@@ -52,6 +53,32 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
+    public void FallbackCapture_DoesNotMaskFallbackCreationFailureDuringCleanup()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var wasapi = new FakeAudioInputCaptureFactory
+        {
+            StartException = new InvalidOperationException("WASAPI activation failed.")
+        };
+        var waveIn = new FakeAudioInputCaptureFactory
+        {
+            CreateException = new InvalidOperationException("WaveIn creation failed.")
+        };
+        var captures = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
+        using var sut = new AudioRecordingService(
+            devices,
+            captures,
+            Timeout.InfiniteTimeSpan);
+
+        var exception = Record.Exception(sut.StartRecording);
+
+        Assert.Null(exception);
+        Assert.False(sut.IsRecording);
+        Assert.True(Assert.Single(wasapi.Created).Disposed);
+        Assert.Empty(waveIn.Created);
+    }
+
+    [Fact]
     public void FallbackCapture_ForwardsWaveInAudioToTheRecordingService()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
@@ -90,9 +117,22 @@ public sealed class AudioRecordingServiceDeviceChangeTests
         var defaultConstructor = TestFile.ExtractBlock(source, "public AudioRecordingService()", 360);
 
         Assert.Contains("new WasapiAudioInputDeviceChangeNotifier()", defaultConstructor);
-        Assert.DoesNotContain("TimeSpan.FromSeconds(2)", source);
+        Assert.Contains(
+            "FallbackDevicePollInterval = TimeSpan.FromSeconds(30);",
+            source);
         Assert.Contains("RegisterEndpointNotificationCallback", source);
         Assert.Contains("UnregisterEndpointNotificationCallback", source);
+    }
+
+    [Fact]
+    public void WasapiDeviceNotifications_IgnoreUnrelatedEndpointProperties()
+    {
+        Assert.True(WasapiAudioInputDeviceChangeNotifier.IsRelevantCaptureProperty(
+            PropertyKeys.PKEY_Device_FriendlyName));
+        Assert.True(WasapiAudioInputDeviceChangeNotifier.IsRelevantCaptureProperty(
+            PropertyKeys.PKEY_AudioEngine_DeviceFormat));
+        Assert.False(WasapiAudioInputDeviceChangeNotifier.IsRelevantCaptureProperty(
+            PropertyKeys.PKEY_Device_IconPath));
     }
 
     [Fact]
@@ -934,10 +974,10 @@ public sealed class SettingsViewModelMicrophoneDeviceTests
         var settings = new FakeSettingsService(AppSettings.Default with { SelectedMicrophoneDevice = 1 });
         using var pluginManager = TestPluginManagerFactory.Create(settings);
         using var speech = new SpeechFeedbackService(settings, pluginManager, new FakeTtsProvider("windows-sapi", "System Voice"));
-        var settingsReloadCount = 0;
+        var uiDispatchCount = 0;
         var sut = CreateSettingsViewModel(settings, audio, speech, action =>
         {
-            settingsReloadCount++;
+            uiDispatchCount++;
             action();
         });
 
@@ -948,7 +988,7 @@ public sealed class SettingsViewModelMicrophoneDeviceTests
         await sut.RefreshMicrophonesCommand.ExecuteAsync(null);
 
         Assert.Equal(1, settings.SaveCount);
-        Assert.Equal(0, settingsReloadCount);
+        Assert.Equal(1, uiDispatchCount);
         Assert.Equal("usb", sut.SelectedMicrophoneItem?.Id);
         Assert.Equal([new MicrophonePriorityItem("usb", "USB Microphone")], settings.Current.MicrophonePriorityList);
     }
@@ -1436,10 +1476,14 @@ internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
 {
     public List<FakeAudioInputCapture> Created { get; } = [];
     public WaveFormat? ActualWaveFormat { get; set; }
+    public Exception? CreateException { get; set; }
     public Exception? StartException { get; set; }
 
     public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
     {
+        if (CreateException is not null)
+            throw CreateException;
+
         var capture = new FakeAudioInputCapture(deviceNumber, ActualWaveFormat ?? waveFormat)
         {
             StartException = StartException

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -13,20 +13,116 @@ namespace TypeWhisper.PluginSystem.Tests;
 public sealed class AudioRecordingServiceDeviceChangeTests
 {
     [Fact]
-    public void DefaultMicrophoneCapture_UsesWaveInInsteadOfWasapi()
+    public void DefaultMicrophoneCapture_UsesWasapiWithWaveInFallback()
     {
         var source = TestFile.ReadProjectFile(
             "src",
             "TypeWhisper.Windows",
             "Services",
             "AudioRecordingService.cs");
-        var defaultConstructor = TestFile.ExtractBlock(source, "public AudioRecordingService()", 260);
+        var defaultConstructor = TestFile.ExtractBlock(source, "public AudioRecordingService()", 420);
         var staticDeviceList = TestFile.ExtractBlock(source, "public static IReadOnlyList<(int DeviceNumber, string Name)> GetAvailableDevices()", 180);
 
         Assert.Contains("new WaveInAudioInputDeviceProvider()", defaultConstructor);
+        Assert.Contains("new FallbackAudioInputCaptureFactory(", defaultConstructor);
+        Assert.Contains("new WasapiAudioInputCaptureFactory()", defaultConstructor);
         Assert.Contains("new WaveInAudioInputCaptureFactory()", defaultConstructor);
-        Assert.DoesNotContain("WasapiAudioInput", defaultConstructor);
+        Assert.DoesNotContain("new WasapiAudioInputDeviceProvider()", defaultConstructor);
         Assert.Contains("new WaveInAudioInputDeviceProvider()", staticDeviceList);
+    }
+
+    [Fact]
+    public void FallbackCapture_UsesWaveInWhenWasapiStartFails()
+    {
+        var wasapi = new FakeAudioInputCaptureFactory
+        {
+            StartException = new InvalidOperationException("WASAPI activation failed.")
+        };
+        var waveIn = new FakeAudioInputCaptureFactory();
+        var factory = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
+        using var capture = factory.Create(
+            deviceNumber: 0,
+            new WaveFormat(16000, 16, 1),
+            bufferMilliseconds: 30);
+
+        capture.StartRecording();
+
+        Assert.True(Assert.Single(wasapi.Created).Disposed);
+        Assert.True(Assert.Single(waveIn.Created).Started);
+    }
+
+    [Fact]
+    public void FallbackCapture_ForwardsWaveInAudioToTheRecordingService()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var wasapi = new FakeAudioInputCaptureFactory
+        {
+            StartException = new InvalidOperationException("WASAPI activation failed.")
+        };
+        var waveIn = new FakeAudioInputCaptureFactory();
+        var captures = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
+        using var sut = new AudioRecordingService(
+            devices,
+            captures,
+            Timeout.InfiniteTimeSpan);
+        sut.NormalizationEnabled = false;
+        var source = new short[] { 8192, 16384 };
+        var bytes = new byte[source.Length * sizeof(short)];
+        Buffer.BlockCopy(source, 0, bytes, 0, bytes.Length);
+
+        sut.StartRecording();
+        Assert.True(sut.IsRecording);
+        Assert.Single(waveIn.Created).RaiseData(bytes, bytes.Length);
+        var samples = sut.StopRecording();
+
+        Assert.NotNull(samples);
+        Assert.Equal(source.Length, samples.Length);
+    }
+
+    [Fact]
+    public void DefaultDeviceMonitoring_UsesWasapiNotificationsInsteadOfTwoSecondPolling()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "AudioRecordingService.cs");
+        var defaultConstructor = TestFile.ExtractBlock(source, "public AudioRecordingService()", 360);
+
+        Assert.Contains("new WasapiAudioInputDeviceChangeNotifier()", defaultConstructor);
+        Assert.DoesNotContain("TimeSpan.FromSeconds(2)", source);
+        Assert.Contains("RegisterEndpointNotificationCallback", source);
+        Assert.Contains("UnregisterEndpointNotificationCallback", source);
+    }
+
+    [Fact]
+    public async Task DeviceChangeNotification_RefreshesCachedDevicesWithoutPeriodicPolling()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        var notifier = new FakeAudioInputDeviceChangeNotifier();
+        using var sut = new AudioRecordingService(
+            devices,
+            captures,
+            Timeout.InfiniteTimeSpan,
+            notifier);
+        Assert.True(sut.WarmUp());
+        var initialDeviceInfoRequests = devices.DeviceInfoRequestCount;
+
+        Assert.Equal("USB Microphone", Assert.Single(sut.GetAvailableInputDeviceInfos()).Name);
+        Assert.Equal("USB Microphone", Assert.Single(sut.GetAvailableInputDeviceInfos()).Name);
+        Assert.Equal(initialDeviceInfoRequests, devices.DeviceInfoRequestCount);
+
+        var changed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        sut.DevicesChanged += (_, _) => changed.TrySetResult();
+        devices.SetDevices("Built-in Microphone");
+
+        notifier.RaiseDevicesChanged();
+        await changed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(1, notifier.StartCount);
+        Assert.Equal(initialDeviceInfoRequests + 1, devices.DeviceInfoRequestCount);
+        Assert.Equal("Built-in Microphone", Assert.Single(sut.GetAvailableInputDeviceInfos()).Name);
     }
 
     [Fact]
@@ -827,7 +923,7 @@ public sealed class SettingsViewModelMicrophoneDeviceTests
     }
 
     [Fact]
-    public void RefreshMicrophones_MigratesLegacyMicrophoneWithoutReentrantSettingsLoad()
+    public async Task RefreshMicrophones_MigratesLegacyMicrophoneWithoutReentrantSettingsLoad()
     {
         Loc.Instance.Initialize();
         Loc.Instance.CurrentLanguage = "en";
@@ -849,7 +945,7 @@ public sealed class SettingsViewModelMicrophoneDeviceTests
             new FakeAudioInputDevice("built-in", "Built-in Microphone"),
             new FakeAudioInputDevice("usb", "USB Microphone"));
 
-        sut.RefreshMicrophonesCommand.Execute(null);
+        await sut.RefreshMicrophonesCommand.ExecuteAsync(null);
 
         Assert.Equal(1, settings.SaveCount);
         Assert.Equal(0, settingsReloadCount);
@@ -952,6 +1048,7 @@ public sealed class SettingsViewModelMicrophoneDeviceTests
         SpeechFeedbackService speech,
         Action<Action>? dispatchToUi = null)
     {
+        audio.RefreshAvailableInputDeviceInfos();
         var api = new ApiServerController(Mock.Of<ILocalApiServer>(), settings);
         var cli = new CliInstallService();
         return new SettingsViewModel(settings, audio, api, cli, speech, dispatchToUi: dispatchToUi ?? (action => action()));
@@ -1266,6 +1363,8 @@ internal sealed class FakeAudioInputDeviceProvider : IAudioInputDeviceProvider
 
     public int DeviceNameRequestCount { get; private set; }
 
+    public int DeviceInfoRequestCount { get; private set; }
+
     public string? DefaultDeviceName { get; set; }
 
     public string GetDeviceName(int deviceNumber)
@@ -1283,6 +1382,7 @@ internal sealed class FakeAudioInputDeviceProvider : IAudioInputDeviceProvider
 
     public IReadOnlyList<AudioInputDeviceInfo> GetDeviceInfos()
     {
+        DeviceInfoRequestCount++;
         return _devices
             .Select((_, index) => ToDeviceInfo(index))
             .ToList();
@@ -1312,14 +1412,38 @@ internal sealed class FakeAudioInputDeviceProvider : IAudioInputDeviceProvider
             _devices[deviceNumber].Name == DefaultDeviceName);
 }
 
+internal sealed class FakeAudioInputDeviceChangeNotifier : IAudioInputDeviceChangeNotifier
+{
+    public event EventHandler? DevicesChanged;
+
+    public int StartCount { get; private set; }
+
+    public bool Start()
+    {
+        StartCount++;
+        return true;
+    }
+
+    public void RaiseDevicesChanged() =>
+        DevicesChanged?.Invoke(this, EventArgs.Empty);
+
+    public void Dispose()
+    {
+    }
+}
+
 internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
 {
     public List<FakeAudioInputCapture> Created { get; } = [];
     public WaveFormat? ActualWaveFormat { get; set; }
+    public Exception? StartException { get; set; }
 
     public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
     {
-        var capture = new FakeAudioInputCapture(deviceNumber, ActualWaveFormat ?? waveFormat);
+        var capture = new FakeAudioInputCapture(deviceNumber, ActualWaveFormat ?? waveFormat)
+        {
+            StartException = StartException
+        };
         Created.Add(capture);
         return capture;
     }
@@ -1332,11 +1456,18 @@ internal sealed class FakeAudioInputCapture(int deviceNumber, WaveFormat waveFor
     public bool Started { get; private set; }
     public bool Stopped { get; private set; }
     public bool Disposed { get; private set; }
+    public Exception? StartException { get; init; }
 
     public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
     public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
 
-    public void StartRecording() => Started = true;
+    public void StartRecording()
+    {
+        if (StartException is not null)
+            throw StartException;
+
+        Started = true;
+    }
 
     public void StopRecording() => Stopped = true;
 

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginManagerTests.cs
@@ -196,6 +196,39 @@ public class PluginManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task InitializeLoadedPluginsAsync_CancellationRollsBackActivatedAndStagedPlugins()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var first = CreateLoadedPlugin(
+            "com.test.first",
+            "1.0.0",
+            @"C:\Plugins\com.test.first",
+            cancellation.Cancel);
+        var second = CreateLoadedPlugin(
+            "com.test.second",
+            "1.0.0",
+            @"C:\Plugins\com.test.second");
+        var firstInstance = Assert.IsType<MultiRolePlugin>(first.Instance);
+        var secondInstance = Assert.IsType<MultiRolePlugin>(second.Instance);
+        var manager = CreateManager();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            manager.InitializeLoadedPluginsAsync([first, second], cancellation.Token));
+
+        Assert.Empty(manager.AllPlugins);
+        Assert.Empty(manager.LlmProviders);
+        Assert.Empty(manager.TranscriptionEngines);
+        Assert.False(manager.IsEnabled(first.Manifest.Id));
+        Assert.False(manager.IsEnabled(second.Manifest.Id));
+        Assert.Equal(1, firstInstance.ActivateCount);
+        Assert.Equal(1, firstInstance.DeactivateCount);
+        Assert.Equal(1, firstInstance.DisposeCount);
+        Assert.Equal(0, secondInstance.ActivateCount);
+        Assert.Equal(0, secondInstance.DeactivateCount);
+        Assert.Equal(1, secondInstance.DisposeCount);
+    }
+
+    [Fact]
     public void CapabilityIndices_IncludeAdditionalRolesWithoutDuplicatingAllPlugins()
     {
         var manager = CreateManager();
@@ -243,9 +276,13 @@ public class PluginManagerTests : IDisposable
         Assert.True(eventFired);
     }
 
-    private static LoadedPlugin CreateLoadedPlugin(string id, string version, string pluginDirectory)
+    private static LoadedPlugin CreateLoadedPlugin(
+        string id,
+        string version,
+        string pluginDirectory,
+        Action? onActivate = null)
     {
-        var plugin = new MultiRolePlugin(id, version);
+        var plugin = new MultiRolePlugin(id, version, onActivate);
         var manifest = new PluginManifest
         {
             Id = plugin.PluginId,
@@ -286,6 +323,7 @@ public class PluginManagerTests : IDisposable
         private readonly ProfileRole _duplicateProfileRole;
         private readonly string _pluginId;
         private readonly string _pluginVersion;
+        private readonly Action? _onActivate;
         private bool _includeAdditionalRoles = true;
 
         public MultiRolePlugin()
@@ -293,10 +331,14 @@ public class PluginManagerTests : IDisposable
         {
         }
 
-        public MultiRolePlugin(string pluginId, string pluginVersion)
+        public MultiRolePlugin(
+            string pluginId,
+            string pluginVersion,
+            Action? onActivate = null)
         {
             _pluginId = pluginId;
             _pluginVersion = pluginVersion;
+            _onActivate = onActivate;
             _profileRole = new ProfileRole(pluginId, "openai-compatible-profile-a", "Profile A");
             _duplicateProfileRole = new ProfileRole(pluginId, "openai-compatible-profile-a", "Profile A Duplicate");
         }
@@ -317,11 +359,23 @@ public class PluginManagerTests : IDisposable
             _includeAdditionalRoles ? [_profileRole, _duplicateProfileRole] : [];
         public IReadOnlyList<ILlmProviderPlugin> AdditionalLlmProviders =>
             _includeAdditionalRoles ? [_profileRole, _duplicateProfileRole] : [];
+        public int ActivateCount { get; private set; }
+        public int DeactivateCount { get; private set; }
         public int DisposeCount { get; private set; }
 
         public void ClearAdditionalRoles() => _includeAdditionalRoles = false;
-        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
-        public Task DeactivateAsync() => Task.CompletedTask;
+        public Task ActivateAsync(IPluginHostServices host)
+        {
+            ActivateCount++;
+            _onActivate?.Invoke();
+            return Task.CompletedTask;
+        }
+
+        public Task DeactivateAsync()
+        {
+            DeactivateCount++;
+            return Task.CompletedTask;
+        }
         public UserControl? CreateSettingsView() => null;
         public void SelectModel(string modelId) { }
         public Task<PluginTranscriptionResult> TranscribeAsync(

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
@@ -33,6 +33,7 @@ public sealed class SettingsWindowWizardLifetimeTests
         Assert.Contains("wizard.Closed += OnSetupWizardClosed;", source);
         Assert.Contains("wizard.Closed -= OnSetupWizardClosed;", source);
         Assert.Contains("_viewModel.SetupWizardRequested -= OnSetupWizardRequested;", source);
+        Assert.Contains("_viewModel.OnWindowClosed();", source);
 
         var ownerIndex = source.IndexOf("wizard.Owner = this;", StringComparison.Ordinal);
         var showIndex = source.IndexOf("wizard.Show();", StringComparison.Ordinal);

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
@@ -35,6 +35,14 @@ public sealed class SettingsWindowWizardLifetimeTests
         Assert.Contains("_viewModel.SetupWizardRequested -= OnSetupWizardRequested;", source);
         Assert.Contains("_viewModel.OnWindowClosed();", source);
 
+        var viewModelSource = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "SettingsWindowViewModel.cs");
+        Assert.Contains("_sectionCache.Clear();", viewModelSource);
+        Assert.DoesNotContain("_sectionFactories.Clear();", viewModelSource);
+
         var ownerIndex = source.IndexOf("wizard.Owner = this;", StringComparison.Ordinal);
         var showIndex = source.IndexOf("wizard.Show();", StringComparison.Ordinal);
         Assert.True(ownerIndex >= 0 && ownerIndex < showIndex, "The wizard owner must be set before it is shown.");

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsWindowWizardLifetimeTests.cs
@@ -40,8 +40,11 @@ public sealed class SettingsWindowWizardLifetimeTests
             "TypeWhisper.Windows",
             "ViewModels",
             "SettingsWindowViewModel.cs");
-        Assert.Contains("_sectionCache.Clear();", viewModelSource);
-        Assert.DoesNotContain("_sectionFactories.Clear();", viewModelSource);
+        var onWindowClosed = TestFile.ExtractBlock(
+            viewModelSource,
+            "public void OnWindowClosed()");
+        Assert.Contains("_sectionCache.Clear();", onWindowClosed);
+        Assert.DoesNotContain("_sectionFactories.Clear();", onWindowClosed);
 
         var ownerIndex = source.IndexOf("wizard.Owner = this;", StringComparison.Ordinal);
         var showIndex = source.IndexOf("wizard.Show();", StringComparison.Ordinal);

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -108,7 +108,8 @@ public class SherpaOnnxPluginTests
             var installer = new FakeCudaRuntimeInstaller(isInstalled: true);
             var sut = new SherpaOnnxPlugin(
                 installer,
-                (_, _, _) => throw new InvalidOperationException("CUDA provider failed to initialize."));
+                (_, _, _) => throw new InvalidOperationException("CUDA provider failed to initialize."),
+                new FakeCudaRuntimeProbe(new CudaRuntimeProbeResult(true, null)));
             var host = new FakePluginHostServices(tempDir);
             CreateParakeetModelFiles(tempDir);
 
@@ -131,6 +132,94 @@ public class SherpaOnnxPluginTests
     }
 
     [Fact]
+    public async Task LoadModelAsync_ExplicitCudaProbeFailure_DoesNotLoadNativeRuntimeInHostProcess()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-probe-{Guid.NewGuid():N}");
+        try
+        {
+            var installer = new FakeCudaRuntimeInstaller(isInstalled: true);
+            var probe = new FakeCudaRuntimeProbe(
+                new CudaRuntimeProbeResult(false, "Native probe exited with code 0xC0000409."));
+            var recognizerFactoryCalled = false;
+            var sut = new SherpaOnnxPlugin(
+                installer,
+                (_, _, _) =>
+                {
+                    recognizerFactoryCalled = true;
+                    throw new InvalidOperationException("Recognizer must not be created after probe failure.");
+                },
+                probe);
+            var host = new FakePluginHostServices(tempDir);
+            CreateParakeetModelFiles(tempDir);
+
+            await sut.ActivateAsync(host);
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.NvidiaCuda);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => sut.LoadModelAsync("parakeet-tdt-0.6b", CancellationToken.None));
+
+            Assert.Contains("0xC0000409", ex.Message);
+            Assert.False(recognizerFactoryCalled);
+            Assert.Equal(1, probe.CallCount);
+            Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
+            Assert.Equal("CUDA unavailable", sut.AccelerationStatus.DisplayText);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CudaProbeCache_InvalidatesWhenTheNativeRuntimeChanges()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-probe-cache-{Guid.NewGuid():N}");
+        var pluginDir = Path.Join(tempDir, "plugin");
+        var modelDir = Path.Join(tempDir, "model");
+        var runtimeDir = Path.Join(tempDir, "runtime");
+        var executablePath = Path.Join(tempDir, "TypeWhisper.exe");
+        var cachePath = Path.Join(runtimeDir, ".typewhisper-cuda-probe-success");
+        try
+        {
+            Directory.CreateDirectory(pluginDir);
+            Directory.CreateDirectory(modelDir);
+            Directory.CreateDirectory(runtimeDir);
+            File.WriteAllText(executablePath, "host");
+            File.WriteAllText(Path.Join(pluginDir, "TypeWhisper.Plugin.SherpaOnnx.dll"), "plugin");
+            File.WriteAllText(Path.Join(modelDir, "encoder.onnx"), "model");
+            var runtimeDll = Path.Join(runtimeDir, "onnxruntime.dll");
+            File.WriteAllText(runtimeDll, "runtime-v1");
+
+            var first = SherpaCudaRuntimeProbe.BuildCacheFingerprint(
+                "parakeet-tdt-0.6b",
+                executablePath,
+                pluginDir,
+                modelDir,
+                runtimeDir);
+            SherpaCudaRuntimeProbe.RecordCachedSuccess(cachePath, first);
+
+            Assert.True(SherpaCudaRuntimeProbe.IsCachedSuccess(cachePath, first));
+
+            File.AppendAllText(runtimeDll, "-changed");
+            var second = SherpaCudaRuntimeProbe.BuildCacheFingerprint(
+                "parakeet-tdt-0.6b",
+                executablePath,
+                pluginDir,
+                modelDir,
+                runtimeDir);
+
+            Assert.NotEqual(first, second);
+            Assert.False(SherpaCudaRuntimeProbe.IsCachedSuccess(cachePath, second));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task LoadModelAsync_AutoCudaAndCpuFailureReportsCpuFallbackFailure()
     {
         var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-load-{Guid.NewGuid():N}");
@@ -140,7 +229,8 @@ public class SherpaOnnxPluginTests
             var sut = new SherpaOnnxPlugin(
                 installer,
                 (_, _, provider) => throw new InvalidOperationException(
-                    $"{provider} provider failed to initialize."));
+                    $"{provider} provider failed to initialize."),
+                new FakeCudaRuntimeProbe(new CudaRuntimeProbeResult(true, null)));
             var host = new FakePluginHostServices(tempDir);
             CreateParakeetModelFiles(tempDir);
 
@@ -360,6 +450,21 @@ public class SherpaOnnxPluginTests
 
             IsInstalled = true;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeCudaRuntimeProbe(CudaRuntimeProbeResult result) : ISherpaCudaRuntimeProbe
+    {
+        public int CallCount { get; private set; }
+
+        public Task<CudaRuntimeProbeResult> ProbeAsync(
+            string modelId,
+            string modelDirectory,
+            string runtimeDirectory,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(result);
         }
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -172,6 +172,44 @@ public class SherpaOnnxPluginTests
     }
 
     [Fact]
+    public async Task LoadModelAsync_AutoCudaProbeFailure_PreservesUnavailableStatusAfterCpuFallback()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-probe-fallback-{Guid.NewGuid():N}");
+        try
+        {
+            var installer = new FakeCudaRuntimeInstaller(isInstalled: true);
+            var probe = new FakeCudaRuntimeProbe(
+                new CudaRuntimeProbeResult(false, "Native probe exited with code 0xC0000409."));
+            string? loadedProvider = null;
+            var sut = new SherpaOnnxPlugin(
+                installer,
+                (_, _, provider) =>
+                {
+                    loadedProvider = provider;
+                    return null!;
+                },
+                probe);
+            var host = new FakePluginHostServices(tempDir);
+            CreateParakeetModelFiles(tempDir);
+
+            await sut.ActivateAsync(host);
+            sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Auto);
+
+            await sut.LoadModelAsync("parakeet-tdt-0.6b", CancellationToken.None);
+
+            Assert.Equal("cpu", loadedProvider);
+            Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
+            Assert.Equal("CUDA unavailable", sut.AccelerationStatus.DisplayText);
+            Assert.Contains("0xC0000409", sut.AccelerationStatus.Detail);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CudaProbeCache_InvalidatesWhenTheNativeRuntimeChanges()
     {
         var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-probe-cache-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary
- render the tray and overlay shell before plugin update and discovery work
- replace two-second audio device polling with endpoint notifications and cached enumeration
- defer local model loading until use and isolate CUDA safety checks in a cached child-process probe
- render the settings shell before microphone enumeration and release window-scoped controls on close
- restore low-latency WASAPI recording with WaveIn fallback while preserving capture release between dictations

## Runtime validation
- idle CPU: 0.094 CPU seconds over 30 seconds, about 0.31% of one core, with no handle growth
- cold settings open: 605 ms to window/API return with the UI responsive
- fresh second capture after full release: 335 ms start request, first non-empty buffer after 326 ms
- capture disposal confirmed after stop

## Validation
- dotnet test TypeWhisper.slnx --no-restore (1675 passed)
- dotnet build src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release --no-restore -p:TypeWhisperStoreBuild=true
- git diff --check

Fixes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUDA runtime safety probing with success caching and automatic CPU fallback when CUDA can’t be validated.
  * Added a native model probing mode to pre-check plugin/runtime/model readiness.
  * Added fallback audio capture when the primary capture method fails.

* **Performance & Reliability**
  * Improved startup responsiveness by deferring heavy plugin work and removing automatic model auto-load on launch.
  * Made plugin initialization cancellable with rollback on cancellation.
  * Upgraded microphone handling: cached enumeration, deferred refresh/preview until the settings window is loaded, and refreshed device state when recording stops.
  * Enhanced audio device monitoring using event-driven notifications (with coalescing) instead of periodic polling.

* **Tests**
  * Expanded coverage for startup sequencing, CUDA probe behavior, and device-change/fallback recording scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->