### PR TITLE
Add local Cohere Transcribe support

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -51,6 +51,7 @@ jobs:
             'script'             = 'TypeWhisper.Plugin.Script'
             'live-transcript'    = 'TypeWhisper.Plugin.LiveTranscript'
             'granite-speech'     = 'TypeWhisper.Plugin.GraniteSpeech'
+            'cohere-transcribe'  = 'TypeWhisper.Plugin.CohereTranscribe'
             'gemma-local'        = 'TypeWhisper.Plugin.GemmaLocal'
             'claude'             = 'TypeWhisper.Plugin.Claude'
             'openrouter'         = 'TypeWhisper.Plugin.OpenRouter'

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
@@ -469,7 +469,10 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
                     ? new FileInfo(destinationPath).Length
                     : 0;
                 if (rangeStart > rangeEnd)
+                {
+                    lastError = null;
                     break;
+                }
 
                 try
                 {
@@ -608,7 +611,8 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
                     $"Incomplete byte range for {artifact.FileName}: expected {expectedBytes} bytes, received {written}.");
             }
 
-            await target.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            inactivityCts.CancelAfter(_downloadInactivityTimeout);
+            await target.WriteAsync(buffer.AsMemory(0, read), inactivityCts.Token);
             written += read;
             inactivityCts.CancelAfter(_downloadInactivityTimeout);
             progress?.Report(new ArtifactTransferProgress(
@@ -616,7 +620,7 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
                 artifact.SizeBytes));
         }
 
-        await target.FlushAsync(cancellationToken);
+        await target.FlushAsync(inactivityCts.Token);
     }
 
     private static bool IsArtifactReady(RemoteArtifact artifact, string destinationPath)

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
@@ -715,7 +715,7 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
             if (File.Exists(path))
                 File.Delete(path);
         }
-        catch
+        catch (Exception exception) when (IsExpectedCleanupFailure(exception))
         {
         }
     }
@@ -727,8 +727,14 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
             if (Directory.Exists(path))
                 Directory.Delete(path, recursive: true);
         }
-        catch
+        catch (Exception exception) when (IsExpectedCleanupFailure(exception))
         {
         }
     }
+
+    private static bool IsExpectedCleanupFailure(Exception exception) =>
+        exception is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or System.Security.SecurityException;
 }

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
@@ -1,0 +1,734 @@
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace TypeWhisper.Plugin.CohereTranscribe;
+
+internal enum CrispAsrBackend
+{
+    Cpu,
+    Cuda,
+    Vulkan
+}
+
+internal sealed record RemoteArtifact(
+    string FileName,
+    string DownloadUrl,
+    long SizeBytes,
+    string Sha256);
+
+internal sealed record RuntimePackage(
+    CrispAsrBackend Backend,
+    string Id,
+    RemoteArtifact Archive);
+
+internal sealed record CohereModelPaths(
+    string ModelPath,
+    string VadModelPath,
+    string LanguageIdModelPath,
+    string CacheDirectory);
+
+internal readonly record struct ArtifactTransferProgress(long BytesTransferred, long TotalBytes);
+
+internal interface ICohereLocalAssetManager
+{
+    long ModelTransferSize { get; }
+
+    void SetHuggingFaceToken(string? token);
+
+    bool IsModelInstalled();
+
+    bool IsRuntimeInstalled(CrispAsrBackend backend);
+
+    long GetRuntimeTransferSize(CrispAsrBackend backend);
+
+    CohereModelPaths GetModelPaths();
+
+    string GetRuntimeExecutablePath(CrispAsrBackend backend);
+
+    Task EnsureModelAsync(IProgress<ArtifactTransferProgress>? progress, CancellationToken cancellationToken);
+
+    Task EnsureRuntimeAsync(
+        CrispAsrBackend backend,
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDisposable
+{
+    private const int DefaultDownloadChunkSizeBytes = 16 * 1024 * 1024;
+    private const int DefaultMaxDownloadAttempts = 5;
+
+    private static readonly TimeSpan DefaultDownloadInactivityTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultDownloadRetryDelay = TimeSpan.FromSeconds(1);
+
+    internal const string CrispAsrVersion = "0.8.24";
+    internal const string CohereModelRevision = "2242638d5dfecc6f1dbe6c3a8713b97deb2e150f";
+    internal const string VadModelRevision = "9ffd54a1e1ee413ddf265af9913beaf518d1639b";
+    internal const string LanguageIdModelRevision = "95fb0613bf78c6e48305fccd9ce023ac15f0b5a6";
+
+    internal static readonly RemoteArtifact CohereModel = new(
+        "cohere-transcribe-q5_0.gguf",
+        $"https://huggingface.co/cstr/cohere-transcribe-03-2026-GGUF/resolve/{CohereModelRevision}/cohere-transcribe-q5_0.gguf",
+        1_738_722_944,
+        "a09696c5cc2ed5052bf290c4f2beb35abc69c0d6986842042d92bebb22c9184e");
+
+    internal static readonly RemoteArtifact VadModel = new(
+        "ggml-silero-v6.2.0.bin",
+        $"https://huggingface.co/ggml-org/whisper-vad/resolve/{VadModelRevision}/ggml-silero-v6.2.0.bin",
+        885_098,
+        "2aa269b785eeb53a82983a20501ddf7c1d9c48e33ab63a41391ac6c9f7fb6987");
+
+    internal static readonly RemoteArtifact LanguageIdModel = new(
+        "ecapa-lid-107-f16.gguf",
+        $"https://huggingface.co/cstr/ecapa-lid-107-GGUF/resolve/{LanguageIdModelRevision}/ecapa-lid-107-f16.gguf",
+        42_838_944,
+        "59db30ba67cec2f36304f794420779c181124332246f75fc66c349f184110340");
+
+    internal static readonly RuntimePackage CpuRuntime = new(
+        CrispAsrBackend.Cpu,
+        "cpu",
+        new RemoteArtifact(
+            "crispasr-windows-x86_64-cpu.zip",
+            $"https://github.com/CrispStrobe/CrispASR/releases/download/v{CrispAsrVersion}/crispasr-windows-x86_64-cpu.zip",
+            7_635_428,
+            "a05456c9adac276289060ae83bd77ed7b4d87ccfd447aed804e497d76e73f8f8"));
+
+    internal static readonly RuntimePackage CudaRuntime = new(
+        CrispAsrBackend.Cuda,
+        "cuda",
+        new RemoteArtifact(
+            "crispasr-windows-x86_64-cuda.zip",
+            $"https://github.com/CrispStrobe/CrispASR/releases/download/v{CrispAsrVersion}/crispasr-windows-x86_64-cuda.zip",
+            729_126_487,
+            "832af6218508ac52fc71ac5653c433786bdfae81f775e2c77bfefd05df6f255b"));
+
+    internal static readonly RuntimePackage VulkanRuntime = new(
+        CrispAsrBackend.Vulkan,
+        "vulkan",
+        new RemoteArtifact(
+            "crispasr-windows-x86_64-vulkan.zip",
+            $"https://github.com/CrispStrobe/CrispASR/releases/download/v{CrispAsrVersion}/crispasr-windows-x86_64-vulkan.zip",
+            35_580_185,
+            "70956638045042b49f61f9f04ee9ceae9fc8b450f6f56a10fc98c2088207628a"));
+
+    private static readonly IReadOnlyList<RemoteArtifact> ModelArtifacts =
+        [CohereModel, VadModel, LanguageIdModel];
+
+    private readonly string _assetRoot;
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+    private readonly int _downloadChunkSizeBytes;
+    private readonly TimeSpan _downloadInactivityTimeout;
+    private readonly int _maxDownloadAttempts;
+    private readonly TimeSpan _downloadRetryDelay;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private string? _huggingFaceToken;
+
+    internal CohereLocalAssetManager(
+        string assetRoot,
+        HttpClient? httpClient = null,
+        int downloadChunkSizeBytes = DefaultDownloadChunkSizeBytes,
+        TimeSpan? downloadInactivityTimeout = null,
+        int maxDownloadAttempts = DefaultMaxDownloadAttempts,
+        TimeSpan? downloadRetryDelay = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assetRoot);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(downloadChunkSizeBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDownloadAttempts);
+
+        var inactivityTimeout = downloadInactivityTimeout ?? DefaultDownloadInactivityTimeout;
+        if (inactivityTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(downloadInactivityTimeout));
+
+        var retryDelay = downloadRetryDelay ?? DefaultDownloadRetryDelay;
+        if (retryDelay < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(downloadRetryDelay));
+
+        _assetRoot = Path.GetFullPath(assetRoot);
+        _ownsHttpClient = httpClient is null;
+        _httpClient = httpClient ?? new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
+        _downloadChunkSizeBytes = downloadChunkSizeBytes;
+        _downloadInactivityTimeout = inactivityTimeout;
+        _maxDownloadAttempts = maxDownloadAttempts;
+        _downloadRetryDelay = retryDelay;
+
+        if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("TypeWhisper-CohereTranscribe/1.0");
+    }
+
+    public long ModelTransferSize => ModelArtifacts.Sum(static artifact => artifact.SizeBytes);
+
+    public void SetHuggingFaceToken(string? token)
+    {
+        Volatile.Write(ref _huggingFaceToken, token);
+    }
+
+    public bool IsModelInstalled()
+    {
+        var paths = GetModelPaths();
+        return IsArtifactReady(CohereModel, paths.ModelPath)
+            && IsArtifactReady(VadModel, paths.VadModelPath)
+            && IsArtifactReady(LanguageIdModel, paths.LanguageIdModelPath);
+    }
+
+    public bool IsRuntimeInstalled(CrispAsrBackend backend)
+    {
+        var package = GetRuntimePackage(backend);
+        var runtimeDirectory = GetRuntimeDirectory(package);
+        var markerPath = GetRuntimeMarkerPath(runtimeDirectory);
+
+        return Directory.Exists(runtimeDirectory)
+            && File.Exists(markerPath)
+            && string.Equals(
+                File.ReadAllText(markerPath).Trim(),
+                package.Archive.Sha256,
+                StringComparison.OrdinalIgnoreCase)
+            && FindRuntimeExecutable(runtimeDirectory) is not null;
+    }
+
+    public long GetRuntimeTransferSize(CrispAsrBackend backend) =>
+        GetRuntimePackage(backend).Archive.SizeBytes;
+
+    public CohereModelPaths GetModelPaths()
+    {
+        var modelDirectory = Path.Join(_assetRoot, "Models", "cohere-transcribe-03-2026-q5_0");
+        var auxiliaryDirectory = Path.Join(modelDirectory, "Auxiliary");
+
+        return new CohereModelPaths(
+            Path.Join(modelDirectory, CohereModel.FileName),
+            Path.Join(auxiliaryDirectory, VadModel.FileName),
+            Path.Join(auxiliaryDirectory, LanguageIdModel.FileName),
+            Path.Join(_assetRoot, "Cache", "CrispASR"));
+    }
+
+    public string GetRuntimeExecutablePath(CrispAsrBackend backend)
+    {
+        var runtimeDirectory = GetRuntimeDirectory(GetRuntimePackage(backend));
+        return FindRuntimeExecutable(runtimeDirectory)
+            ?? throw new FileNotFoundException(
+                $"CrispASR executable was not found in '{runtimeDirectory}'.");
+    }
+
+    public async Task EnsureModelAsync(
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            var paths = GetModelPaths();
+            var targets = new[]
+            {
+                (Artifact: CohereModel, Path: paths.ModelPath),
+                (Artifact: VadModel, Path: paths.VadModelPath),
+                (Artifact: LanguageIdModel, Path: paths.LanguageIdModelPath)
+            };
+
+            long completed = 0;
+            foreach (var target in targets)
+            {
+                var completedBeforeArtifact = completed;
+                var adapter = progress is null
+                    ? null
+                    : new Progress<ArtifactTransferProgress>(value =>
+                        progress.Report(new ArtifactTransferProgress(
+                            completedBeforeArtifact + value.BytesTransferred,
+                            ModelTransferSize)));
+
+                await EnsureArtifactAsync(
+                    target.Artifact,
+                    target.Path,
+                    adapter,
+                    cancellationToken);
+
+                completed += target.Artifact.SizeBytes;
+                progress?.Report(new ArtifactTransferProgress(completed, ModelTransferSize));
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task EnsureRuntimeAsync(
+        CrispAsrBackend backend,
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        EnsureSupportedPlatform();
+        var package = GetRuntimePackage(backend);
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (IsRuntimeInstalled(backend))
+            {
+                progress?.Report(new ArtifactTransferProgress(
+                    package.Archive.SizeBytes,
+                    package.Archive.SizeBytes));
+                return;
+            }
+
+            var runtimeDirectory = GetRuntimeDirectory(package);
+            var runtimeParent = Path.GetDirectoryName(runtimeDirectory)
+                ?? throw new InvalidOperationException("CrispASR runtime directory has no parent.");
+            Directory.CreateDirectory(runtimeParent);
+
+            var operationId = Guid.NewGuid().ToString("N");
+            var archivePath = Path.Join(runtimeParent, $".{package.Archive.FileName}.download");
+            var stagingDirectory = Path.Join(runtimeParent, $".{package.Id}.{operationId}.staging");
+            EnsurePathWithinAssetRoot(runtimeDirectory);
+            EnsurePathWithinAssetRoot(archivePath);
+            EnsurePathWithinAssetRoot(stagingDirectory);
+
+            try
+            {
+                await DownloadVerifiedAsync(
+                    package.Archive,
+                    archivePath,
+                    progress,
+                    cancellationToken);
+
+                Directory.CreateDirectory(stagingDirectory);
+                await ExtractArchiveAsync(archivePath, stagingDirectory, cancellationToken);
+
+                if (FindRuntimeExecutable(stagingDirectory) is null)
+                {
+                    throw new InvalidDataException(
+                        $"The verified CrispASR {package.Id} archive did not contain crispasr.exe.");
+                }
+
+                File.WriteAllText(
+                    GetRuntimeMarkerPath(stagingDirectory),
+                    package.Archive.Sha256);
+
+                if (Directory.Exists(runtimeDirectory))
+                    Directory.Delete(runtimeDirectory, recursive: true);
+
+                Directory.Move(stagingDirectory, runtimeDirectory);
+                TryDeleteFile(archivePath);
+            }
+            catch (InvalidDataException)
+            {
+                TryDeleteFile(archivePath);
+                throw;
+            }
+            finally
+            {
+                TryDeleteDirectory(stagingDirectory);
+            }
+
+            progress?.Report(new ArtifactTransferProgress(
+                package.Archive.SizeBytes,
+                package.Archive.SizeBytes));
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _gate.Dispose();
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
+    }
+
+    internal static RuntimePackage GetRuntimePackage(CrispAsrBackend backend) =>
+        backend switch
+        {
+            CrispAsrBackend.Cpu => CpuRuntime,
+            CrispAsrBackend.Cuda => CudaRuntime,
+            CrispAsrBackend.Vulkan => VulkanRuntime,
+            _ => throw new ArgumentOutOfRangeException(nameof(backend), backend, null)
+        };
+
+    internal static async Task ExtractArchiveAsync(
+        string archivePath,
+        string destinationDirectory,
+        CancellationToken cancellationToken)
+    {
+        var destinationRoot = Path.GetFullPath(destinationDirectory);
+        var destinationPrefix = destinationRoot.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        using var archive = ZipFile.OpenRead(archivePath);
+        foreach (var entry in archive.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var normalizedEntryPath = entry.FullName.Replace(
+                Path.AltDirectorySeparatorChar,
+                Path.DirectorySeparatorChar);
+            var targetPath = Path.GetFullPath(Path.Join(destinationRoot, normalizedEntryPath));
+
+            if (!targetPath.StartsWith(destinationPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException(
+                    $"Archive entry escapes the destination directory: {entry.FullName}");
+            }
+
+            if (string.IsNullOrEmpty(entry.Name))
+            {
+                Directory.CreateDirectory(targetPath);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+            await using var input = entry.Open();
+            await using var output = new FileStream(
+                targetPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                81_920,
+                useAsync: true);
+            await input.CopyToAsync(output, cancellationToken);
+        }
+    }
+
+    private async Task EnsureArtifactAsync(
+        RemoteArtifact artifact,
+        string destinationPath,
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (IsArtifactReady(artifact, destinationPath))
+        {
+            progress?.Report(new ArtifactTransferProgress(artifact.SizeBytes, artifact.SizeBytes));
+            return;
+        }
+
+        if (await TryAdoptExistingArtifactAsync(artifact, destinationPath, cancellationToken))
+        {
+            progress?.Report(new ArtifactTransferProgress(artifact.SizeBytes, artifact.SizeBytes));
+            return;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+        var temporaryPath = $"{destinationPath}.download";
+        EnsurePathWithinAssetRoot(destinationPath);
+        EnsurePathWithinAssetRoot(temporaryPath);
+
+        try
+        {
+            await DownloadVerifiedAsync(
+                artifact,
+                temporaryPath,
+                progress,
+                cancellationToken);
+            File.Move(temporaryPath, destinationPath, overwrite: true);
+            File.WriteAllText(GetArtifactMarkerPath(destinationPath), artifact.Sha256);
+        }
+        catch (InvalidDataException)
+        {
+            TryDeleteFile(temporaryPath);
+            throw;
+        }
+    }
+
+    internal async Task DownloadVerifiedAsync(
+        RemoteArtifact artifact,
+        string destinationPath,
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+
+        var existingLength = File.Exists(destinationPath)
+            ? new FileInfo(destinationPath).Length
+            : 0;
+        if (existingLength > artifact.SizeBytes)
+        {
+            TryDeleteFile(destinationPath);
+            existingLength = 0;
+        }
+
+        progress?.Report(new ArtifactTransferProgress(existingLength, artifact.SizeBytes));
+
+        while (existingLength < artifact.SizeBytes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var rangeEnd = Math.Min(
+                artifact.SizeBytes - 1,
+                existingLength + _downloadChunkSizeBytes - 1);
+            Exception? lastError = null;
+
+            for (var attempt = 1; attempt <= _maxDownloadAttempts; attempt++)
+            {
+                var rangeStart = File.Exists(destinationPath)
+                    ? new FileInfo(destinationPath).Length
+                    : 0;
+                if (rangeStart > rangeEnd)
+                    break;
+
+                try
+                {
+                    await DownloadRangeAsync(
+                        artifact,
+                        destinationPath,
+                        rangeStart,
+                        rangeEnd,
+                        progress,
+                        cancellationToken);
+                    lastError = null;
+                    break;
+                }
+                catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+                {
+                    lastError = new TimeoutException(
+                        $"Download of {artifact.FileName} made no progress for {_downloadInactivityTimeout.TotalSeconds:0} seconds.",
+                        ex);
+                }
+                catch (Exception ex) when (ex is HttpRequestException or IOException)
+                {
+                    lastError = ex;
+                }
+
+                if (attempt < _maxDownloadAttempts && _downloadRetryDelay > TimeSpan.Zero)
+                    await Task.Delay(_downloadRetryDelay, cancellationToken);
+            }
+
+            if (lastError is not null)
+            {
+                throw new IOException(
+                    $"Failed to download {artifact.FileName} after {_maxDownloadAttempts} attempts. "
+                    + "The partial download was kept and will resume on the next attempt.",
+                    lastError);
+            }
+
+            existingLength = new FileInfo(destinationPath).Length;
+        }
+
+        var actualHash = await ComputeSha256Async(destinationPath, cancellationToken);
+        if (!string.Equals(actualHash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
+        {
+            TryDeleteFile(destinationPath);
+            throw new InvalidDataException(
+                $"SHA-256 verification failed for {artifact.FileName}.");
+        }
+
+        progress?.Report(new ArtifactTransferProgress(artifact.SizeBytes, artifact.SizeBytes));
+    }
+
+    private async Task DownloadRangeAsync(
+        RemoteArtifact artifact,
+        string destinationPath,
+        long rangeStart,
+        long rangeEnd,
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var useRange = rangeStart > 0 || artifact.SizeBytes > _downloadChunkSizeBytes;
+        var expectedBytes = rangeEnd - rangeStart + 1;
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, artifact.DownloadUrl);
+        if (IsHuggingFaceDownload(artifact.DownloadUrl)
+            && Volatile.Read(ref _huggingFaceToken) is { Length: > 0 } huggingFaceToken)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                huggingFaceToken);
+        }
+
+        if (useRange)
+            request.Headers.Range = new RangeHeaderValue(rangeStart, rangeEnd);
+
+        using var inactivityCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        inactivityCts.CancelAfter(_downloadInactivityTimeout);
+
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            inactivityCts.Token);
+        response.EnsureSuccessStatusCode();
+
+        if (useRange)
+        {
+            if (response.StatusCode != HttpStatusCode.PartialContent)
+            {
+                throw new InvalidDataException(
+                    $"Server did not honor the byte range for {artifact.FileName}.");
+            }
+
+            var contentRange = response.Content.Headers.ContentRange;
+            if (contentRange?.From != rangeStart
+                || contentRange.To != rangeEnd
+                || (contentRange.Length is { } totalLength && totalLength != artifact.SizeBytes))
+            {
+                throw new InvalidDataException(
+                    $"Server returned an unexpected byte range for {artifact.FileName}.");
+            }
+        }
+
+        if (response.Content.Headers.ContentLength is { } contentLength
+            && contentLength != expectedBytes)
+        {
+            throw new InvalidDataException(
+                $"Unexpected range size for {artifact.FileName}: expected {expectedBytes} bytes, received {contentLength}.");
+        }
+
+        await using var source = await response.Content.ReadAsStreamAsync(inactivityCts.Token);
+        await using var target = new FileStream(
+            destinationPath,
+            FileMode.OpenOrCreate,
+            FileAccess.Write,
+            FileShare.None,
+            81_920,
+            useAsync: true);
+
+        if (target.Length != rangeStart)
+        {
+            throw new IOException(
+                $"Partial download length changed unexpectedly for {artifact.FileName}.");
+        }
+
+        target.Position = rangeStart;
+        var buffer = new byte[81_920];
+        long written = 0;
+
+        while (written < expectedBytes)
+        {
+            var bytesToRead = (int)Math.Min(buffer.Length, expectedBytes - written);
+            var read = await source.ReadAsync(
+                buffer.AsMemory(0, bytesToRead),
+                inactivityCts.Token);
+            if (read == 0)
+            {
+                throw new IOException(
+                    $"Incomplete byte range for {artifact.FileName}: expected {expectedBytes} bytes, received {written}.");
+            }
+
+            await target.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            written += read;
+            inactivityCts.CancelAfter(_downloadInactivityTimeout);
+            progress?.Report(new ArtifactTransferProgress(
+                rangeStart + written,
+                artifact.SizeBytes));
+        }
+
+        await target.FlushAsync(cancellationToken);
+    }
+
+    private static bool IsArtifactReady(RemoteArtifact artifact, string destinationPath)
+    {
+        var file = new FileInfo(destinationPath);
+        if (!file.Exists || file.Length != artifact.SizeBytes)
+            return false;
+
+        var markerPath = GetArtifactMarkerPath(destinationPath);
+        return File.Exists(markerPath)
+            && string.Equals(
+                File.ReadAllText(markerPath).Trim(),
+                artifact.Sha256,
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task<bool> TryAdoptExistingArtifactAsync(
+        RemoteArtifact artifact,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        var file = new FileInfo(destinationPath);
+        if (!file.Exists || file.Length != artifact.SizeBytes)
+            return false;
+
+        var actualHash = await ComputeSha256Async(destinationPath, cancellationToken);
+        if (!string.Equals(actualHash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        File.WriteAllText(GetArtifactMarkerPath(destinationPath), artifact.Sha256);
+        return true;
+    }
+
+    private static async Task<string> ComputeSha256Async(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            1_048_576,
+            useAsync: true);
+        using var sha256 = SHA256.Create();
+        var hash = await sha256.ComputeHashAsync(stream, cancellationToken);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private string GetRuntimeDirectory(RuntimePackage package) =>
+        Path.Join(_assetRoot, "Runtimes", "CrispASR", CrispAsrVersion, package.Id);
+
+    private static string GetArtifactMarkerPath(string destinationPath) =>
+        destinationPath + ".sha256";
+
+    private static string GetRuntimeMarkerPath(string runtimeDirectory) =>
+        Path.Join(runtimeDirectory, ".typewhisper-runtime.sha256");
+
+    private static string? FindRuntimeExecutable(string runtimeDirectory) =>
+        Directory.Exists(runtimeDirectory)
+            ? Directory.EnumerateFiles(
+                runtimeDirectory,
+                "crispasr.exe",
+                SearchOption.AllDirectories).FirstOrDefault()
+            : null;
+
+    private static bool IsHuggingFaceDownload(string downloadUrl) =>
+        Uri.TryCreate(downloadUrl, UriKind.Absolute, out var uri)
+        && string.Equals(uri.Host, "huggingface.co", StringComparison.OrdinalIgnoreCase);
+
+    private void EnsurePathWithinAssetRoot(string path)
+    {
+        var rootPrefix = _assetRoot.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+
+        if (!fullPath.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Asset path escapes plugin storage: {fullPath}");
+    }
+
+    private static void EnsureSupportedPlatform()
+    {
+        if (!OperatingSystem.IsWindows()
+            || RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            throw new PlatformNotSupportedException(
+                "Cohere Transcribe local inference currently requires Windows x64.");
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
@@ -1,0 +1,731 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows.Controls;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.CohereTranscribe;
+
+/// <summary>
+/// Provides fully local Cohere Transcribe inference on Windows through CrispASR.
+/// </summary>
+public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
+{
+    internal const string ModelId = "cohere-transcribe-03-2026-q5_0";
+    internal const string HuggingFaceTokenSecretName = "hugging-face-token";
+
+    private static readonly IReadOnlyList<string> Languages =
+        ["en", "de", "fr", "it", "es", "pt", "el", "nl", "pl", "vi", "zh", "ar", "ja", "ko"];
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private ICohereLocalAssetManager? _assets;
+    private ICrispAsrServer? _server;
+    private IPluginHostServices? _host;
+    private string? _selectedModelId;
+    private string? _loadedModelId;
+    private string? _huggingFaceToken;
+    private bool _disposed;
+    private TranscriptionAccelerationPreference _accelerationPreference =
+        TranscriptionAccelerationPreference.Auto;
+    private TranscriptionAccelerationStatus _accelerationStatus = new(
+        TranscriptionAccelerationBackend.Cpu,
+        "Not loaded",
+        "The best available local runtime will be selected when the model loads.");
+
+    /// <summary>
+    /// Initializes a new instance of the Cohere Transcribe plugin.
+    /// </summary>
+    public CohereTranscribePlugin()
+    {
+    }
+
+    internal CohereTranscribePlugin(
+        ICohereLocalAssetManager assets,
+        ICrispAsrServer server)
+    {
+        _assets = assets;
+        _server = server;
+    }
+
+    /// <summary>
+    /// Gets the stable plugin identifier used by the host.
+    /// </summary>
+    public string PluginId => "com.typewhisper.cohere-transcribe";
+
+    /// <summary>
+    /// Gets the plugin name displayed by the host.
+    /// </summary>
+    public string PluginName => "Cohere Transcribe (Local)";
+
+    /// <summary>
+    /// Gets the plugin version reported to the host.
+    /// </summary>
+    public string PluginVersion => "1.0.0";
+
+    /// <summary>
+    /// Gets the stable transcription provider identifier.
+    /// </summary>
+    public string ProviderId => "cohere-transcribe";
+
+    /// <summary>
+    /// Gets the provider name displayed in the model manager.
+    /// </summary>
+    public string ProviderDisplayName => "Cohere Transcribe (Local)";
+
+    /// <summary>
+    /// Gets whether the local runtime platform is supported.
+    /// </summary>
+    public bool IsConfigured =>
+        OperatingSystem.IsWindows()
+        && RuntimeInformation.ProcessArchitecture == Architecture.X64;
+
+    /// <summary>
+    /// Gets the available local Cohere transcription models.
+    /// </summary>
+    public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
+    [
+        new PluginModelInfo(ModelId, "Cohere Transcribe 2B (Q5_0)")
+        {
+            SizeDescription = "~1.7 GB + local runtime",
+            EstimatedSizeMB = 1_700,
+            IsRecommended = true,
+            LanguageCount = 14
+        }
+    ];
+
+    /// <summary>
+    /// Gets the currently selected model identifier.
+    /// </summary>
+    public string? SelectedModelId => _selectedModelId;
+
+    /// <summary>
+    /// Gets whether speech-to-English translation is supported.
+    /// </summary>
+    public bool SupportsTranslation => false;
+
+    /// <summary>
+    /// Gets whether the host can download the model and runtime.
+    /// </summary>
+    public bool SupportsModelDownload => true;
+
+    /// <summary>
+    /// Gets the language codes supported by Cohere Transcribe.
+    /// </summary>
+    public IReadOnlyList<string> SupportedLanguages => Languages;
+
+    /// <summary>
+    /// Gets the local acceleration backends offered on Windows.
+    /// </summary>
+    public IReadOnlyList<TranscriptionAccelerationBackend> SupportedAccelerationBackends { get; } =
+    [
+        TranscriptionAccelerationBackend.Cpu,
+        TranscriptionAccelerationBackend.NvidiaCuda,
+        TranscriptionAccelerationBackend.AmdVulkan
+    ];
+
+    /// <summary>
+    /// Gets the requested acceleration preference.
+    /// </summary>
+    public TranscriptionAccelerationPreference AccelerationPreference => _accelerationPreference;
+
+    /// <summary>
+    /// Gets the active acceleration status.
+    /// </summary>
+    public TranscriptionAccelerationStatus AccelerationStatus => _accelerationStatus;
+
+    /// <summary>
+    /// Activates the plugin and prepares its isolated asset storage.
+    /// </summary>
+    public async Task ActivateAsync(IPluginHostServices host)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(host);
+
+        _host = host;
+        _assets ??= new CohereLocalAssetManager(host.PluginAssetDirectory);
+        _server ??= new CrispAsrServer(host.Log);
+        _huggingFaceToken = NormalizeHuggingFaceToken(
+            await host.LoadSecretAsync(HuggingFaceTokenSecretName));
+        _assets.SetHuggingFaceToken(_huggingFaceToken);
+
+        var persistedModel = host.GetSetting<string>("selectedModel");
+        _selectedModelId = string.Equals(persistedModel, ModelId, StringComparison.Ordinal)
+            ? persistedModel
+            : ModelId;
+
+        host.Log(
+            PluginLogLevel.Info,
+            $"Activated local Cohere Transcribe support (CrispASR {CohereLocalAssetManager.CrispAsrVersion}).");
+    }
+
+    /// <summary>
+    /// Deactivates the plugin and stops its loopback-only sidecar process.
+    /// </summary>
+    public async Task DeactivateAsync()
+    {
+        await UnloadModelAsync();
+        _assets?.SetHuggingFaceToken(null);
+        _huggingFaceToken = null;
+        _host = null;
+    }
+
+    /// <summary>
+    /// Creates the optional Hugging Face authentication settings.
+    /// </summary>
+    public UserControl? CreateSettingsView() => new CohereTranscribeSettingsView(this);
+
+    /// <summary>
+    /// Selects the single Cohere Transcribe model.
+    /// </summary>
+    public void SelectModel(string modelId)
+    {
+        ValidateModelId(modelId);
+        _selectedModelId = modelId;
+        _host?.SetSetting("selectedModel", modelId);
+    }
+
+    /// <summary>
+    /// Gets whether all pinned model, VAD, and language-ID files are present.
+    /// </summary>
+    public bool IsModelDownloaded(string modelId)
+    {
+        ValidateModelId(modelId);
+        return _assets?.IsModelInstalled() == true;
+    }
+
+    /// <summary>
+    /// Downloads and verifies the local model plus the selected Windows runtime.
+    /// </summary>
+    public async Task DownloadModelAsync(
+        string modelId,
+        IProgress<double>? progress,
+        CancellationToken cancellationToken)
+    {
+        ValidateModelId(modelId);
+        EnsureSupportedPlatform();
+        var assets = GetAssets();
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            _accelerationStatus = new(
+                TranscriptionAccelerationBackend.Cpu,
+                "Downloading local model",
+                "Downloading SHA-256 verified Cohere, VAD, and language-ID files.");
+
+            var candidates = GetBackendCandidatesForCurrentMachine(_accelerationPreference);
+            var initialBackend = candidates[0];
+            var totalBytes = assets.ModelTransferSize + assets.GetRuntimeTransferSize(initialBackend);
+
+            var modelProgress = progress is null
+                ? null
+                : new Progress<ArtifactTransferProgress>(value =>
+                    progress.Report(totalBytes <= 0
+                        ? 0
+                        : Math.Clamp((double)value.BytesTransferred / totalBytes, 0, 1)));
+
+            await assets.EnsureModelAsync(modelProgress, cancellationToken);
+
+            Exception? lastError = null;
+            foreach (var backend in candidates)
+            {
+                try
+                {
+                    var runtimeSize = assets.GetRuntimeTransferSize(backend);
+                    var runtimeTotal = assets.ModelTransferSize + runtimeSize;
+                    var runtimeProgress = progress is null
+                        ? null
+                        : new Progress<ArtifactTransferProgress>(value =>
+                            progress.Report(Math.Clamp(
+                                (double)(assets.ModelTransferSize + value.BytesTransferred) / runtimeTotal,
+                                0,
+                                1)));
+
+                    _accelerationStatus = CreateInstallingStatus(backend);
+                    await assets.EnsureRuntimeAsync(backend, runtimeProgress, cancellationToken);
+                    progress?.Report(1);
+                    _accelerationStatus = CreatePendingStatus(_accelerationPreference);
+                    return;
+                }
+                catch (Exception exception) when (
+                    exception is not OperationCanceledException
+                    && _accelerationPreference == TranscriptionAccelerationPreference.Auto)
+                {
+                    lastError = exception;
+                    _host?.Log(
+                        PluginLogLevel.Warning,
+                        $"{GetBackendDisplayName(backend)} runtime download failed; trying the next local backend: {exception.Message}");
+                }
+            }
+
+            throw lastError ?? new InvalidOperationException("No compatible CrispASR runtime is available.");
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _accelerationStatus = CreateUnavailableStatus(_accelerationPreference, exception.Message);
+            throw;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Loads the verified model into a persistent loopback-only CrispASR process.
+    /// </summary>
+    public async Task LoadModelAsync(string modelId, CancellationToken cancellationToken)
+    {
+        ValidateModelId(modelId);
+        EnsureSupportedPlatform();
+
+        var assets = GetAssets();
+        if (!assets.IsModelInstalled())
+        {
+            throw new FileNotFoundException(
+                "Cohere Transcribe model files are not downloaded. Download the model first.");
+        }
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            var server = GetServer();
+            var candidates = GetBackendCandidatesForCurrentMachine(_accelerationPreference);
+            Exception? lastError = null;
+
+            foreach (var backend in candidates)
+            {
+                try
+                {
+                    if (server.IsRunning
+                        && server.ActiveBackend == backend
+                        && string.Equals(_loadedModelId, modelId, StringComparison.Ordinal))
+                    {
+                        _accelerationStatus = CreateLoadedStatus(backend, fallbackDetail: null);
+                        _selectedModelId = modelId;
+                        return;
+                    }
+
+                    _accelerationStatus = CreateInstallingStatus(backend);
+                    await assets.EnsureRuntimeAsync(backend, progress: null, cancellationToken);
+
+                    _accelerationStatus = new(
+                        TranscriptionAccelerationBackend.Cpu,
+                        $"Loading with {GetBackendDisplayName(backend)}",
+                        "Starting the local Cohere Transcribe runtime.");
+
+                    var configuration = new CrispAsrServerConfiguration(
+                        assets.GetRuntimeExecutablePath(backend),
+                        assets.GetModelPaths(),
+                        backend,
+                        GetRecommendedThreadCount(Environment.ProcessorCount));
+
+                    _loadedModelId = null;
+                    await server.StartAsync(configuration, cancellationToken);
+
+                    _loadedModelId = modelId;
+                    _selectedModelId = modelId;
+                    _host?.SetSetting("selectedModel", modelId);
+                    _accelerationStatus = CreateLoadedStatus(
+                        backend,
+                        lastError is null
+                            ? null
+                            : $"Automatic fallback after another local backend failed: {lastError.Message}");
+                    return;
+                }
+                catch (Exception exception) when (
+                    exception is not OperationCanceledException
+                    && _accelerationPreference == TranscriptionAccelerationPreference.Auto)
+                {
+                    lastError = exception;
+                    _loadedModelId = null;
+                    await server.StopAsync();
+                    _host?.Log(
+                        PluginLogLevel.Warning,
+                        $"{GetBackendDisplayName(backend)} could not load Cohere Transcribe; trying the next local backend: {exception.Message}");
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    _loadedModelId = null;
+                    await server.StopAsync();
+                    _accelerationStatus = CreateUnavailableStatus(
+                        _accelerationPreference,
+                        exception.Message);
+                    throw;
+                }
+            }
+
+            _accelerationStatus = new(
+                TranscriptionAccelerationBackend.Cpu,
+                "Local runtime error",
+                lastError?.Message ?? "No compatible CrispASR runtime is available.");
+            _loadedModelId = null;
+            throw new InvalidOperationException(
+                "Cohere Transcribe could not start with any available local runtime.",
+                lastError);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Applies the host-selected acceleration preference.
+    /// </summary>
+    public void SetAccelerationPreference(TranscriptionAccelerationPreference preference)
+    {
+        _accelerationPreference = preference;
+
+        if (preference == TranscriptionAccelerationPreference.AmdRocm)
+        {
+            _accelerationStatus = new(
+                TranscriptionAccelerationBackend.Cpu,
+                "ROCm unavailable",
+                "CrispASR currently provides CPU, CUDA, and Vulkan runtimes for this Windows plugin.");
+            return;
+        }
+
+        if (_server?.IsRunning == true && _server.ActiveBackend is { } activeBackend)
+        {
+            var preferredBackend = GetPreferredBackendForStatus(preference);
+            _accelerationStatus = preferredBackend == activeBackend
+                ? CreateLoadedStatus(activeBackend, fallbackDetail: null)
+                : new TranscriptionAccelerationStatus(
+                    ToPublicBackend(activeBackend),
+                    $"Using {GetBackendDisplayName(activeBackend)}",
+                    $"{GetBackendDisplayName(preferredBackend)} will be used when the model reloads.");
+            return;
+        }
+
+        _accelerationStatus = CreatePendingStatus(preference);
+    }
+
+    /// <summary>
+    /// Transcribes WAV audio using the loaded local model.
+    /// </summary>
+    public async Task<PluginTranscriptionResult> TranscribeAsync(
+        byte[] wavAudio,
+        string? language,
+        bool translate,
+        string? prompt,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(wavAudio);
+        if (translate)
+            throw new NotSupportedException("Cohere Transcribe does not support speech translation.");
+
+        var normalizedLanguage = NormalizeLanguage(language);
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_loadedModelId is null)
+                throw new InvalidOperationException("No Cohere Transcribe model is loaded.");
+
+            return await GetServer().TranscribeAsync(
+                wavAudio,
+                normalizedLanguage,
+                cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Transcribes WAV audio using the first Cohere-supported language hint.
+    /// </summary>
+    public Task<PluginTranscriptionResult> TranscribeWithLanguageHintsAsync(
+        byte[] wavAudio,
+        IReadOnlyList<string> languageHints,
+        bool translate,
+        string? prompt,
+        CancellationToken cancellationToken)
+    {
+        var language = languageHints
+            .Select(NormalizeLanguageOrNull)
+            .FirstOrDefault(static candidate => candidate is not null);
+        return TranscribeAsync(wavAudio, language, translate, prompt, cancellationToken);
+    }
+
+    /// <summary>
+    /// Stops the local sidecar and releases model memory.
+    /// </summary>
+    public async Task UnloadModelAsync()
+    {
+        if (_disposed)
+            return;
+
+        await _gate.WaitAsync();
+        try
+        {
+            if (_server is not null)
+                await _server.StopAsync();
+
+            _loadedModelId = null;
+            _accelerationStatus = CreatePendingStatus(_accelerationPreference);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Releases the local sidecar, download client, and synchronization resources.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _server?.Dispose();
+        if (_assets is IDisposable disposableAssets)
+            disposableAssets.Dispose();
+
+        _gate.Dispose();
+        _disposed = true;
+    }
+
+    internal static IReadOnlyList<CrispAsrBackend> ResolveBackendCandidates(
+        TranscriptionAccelerationPreference preference,
+        bool cudaAvailable,
+        bool vulkanAvailable)
+    {
+        return preference switch
+        {
+            TranscriptionAccelerationPreference.Cpu => [CrispAsrBackend.Cpu],
+            TranscriptionAccelerationPreference.NvidiaCuda => [CrispAsrBackend.Cuda],
+            TranscriptionAccelerationPreference.AmdVulkan => [CrispAsrBackend.Vulkan],
+            TranscriptionAccelerationPreference.AmdRocm =>
+                throw new NotSupportedException("ROCm is not available for the local CrispASR Windows runtime."),
+            _ => BuildAutomaticBackendOrder(cudaAvailable, vulkanAvailable)
+        };
+    }
+
+    internal static int GetRecommendedThreadCount(int logicalProcessorCount) =>
+        Math.Clamp(Math.Max(1, logicalProcessorCount / 2), 1, 12);
+
+    internal string? HuggingFaceToken => _huggingFaceToken;
+
+    internal IPluginLocalization? Loc => _host?.Localization;
+
+    internal async Task SetHuggingFaceTokenAsync(string? token)
+    {
+        var normalized = NormalizeHuggingFaceToken(token);
+        if (string.Equals(_huggingFaceToken, normalized, StringComparison.Ordinal))
+            return;
+
+        if (_host is not null)
+        {
+            if (normalized is null)
+                await _host.DeleteSecretAsync(HuggingFaceTokenSecretName);
+            else
+                await _host.StoreSecretAsync(HuggingFaceTokenSecretName, normalized);
+        }
+
+        _huggingFaceToken = normalized;
+        _assets?.SetHuggingFaceToken(normalized);
+    }
+
+    internal static string? NormalizeHuggingFaceToken(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+
+        var normalized = token.Trim();
+        if (normalized.Any(char.IsWhiteSpace))
+        {
+            throw new ArgumentException(
+                "Hugging Face tokens cannot contain whitespace.",
+                nameof(token));
+        }
+
+        return normalized;
+    }
+
+    internal static string? NormalizeLanguageOrNull(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language)
+            || language.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var normalized = language.Trim().ToLowerInvariant().Replace('_', '-');
+        if (Languages.Contains(normalized, StringComparer.Ordinal))
+            return normalized;
+
+        var separator = normalized.IndexOf('-');
+        if (separator > 0)
+        {
+            var primary = normalized[..separator];
+            if (Languages.Contains(primary, StringComparer.Ordinal))
+                return primary;
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeLanguage(string? language)
+    {
+        var normalized = NormalizeLanguageOrNull(language);
+        if (normalized is not null
+            || string.IsNullOrWhiteSpace(language)
+            || language.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            return normalized;
+        }
+
+        throw new NotSupportedException(
+            $"Cohere Transcribe does not support language '{language}'.");
+    }
+
+    private static IReadOnlyList<CrispAsrBackend> BuildAutomaticBackendOrder(
+        bool cudaAvailable,
+        bool vulkanAvailable)
+    {
+        var backends = new List<CrispAsrBackend>(3);
+        if (cudaAvailable)
+            backends.Add(CrispAsrBackend.Cuda);
+        if (vulkanAvailable)
+            backends.Add(CrispAsrBackend.Vulkan);
+        backends.Add(CrispAsrBackend.Cpu);
+        return backends;
+    }
+
+    private static IReadOnlyList<CrispAsrBackend> GetBackendCandidatesForCurrentMachine(
+        TranscriptionAccelerationPreference preference)
+    {
+        var cudaAvailable = IsNativeLibraryAvailable("nvcuda.dll");
+        var vulkanAvailable = IsNativeLibraryAvailable("vulkan-1.dll");
+
+        if (preference == TranscriptionAccelerationPreference.NvidiaCuda && !cudaAvailable)
+        {
+            throw new InvalidOperationException(
+                "NVIDIA CUDA was selected, but the NVIDIA driver runtime (nvcuda.dll) is unavailable.");
+        }
+
+        if (preference == TranscriptionAccelerationPreference.AmdVulkan && !vulkanAvailable)
+        {
+            throw new InvalidOperationException(
+                "Vulkan was selected, but the Vulkan loader (vulkan-1.dll) is unavailable.");
+        }
+
+        return ResolveBackendCandidates(preference, cudaAvailable, vulkanAvailable);
+    }
+
+    private static bool IsNativeLibraryAvailable(string libraryName)
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        if (!NativeLibrary.TryLoad(libraryName, out var handle))
+            return false;
+
+        NativeLibrary.Free(handle);
+        return true;
+    }
+
+    private static TranscriptionAccelerationStatus CreatePendingStatus(
+        TranscriptionAccelerationPreference preference)
+    {
+        if (preference == TranscriptionAccelerationPreference.AmdRocm)
+        {
+            return new(
+                TranscriptionAccelerationBackend.Cpu,
+                "ROCm unavailable",
+                "CrispASR currently provides CPU, CUDA, and Vulkan runtimes for this Windows plugin.");
+        }
+
+        var backend = GetPreferredBackendForStatus(preference);
+        return new(
+            TranscriptionAccelerationBackend.Cpu,
+            "Not loaded",
+            $"{GetBackendDisplayName(backend)} will be used when the model loads.");
+    }
+
+    private static CrispAsrBackend GetPreferredBackendForStatus(
+        TranscriptionAccelerationPreference preference) =>
+        preference switch
+        {
+            TranscriptionAccelerationPreference.Cpu => CrispAsrBackend.Cpu,
+            TranscriptionAccelerationPreference.NvidiaCuda => CrispAsrBackend.Cuda,
+            TranscriptionAccelerationPreference.AmdVulkan => CrispAsrBackend.Vulkan,
+            _ => ResolveBackendCandidates(
+                TranscriptionAccelerationPreference.Auto,
+                IsNativeLibraryAvailable("nvcuda.dll"),
+                IsNativeLibraryAvailable("vulkan-1.dll"))[0]
+        };
+
+    private static TranscriptionAccelerationStatus CreateInstallingStatus(CrispAsrBackend backend) =>
+        new(
+            TranscriptionAccelerationBackend.Cpu,
+            $"Preparing {GetBackendDisplayName(backend)}",
+            $"Installing the verified local CrispASR {GetBackendDisplayName(backend)} runtime if needed.");
+
+    private static TranscriptionAccelerationStatus CreateLoadedStatus(
+        CrispAsrBackend backend,
+        string? fallbackDetail) =>
+        new(
+            ToPublicBackend(backend),
+            $"Using {GetBackendDisplayName(backend)}",
+            fallbackDetail ?? $"CrispASR {CohereLocalAssetManager.CrispAsrVersion}, local loopback process.");
+
+    private static TranscriptionAccelerationStatus CreateUnavailableStatus(
+        TranscriptionAccelerationPreference preference,
+        string detail)
+    {
+        var displayName = preference switch
+        {
+            TranscriptionAccelerationPreference.NvidiaCuda => "CUDA unavailable",
+            TranscriptionAccelerationPreference.AmdVulkan => "Vulkan unavailable",
+            TranscriptionAccelerationPreference.AmdRocm => "ROCm unavailable",
+            _ => "Local runtime error"
+        };
+
+        return new(TranscriptionAccelerationBackend.Cpu, displayName, detail);
+    }
+
+    private static TranscriptionAccelerationBackend ToPublicBackend(CrispAsrBackend backend) =>
+        backend switch
+        {
+            CrispAsrBackend.Cpu => TranscriptionAccelerationBackend.Cpu,
+            CrispAsrBackend.Cuda => TranscriptionAccelerationBackend.NvidiaCuda,
+            CrispAsrBackend.Vulkan => TranscriptionAccelerationBackend.AmdVulkan,
+            _ => throw new ArgumentOutOfRangeException(nameof(backend), backend, null)
+        };
+
+    private static string GetBackendDisplayName(CrispAsrBackend backend) =>
+        backend switch
+        {
+            CrispAsrBackend.Cpu => "CPU",
+            CrispAsrBackend.Cuda => "CUDA",
+            CrispAsrBackend.Vulkan => "Vulkan",
+            _ => throw new ArgumentOutOfRangeException(nameof(backend), backend, null)
+        };
+
+    private static void ValidateModelId(string modelId)
+    {
+        if (!string.Equals(modelId, ModelId, StringComparison.Ordinal))
+            throw new ArgumentException($"Unknown model: {modelId}", nameof(modelId));
+    }
+
+    private static void EnsureSupportedPlatform()
+    {
+        if (!OperatingSystem.IsWindows()
+            || RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            throw new PlatformNotSupportedException(
+                "Cohere Transcribe local inference currently requires Windows x64.");
+        }
+    }
+
+    private ICohereLocalAssetManager GetAssets() =>
+        _assets ?? throw new InvalidOperationException("Plugin is not activated.");
+
+    private ICrispAsrServer GetServer() =>
+        _server ?? throw new InvalidOperationException("Plugin is not activated.");
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
@@ -144,8 +144,29 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
         _host = host;
         _assets ??= new CohereLocalAssetManager(host.PluginAssetDirectory);
         _server ??= new CrispAsrServer(host.Log);
-        _huggingFaceToken = NormalizeHuggingFaceToken(
-            await host.LoadSecretAsync(HuggingFaceTokenSecretName));
+        var storedToken = await host.LoadSecretAsync(HuggingFaceTokenSecretName);
+        try
+        {
+            _huggingFaceToken = NormalizeHuggingFaceToken(storedToken);
+        }
+        catch (ArgumentException)
+        {
+            _huggingFaceToken = null;
+            host.Log(
+                PluginLogLevel.Warning,
+                "Ignoring and removing the stored Hugging Face token because it is malformed.");
+            try
+            {
+                await host.DeleteSecretAsync(HuggingFaceTokenSecretName);
+            }
+            catch (Exception exception) when (IsExpectedSecretStorageFailure(exception))
+            {
+                host.Log(
+                    PluginLogLevel.Warning,
+                    $"The malformed Hugging Face token could not be removed: {exception.Message}");
+            }
+        }
+
         _assets.SetHuggingFaceToken(_huggingFaceToken);
 
         var persistedModel = host.GetSetting<string>("selectedModel");
@@ -515,8 +536,11 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
     internal async Task SetHuggingFaceTokenAsync(string? token)
     {
         var normalized = NormalizeHuggingFaceToken(token);
-        if (string.Equals(_huggingFaceToken, normalized, StringComparison.Ordinal))
+        if (normalized is not null
+            && string.Equals(_huggingFaceToken, normalized, StringComparison.Ordinal))
+        {
             return;
+        }
 
         if (_host is not null)
         {
@@ -545,6 +569,14 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
 
         return normalized;
     }
+
+    internal static bool IsExpectedSecretStorageFailure(Exception exception) =>
+        exception is InvalidOperationException
+            or IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or System.Security.Cryptography.CryptographicException
+            or System.Security.SecurityException;
 
     internal static string? NormalizeLanguageOrNull(string? language)
     {

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="TypeWhisper.Plugin.CohereTranscribe.CohereTranscribeSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="0,4" MaxWidth="520">
+        <TextBlock x:Name="TokenLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
+        <PasswordBox x:Name="TokenBox"
+                     MaxLength="500"
+                     PasswordChanged="OnPasswordChanged" />
+        <TextBlock x:Name="TokenHintText"
+                   Margin="0,4,0,0"
+                   FontSize="11"
+                   Foreground="Gray"
+                   TextWrapping="Wrap" />
+        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+            <Button x:Name="SaveButton"
+                    Padding="12,4"
+                    Click="OnSaveClick" />
+            <Button x:Name="RemoveButton"
+                    Margin="8,0,0,0"
+                    Padding="12,4"
+                    Click="OnRemoveClick" />
+        </StackPanel>
+        <TextBlock x:Name="StatusText"
+                   Margin="0,6,0,0"
+                   FontSize="12"
+                   TextWrapping="Wrap" />
+    </StackPanel>
+</UserControl>

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml
@@ -5,6 +5,7 @@
         <TextBlock x:Name="TokenLabel" FontWeight="SemiBold" Margin="0,0,0,4" />
         <PasswordBox x:Name="TokenBox"
                      MaxLength="500"
+                     AutomationProperties.LabeledBy="{Binding ElementName=TokenLabel}"
                      PasswordChanged="OnPasswordChanged" />
         <TextBlock x:Name="TokenHintText"
                    Margin="0,4,0,0"

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -68,7 +69,7 @@ public partial class CohereTranscribeSettingsView : UserControl
             StatusText.Text = L("Settings.InvalidToken");
             StatusText.Foreground = Brushes.Red;
         }
-        catch (Exception)
+        catch (Exception exception) when (IsExpectedSecretStorageFailure(exception))
         {
             StatusText.Text = L("Settings.SaveFailed");
             StatusText.Foreground = Brushes.Red;
@@ -93,7 +94,7 @@ public partial class CohereTranscribeSettingsView : UserControl
             StatusText.Text = L("Settings.Removed");
             StatusText.Foreground = Brushes.Green;
         }
-        catch (Exception)
+        catch (Exception exception) when (IsExpectedSecretStorageFailure(exception))
         {
             StatusText.Text = L("Settings.SaveFailed");
             StatusText.Foreground = Brushes.Red;
@@ -114,6 +115,14 @@ public partial class CohereTranscribeSettingsView : UserControl
                 ? Visibility.Visible
                 : Visibility.Collapsed;
     }
+
+    private static bool IsExpectedSecretStorageFailure(Exception exception) =>
+        exception is InvalidOperationException
+            or IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or System.Security.Cryptography.CryptographicException
+            or System.Security.SecurityException;
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml.cs
@@ -1,0 +1,119 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace TypeWhisper.Plugin.CohereTranscribe;
+
+/// <summary>
+/// Provides optional Hugging Face authentication settings for local asset downloads.
+/// </summary>
+public partial class CohereTranscribeSettingsView : UserControl
+{
+    private readonly CohereTranscribePlugin _plugin;
+    private bool _suppressChanges;
+
+    /// <summary>
+    /// Initializes a new instance of the CohereTranscribeSettingsView class.
+    /// </summary>
+    public CohereTranscribeSettingsView(CohereTranscribePlugin plugin)
+    {
+        _plugin = plugin;
+        InitializeComponent();
+
+        TokenLabel.Text = L("Settings.HuggingFaceToken");
+        TokenHintText.Text = L("Settings.HuggingFaceTokenHint");
+        SaveButton.Content = L("Settings.Save");
+        RemoveButton.Content = L("Settings.Remove");
+
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _suppressChanges = true;
+        try
+        {
+            TokenBox.Password = _plugin.HuggingFaceToken ?? "";
+            UpdateRemoveButton();
+        }
+        finally
+        {
+            _suppressChanges = false;
+        }
+    }
+
+    private void OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (_suppressChanges)
+            return;
+
+        StatusText.Text = "";
+        UpdateRemoveButton();
+    }
+
+    private async void OnSaveClick(object sender, RoutedEventArgs e)
+    {
+        SaveButton.IsEnabled = false;
+        RemoveButton.IsEnabled = false;
+        try
+        {
+            await _plugin.SetHuggingFaceTokenAsync(TokenBox.Password);
+            StatusText.Text = _plugin.HuggingFaceToken is null
+                ? L("Settings.Removed")
+                : L("Settings.Saved");
+            StatusText.Foreground = Brushes.Green;
+        }
+        catch (ArgumentException)
+        {
+            StatusText.Text = L("Settings.InvalidToken");
+            StatusText.Foreground = Brushes.Red;
+        }
+        catch (Exception)
+        {
+            StatusText.Text = L("Settings.SaveFailed");
+            StatusText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            SaveButton.IsEnabled = true;
+            RemoveButton.IsEnabled = true;
+            UpdateRemoveButton();
+        }
+    }
+
+    private async void OnRemoveClick(object sender, RoutedEventArgs e)
+    {
+        SaveButton.IsEnabled = false;
+        RemoveButton.IsEnabled = false;
+        try
+        {
+            await _plugin.SetHuggingFaceTokenAsync(null);
+            _suppressChanges = true;
+            TokenBox.Password = "";
+            StatusText.Text = L("Settings.Removed");
+            StatusText.Foreground = Brushes.Green;
+        }
+        catch (Exception)
+        {
+            StatusText.Text = L("Settings.SaveFailed");
+            StatusText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            _suppressChanges = false;
+            SaveButton.IsEnabled = true;
+            RemoveButton.IsEnabled = true;
+            UpdateRemoveButton();
+        }
+    }
+
+    private void UpdateRemoveButton()
+    {
+        RemoveButton.Visibility =
+            !string.IsNullOrWhiteSpace(TokenBox.Password) || _plugin.HuggingFaceToken is not null
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+    }
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribeSettingsView.xaml.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -69,7 +68,8 @@ public partial class CohereTranscribeSettingsView : UserControl
             StatusText.Text = L("Settings.InvalidToken");
             StatusText.Foreground = Brushes.Red;
         }
-        catch (Exception exception) when (IsExpectedSecretStorageFailure(exception))
+        catch (Exception exception) when (
+            CohereTranscribePlugin.IsExpectedSecretStorageFailure(exception))
         {
             StatusText.Text = L("Settings.SaveFailed");
             StatusText.Foreground = Brushes.Red;
@@ -94,7 +94,8 @@ public partial class CohereTranscribeSettingsView : UserControl
             StatusText.Text = L("Settings.Removed");
             StatusText.Foreground = Brushes.Green;
         }
-        catch (Exception exception) when (IsExpectedSecretStorageFailure(exception))
+        catch (Exception exception) when (
+            CohereTranscribePlugin.IsExpectedSecretStorageFailure(exception))
         {
             StatusText.Text = L("Settings.SaveFailed");
             StatusText.Foreground = Brushes.Red;
@@ -115,14 +116,6 @@ public partial class CohereTranscribeSettingsView : UserControl
                 ? Visibility.Visible
                 : Visibility.Collapsed;
     }
-
-    private static bool IsExpectedSecretStorageFailure(Exception exception) =>
-        exception is InvalidOperationException
-            or IOException
-            or UnauthorizedAccessException
-            or NotSupportedException
-            or System.Security.Cryptography.CryptographicException
-            or System.Security.SecurityException;
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
 }

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -175,7 +175,7 @@ internal sealed class CrispAsrServer : ICrispAsrServer
                 process.Kill(entireProcessTree: true);
 
             using var timeout = new CancellationTokenSource(ShutdownTimeout);
-            await process.WaitForExitAsync(timeout.Token);
+            await process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -1,0 +1,331 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Helpers;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.CohereTranscribe;
+
+internal sealed record CrispAsrServerConfiguration(
+    string ExecutablePath,
+    CohereModelPaths ModelPaths,
+    CrispAsrBackend Backend,
+    int ThreadCount);
+
+internal interface ICrispAsrServer : IDisposable
+{
+    bool IsRunning { get; }
+
+    CrispAsrBackend? ActiveBackend { get; }
+
+    Task StartAsync(CrispAsrServerConfiguration configuration, CancellationToken cancellationToken);
+
+    Task<PluginTranscriptionResult> TranscribeAsync(
+        byte[] wavAudio,
+        string? language,
+        CancellationToken cancellationToken);
+
+    Task StopAsync();
+}
+
+internal sealed class CrispAsrServer : ICrispAsrServer
+{
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromMinutes(10) };
+    private readonly Action<PluginLogLevel, string> _log;
+    private readonly object _outputLock = new();
+    private readonly Queue<string> _outputTail = new();
+
+    private Process? _process;
+    private WindowsProcessJob? _processJob;
+    private string? _baseUrl;
+    private string? _apiKey;
+
+    internal CrispAsrServer(Action<PluginLogLevel, string> log)
+    {
+        _log = log;
+    }
+
+    public bool IsRunning => _process is { HasExited: false } && _baseUrl is not null;
+
+    public CrispAsrBackend? ActiveBackend { get; private set; }
+
+    public async Task StartAsync(
+        CrispAsrServerConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        await StopAsync();
+
+        if (!File.Exists(configuration.ExecutablePath))
+        {
+            throw new FileNotFoundException(
+                "The local CrispASR runtime executable is missing.",
+                configuration.ExecutablePath);
+        }
+
+        Directory.CreateDirectory(configuration.ModelPaths.CacheDirectory);
+
+        var port = ReserveLoopbackPort();
+        var apiKey = Convert.ToHexStringLower(RandomNumberGenerator.GetBytes(32));
+        var startInfo = BuildStartInfo(configuration, port, apiKey);
+        var process = new Process
+        {
+            StartInfo = startInfo,
+            EnableRaisingEvents = true
+        };
+
+        process.OutputDataReceived += (_, args) => CaptureOutput(args.Data);
+        process.ErrorDataReceived += (_, args) => CaptureOutput(args.Data);
+
+        lock (_outputLock)
+            _outputTail.Clear();
+
+        try
+        {
+            if (!process.Start())
+                throw new InvalidOperationException("CrispASR did not start.");
+
+            _process = process;
+            _processJob = WindowsProcessJob.CreateAndAssign(process);
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            _baseUrl = $"http://127.0.0.1:{port}";
+            _apiKey = apiKey;
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(StartupTimeout);
+            await WaitUntilReadyAsync(process, _baseUrl, timeout.Token);
+
+            ActiveBackend = configuration.Backend;
+            _log(
+                PluginLogLevel.Info,
+                $"CrispASR {CohereLocalAssetManager.CrispAsrVersion} is ready on loopback using {GetBackendName(configuration.Backend)}.");
+        }
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            var output = GetOutputTail();
+            await StopAsync();
+            throw new TimeoutException(
+                $"CrispASR did not become ready within {StartupTimeout.TotalMinutes:0} minutes.{output}",
+                exception);
+        }
+        catch
+        {
+            if (_process is null)
+                process.Dispose();
+            await StopAsync();
+            throw;
+        }
+    }
+
+    public async Task<PluginTranscriptionResult> TranscribeAsync(
+        byte[] wavAudio,
+        string? language,
+        CancellationToken cancellationToken)
+    {
+        if (!IsRunning || _baseUrl is null || _apiKey is null || _process is null)
+            throw new InvalidOperationException("The local Cohere Transcribe model is not loaded.");
+
+        if (_process.HasExited)
+        {
+            throw new InvalidOperationException(
+                $"The local CrispASR process exited unexpectedly with code {_process.ExitCode}.{GetOutputTail()}");
+        }
+
+        return await OpenAiTranscriptionHelper.TranscribeAsync(
+            _httpClient,
+            _baseUrl,
+            _apiKey,
+            CohereTranscribePlugin.ModelId,
+            wavAudio,
+            language,
+            translate: false,
+            responseFormat: "verbose_json",
+            cancellationToken,
+            prompt: null);
+    }
+
+    public async Task StopAsync()
+    {
+        var process = _process;
+        var processJob = _processJob;
+        _process = null;
+        _processJob = null;
+        _baseUrl = null;
+        _apiKey = null;
+        ActiveBackend = null;
+
+        if (process is null)
+        {
+            processJob?.Dispose();
+            return;
+        }
+
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+
+            using var timeout = new CancellationTokenSource(ShutdownTimeout);
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _log(PluginLogLevel.Warning, "Timed out while stopping the local CrispASR process.");
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        finally
+        {
+            process.Dispose();
+            processJob?.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        _httpClient.Dispose();
+    }
+
+    internal static ProcessStartInfo BuildStartInfo(
+        CrispAsrServerConfiguration configuration,
+        int port,
+        string apiKey)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = configuration.ExecutablePath,
+            WorkingDirectory = Path.GetDirectoryName(configuration.ExecutablePath)
+                ?? AppContext.BaseDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+
+        AddArgument(startInfo, "--server");
+        AddArgument(startInfo, "--backend", "cohere");
+        AddArgument(startInfo, "--model", configuration.ModelPaths.ModelPath);
+        AddArgument(startInfo, "--host", "127.0.0.1");
+        AddArgument(startInfo, "--port", port.ToString());
+        AddArgument(startInfo, "--language", "auto");
+        AddArgument(startInfo, "--lid-backend", "ecapa");
+        AddArgument(startInfo, "--lid-model", configuration.ModelPaths.LanguageIdModelPath);
+        AddArgument(startInfo, "--vad");
+        AddArgument(startInfo, "--vad-model", configuration.ModelPaths.VadModelPath);
+        AddArgument(startInfo, "--strict-pipeline");
+        AddArgument(startInfo, "--require-vad");
+        AddArgument(startInfo, "--threads", configuration.ThreadCount.ToString());
+        AddArgument(startInfo, "--gpu-backend", GetBackendName(configuration.Backend));
+
+        if (configuration.Backend == CrispAsrBackend.Cpu)
+            AddArgument(startInfo, "--no-gpu");
+
+        startInfo.Environment["CRISPASR_API_KEYS"] = apiKey;
+        startInfo.Environment["CRISPASR_CACHE_DIR"] = configuration.ModelPaths.CacheDirectory;
+        return startInfo;
+    }
+
+    private async Task WaitUntilReadyAsync(
+        Process process,
+        string baseUrl,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (process.HasExited)
+            {
+                throw new InvalidOperationException(
+                    $"CrispASR exited during startup with code {process.ExitCode}.{GetOutputTail()}");
+            }
+
+            try
+            {
+                using var attempt = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                attempt.CancelAfter(TimeSpan.FromSeconds(2));
+                using var response = await _httpClient.GetAsync(
+                    $"{baseUrl}/health",
+                    attempt.Token);
+                if (response.StatusCode == HttpStatusCode.OK)
+                    return;
+            }
+            catch (Exception exception) when (
+                (exception is HttpRequestException
+                    or TaskCanceledException
+                    or OperationCanceledException)
+                && !cancellationToken.IsCancellationRequested)
+            {
+            }
+
+            await Task.Delay(250, cancellationToken);
+        }
+    }
+
+    private void CaptureOutput(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return;
+
+        lock (_outputLock)
+        {
+            _outputTail.Enqueue(line.Trim());
+            while (_outputTail.Count > 80)
+                _outputTail.Dequeue();
+        }
+    }
+
+    private string GetOutputTail()
+    {
+        lock (_outputLock)
+        {
+            if (_outputTail.Count == 0)
+                return string.Empty;
+
+            return Environment.NewLine + string.Join(
+                Environment.NewLine,
+                _outputTail.TakeLast(20));
+        }
+    }
+
+    private static int ReserveLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static string GetBackendName(CrispAsrBackend backend) =>
+        backend switch
+        {
+            CrispAsrBackend.Cpu => "cpu",
+            CrispAsrBackend.Cuda => "cuda",
+            CrispAsrBackend.Vulkan => "vulkan",
+            _ => throw new ArgumentOutOfRangeException(nameof(backend), backend, null)
+        };
+
+    private static void AddArgument(ProcessStartInfo startInfo, params string[] values)
+    {
+        foreach (var value in values)
+            startInfo.ArgumentList.Add(value);
+    }
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -302,16 +302,9 @@ internal sealed class CrispAsrServer : ICrispAsrServer
 
     private static int ReserveLoopbackPort()
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
-        try
-        {
-            return ((IPEndPoint)listener.LocalEndpoint).Port;
-        }
-        finally
-        {
-            listener.Stop();
-        }
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     private static string GetBackendName(CrispAsrBackend backend) =>

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/Localization/de.json
@@ -1,0 +1,10 @@
+{
+  "Settings.HuggingFaceToken": "Hugging-Face-Token (optional)",
+  "Settings.HuggingFaceTokenHint": "Wird sicher per Windows-DPAPI gespeichert und nur für Modell-Downloads an huggingface.co gesendet. Öffentliche Downloads funktionieren auch ohne Token. Die Anmeldung kann Rate-Limits zuverlässiger machen, garantiert aber keine höhere Übertragungsgeschwindigkeit.",
+  "Settings.Save": "Speichern",
+  "Settings.Remove": "Entfernen",
+  "Settings.Saved": "Token sicher gespeichert.",
+  "Settings.Removed": "Token entfernt.",
+  "Settings.InvalidToken": "Der Token darf keine Leerzeichen oder Zeilenumbrüche enthalten.",
+  "Settings.SaveFailed": "Der Token konnte nicht sicher gespeichert werden. Bitte erneut versuchen."
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/Localization/en.json
@@ -1,0 +1,10 @@
+{
+  "Settings.HuggingFaceToken": "Hugging Face token (optional)",
+  "Settings.HuggingFaceTokenHint": "Stored securely with Windows DPAPI and sent only to huggingface.co for model downloads. Public downloads also work without a token. Authentication can improve rate-limit reliability but does not guarantee higher transfer speed.",
+  "Settings.Save": "Save",
+  "Settings.Remove": "Remove",
+  "Settings.Saved": "Token saved securely.",
+  "Settings.Removed": "Token removed.",
+  "Settings.InvalidToken": "The token must not contain spaces or line breaks.",
+  "Settings.SaveFailed": "The token could not be stored securely. Please try again."
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>TypeWhisper.Plugin.CohereTranscribe</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <Target Name="CopyToAppPlugins" AfterTargets="Build">
+    <PropertyGroup>
+      <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
+      <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.cohere-transcribe\</PluginOutputDir>
+    </PropertyGroup>
+
+    <RemoveDir Directories="$(PluginOutputDir)" Condition="Exists('$(PluginOutputDir)')" />
+    <MakeDir Directories="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json"
+          DestinationFolder="$(PluginOutputDir)"
+          Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
+  </Target>
+</Project>

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/WindowsProcessJob.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/WindowsProcessJob.cs
@@ -1,0 +1,137 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace TypeWhisper.Plugin.CohereTranscribe;
+
+internal sealed class WindowsProcessJob : IDisposable
+{
+    private const uint JobObjectLimitKillOnJobClose = 0x00002000;
+    private const int JobObjectExtendedLimitInformation = 9;
+
+    private readonly SafeFileHandle _handle;
+
+    private WindowsProcessJob(SafeFileHandle handle)
+    {
+        _handle = handle;
+    }
+
+    public static WindowsProcessJob CreateAndAssign(Process process)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        var handle = CreateJobObjectW(IntPtr.Zero, null);
+        if (handle.IsInvalid)
+        {
+            var error = Marshal.GetLastWin32Error();
+            handle.Dispose();
+            throw new Win32Exception(error, "Failed to create the CrispASR process job.");
+        }
+
+        try
+        {
+            var information = new JobObjectExtendedLimitInformationNative
+            {
+                BasicLimitInformation = new JobObjectBasicLimitInformation
+                {
+                    LimitFlags = JobObjectLimitKillOnJobClose
+                }
+            };
+            var informationSize = Marshal.SizeOf<JobObjectExtendedLimitInformationNative>();
+            var informationPointer = Marshal.AllocHGlobal(informationSize);
+            try
+            {
+                Marshal.StructureToPtr(information, informationPointer, fDeleteOld: false);
+                if (!SetInformationJobObject(
+                    handle,
+                    JobObjectExtendedLimitInformation,
+                    informationPointer,
+                    (uint)informationSize))
+                {
+                    throw new Win32Exception(
+                        Marshal.GetLastWin32Error(),
+                        "Failed to configure the CrispASR process job.");
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(informationPointer);
+            }
+
+            if (!AssignProcessToJobObject(handle, process.Handle))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "Failed to attach CrispASR to the TypeWhisper process lifetime.");
+            }
+
+            return new WindowsProcessJob(handle);
+        }
+        catch
+        {
+            handle.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateJobObjectW", SetLastError = true)]
+    private static extern SafeFileHandle CreateJobObjectW(
+        IntPtr jobAttributes,
+        [MarshalAs(UnmanagedType.LPWStr)] string? name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetInformationJobObject(
+        SafeFileHandle job,
+        int informationClass,
+        IntPtr jobObjectInformation,
+        uint jobObjectInformationLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AssignProcessToJobObject(
+        SafeFileHandle job,
+        IntPtr process);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectBasicLimitInformation
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoCounters
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectExtendedLimitInformationNative
+    {
+        public JobObjectBasicLimitInformation BasicLimitInformation;
+        public IoCounters IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+}

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/manifest.json
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "com.typewhisper.cohere-transcribe",
+  "name": "Cohere Transcribe (Local)",
+  "version": "1.0.0",
+  "minHostVersion": "1.0.6",
+  "author": "TypeWhisper",
+  "description": "Offline Cohere Transcribe inference via a managed local CrispASR runtime",
+  "category": "transcription",
+  "isLocal": true,
+  "assemblyName": "TypeWhisper.Plugin.CohereTranscribe.dll",
+  "pluginClass": "TypeWhisper.Plugin.CohereTranscribe.CohereTranscribePlugin"
+}

--- a/src/TypeWhisper.Windows/Services/ModelManagerService.cs
+++ b/src/TypeWhisper.Windows/Services/ModelManagerService.cs
@@ -241,6 +241,8 @@ public sealed class ModelManagerService : INotifyPropertyChanged, IDisposable
         {
             SetStatus(modelId, ModelStatus.DownloadingModel(0));
 
+            plugin.SetAccelerationPreference(
+                GetAccelerationPreference(_settings.Current.LocalModelAcceleration));
             var progress = new Progress<double>(p => SetStatus(modelId, ModelStatus.DownloadingModel(p)));
             await plugin.DownloadModelAsync(pluginModelId, progress, cancellationToken);
         }

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -149,6 +149,37 @@ public sealed class CohereTranscribePluginTests
     }
 
     [Fact]
+    public async Task DownloadVerifiedAsync_AcceptsCompletedRangeAfterLateStreamFailure()
+    {
+        using var temp = new TempDirectory();
+        var payload = Encoding.UTF8.GetBytes("completed-before-dispose");
+        var destination = Path.Join(temp.Path, "model.gguf.download");
+        var handler = new RangeDownloadHandler(payload, disposeFailuresRemaining: 1);
+        using var httpClient = new HttpClient(handler);
+        using var sut = new CohereLocalAssetManager(
+            temp.Path,
+            httpClient,
+            downloadChunkSizeBytes: 64,
+            downloadInactivityTimeout: TimeSpan.FromSeconds(5),
+            maxDownloadAttempts: 2,
+            downloadRetryDelay: TimeSpan.Zero);
+        var artifact = new RemoteArtifact(
+            "model.gguf",
+            "https://downloads.example/model.gguf",
+            payload.Length,
+            Convert.ToHexStringLower(SHA256.HashData(payload)));
+
+        await sut.DownloadVerifiedAsync(
+            artifact,
+            destination,
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(payload, await File.ReadAllBytesAsync(destination));
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
     public async Task DownloadVerifiedAsync_SendsTokenOnlyToHuggingFace()
     {
         using var temp = new TempDirectory();
@@ -438,6 +469,46 @@ public sealed class CohereTranscribePluginTests
     }
 
     [Fact]
+    public async Task ActivateAsync_IgnoresAndRemovesMalformedStoredHuggingFaceToken()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        using var sut = new CohereTranscribePlugin(assets, new FakeCrispAsrServer());
+        var host = new FakePluginHostServices(
+            temp.Path,
+            new Dictionary<string, string>
+            {
+                [CohereTranscribePlugin.HuggingFaceTokenSecretName] = "hf_bad token"
+            });
+
+        await sut.ActivateAsync(host);
+
+        Assert.Null(sut.HuggingFaceToken);
+        Assert.Null(assets.HuggingFaceToken);
+        Assert.DoesNotContain(
+            CohereTranscribePlugin.HuggingFaceTokenSecretName,
+            host.Secrets);
+        Assert.Contains(
+            host.Logs,
+            entry => entry.Level == PluginLogLevel.Warning
+                && entry.Message.Contains("malformed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SettingsView_LabelsTheOptionalTokenFieldForAssistiveTechnology()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "plugins",
+            "TypeWhisper.Plugin.CohereTranscribe",
+            "CohereTranscribeSettingsView.xaml");
+
+        Assert.Contains(
+            "AutomationProperties.LabeledBy=\"{Binding ElementName=TokenLabel}\"",
+            xaml,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task SetHuggingFaceTokenAsync_DoesNotApplyTokenWhenSecureStoreFails()
     {
         using var temp = new TempDirectory();
@@ -558,9 +629,11 @@ public sealed class CohereTranscribePluginTests
 
     private sealed class RangeDownloadHandler(
         byte[] payload,
-        int failuresRemaining = 0) : HttpMessageHandler
+        int failuresRemaining = 0,
+        int disposeFailuresRemaining = 0) : HttpMessageHandler
     {
         private int _failuresRemaining = failuresRemaining;
+        private int _disposeFailuresRemaining = disposeFailuresRemaining;
 
         public int RequestCount { get; private set; }
         public List<string> RequestedRanges { get; } = [];
@@ -589,10 +662,22 @@ public sealed class CohereTranscribePluginTests
                 RequestedRanges.Add($"bytes={start}-{end}");
 
             var segment = payload[(int)start..((int)end + 1)];
+            HttpContent content;
+            if (_disposeFailuresRemaining > 0)
+            {
+                _disposeFailuresRemaining--;
+                content = new StreamContent(new DisposeFailingMemoryStream(segment));
+                content.Headers.ContentLength = segment.Length;
+            }
+            else
+            {
+                content = new ByteArrayContent(segment);
+            }
+
             var response = new HttpResponseMessage(
                 requestedRange is null ? HttpStatusCode.OK : HttpStatusCode.PartialContent)
             {
-                Content = new ByteArrayContent(segment)
+                Content = content
             };
             if (requestedRange is not null)
             {
@@ -603,6 +688,23 @@ public sealed class CohereTranscribePluginTests
             }
 
             return Task.FromResult(response);
+        }
+    }
+
+    private sealed class DisposeFailingMemoryStream(byte[] buffer)
+        : MemoryStream(buffer, writable: false)
+    {
+        private bool _shouldFail = true;
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (_shouldFail)
+            {
+                _shouldFail = false;
+                throw new IOException("Simulated failure after the completed transfer.");
+            }
+
+            await base.DisposeAsync();
         }
     }
 
@@ -662,6 +764,7 @@ public sealed class CohereTranscribePluginTests
         }
 
         public Dictionary<string, string> Secrets { get; }
+        public List<(PluginLogLevel Level, string Message)> Logs { get; } = [];
         public Exception? StoreSecretException { get; init; }
         public Exception? DeleteSecretException { get; init; }
         public string PluginDataDirectory { get; }
@@ -694,7 +797,8 @@ public sealed class CohereTranscribePluginTests
         }
         public T? GetSetting<T>(string key) => default;
         public void SetSetting<T>(string key, T value) { }
-        public void Log(PluginLogLevel level, string message) { }
+        public void Log(PluginLogLevel level, string message) =>
+            Logs.Add((level, message));
         public void NotifyCapabilitiesChanged() { }
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -1,0 +1,745 @@
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.Plugin.CohereTranscribe;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class CohereTranscribePluginTests
+{
+    [Fact]
+    public void ManifestAndPluginMetadata_AreLocalAndVersionMatched()
+    {
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            TestFile.ReadProjectFile(
+                "plugins",
+                "TypeWhisper.Plugin.CohereTranscribe",
+                "manifest.json"),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var sut = new CohereTranscribePlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal("com.typewhisper.cohere-transcribe", manifest.Id);
+        Assert.Equal("transcription", manifest.Category);
+        Assert.True(manifest.IsLocal);
+        Assert.Equal("1.0.6", manifest.MinHostVersion);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+        Assert.Equal(manifest.Id, sut.PluginId);
+        Assert.Equal("cohere-transcribe", sut.ProviderId);
+        Assert.True(sut.SupportsModelDownload);
+        Assert.False(sut.SupportsTranslation);
+    }
+
+    [Fact]
+    public void ModelMetadata_ExposesPinnedBalancedModelAndFourteenLanguages()
+    {
+        var sut = new CohereTranscribePlugin();
+        var model = Assert.Single(sut.TranscriptionModels);
+
+        Assert.Equal(CohereTranscribePlugin.ModelId, model.Id);
+        Assert.True(model.IsRecommended);
+        Assert.Equal(14, model.LanguageCount);
+        Assert.Equal(14, sut.SupportedLanguages.Count);
+        Assert.Contains("de", sut.SupportedLanguages);
+        Assert.Contains("ja", sut.SupportedLanguages);
+        Assert.DoesNotContain("ru", sut.SupportedLanguages);
+    }
+
+    [Fact]
+    public void DownloadDefinitions_AreRevisionPinnedAndSha256Pinned()
+    {
+        Assert.Contains(
+            CohereLocalAssetManager.CohereModelRevision,
+            CohereLocalAssetManager.CohereModel.DownloadUrl);
+        Assert.Contains(
+            CohereLocalAssetManager.VadModelRevision,
+            CohereLocalAssetManager.VadModel.DownloadUrl);
+        Assert.Contains(
+            CohereLocalAssetManager.LanguageIdModelRevision,
+            CohereLocalAssetManager.LanguageIdModel.DownloadUrl);
+
+        Assert.All(
+            new[]
+            {
+                CohereLocalAssetManager.CohereModel,
+                CohereLocalAssetManager.VadModel,
+                CohereLocalAssetManager.LanguageIdModel,
+                CohereLocalAssetManager.CpuRuntime.Archive,
+                CohereLocalAssetManager.CudaRuntime.Archive,
+                CohereLocalAssetManager.VulkanRuntime.Archive
+            },
+            artifact =>
+            {
+                Assert.Equal(64, artifact.Sha256.Length);
+                Assert.True(artifact.SizeBytes > 0);
+                Assert.StartsWith("https://", artifact.DownloadUrl);
+            });
+    }
+
+    [Fact]
+    public async Task DownloadVerifiedAsync_ResumesWithVerifiedRangeChunks()
+    {
+        using var temp = new TempDirectory();
+        var payload = Encoding.UTF8.GetBytes("cohere-local");
+        var destination = Path.Join(temp.Path, "model.gguf.download");
+        await File.WriteAllBytesAsync(destination, payload[..3]);
+
+        var handler = new RangeDownloadHandler(payload);
+        using var httpClient = new HttpClient(handler);
+        using var sut = new CohereLocalAssetManager(
+            temp.Path,
+            httpClient,
+            downloadChunkSizeBytes: 4,
+            downloadInactivityTimeout: TimeSpan.FromSeconds(5),
+            maxDownloadAttempts: 2,
+            downloadRetryDelay: TimeSpan.Zero);
+        var artifact = new RemoteArtifact(
+            "model.gguf",
+            "https://downloads.example/model.gguf",
+            payload.Length,
+            Convert.ToHexStringLower(SHA256.HashData(payload)));
+
+        await sut.DownloadVerifiedAsync(
+            artifact,
+            destination,
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(payload, await File.ReadAllBytesAsync(destination));
+        Assert.Equal(["bytes=3-6", "bytes=7-10", "bytes=11-11"], handler.RequestedRanges);
+    }
+
+    [Fact]
+    public async Task DownloadVerifiedAsync_RetriesTransientRangeFailure()
+    {
+        using var temp = new TempDirectory();
+        var payload = Encoding.UTF8.GetBytes("retry-local");
+        var destination = Path.Join(temp.Path, "model.gguf.download");
+        var handler = new RangeDownloadHandler(payload, failuresRemaining: 1);
+        using var httpClient = new HttpClient(handler);
+        using var sut = new CohereLocalAssetManager(
+            temp.Path,
+            httpClient,
+            downloadChunkSizeBytes: 64,
+            downloadInactivityTimeout: TimeSpan.FromSeconds(5),
+            maxDownloadAttempts: 2,
+            downloadRetryDelay: TimeSpan.Zero);
+        var artifact = new RemoteArtifact(
+            "model.gguf",
+            "https://downloads.example/model.gguf",
+            payload.Length,
+            Convert.ToHexStringLower(SHA256.HashData(payload)));
+
+        await sut.DownloadVerifiedAsync(
+            artifact,
+            destination,
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(payload, await File.ReadAllBytesAsync(destination));
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task DownloadVerifiedAsync_SendsTokenOnlyToHuggingFace()
+    {
+        using var temp = new TempDirectory();
+        var payload = Encoding.UTF8.GetBytes("authenticated-local");
+        var handler = new RangeDownloadHandler(payload);
+        using var httpClient = new HttpClient(handler);
+        using var sut = new CohereLocalAssetManager(
+            temp.Path,
+            httpClient,
+            downloadChunkSizeBytes: 64,
+            downloadInactivityTimeout: TimeSpan.FromSeconds(5),
+            maxDownloadAttempts: 2,
+            downloadRetryDelay: TimeSpan.Zero);
+        sut.SetHuggingFaceToken("hf_read_only_test");
+
+        var hash = Convert.ToHexStringLower(SHA256.HashData(payload));
+        await sut.DownloadVerifiedAsync(
+            new RemoteArtifact(
+                "model.gguf",
+                "https://huggingface.co/example/model/resolve/revision/model.gguf",
+                payload.Length,
+                hash),
+            Path.Join(temp.Path, "model.gguf.download"),
+            progress: null,
+            CancellationToken.None);
+        await sut.DownloadVerifiedAsync(
+            new RemoteArtifact(
+                "runtime.zip",
+                "https://github.com/example/runtime/releases/download/v1/runtime.zip",
+                payload.Length,
+                hash),
+            Path.Join(temp.Path, "runtime.zip.download"),
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("huggingface.co", handler.Requests[0].Host);
+        Assert.Equal("Bearer", handler.Requests[0].AuthorizationScheme);
+        Assert.Equal("hf_read_only_test", handler.Requests[0].AuthorizationParameter);
+        Assert.Equal("github.com", handler.Requests[1].Host);
+        Assert.Null(handler.Requests[1].AuthorizationScheme);
+        Assert.Null(handler.Requests[1].AuthorizationParameter);
+    }
+
+    [Theory]
+    [InlineData(TranscriptionAccelerationPreference.Auto, true, true, "Cuda,Vulkan,Cpu")]
+    [InlineData(TranscriptionAccelerationPreference.Auto, false, true, "Vulkan,Cpu")]
+    [InlineData(TranscriptionAccelerationPreference.Auto, false, false, "Cpu")]
+    [InlineData(TranscriptionAccelerationPreference.Cpu, false, false, "Cpu")]
+    [InlineData(TranscriptionAccelerationPreference.NvidiaCuda, false, false, "Cuda")]
+    [InlineData(TranscriptionAccelerationPreference.AmdVulkan, false, false, "Vulkan")]
+    public void ResolveBackendCandidates_MapsPreferencesAndAutomaticFallbackOrder(
+        TranscriptionAccelerationPreference preference,
+        bool cudaAvailable,
+        bool vulkanAvailable,
+        string expected)
+    {
+        var actual = CohereTranscribePlugin.ResolveBackendCandidates(
+            preference,
+            cudaAvailable,
+            vulkanAvailable);
+
+        Assert.Equal(expected, string.Join(",", actual));
+    }
+
+    [Theory]
+    [InlineData("de", "de")]
+    [InlineData("de-DE", "de")]
+    [InlineData("PT_br", "pt")]
+    [InlineData("auto", null)]
+    [InlineData("", null)]
+    [InlineData("ru", null)]
+    public void NormalizeLanguageOrNull_UsesOnlySupportedPrimaryLanguageCodes(
+        string input,
+        string? expected)
+    {
+        Assert.Equal(expected, CohereTranscribePlugin.NormalizeLanguageOrNull(input));
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(8, 4)]
+    [InlineData(16, 8)]
+    [InlineData(64, 12)]
+    public void GetRecommendedThreadCount_UsesPhysicalCoreApproximationWithCap(
+        int logicalProcessors,
+        int expected)
+    {
+        Assert.Equal(
+            expected,
+            CohereTranscribePlugin.GetRecommendedThreadCount(logicalProcessors));
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("  hf_example  ", "hf_example")]
+    public void NormalizeHuggingFaceToken_TrimsAndKeepsOptionalValues(
+        string? token,
+        string? expected)
+    {
+        Assert.Equal(expected, CohereTranscribePlugin.NormalizeHuggingFaceToken(token));
+    }
+
+    [Theory]
+    [InlineData("hf_bad token")]
+    [InlineData("hf_bad\ntoken")]
+    public void NormalizeHuggingFaceToken_RejectsWhitespaceInsideToken(string token)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            CohereTranscribePlugin.NormalizeHuggingFaceToken(token));
+    }
+
+    [Fact]
+    public void BuildStartInfo_IsLoopbackOnlyAuthenticatedAndUsesManagedAuxiliaryModels()
+    {
+        var paths = new CohereModelPaths(
+            @"C:\models\cohere.gguf",
+            @"C:\models\vad.bin",
+            @"C:\models\lid.gguf",
+            @"C:\models\cache");
+        var configuration = new CrispAsrServerConfiguration(
+            @"C:\runtime\crispasr.exe",
+            paths,
+            CrispAsrBackend.Cuda,
+            8);
+        const string apiKey = "not-on-the-command-line";
+
+        var startInfo = CrispAsrServer.BuildStartInfo(configuration, 43123, apiKey);
+        var arguments = startInfo.ArgumentList.ToArray();
+
+        AssertArgumentPair(arguments, "--host", "127.0.0.1");
+        AssertArgumentPair(arguments, "--port", "43123");
+        AssertArgumentPair(arguments, "--backend", "cohere");
+        AssertArgumentPair(arguments, "--model", paths.ModelPath);
+        AssertArgumentPair(arguments, "--lid-backend", "ecapa");
+        AssertArgumentPair(arguments, "--lid-model", paths.LanguageIdModelPath);
+        AssertArgumentPair(arguments, "--vad-model", paths.VadModelPath);
+        AssertArgumentPair(arguments, "--gpu-backend", "cuda");
+        Assert.Contains("--strict-pipeline", arguments);
+        Assert.Contains("--require-vad", arguments);
+        Assert.DoesNotContain("--api-keys", arguments);
+        Assert.DoesNotContain(apiKey, arguments);
+        Assert.Equal(apiKey, startInfo.Environment["CRISPASR_API_KEYS"]);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.Equal(System.Diagnostics.ProcessWindowStyle.Hidden, startInfo.WindowStyle);
+    }
+
+    [Fact]
+    public async Task WindowsProcessJob_DisposeTerminatesAssignedProcess()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Path.Join(Environment.SystemDirectory, "ping.exe"),
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("127.0.0.1");
+        startInfo.ArgumentList.Add("-n");
+        startInfo.ArgumentList.Add("30");
+        startInfo.ArgumentList.Add("-w");
+        startInfo.ArgumentList.Add("1000");
+
+        using var process = new Process { StartInfo = startInfo };
+        var started = false;
+        try
+        {
+            started = process.Start();
+            Assert.True(started);
+            using (WindowsProcessJob.CreateAndAssign(process))
+            {
+            }
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await process.WaitForExitAsync(timeout.Token);
+            Assert.True(process.HasExited);
+        }
+        finally
+        {
+            if (started && !process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExtractArchiveAsync_RejectsPathTraversal()
+    {
+        using var temp = new TempDirectory();
+        var archivePath = Path.Join(temp.Path, "malicious.zip");
+        var destination = Path.Join(temp.Path, "runtime");
+        var escapedPath = Path.Join(temp.Path, "escaped.txt");
+
+        using (var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("../escaped.txt");
+            await using var writer = new StreamWriter(entry.Open());
+            await writer.WriteAsync("must not escape");
+        }
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            CohereLocalAssetManager.ExtractArchiveAsync(
+                archivePath,
+                destination,
+                CancellationToken.None));
+        Assert.False(File.Exists(escapedPath));
+    }
+
+    [Fact]
+    public async Task PluginLifecycle_UsesManagedCpuRuntimeAndNormalizesLanguage()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        var server = new FakeCrispAsrServer();
+        using var sut = new CohereTranscribePlugin(assets, server);
+        var host = new FakePluginHostServices(temp.Path);
+        var downloadProgress = new List<double>();
+
+        await sut.ActivateAsync(host);
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Cpu);
+        await sut.DownloadModelAsync(
+            CohereTranscribePlugin.ModelId,
+            new InlineProgress<double>(downloadProgress.Add),
+            CancellationToken.None);
+        await sut.LoadModelAsync(CohereTranscribePlugin.ModelId, CancellationToken.None);
+        var result = await sut.TranscribeAsync(
+            [1, 2, 3],
+            "de-DE",
+            translate: false,
+            prompt: "ignored",
+            CancellationToken.None);
+
+        Assert.True(assets.ModelInstalled);
+        Assert.Equal([CrispAsrBackend.Cpu], assets.EnsuredRuntimes);
+        Assert.Equal(CrispAsrBackend.Cpu, server.LastConfiguration?.Backend);
+        Assert.Equal("de", server.LastLanguage);
+        Assert.Equal("lokal", result.Text);
+        Assert.Equal(TranscriptionAccelerationBackend.Cpu, sut.AccelerationStatus.ActiveBackend);
+        Assert.Equal("Using CPU", sut.AccelerationStatus.DisplayText);
+        Assert.Contains(downloadProgress, value => value >= 1);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            sut.TranscribeAsync(
+                [1],
+                "de",
+                translate: true,
+                prompt: null,
+                CancellationToken.None));
+
+        await sut.UnloadModelAsync();
+        Assert.False(server.IsRunning);
+    }
+
+    [Fact]
+    public async Task PluginLifecycle_LoadsStoresAndRemovesOptionalHuggingFaceToken()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        using var sut = new CohereTranscribePlugin(assets, new FakeCrispAsrServer());
+        var host = new FakePluginHostServices(
+            temp.Path,
+            new Dictionary<string, string>
+            {
+                [CohereTranscribePlugin.HuggingFaceTokenSecretName] = "  hf_saved  "
+            });
+
+        await sut.ActivateAsync(host);
+
+        Assert.Equal("hf_saved", sut.HuggingFaceToken);
+        Assert.Equal("hf_saved", assets.HuggingFaceToken);
+        Assert.True(sut.IsConfigured);
+
+        await sut.SetHuggingFaceTokenAsync("  hf_replaced  ");
+
+        Assert.Equal("hf_replaced", sut.HuggingFaceToken);
+        Assert.Equal("hf_replaced", assets.HuggingFaceToken);
+        Assert.Equal(
+            "hf_replaced",
+            host.Secrets[CohereTranscribePlugin.HuggingFaceTokenSecretName]);
+
+        await sut.SetHuggingFaceTokenAsync("");
+
+        Assert.Null(sut.HuggingFaceToken);
+        Assert.Null(assets.HuggingFaceToken);
+        Assert.DoesNotContain(
+            CohereTranscribePlugin.HuggingFaceTokenSecretName,
+            host.Secrets);
+    }
+
+    [Fact]
+    public async Task SetHuggingFaceTokenAsync_DoesNotApplyTokenWhenSecureStoreFails()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        using var sut = new CohereTranscribePlugin(assets, new FakeCrispAsrServer());
+        var host = new FakePluginHostServices(temp.Path)
+        {
+            StoreSecretException = new InvalidOperationException("secure store failed")
+        };
+        await sut.ActivateAsync(host);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetHuggingFaceTokenAsync("hf_new"));
+
+        Assert.Null(sut.HuggingFaceToken);
+        Assert.Null(assets.HuggingFaceToken);
+        Assert.DoesNotContain(
+            CohereTranscribePlugin.HuggingFaceTokenSecretName,
+            host.Secrets);
+    }
+
+    [Fact]
+    public async Task SetHuggingFaceTokenAsync_KeepsExistingTokenWhenSecureDeleteFails()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        using var sut = new CohereTranscribePlugin(assets, new FakeCrispAsrServer());
+        var host = new FakePluginHostServices(
+            temp.Path,
+            new Dictionary<string, string>
+            {
+                [CohereTranscribePlugin.HuggingFaceTokenSecretName] = "hf_existing"
+            })
+        {
+            DeleteSecretException = new InvalidOperationException("secure delete failed")
+        };
+        await sut.ActivateAsync(host);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetHuggingFaceTokenAsync(null));
+
+        Assert.Equal("hf_existing", sut.HuggingFaceToken);
+        Assert.Equal("hf_existing", assets.HuggingFaceToken);
+        Assert.Equal(
+            "hf_existing",
+            host.Secrets[CohereTranscribePlugin.HuggingFaceTokenSecretName]);
+    }
+
+    [Fact]
+    public void PublishWorkflow_MapsCohereTranscribePluginTag()
+    {
+        var workflow = TestFile.ReadProjectFile(
+            ".github",
+            "workflows",
+            "publish-plugins.yml");
+
+        Assert.Contains(
+            "'cohere-transcribe'  = 'TypeWhisper.Plugin.CohereTranscribe'",
+            workflow,
+            StringComparison.Ordinal);
+    }
+
+    private static void AssertArgumentPair(
+        IReadOnlyList<string> arguments,
+        string name,
+        string expectedValue)
+    {
+        var index = arguments.ToList().IndexOf(name);
+        Assert.True(index >= 0, $"Expected argument '{name}'.");
+        Assert.True(index + 1 < arguments.Count, $"Expected value after '{name}'.");
+        Assert.Equal(expectedValue, arguments[index + 1]);
+    }
+
+    private sealed class FakeAssetManager : ICohereLocalAssetManager
+    {
+        public long ModelTransferSize => 100;
+        public bool ModelInstalled { get; private set; }
+        public string? HuggingFaceToken { get; private set; }
+        public List<CrispAsrBackend> EnsuredRuntimes { get; } = [];
+
+        public void SetHuggingFaceToken(string? token)
+        {
+            HuggingFaceToken = token;
+        }
+
+        public bool IsModelInstalled() => ModelInstalled;
+        public bool IsRuntimeInstalled(CrispAsrBackend backend) =>
+            EnsuredRuntimes.Contains(backend);
+        public long GetRuntimeTransferSize(CrispAsrBackend backend) => 20;
+        public CohereModelPaths GetModelPaths() => new(
+            @"C:\models\cohere.gguf",
+            @"C:\models\vad.bin",
+            @"C:\models\lid.gguf",
+            @"C:\models\cache");
+        public string GetRuntimeExecutablePath(CrispAsrBackend backend) =>
+            @"C:\runtime\crispasr.exe";
+
+        public Task EnsureModelAsync(
+            IProgress<ArtifactTransferProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            ModelInstalled = true;
+            progress?.Report(new ArtifactTransferProgress(100, 100));
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureRuntimeAsync(
+            CrispAsrBackend backend,
+            IProgress<ArtifactTransferProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            if (!EnsuredRuntimes.Contains(backend))
+                EnsuredRuntimes.Add(backend);
+            progress?.Report(new ArtifactTransferProgress(20, 20));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RangeDownloadHandler(
+        byte[] payload,
+        int failuresRemaining = 0) : HttpMessageHandler
+    {
+        private int _failuresRemaining = failuresRemaining;
+
+        public int RequestCount { get; private set; }
+        public List<string> RequestedRanges { get; } = [];
+        public List<CapturedDownloadRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            Requests.Add(new CapturedDownloadRequest(
+                request.RequestUri?.Host,
+                request.Headers.Authorization?.Scheme,
+                request.Headers.Authorization?.Parameter));
+
+            if (_failuresRemaining > 0)
+            {
+                _failuresRemaining--;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            }
+
+            var requestedRange = request.Headers.Range?.Ranges.SingleOrDefault();
+            var start = requestedRange?.From ?? 0;
+            var end = requestedRange?.To ?? payload.LongLength - 1;
+            if (requestedRange is not null)
+                RequestedRanges.Add($"bytes={start}-{end}");
+
+            var segment = payload[(int)start..((int)end + 1)];
+            var response = new HttpResponseMessage(
+                requestedRange is null ? HttpStatusCode.OK : HttpStatusCode.PartialContent)
+            {
+                Content = new ByteArrayContent(segment)
+            };
+            if (requestedRange is not null)
+            {
+                response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                    start,
+                    end,
+                    payload.LongLength);
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed record CapturedDownloadRequest(
+        string? Host,
+        string? AuthorizationScheme,
+        string? AuthorizationParameter);
+
+    private sealed class FakeCrispAsrServer : ICrispAsrServer
+    {
+        public bool IsRunning { get; private set; }
+        public CrispAsrBackend? ActiveBackend { get; private set; }
+        public CrispAsrServerConfiguration? LastConfiguration { get; private set; }
+        public string? LastLanguage { get; private set; }
+
+        public Task StartAsync(
+            CrispAsrServerConfiguration configuration,
+            CancellationToken cancellationToken)
+        {
+            LastConfiguration = configuration;
+            ActiveBackend = configuration.Backend;
+            IsRunning = true;
+            return Task.CompletedTask;
+        }
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(
+            byte[] wavAudio,
+            string? language,
+            CancellationToken cancellationToken)
+        {
+            LastLanguage = language;
+            return Task.FromResult(new PluginTranscriptionResult("lokal", language, 1, null));
+        }
+
+        public Task StopAsync()
+        {
+            IsRunning = false;
+            ActiveBackend = null;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsRunning = false;
+            ActiveBackend = null;
+        }
+    }
+
+    private sealed class FakePluginHostServices : IPluginHostServices
+    {
+        public FakePluginHostServices(
+            string pluginAssetDirectory,
+            Dictionary<string, string>? secrets = null)
+        {
+            PluginDataDirectory = pluginAssetDirectory;
+            Secrets = secrets ?? [];
+        }
+
+        public Dictionary<string, string> Secrets { get; }
+        public Exception? StoreSecretException { get; init; }
+        public Exception? DeleteSecretException { get; init; }
+        public string PluginDataDirectory { get; }
+        public string PluginAssetDirectory => PluginDataDirectory;
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new NoOpPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public IPluginLocalization Localization { get; } = new NoOpPluginLocalization();
+
+        public Task StoreSecretAsync(string key, string value)
+        {
+            if (StoreSecretException is not null)
+                throw StoreSecretException;
+
+            Secrets[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadSecretAsync(string key) =>
+            Task.FromResult(Secrets.GetValueOrDefault(key));
+
+        public Task DeleteSecretAsync(string key)
+        {
+            if (DeleteSecretException is not null)
+                throw DeleteSecretException;
+
+            Secrets.Remove(key);
+            return Task.CompletedTask;
+        }
+        public T? GetSetting<T>(string key) => default;
+        public void SetSetting<T>(string key, T value) { }
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() { }
+    }
+
+    private sealed class NoOpPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    private sealed class NoOpPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) =>
+            string.Format(key, args);
+    }
+
+    private sealed class InlineProgress<T>(Action<T> report) : IProgress<T>
+    {
+        public void Report(T value) => report(value);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Join(
+                System.IO.Path.GetTempPath(),
+                $"tw-cohere-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerServiceTests.cs
@@ -256,6 +256,41 @@ public class ModelManagerServiceTests
         Assert.Equal(expectedPreference, plugin.AccelerationPreferenceAtLoad);
     }
 
+    [Fact]
+    public async Task DownloadAndLoadModelAsync_AppliesSavedAccelerationPreferenceBeforeDownloading()
+    {
+        const string pluginId = "com.typewhisper.cohere-transcribe";
+        const string modelId = "cohere-transcribe-03-2026-q5_0";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+
+        _settings.Setup(s => s.Current).Returns(new AppSettings
+        {
+            LocalModelAcceleration = AppSettings.LocalModelAccelerationCpu
+        });
+
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            configured: true,
+            selectedModelId: null,
+            supportsModelDownload: true,
+            modelIds: [modelId])
+        {
+            ModelDownloaded = false
+        };
+        var pluginManager = CreatePluginManager(plugin);
+        var sut = new ModelManagerService(pluginManager, _settings.Object);
+
+        await sut.DownloadAndLoadModelAsync(fullModelId);
+
+        Assert.Equal(1, plugin.DownloadCallCount);
+        Assert.Equal(
+            TranscriptionAccelerationPreference.Cpu,
+            plugin.AccelerationPreferenceAtDownload);
+        Assert.Equal(
+            TranscriptionAccelerationPreference.Cpu,
+            plugin.AccelerationPreferenceAtLoad);
+    }
+
     [Theory]
     [InlineData("Vulkan unavailable", AppSettings.LocalModelAccelerationAmdVulkan)]
     [InlineData("ROCm unavailable", AppSettings.LocalModelAccelerationAmdRocm)]
@@ -481,15 +516,18 @@ public class ModelManagerServiceTests
         public string? LastPrompt { get; private set; }
         public string? LastLoadedModelId { get; private set; }
         public int LoadCallCount { get; private set; }
+        public int DownloadCallCount { get; private set; }
         public List<TranscriptionAccelerationPreference> AccelerationPreferencesAtLoad { get; } = [];
         public TranscriptionAccelerationPreference LastAccelerationPreference { get; private set; } =
             TranscriptionAccelerationPreference.Auto;
+        public TranscriptionAccelerationPreference? AccelerationPreferenceAtDownload { get; private set; }
         public TranscriptionAccelerationPreference? AccelerationPreferenceAtLoad { get; private set; }
         public TranscriptionAccelerationStatus? AccelerationStatusOverride { get; init; }
         public TranscriptionAccelerationStatus AccelerationStatus => AccelerationStatusOverride
             ?? new TranscriptionAccelerationStatus(TranscriptionAccelerationBackend.Cpu, "Using CPU");
         public Exception? LoadException { get; init; }
         public Exception? DownloadStatusException { get; init; }
+        public bool ModelDownloaded { get; init; } = true;
 
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
         public Task DeactivateAsync() => Task.CompletedTask;
@@ -502,7 +540,18 @@ public class ModelManagerServiceTests
             if (DownloadStatusException is not null)
                 throw DownloadStatusException;
 
-            return true;
+            return ModelDownloaded;
+        }
+
+        public Task DownloadModelAsync(
+            string modelId,
+            IProgress<double>? progress,
+            CancellationToken ct)
+        {
+            DownloadCallCount++;
+            AccelerationPreferenceAtDownload = LastAccelerationPreference;
+            progress?.Report(1);
+            return Task.CompletedTask;
         }
 
         public Task LoadModelAsync(string modelId, CancellationToken ct)

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SherpaOnnx\TypeWhisper.Plugin.SherpaOnnx.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SupertonicTts\TypeWhisper.Plugin.SupertonicTts.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.GraniteSpeech\TypeWhisper.Plugin.GraniteSpeech.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.CohereTranscribe\TypeWhisper.Plugin.CohereTranscribe.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Script\TypeWhisper.Plugin.Script.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SmallestAi\TypeWhisper.Plugin.SmallestAi.csproj" />


### PR DESCRIPTION
## Summary

- add a Windows x64 local Cohere Transcribe plugin backed by pinned Cohere, VAD, language-ID, and CrispASR assets
- support CPU, NVIDIA CUDA, and AMD Vulkan with resumable SHA-256-verified downloads
- add an optional DPAPI-protected Hugging Face token that is sent only to huggingface.co
- integrate saved acceleration preferences and plugin release publishing

## Validation

- dotnet test TypeWhisper.slnx -c Debug --no-restore (1,746 tests passed)
- dotnet build plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj -c Release --no-restore
- dotnet format TypeWhisper.slnx --verify-no-changes --no-restore for the changed projects
- local Windows dev smoke: plugin loaded, CUDA transcription completed, model reported ready/downloaded, and the localized token settings modal opened successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Cohere Transcribe (Local)”, a Windows-only local transcription plugin with CPU/CUDA/Vulkan acceleration, automatic backend fallback, and local runtime management.
  * Added SHA-256 verified, resumable model and runtime downloads/installation with safe archive extraction and progress feedback.
  * Added optional Hugging Face token settings (save/remove) with localized UI text.
  * Updated publishing to recognize the new plugin via tag mapping.
* **Bug Fixes**
  * Apply saved acceleration preference before starting model downloads.
* **Tests**
  * Added extensive plugin and model manager coverage, including download verification/resume, token handling, backend selection, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->