### PR TITLE
Release Sherpa ONNX plugin 1.0.4

### DIFF
--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -98,7 +98,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.2";
+    public string PluginVersion => "1.0.4";
 
     // ITranscriptionEnginePlugin
     /// <summary>

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.sherpa-onnx",
   "name": "Lokale Modelle (sherpa-onnx)",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "author": "TypeWhisper",
   "description": "Offline transcription via sherpa-onnx (NVIDIA NeMo Parakeet + Canary)",
   "assemblyName": "TypeWhisper.Plugin.SherpaOnnx.dll",

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginsViewModelMarketplaceFilterTests.cs
@@ -198,7 +198,12 @@ public class PluginsViewModelMarketplaceFilterTests : IDisposable
         var manager = CreateManager();
         if (loadedPlugins is not null)
             TestPluginManagerFactory.SetPrivateField(manager, "_allPlugins", loadedPlugins.ToList());
-        var service = new PluginRegistryService(manager, _loader, _settings.Object, CreateMockHttpClient(json), pluginsPath);
+        var service = new PluginRegistryService(
+            manager,
+            _loader,
+            _settings.Object,
+            CreateMockHttpClient(json),
+            pluginsPath ?? _pluginsRoot);
         var viewModel = new PluginsViewModel(manager, service);
 
         await viewModel.RefreshRegistryCommand.ExecuteAsync(null);

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -29,7 +29,7 @@ public class SherpaOnnxPluginTests
         var sut = new SherpaOnnxPlugin();
 
         Assert.NotNull(manifest);
-        Assert.Equal("1.0.2", manifest.Version);
+        Assert.Equal("1.0.4", manifest.Version);
         Assert.Equal(manifest.Version, sut.PluginVersion);
     }
 


### PR DESCRIPTION
## Summary
- publish the Sherpa ONNX CUDA safety probe and automatic fallback as plugin version 1.0.4
- align the plugin manifest and runtime-reported version
- isolate marketplace view-model tests from plugins installed in the developer profile

## Verification
- `dotnet test TypeWhisper.slnx --no-restore` (302 Core tests and 1,390 PluginSystem tests passed)
- `dotnet build plugins/TypeWhisper.Plugin.SherpaOnnx/TypeWhisper.Plugin.SherpaOnnx.csproj -c Release --no-restore`
- installed and launched through the Windows plugin development workflow
- native CUDA model probe completed successfully with an RTX 4060 Ti and the Microsoft Store model/runtime assets; the host process remained alive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Sherpa ONNX plugin version to 1.0.4.

* **Bug Fixes**
  * Improved plugin marketplace test setup when a custom plugins directory is unavailable.

* **Tests**
  * Updated version validation to reflect the latest plugin release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->