### PR TITLE
Fix cuDNN loading in packaged Windows installs

### DIFF
--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeInstaller.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaCudaRuntimeInstaller.cs
@@ -42,6 +42,20 @@ internal sealed class SherpaCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
         SherpaOnnxRuntimeDependencyFileName
     ];
 
+    internal static IReadOnlyList<string> CudnnRuntimeFileNames { get; } =
+    [
+        "cudnn64_9.dll",
+        "cudnn_ops64_9.dll",
+        "cudnn_cnn64_9.dll",
+        "cudnn_adv64_9.dll",
+        "cudnn_graph64_9.dll",
+        "cudnn_heuristic64_9.dll",
+        "cudnn_engines_runtime_compiled64_9.dll",
+        "cudnn_engines_precompiled64_9.dll",
+        "cudnn_engines_tensor_ir64_9.dll",
+        "cudnn_ext64_9.dll"
+    ];
+
     private static readonly CudaDependencyPackage[] CudaDependencyPackages =
     [
         new(
@@ -59,16 +73,7 @@ internal sealed class SherpaCudaRuntimeInstaller : ISherpaCudaRuntimeInstaller
         new(
             "nvidia-cudnn-cu12",
             "9.22.0.52",
-            [
-                "cudnn64_9.dll",
-                "cudnn_adv64_9.dll",
-                "cudnn_cnn64_9.dll",
-                "cudnn_engines_precompiled64_9.dll",
-                "cudnn_engines_runtime_compiled64_9.dll",
-                "cudnn_graph64_9.dll",
-                "cudnn_heuristic64_9.dll",
-                "cudnn_ops64_9.dll"
-            ])
+            CudnnRuntimeFileNames)
     ];
 
     private static readonly string[] RequiredFiles =

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxNativeRuntime.cs
@@ -15,9 +15,14 @@ internal static class SherpaOnnxNativeRuntime
         DllImportSearchPath.UseDllDirectoryForDependencies | DllImportSearchPath.SafeDirectories;
 
     private static readonly object Sync = new();
+    private static readonly Dictionary<string, IntPtr> LoadedCudaLibraries =
+        new(StringComparer.OrdinalIgnoreCase);
     private static bool _resolverRegistered;
     private static string? _bundledRuntimeDirectory;
     private static string? _cudaRuntimeDirectory;
+
+    internal static IReadOnlyList<string> CudaPreloadFileNames =>
+        SherpaCudaRuntimeInstaller.CudnnRuntimeFileNames;
 
     /// <summary>
     /// Performs register resolver.
@@ -82,6 +87,14 @@ internal static class SherpaOnnxNativeRuntime
 
         try
         {
+            if (_cudaRuntimeDirectory is not null)
+            {
+                // cuDNN 9 resolves its split component libraries by name. A packaged
+                // Windows host does not reliably honor a PATH update for those loads.
+                lock (Sync)
+                    PreloadCudaDependencies(runtimeDirectory, NativeLibrary.Load, LoadedCudaLibraries);
+            }
+
             return NativeLibrary.Load(
                 candidate,
                 typeof(SherpaOnnxNativeRuntime).Assembly,
@@ -123,6 +136,44 @@ internal static class SherpaOnnxNativeRuntime
     {
         var fileName = Path.GetFileNameWithoutExtension(libraryName);
         return string.Equals(fileName, SherpaNativeLibraryBaseName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static void PreloadCudaDependencies(
+        string runtimeDirectory,
+        Func<string, IntPtr> loadLibrary,
+        IDictionary<string, IntPtr> loadedLibraries)
+    {
+        var resolvedRuntimeDirectory = Path.GetFullPath(runtimeDirectory);
+        foreach (var fileName in CudaPreloadFileNames)
+        {
+            var libraryPath = Path.Join(resolvedRuntimeDirectory, fileName);
+            if (!File.Exists(libraryPath))
+            {
+                throw new DllNotFoundException(
+                    $"The sherpa-onnx CUDA runtime is missing {fileName} under '{resolvedRuntimeDirectory}'.");
+            }
+
+            if (loadedLibraries.ContainsKey(libraryPath))
+                continue;
+
+            try
+            {
+                var handle = loadLibrary(libraryPath);
+                if (handle == IntPtr.Zero)
+                    throw new DllNotFoundException($"The native loader returned an invalid handle for {fileName}.");
+
+                loadedLibraries.Add(libraryPath, handle);
+            }
+            catch (Exception ex) when (
+                ex is DllNotFoundException
+                    or BadImageFormatException
+                    or FileLoadException)
+            {
+                throw new DllNotFoundException(
+                    $"Unable to preload {fileName} from the sherpa-onnx CUDA runtime. Loader error: {ex.Message}",
+                    ex);
+            }
+        }
     }
 
     private static void PrependToPath(string runtimeDirectory)

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -98,7 +98,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.4";
+    public string PluginVersion => "1.0.5";
 
     // ITranscriptionEnginePlugin
     /// <summary>

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.sherpa-onnx",
   "name": "Lokale Modelle (sherpa-onnx)",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "TypeWhisper",
   "description": "Offline transcription via sherpa-onnx (NVIDIA NeMo Parakeet + Canary)",
   "assemblyName": "TypeWhisper.Plugin.SherpaOnnx.dll",

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -29,7 +29,7 @@ public class SherpaOnnxPluginTests
         var sut = new SherpaOnnxPlugin();
 
         Assert.NotNull(manifest);
-        Assert.Equal("1.0.4", manifest.Version);
+        Assert.Equal("1.0.5", manifest.Version);
         Assert.Equal(manifest.Version, sut.PluginVersion);
     }
 
@@ -390,6 +390,50 @@ public class SherpaOnnxPluginTests
         Assert.Equal(
             Path.Join("C:", "TypeWhisper", "Plugins", "com.typewhisper.sherpa-onnx", "runtimes", "win-x64", "native"),
             runtimeDirectory);
+    }
+
+    [Fact]
+    public void NativeRuntime_PreloadsCudnnComponentsByAbsolutePathOnce()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"tw-sherpa-cudnn-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            foreach (var fileName in SherpaOnnxNativeRuntime.CudaPreloadFileNames)
+                File.WriteAllBytes(Path.Join(tempDir, fileName), []);
+
+            var loadedPaths = new List<string>();
+            var handles = new Dictionary<string, IntPtr>(StringComparer.OrdinalIgnoreCase);
+
+            SherpaOnnxNativeRuntime.PreloadCudaDependencies(
+                tempDir,
+                path =>
+                {
+                    loadedPaths.Add(path);
+                    return new IntPtr(loadedPaths.Count);
+                },
+                handles);
+            SherpaOnnxNativeRuntime.PreloadCudaDependencies(
+                tempDir,
+                path =>
+                {
+                    loadedPaths.Add(path);
+                    return new IntPtr(loadedPaths.Count);
+                },
+                handles);
+
+            Assert.Equal(SherpaOnnxNativeRuntime.CudaPreloadFileNames.Count, loadedPaths.Count);
+            Assert.Equal(
+                SherpaOnnxNativeRuntime.CudaPreloadFileNames,
+                loadedPaths.Select(Path.GetFileName));
+            Assert.All(loadedPaths, path => Assert.True(Path.IsPathFullyQualified(path)));
+            Assert.Equal(loadedPaths.Count, handles.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preload the split cuDNN 9 libraries by absolute path before the sherpa-onnx native runtime loads, avoiding the packaged-app DLL search failure
- use the same cuDNN component list for installation validation and native preloading, including the complete pinned cuDNN 9.22 runtime
- bump the sherpa-onnx plugin to 1.0.5
- add regression coverage for deterministic, one-time absolute-path preloading

## Validation
- dotnet build TypeWhisper.slnx -c Release --no-restore
- TypeWhisper.Core.Tests: 302 passed
- TypeWhisper.PluginSystem.Tests: 1,391 passed
- Sherpa ONNX release plugin build: succeeded with 0 warnings and 0 errors
- Store app 1.0.6 with plugin 1.0.5: CUDA safety probe refreshed successfully and a Parakeet TDT 0.6B local-file transcription completed through sherpa-onnx
- Store UI confirmed the active acceleration status as Using CUDA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA runtime initialization by preloading required components from configured runtime directories.
  * Prevented duplicate loading of CUDA dependencies and improved error reporting when files are missing or cannot be loaded.

* **Maintenance**
  * Updated the Sherpa ONNX plugin version to 1.0.5.
  * Added validation to ensure CUDA components load correctly and only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->