### PR TITLE
Increase Individual license limit to three devices

### DIFF
--- a/src/TypeWhisper.Windows/Services/LicenseService.cs
+++ b/src/TypeWhisper.Windows/Services/LicenseService.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using TypeWhisper.Core;
 
@@ -25,6 +26,10 @@ public sealed partial class LicenseService : ObservableObject
     private static readonly byte[] Entropy = "TypeWhisper.License.v2"u8.ToArray();
     private static readonly TimeSpan CommercialValidationInterval = TimeSpan.FromDays(7);
     private static readonly TimeSpan SupporterValidationInterval = TimeSpan.FromDays(30);
+    private static readonly Regex IndividualDeviceCountPattern = new(
+        @"(?<!\d)3 devices?\b",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromMilliseconds(100));
     private static readonly Dictionary<string, CommercialLicenseTier> KnownCommercialBenefitIds = new(StringComparer.OrdinalIgnoreCase)
     {
         ["a4c0b152-0b91-4588-b8f8-779870affba9"] = CommercialLicenseTier.Individual,
@@ -927,7 +932,7 @@ public sealed partial class LicenseService : ObservableObject
             description.Contains("single-seat") ||
             description.Contains("single seat") ||
             description.Contains("freelancer") ||
-            description.Contains("3 device"))
+            IndividualDeviceCountPattern.IsMatch(description))
         {
             return CommercialLicenseTier.Individual;
         }

--- a/src/TypeWhisper.Windows/Services/LicenseService.cs
+++ b/src/TypeWhisper.Windows/Services/LicenseService.cs
@@ -927,7 +927,7 @@ public sealed partial class LicenseService : ObservableObject
             description.Contains("single-seat") ||
             description.Contains("single seat") ||
             description.Contains("freelancer") ||
-            description.Contains("2 device"))
+            description.Contains("3 device"))
         {
             return CommercialLicenseTier.Individual;
         }

--- a/tests/TypeWhisper.PluginSystem.Tests/LicenseServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/LicenseServiceTests.cs
@@ -28,7 +28,9 @@ public sealed class LicenseServiceTests : IDisposable
 
         Assert.Equal(
             CommercialLicenseTier.Individual,
-            LicenseService.DetectCommercialTier("legacy", "Freelancer single-seat license for 2 devices"));
+            LicenseService.DetectCommercialTier("legacy", "Legacy commercial license for 3 devices"));
+        Assert.Null(
+            LicenseService.DetectCommercialTier("legacy", "Legacy commercial license for 2 devices"));
         Assert.Equal(
             CommercialLicenseTier.Team,
             LicenseService.DetectCommercialTier("legacy", "Small teams up to 10 devices"));

--- a/tests/TypeWhisper.PluginSystem.Tests/LicenseServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/LicenseServiceTests.cs
@@ -31,6 +31,8 @@ public sealed class LicenseServiceTests : IDisposable
             LicenseService.DetectCommercialTier("legacy", "Legacy commercial license for 3 devices"));
         Assert.Null(
             LicenseService.DetectCommercialTier("legacy", "Legacy commercial license for 2 devices"));
+        Assert.Null(
+            LicenseService.DetectCommercialTier("legacy", "Legacy commercial license for 13 devices"));
         Assert.Equal(
             CommercialLicenseTier.Team,
             LicenseService.DetectCommercialTier("legacy", "Small teams up to 10 devices"));


### PR DESCRIPTION
## Summary

- update the Windows Individual license tier fallback from two to three devices
- match three as an exact numeric device count so values such as 13 devices are not misclassified
- add regression coverage for the new three-device description and obsolete or multi-digit counts

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~LicenseServiceTests.CommercialTierInference_MapsKnownPolarBenefitIdsAndLegacyDescriptions"`
- `dotnet test TypeWhisper.slnx --no-restore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved commercial license detection so individual-tier entitlements are correctly recognized as covering three devices.
  - Fixed incorrect tier assignment where outdated two-device license descriptions could be mapped improperly.

- **Tests**
  - Updated license inference expectations to match the revised device-count mapping and ensure legacy descriptions are categorized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->