### PR TITLE
Prepare TypeWhisper 1.0.6 release

### DIFF
--- a/docs/releases/v1.0.6.md
+++ b/docs/releases/v1.0.6.md
@@ -1,0 +1,48 @@
+# TypeWhisper v1.0.6
+
+TypeWhisper 1.0.6 is a stable Windows performance and reliability release
+focused on faster startup, responsive settings, dependable microphone capture,
+and safer local transcription.
+
+## Highlights
+
+- Rendered the tray, recording overlay, and settings shell before slower plugin,
+  model, and audio-device initialization work.
+- Replaced periodic audio-device polling with event-driven notifications and
+  cached enumeration.
+- Restored low-latency WASAPI recording with automatic WaveIn fallback while
+  continuing to release capture resources between dictations.
+- Added isolated CUDA runtime safety checks with automatic CPU fallback for
+  local transcription.
+- Increased the Individual license tier from two to three devices.
+
+## Integration Updates
+
+- OpenAI plugin 1.1.1 adds `gpt-transcribe` and `gpt-live-transcribe`, dynamic
+  account-specific model catalogs, ordered language hints, dictionary terms,
+  and safer cached fallbacks.
+- Soniox plugin 1.1.0 uses compressed M4A uploads when available and retries
+  with the original WAV when compression is unavailable or rejected.
+- Both integration updates are available through the TypeWhisper plugin
+  marketplace and remain optional.
+
+## Reliability Improvements
+
+- Deferred local model loading until first use to reduce startup work.
+- Rolled back cancelled plugin initialization cleanly.
+- Hardened microphone device changes, capture startup, and fallback paths.
+- Preserved valid OpenAI model selections when remote catalogs are sparse or
+  temporarily unavailable.
+- Matched the three-device Individual entitlement exactly without
+  misclassifying larger device counts.
+
+## Validation Notes
+
+- Verify stable Velopack channels `win-x64` and `win-arm64`.
+- Confirm x64 and ARM64 installers, portable ZIPs, full nupkg packages,
+  RELEASES files, and JSON manifests are present without `-rc` or `-daily`
+  suffixes.
+- Validate both published portable ZIPs and record the Authenticode status of
+  the published installers.
+- Publish Microsoft Store package `1.0.6.0` and WinGet package `1.0.6`
+  separately from the GitHub release.


### PR DESCRIPTION
## Summary

- add curated release notes for TypeWhisper 1.0.6
- cover startup, settings, recording, CUDA fallback, licensing, and companion plugin updates
- document the separate GitHub, Microsoft Store, and WinGet release versions

## Related Issue

Not applicable. This is the scheduled stable release preparation.

## Test Plan

- [x] Release metadata resolver tests pass
- [x] `v1.0.6` resolves to stable package version `1.0.6`
- [x] `git diff --check` passes
- [x] No product code is changed by this PR

## Notes

The GitHub/Velopack release, Microsoft Store package `1.0.6.0`, and WinGet package `1.0.6` are published as separate downstream steps after this PR merges.