### PR TITLE
Fix portable update checks and app release filtering

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -257,7 +257,8 @@ public partial class App : Application
         // Check for updates in background
         var updateService = _serviceProvider.GetRequiredService<UpdateService>();
         updateService.Initialize();
-        _ = updateService.CheckForUpdatesAsync();
+        if (updateService.ShouldCheckAutomatically)
+            _ = updateService.CheckForUpdatesAsync();
     }
 
     private async Task RunTrackedStartupWorkAsync(Func<CancellationToken, Task> work)

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -138,7 +138,7 @@ public static class Program
 
         var contentDirectory = new DirectoryInfo(Path.GetFullPath(appBaseDirectory));
         return contentDirectory.Parent is { } packageRoot
-            && File.Exists(Path.Combine(packageRoot.FullName, ".portable"));
+            && File.Exists(Path.Join(packageRoot.FullName, ".portable"));
     }
 
     private static void StartRestartProcess(IReadOnlyList<string> args)

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -58,6 +58,7 @@ public static class Program
         }
 #else
         VelopackApp.Build()
+            .SetAutoApplyOnStartup(!IsPortableLayout(AppContext.BaseDirectory))
             .OnFirstRun((_) => StartupService.Enable())
             .OnBeforeUninstallFastCallback((v) =>
             {
@@ -128,6 +129,16 @@ public static class Program
             if (restartArgs is not null)
                 StartRestartProcess(restartArgs);
         }
+    }
+
+    internal static bool IsPortableLayout(string appBaseDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(appBaseDirectory))
+            return false;
+
+        var contentDirectory = new DirectoryInfo(Path.GetFullPath(appBaseDirectory));
+        return contentDirectory.Parent is { } packageRoot
+            && File.Exists(Path.Combine(packageRoot.FullName, ".portable"));
     }
 
     private static void StartRestartProcess(IReadOnlyList<string> args)

--- a/src/TypeWhisper.Windows/Services/AppReleaseGithubSource.cs
+++ b/src/TypeWhisper.Windows/Services/AppReleaseGithubSource.cs
@@ -9,6 +9,7 @@ namespace TypeWhisper.Windows.Services;
 internal sealed class AppReleaseGithubSource : GithubSource
 {
     private const int ReleasesPerPage = 100;
+    private const int MaximumPages = 10;
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -29,7 +30,7 @@ internal sealed class AppReleaseGithubSource : GithubSource
 
     protected override async Task<GithubRelease[]> GetReleases(bool includePrereleases)
     {
-        for (var page = 1; ; page++)
+        for (var page = 1; page <= MaximumPages; page++)
         {
             var releasesPath = $"repos{RepoUri.AbsolutePath}/releases?per_page={ReleasesPerPage}&page={page}";
             var releasesUri = new Uri(GetApiBaseUrl(RepoUri), releasesPath);
@@ -51,6 +52,8 @@ internal sealed class AppReleaseGithubSource : GithubSource
             if (releases.Length < ReleasesPerPage)
                 return [];
         }
+
+        return [];
     }
 
     private bool ContainsReleaseIndex(GithubRelease release) =>

--- a/src/TypeWhisper.Windows/Services/AppReleaseGithubSource.cs
+++ b/src/TypeWhisper.Windows/Services/AppReleaseGithubSource.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Velopack.Sources;
+
+namespace TypeWhisper.Windows.Services;
+
+/// <summary>
+/// Retrieves app updates from GitHub releases that contain the exact Velopack channel feed.
+/// </summary>
+internal sealed class AppReleaseGithubSource : GithubSource
+{
+    private const int ReleasesPerPage = 100;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly string _releaseIndexName;
+
+    public AppReleaseGithubSource(
+        string repoUrl,
+        string channel,
+        bool prerelease,
+        IFileDownloader? downloader = null)
+        : base(repoUrl, accessToken: null, prerelease, downloader)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        _releaseIndexName = $"releases.{channel}.json";
+    }
+
+    protected override async Task<GithubRelease[]> GetReleases(bool includePrereleases)
+    {
+        for (var page = 1; ; page++)
+        {
+            var releasesPath = $"repos{RepoUri.AbsolutePath}/releases?per_page={ReleasesPerPage}&page={page}";
+            var releasesUri = new Uri(GetApiBaseUrl(RepoUri), releasesPath);
+            var response = await Downloader.DownloadString(
+                releasesUri.ToString(),
+                GetRequestHeaders("application/vnd.github.v3+json"))
+                .ConfigureAwait(false);
+
+            var releases = JsonSerializer.Deserialize<GithubRelease[]>(response, JsonOptions) ?? [];
+            var matchingRelease = releases
+                .Where(release => includePrereleases || !release.Prerelease)
+                .Where(ContainsReleaseIndex)
+                .OrderByDescending(release => release.PublishedAt)
+                .FirstOrDefault();
+
+            if (matchingRelease is not null)
+                return [matchingRelease];
+
+            if (releases.Length < ReleasesPerPage)
+                return [];
+        }
+    }
+
+    private bool ContainsReleaseIndex(GithubRelease release) =>
+        release.Assets?.Any(asset =>
+            string.Equals(asset.Name, _releaseIndexName, StringComparison.Ordinal)) == true;
+}

--- a/src/TypeWhisper.Windows/Services/UpdateService.cs
+++ b/src/TypeWhisper.Windows/Services/UpdateService.cs
@@ -62,6 +62,14 @@ public sealed class UpdateService
     public ReleaseChannel Channel { get; private set; } = ReleaseChannel.Stable;
 
     /// <summary>
+    /// Gets whether this installation should check for updates automatically.
+    /// </summary>
+    internal bool ShouldCheckAutomatically => ShouldCheckAutomaticallyFor(
+        _distributionKind,
+        _updateManager?.IsInstalled == true,
+        _updateManager?.IsPortable == true);
+
+    /// <summary>
     /// Raised when update available.
     /// </summary>
     public event EventHandler? UpdateAvailable;
@@ -98,8 +106,12 @@ public sealed class UpdateService
         _updateManager = null;
         try
         {
+            var velopackChannel = GetVelopackChannel(RuntimeInformation.OSArchitecture, resolvedChannel);
             _updateManager = new UpdateManager(
-                new GithubSource(TypeWhisperEnvironment.GithubRepoUrl, null, resolvedChannel != ReleaseChannel.Stable),
+                new AppReleaseGithubSource(
+                    TypeWhisperEnvironment.GithubRepoUrl,
+                    velopackChannel,
+                    resolvedChannel != ReleaseChannel.Stable),
                 CreateUpdateOptions(RuntimeInformation.OSArchitecture, resolvedChannel));
         }
         catch
@@ -187,6 +199,14 @@ public sealed class UpdateService
 
     internal static bool IsManagedByMicrosoftStore(AppDistributionKind distributionKind) =>
         distributionKind == AppDistributionKind.Store;
+
+    internal static bool ShouldCheckAutomaticallyFor(
+        AppDistributionKind distributionKind,
+        bool isInstalled,
+        bool isPortable) =>
+        distributionKind == AppDistributionKind.Direct
+        && isInstalled
+        && !isPortable;
 
     internal static ReleaseChannel InferReleaseChannel(string? version)
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/AppReleaseGithubSourceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppReleaseGithubSourceTests.cs
@@ -1,0 +1,296 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Velopack.Logging;
+using Velopack.Sources;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class AppReleaseGithubSourceTests
+{
+    private const string RepositoryUrl = "https://github.com/TypeWhisper/typewhisper-win";
+    private const string PackageFileName = "TypeWhisper-1.0.6-win-x64-full.nupkg";
+    private const string FeedJson =
+        """
+        {
+          "Assets": [
+            {
+              "PackageId": "TypeWhisper",
+              "Version": "1.0.6",
+              "Type": "Full",
+              "FileName": "TypeWhisper-1.0.6-win-x64-full.nupkg",
+              "SHA1": "7806F55FB92B86005F703127C5CC7EF8ED0EF044",
+              "SHA256": "F7E3758F1D04D0E0AEBED90E29FD77FF71CD833F8CCC7871CAE90D6C1633365C",
+              "Size": 20317312
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task GetReleaseFeed_IgnoresMoreThanTenNewerPluginReleases()
+    {
+        var releases = Enumerable.Range(1, 12)
+            .Select(index => CreateRelease(
+                $"Plugin {index}",
+                publishedAt: new DateTime(2026, 7, 29, 12, index, 0, DateTimeKind.Utc),
+                prerelease: false,
+                [$"com.typewhisper.plugin-{index}.zip"]))
+            .Append(CreateRelease(
+                "v1.0.6",
+                publishedAt: new DateTime(2026, 7, 28, 20, 47, 0, DateTimeKind.Utc),
+                prerelease: false,
+                ["releases.win-x64.json", PackageFileName]))
+            .ToArray();
+        var downloader = new FakeDownloader(url =>
+            url.Contains("/releases?", StringComparison.Ordinal)
+                ? SerializeReleases(releases)
+                : throw new InvalidOperationException($"Unexpected string request: {url}"))
+        {
+            BytesResponse = Encoding.UTF8.GetBytes(FeedJson)
+        };
+        var source = new AppReleaseGithubSource(
+            RepositoryUrl,
+            "win-x64",
+            prerelease: false,
+            downloader);
+
+        var feed = await source.GetReleaseFeed(new TestLogger(), "TypeWhisper", "win-x64");
+
+        var asset = Assert.Single(feed.Assets);
+        Assert.Equal(PackageFileName, asset.FileName);
+        Assert.Contains(
+            downloader.StringRequests,
+            url => url.Contains("per_page=100&page=1", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            downloader.BytesRequests,
+            url => url.Contains("plugin", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task GetReleaseFeed_PaginatesUntilItFindsTheExactChannelFeed()
+    {
+        var firstPage = Enumerable.Range(1, 100)
+            .Select(index => CreateRelease(
+                $"Plugin {index}",
+                publishedAt: new DateTime(2026, 7, 29, 12, 0, 0, DateTimeKind.Utc).AddMinutes(-index),
+                prerelease: false,
+                [$"plugin-{index}.zip"]))
+            .ToArray();
+        var secondPage = new[]
+        {
+            CreateRelease(
+                "v1.0.7-daily.20260729",
+                publishedAt: new DateTime(2026, 7, 29, 6, 31, 0, DateTimeKind.Utc),
+                prerelease: true,
+                ["releases.win-x64-daily.json", PackageFileName])
+        };
+        var downloader = new FakeDownloader(url =>
+        {
+            if (url.Contains("&page=1", StringComparison.Ordinal))
+                return SerializeReleases(firstPage);
+            if (url.Contains("&page=2", StringComparison.Ordinal))
+                return SerializeReleases(secondPage);
+
+            throw new InvalidOperationException($"Unexpected string request: {url}");
+        })
+        {
+            BytesResponse = Encoding.UTF8.GetBytes(FeedJson)
+        };
+        var source = new AppReleaseGithubSource(
+            RepositoryUrl,
+            "win-x64-daily",
+            prerelease: true,
+            downloader);
+
+        var feed = await source.GetReleaseFeed(new TestLogger(), "TypeWhisper", "win-x64-daily");
+
+        Assert.Single(feed.Assets);
+        Assert.Equal(2, downloader.StringRequests.Count);
+        Assert.Contains(
+            downloader.StringRequests,
+            url => url.Contains("per_page=100&page=2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetReleaseFeed_StableChannelSkipsPrereleaseWithMatchingFeed()
+    {
+        var releases = new[]
+        {
+            CreateRelease(
+                "v1.0.7-preview",
+                publishedAt: new DateTime(2026, 7, 29, 6, 31, 0, DateTimeKind.Utc),
+                prerelease: true,
+                ["releases.win-x64.json", PackageFileName]),
+            CreateRelease(
+                "v1.0.6",
+                publishedAt: new DateTime(2026, 7, 28, 20, 47, 0, DateTimeKind.Utc),
+                prerelease: false,
+                ["releases.win-x64.json", PackageFileName])
+        };
+        var stableFeedUrl = "https://example.test/v1.0.6/releases.win-x64.json";
+        var downloader = new FakeDownloader(_ => SerializeReleases(releases))
+        {
+            BytesResponder = url =>
+            {
+                Assert.Equal(stableFeedUrl, url);
+                return Encoding.UTF8.GetBytes(FeedJson);
+            }
+        };
+        releases[1].Assets.Single(asset => asset.Name == "releases.win-x64.json").BrowserDownloadUrl = stableFeedUrl;
+        var source = new AppReleaseGithubSource(
+            RepositoryUrl,
+            "win-x64",
+            prerelease: false,
+            downloader);
+
+        var feed = await source.GetReleaseFeed(new TestLogger(), "TypeWhisper", "win-x64");
+
+        Assert.Single(feed.Assets);
+        Assert.Equal([stableFeedUrl], downloader.BytesRequests);
+    }
+
+    [Fact]
+    public async Task GetReleaseFeed_ReturnsEmptyWhenNoReleaseContainsTheChannelFeed()
+    {
+        var releases = new[]
+        {
+            CreateRelease(
+                "TypeWhisper.Plugin.SherpaOnnx v1.0.5",
+                publishedAt: new DateTime(2026, 7, 29, 12, 24, 0, DateTimeKind.Utc),
+                prerelease: false,
+                [
+                    "com.typewhisper.sherpa-onnx-1.0.5.zip",
+                    "RELEASES.WIN-X64.JSON",
+                    "releases.win-x64-daily.json"
+                ])
+        };
+        var downloader = new FakeDownloader(_ => SerializeReleases(releases));
+        var source = new AppReleaseGithubSource(
+            RepositoryUrl,
+            "win-x64",
+            prerelease: false,
+            downloader);
+
+        var feed = await source.GetReleaseFeed(new TestLogger(), "TypeWhisper", "win-x64");
+
+        Assert.Empty(feed.Assets);
+        Assert.Empty(downloader.BytesRequests);
+    }
+
+    [Fact]
+    public async Task DownloadReleaseEntry_UsesPackageFromTheSelectedAppRelease()
+    {
+        var packageUrl = $"https://example.test/v1.0.6/{PackageFileName}";
+        var releases = new[]
+        {
+            CreateRelease(
+                "v1.0.6",
+                publishedAt: new DateTime(2026, 7, 28, 20, 47, 0, DateTimeKind.Utc),
+                prerelease: false,
+                ["releases.win-x64.json", PackageFileName])
+        };
+        releases[0].Assets.Single(asset => asset.Name == PackageFileName).BrowserDownloadUrl = packageUrl;
+        var downloader = new FakeDownloader(_ => SerializeReleases(releases))
+        {
+            BytesResponse = Encoding.UTF8.GetBytes(FeedJson)
+        };
+        var source = new AppReleaseGithubSource(
+            RepositoryUrl,
+            "win-x64",
+            prerelease: false,
+            downloader);
+        var logger = new TestLogger();
+        var feed = await source.GetReleaseFeed(logger, "TypeWhisper", "win-x64");
+        var targetFile = Path.Join(Path.GetTempPath(), $"tw_update_source_{Guid.NewGuid():N}.nupkg");
+
+        try
+        {
+            await source.DownloadReleaseEntry(
+                logger,
+                Assert.Single(feed.Assets),
+                targetFile,
+                _ => { },
+                CancellationToken.None);
+
+            Assert.Equal([packageUrl], downloader.FileRequests);
+            Assert.True(File.Exists(targetFile));
+        }
+        finally
+        {
+            if (File.Exists(targetFile))
+                File.Delete(targetFile);
+        }
+    }
+
+    private static GithubRelease CreateRelease(
+        string name,
+        DateTime publishedAt,
+        bool prerelease,
+        IReadOnlyList<string> assetNames) =>
+        new()
+        {
+            Name = name,
+            PublishedAt = publishedAt,
+            Prerelease = prerelease,
+            Assets = assetNames
+                .Select(assetName => new GithubReleaseAsset
+                {
+                    Name = assetName,
+                    BrowserDownloadUrl = $"https://example.test/{Uri.EscapeDataString(name)}/{assetName}",
+                    Url = $"https://api.example.test/{Uri.EscapeDataString(name)}/{assetName}"
+                })
+                .ToArray()
+        };
+
+    private static string SerializeReleases(IEnumerable<GithubRelease> releases) =>
+        JsonSerializer.Serialize(releases);
+
+    private sealed class FakeDownloader(Func<string, string> stringResponder) : IFileDownloader
+    {
+        public List<string> StringRequests { get; } = [];
+        public List<string> BytesRequests { get; } = [];
+        public List<string> FileRequests { get; } = [];
+        public byte[] BytesResponse { get; init; } = [];
+        public Func<string, byte[]>? BytesResponder { get; init; }
+
+        public Task<string> DownloadString(
+            string url,
+            IDictionary<string, string>? headers = null,
+            double timeout = 30)
+        {
+            StringRequests.Add(url);
+            return Task.FromResult(stringResponder(url));
+        }
+
+        public Task<byte[]> DownloadBytes(
+            string url,
+            IDictionary<string, string>? headers = null,
+            double timeout = 30)
+        {
+            BytesRequests.Add(url);
+            return Task.FromResult(BytesResponder?.Invoke(url) ?? BytesResponse);
+        }
+
+        public async Task DownloadFile(
+            string url,
+            string targetFile,
+            Action<int> progress,
+            IDictionary<string, string>? headers = null,
+            double timeout = 30,
+            CancellationToken cancelToken = default)
+        {
+            FileRequests.Add(url);
+            await File.WriteAllBytesAsync(targetFile, [1, 2, 3], cancelToken);
+            progress(100);
+        }
+    }
+
+    private sealed class TestLogger : IVelopackLogger
+    {
+        public void Log(VelopackLogLevel logLevel, string? message, Exception? exception)
+        {
+        }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/AppReleaseGithubSourceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppReleaseGithubSourceTests.cs
@@ -180,6 +180,35 @@ public sealed class AppReleaseGithubSourceTests
     }
 
     [Fact]
+    public async Task GetReleaseFeed_StopsAfterMaximumNumberOfFullPages()
+    {
+        var fullPage = Enumerable.Range(1, 100)
+            .Select(index => CreateRelease(
+                $"Plugin {index}",
+                publishedAt: new DateTime(2026, 7, 29, 12, 0, 0, DateTimeKind.Utc).AddMinutes(-index),
+                prerelease: false,
+                [$"plugin-{index}.zip"]))
+            .ToArray();
+        var downloader = new FakeDownloader(_ => SerializeReleases(fullPage));
+        var source = new AppReleaseGithubSource(
+            RepositoryUrl,
+            "win-x64",
+            prerelease: false,
+            downloader);
+
+        var feed = await source.GetReleaseFeed(new TestLogger(), "TypeWhisper", "win-x64");
+
+        Assert.Empty(feed.Assets);
+        Assert.Equal(10, downloader.StringRequests.Count);
+        Assert.Contains(
+            downloader.StringRequests,
+            url => url.Contains("per_page=100&page=10", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            downloader.StringRequests,
+            url => url.Contains("per_page=100&page=11", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task DownloadReleaseEntry_UsesPackageFromTheSelectedAppRelease()
     {
         var packageUrl = $"https://example.test/v1.0.6/{PackageFileName}";

--- a/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AppStartupPerformanceTests.cs
@@ -16,6 +16,47 @@ public sealed class AppStartupPerformanceTests
     }
 
     [Fact]
+    public void OnStartup_SkipsAutomaticUpdateCheckWhenPolicyDisallowsIt()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var updateBlock = TestFile.ExtractBlock(source, "// Check for updates in background", 420);
+
+        Assert.Contains("updateService.Initialize();", updateBlock);
+        Assert.Contains("if (updateService.ShouldCheckAutomatically)", updateBlock);
+        Assert.Contains("_ = updateService.CheckForUpdatesAsync();", updateBlock);
+    }
+
+    [Fact]
+    public void ManualUpdateChecks_RemainAvailableOutsideAutomaticPolicy()
+    {
+        var appSource = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+        var trayCheckBlock = TestFile.ExtractBlock(
+            appSource,
+            "_trayIcon.UpdateCheckRequested",
+            520);
+        var settingsSource = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "SettingsWindowViewModel.cs");
+        var settingsCheckBlock = TestFile.ExtractBlock(
+            settingsSource,
+            "private async Task CheckForUpdatesAsync()",
+            700);
+
+        Assert.Contains("await update.CheckForUpdatesAsync();", trayCheckBlock);
+        Assert.DoesNotContain("ShouldCheckAutomatically", trayCheckBlock);
+        Assert.Contains("await _updateService.CheckForUpdatesAsync();", settingsCheckBlock);
+        Assert.DoesNotContain("ShouldCheckAutomatically", settingsCheckBlock);
+    }
+
+    [Fact]
     public void OnStartup_DoesNotEagerLoadTheSelectedLocalModel()
     {
         var source = TestFile.ReadProjectFile(

--- a/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UninstallUserDataProtectorTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using TypeWhisper.Windows;
 using TypeWhisper.Windows.Services;
 
 namespace TypeWhisper.PluginSystem.Tests;
@@ -69,6 +70,36 @@ public sealed class UninstallUserDataProtectorTests : IDisposable
 
         Assert.Contains(".OnBeforeUninstallFastCallback", source);
         Assert.Contains("UninstallUserDataProtector.ProtectLegacyAudioDirectory()", source);
+    }
+
+    [Fact]
+    public void Program_DisablesStartupAutoApplyForPortableLayout()
+    {
+        var source = TestFile.ReadProjectFile("src", "TypeWhisper.Windows", "Program.cs");
+
+        Assert.Contains(
+            ".SetAutoApplyOnStartup(!IsPortableLayout(AppContext.BaseDirectory))",
+            source);
+    }
+
+    [Fact]
+    public void IsPortableLayout_DetectsPackageRootMarker()
+    {
+        var packageRoot = Path.Join(_root, "portable");
+        var contentDirectory = Path.Join(packageRoot, "current");
+        Directory.CreateDirectory(contentDirectory);
+        File.WriteAllText(Path.Join(packageRoot, ".portable"), string.Empty);
+
+        Assert.True(Program.IsPortableLayout(contentDirectory));
+    }
+
+    [Fact]
+    public void IsPortableLayout_RejectsLayoutWithoutMarker()
+    {
+        var contentDirectory = Path.Join(_root, "installed", "current");
+        Directory.CreateDirectory(contentDirectory);
+
+        Assert.False(Program.IsPortableLayout(contentDirectory));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
@@ -26,6 +26,23 @@ public class UpdateServiceTests
     }
 
     [Theory]
+    [InlineData(AppDistributionKind.Direct, true, false, true)]
+    [InlineData(AppDistributionKind.Direct, true, true, false)]
+    [InlineData(AppDistributionKind.Direct, false, false, false)]
+    [InlineData(AppDistributionKind.Store, true, false, false)]
+    [InlineData(AppDistributionKind.Store, true, true, false)]
+    public void ShouldCheckAutomaticallyFor_RequiresInstalledNonPortableDirectBuild(
+        AppDistributionKind distributionKind,
+        bool isInstalled,
+        bool isPortable,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            UpdateService.ShouldCheckAutomaticallyFor(distributionKind, isInstalled, isPortable));
+    }
+
+    [Theory]
     [InlineData("0.7.1-daily.20260423", ReleaseChannel.Daily)]
     [InlineData("0.7.1-DAILY.20260423+build", ReleaseChannel.Daily)]
     [InlineData("0.7.0-rc1", ReleaseChannel.ReleaseCandidate)]
@@ -75,6 +92,7 @@ public class UpdateServiceTests
     [InlineData("daily", "0.7.0", ReleaseChannel.Daily)]
     [InlineData(null, "0.7.1-daily.20260423", ReleaseChannel.Daily)]
     [InlineData("", "0.7.0-rc1", ReleaseChannel.ReleaseCandidate)]
+    [InlineData("null", "0.7.1-daily.20260423", ReleaseChannel.Daily)]
     [InlineData("unknown", "0.7.0", ReleaseChannel.Stable)]
     public void ResolveReleaseChannel_UsesSavedPreferenceBeforeInstalledVersion(
         string? configuredChannel,


### PR DESCRIPTION
## Summary
- page through GitHub releases and select only the newest release containing the exact app channel feed
- limit automatic startup checks to installed non-portable direct builds and disable startup auto-apply for portable layouts
- preserve manual update checks and channel inference, including the literal `"null"` setting value
- add release-source, update-policy, startup, and portable-layout coverage

## Testing
- `dotnet test TypeWhisper.slnx --no-restore -m:1`
- focused update and startup tests in Release configuration
- `dotnet build TypeWhisper.slnx -c Release --no-restore -m:1`
- Store Release build with `TypeWhisperStoreBuild=true`
- x64 and ARM64 Daily packages with Velopack CLI 1.2.0
- `eng/Test-PortablePackage.ps1` for x64 and ARM64
- targeted `dotnet format --verify-no-changes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved update behavior for portable installations: startup auto-application is disabled, and background auto-checking is only enabled when policy allows.
  - Update checks are now targeted using the app’s OS architecture and release channel for more accurate matching.

- **Bug Fixes**
  - Manual update checks still work from the tray and settings even when automatic checking is disabled.
  - GitHub release discovery is more reliable, including correct handling across paginated results and prerelease filtering.

- **Tests**
  - Added coverage for portable auto-apply/update-check rules and GitHub release feed selection/downloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->