### PR TITLE
Fix Cohere Store runtime loading and add quantization options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ artifacts/
 .agents/
 .claude/
 .venv
+__pycache__/
+*.pyc
 granite-speech-onnx/
 granite-speech-onnx-int8/
 granite-speech-genai/

--- a/eng/benchmark_cohere_quantizations.py
+++ b/eng/benchmark_cohere_quantizations.py
@@ -1,0 +1,1046 @@
+#!/usr/bin/env python3
+"""Benchmark the local Cohere Transcribe GGUF variants through TypeWhisper.
+
+The runner downloads a pinned subset of the public FLEURS test corpus, prepares
+the selected models through TypeWhisper's local API, and records accuracy,
+throughput, wall time, peak CrispASR working set, and silence/noise behavior.
+It intentionally uses only the Python standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import math
+import os
+import platform
+import random
+import re
+import statistics
+import struct
+import subprocess
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCRIPT_VERSION = 1
+EUROPE_DATASET = (
+    "FluidInference/fleurs",
+    "8944693da251acbaf2f9686bddc4fedce8bd2edd",
+)
+FULL_DATASET = (
+    "FluidInference/fleurs-full",
+    "1cca811bb8ea4d370345f108f00518167040282c",
+)
+DEFAULT_MODELS = [
+    "cohere-transcribe-03-2026-q4_k",
+    "cohere-transcribe-03-2026-q5_0",
+    "cohere-transcribe-03-2026-q6_k",
+    "cohere-transcribe-03-2026-q8_0",
+]
+LANGUAGES = {
+    "de_de": ("de", EUROPE_DATASET, "wer"),
+    "en_us": ("en", EUROPE_DATASET, "wer"),
+    "fr_fr": ("fr", EUROPE_DATASET, "wer"),
+    "es_419": ("es", EUROPE_DATASET, "wer"),
+    "it_it": ("it", EUROPE_DATASET, "wer"),
+    "pt_br": ("pt", EUROPE_DATASET, "wer"),
+    "el_gr": ("el", EUROPE_DATASET, "wer"),
+    "nl_nl": ("nl", EUROPE_DATASET, "wer"),
+    "pl_pl": ("pl", EUROPE_DATASET, "wer"),
+    "ja_jp": ("ja", FULL_DATASET, "cer"),
+    "cmn_hans_cn": ("zh", FULL_DATASET, "cer"),
+    "ko_kr": ("ko", FULL_DATASET, "cer"),
+    "vi_vn": ("vi", FULL_DATASET, "wer"),
+    "ar_eg": ("ar", FULL_DATASET, "wer"),
+}
+DEFAULT_LANGUAGES = list(LANGUAGES)
+CJK_LANGUAGES = {"ja_jp", "cmn_hans_cn", "ko_kr"}
+
+
+@dataclass(frozen=True)
+class Sample:
+    language: str
+    language_hint: str
+    sample_id: str
+    reference: str
+    audio_path: Path
+    duration_seconds: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark Cohere GGUF quantizations through the TypeWhisper API."
+    )
+    parser.add_argument("--api-url", default="http://127.0.0.1:8978")
+    parser.add_argument(
+        "--api-token",
+        default=os.environ.get("TYPEWHISPER_API_TOKEN"),
+        help="Optional local API bearer token (or TYPEWHISPER_API_TOKEN).",
+    )
+    parser.add_argument(
+        "--hf-token",
+        default=os.environ.get("HF_TOKEN"),
+        help="Optional Hugging Face token for corpus downloads (or HF_TOKEN).",
+    )
+    parser.add_argument(
+        "--models",
+        default=",".join(DEFAULT_MODELS),
+        help="Comma-separated Cohere model IDs.",
+    )
+    parser.add_argument(
+        "--languages",
+        default=",".join(DEFAULT_LANGUAGES),
+        help="Comma-separated FLEURS language configurations.",
+    )
+    parser.add_argument("--samples", type=int, default=50)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("artifacts/cohere-quantization-benchmark/fleurs"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/cohere-quantization-benchmark/results.json"),
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        default=Path("artifacts/cohere-quantization-benchmark/results.md"),
+    )
+    parser.add_argument(
+        "--backend",
+        default="configured in TypeWhisper",
+        help=(
+            "Expected active backend reported by TypeWhisper, for example "
+            "nvidia-cuda, amd-vulkan, or cpu."
+        ),
+    )
+    parser.add_argument(
+        "--allow-dictionary",
+        action="store_true",
+        help="Allow enabled dictionary terms or corrections to modify benchmark output.",
+    )
+    parser.add_argument(
+        "--no-prepare-models",
+        action="store_true",
+        help="Require every model to be downloaded instead of preparing it through the API.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Continue an existing compatible result file.",
+    )
+    parser.add_argument("--checkpoint-every", type=int, default=10)
+    parser.add_argument("--request-timeout", type=int, default=7_200)
+    parser.add_argument("--download-retries", type=int, default=4)
+    parser.add_argument("--download-workers", type=int, default=8)
+    args = parser.parse_args()
+
+    args.models = split_csv(args.models)
+    args.languages = split_csv(args.languages)
+    if not args.models:
+        parser.error("At least one model is required.")
+    if not args.languages:
+        parser.error("At least one language is required.")
+    unknown_languages = sorted(set(args.languages) - set(LANGUAGES))
+    if unknown_languages:
+        parser.error(f"Unsupported FLEURS languages: {', '.join(unknown_languages)}")
+    if args.samples <= 0:
+        parser.error("--samples must be positive.")
+    if args.checkpoint_every <= 0:
+        parser.error("--checkpoint-every must be positive.")
+    if args.download_workers <= 0:
+        parser.error("--download-workers must be positive.")
+    return args
+
+
+def split_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def auth_headers(token: str | None) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def download_file(
+    url: str,
+    destination: Path,
+    token: str | None,
+    attempts: int,
+) -> None:
+    if destination.exists() and destination.stat().st_size > 0:
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    last_error: Exception | None = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            request = urllib.request.Request(url, headers=auth_headers(token))
+            with urllib.request.urlopen(request, timeout=120) as response:
+                with temporary.open("wb") as output:
+                    while chunk := response.read(1024 * 1024):
+                        output.write(chunk)
+            temporary.replace(destination)
+            return
+        except (OSError, urllib.error.URLError) as error:
+            last_error = error
+            if temporary.exists():
+                temporary.unlink()
+            if attempt < attempts:
+                time.sleep(attempt)
+
+    raise RuntimeError(f"Failed to download {url}") from last_error
+
+
+def dataset_url(repository: str, revision: str, relative_path: str) -> str:
+    escaped_path = "/".join(
+        urllib.parse.quote(part, safe="") for part in relative_path.split("/")
+    )
+    return (
+        f"https://huggingface.co/datasets/{repository}/resolve/"
+        f"{revision}/{escaped_path}"
+    )
+
+
+def read_wav_duration(path: Path) -> float:
+    with wave.open(str(path), "rb") as audio:
+        return audio.getnframes() / audio.getframerate()
+
+
+def prepare_samples(args: argparse.Namespace) -> list[Sample]:
+    samples: list[Sample] = []
+    for language in args.languages:
+        language_hint, (repository, revision), _ = LANGUAGES[language]
+        language_dir = args.cache_dir / repository.replace("/", "--") / revision / language
+        transcript_path = language_dir / f"{language}.trans.txt"
+        download_file(
+            dataset_url(
+                repository,
+                revision,
+                f"{language}/{language}.trans.txt",
+            ),
+            transcript_path,
+            args.hf_token,
+            args.download_retries,
+        )
+
+        transcript_entries = []
+        for line in transcript_path.read_text(encoding="utf-8").splitlines():
+            sample_id, separator, reference = line.partition(" ")
+            if separator and reference.strip():
+                transcript_entries.append((sample_id, reference.strip()))
+
+        if len(transcript_entries) < args.samples:
+            raise RuntimeError(
+                f"{language} has only {len(transcript_entries)} transcript entries; "
+                f"{args.samples} requested."
+            )
+
+        selected_entries = transcript_entries[: args.samples]
+
+        def download_audio(entry: tuple[str, str]) -> None:
+            sample_id, _ = entry
+            audio_path = language_dir / f"{sample_id}.wav"
+            download_file(
+                dataset_url(
+                    repository,
+                    revision,
+                    f"{language}/{sample_id}.wav",
+                ),
+                audio_path,
+                args.hf_token,
+                args.download_retries,
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.download_workers
+        ) as executor:
+            list(executor.map(download_audio, selected_entries))
+
+        for sample_id, reference in selected_entries:
+            audio_path = language_dir / f"{sample_id}.wav"
+            samples.append(
+                Sample(
+                    language=language,
+                    language_hint=language_hint,
+                    sample_id=sample_id,
+                    reference=reference,
+                    audio_path=audio_path,
+                    duration_seconds=read_wav_duration(audio_path),
+                )
+            )
+    return samples
+
+
+def sample_manifest_sha256(samples: Iterable[Sample]) -> str:
+    digest = hashlib.sha256()
+    for sample in samples:
+        audio_hash = hashlib.sha256(sample.audio_path.read_bytes()).hexdigest()
+        line = (
+            f"{sample.language}\t{sample.sample_id}\t{audio_hash}\t"
+            f"{sample.reference}\n"
+        )
+        digest.update(line.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def api_request(
+    args: argparse.Namespace,
+    method: str,
+    path: str,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> Any:
+    url = args.api_url.rstrip("/") + path
+    request_headers = {
+        "Accept": "application/json",
+        **auth_headers(args.api_token),
+        **(headers or {}),
+    }
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method=method,
+        headers=request_headers,
+    )
+    try:
+        with urllib.request.urlopen(
+            request,
+            timeout=args.request_timeout,
+        ) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        response_body = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"TypeWhisper API returned HTTP {error.code}: {response_body}"
+        ) from error
+
+
+def multipart_body(
+    fields: dict[str, str],
+    file_name: str,
+    file_data: bytes,
+) -> tuple[bytes, str]:
+    boundary = f"----typewhisper-benchmark-{uuid.uuid4().hex}"
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode(),
+                value.encode("utf-8"),
+                b"\r\n",
+            ]
+        )
+    chunks.extend(
+        [
+            f"--{boundary}\r\n".encode(),
+            (
+                'Content-Disposition: form-data; name="file"; '
+                f'filename="{file_name}"\r\n'
+            ).encode(),
+            b"Content-Type: audio/wav\r\n\r\n",
+            file_data,
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    return b"".join(chunks), boundary
+
+
+def transcribe(
+    args: argparse.Namespace,
+    model: str,
+    sample: Sample,
+    await_download: bool,
+) -> tuple[dict[str, Any], float]:
+    body, boundary = multipart_body(
+        {
+            "engine": "cohere-transcribe",
+            "model": model,
+            "language": sample.language_hint,
+            "response_format": "verbose_json",
+            "normalize_numbers": "false",
+        },
+        sample.audio_path.name,
+        sample.audio_path.read_bytes(),
+    )
+    query = "?await_download=1" if await_download else ""
+    started = time.perf_counter()
+    response = api_request(
+        args,
+        "POST",
+        f"/v1/transcribe{query}",
+        body,
+        {"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    wall_seconds = time.perf_counter() - started
+    if response.get("model") != model:
+        raise RuntimeError(
+            f"Requested {model}, but TypeWhisper reported {response.get('model')}."
+        )
+    return response, wall_seconds
+
+
+def normalize_text(text: str) -> str:
+    normalized = unicodedata.normalize("NFKC", text).casefold()
+    characters = []
+    for character in normalized:
+        category = unicodedata.category(character)
+        characters.append(" " if category[0] in {"P", "S"} else character)
+    return re.sub(r"\s+", " ", "".join(characters)).strip()
+
+
+def edit_distance(reference: list[str], hypothesis: list[str]) -> int:
+    previous = list(range(len(hypothesis) + 1))
+    for row, reference_item in enumerate(reference, start=1):
+        current = [row]
+        for column, hypothesis_item in enumerate(hypothesis, start=1):
+            current.append(
+                min(
+                    current[column - 1] + 1,
+                    previous[column] + 1,
+                    previous[column - 1]
+                    + (0 if reference_item == hypothesis_item else 1),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def score(reference: str, hypothesis: str) -> dict[str, int | str]:
+    normalized_reference = normalize_text(reference)
+    normalized_hypothesis = normalize_text(hypothesis)
+    reference_words = normalized_reference.split()
+    hypothesis_words = normalized_hypothesis.split()
+    reference_characters = list(normalized_reference.replace(" ", ""))
+    hypothesis_characters = list(normalized_hypothesis.replace(" ", ""))
+    return {
+        "normalized_reference": normalized_reference,
+        "normalized_hypothesis": normalized_hypothesis,
+        "word_edits": edit_distance(reference_words, hypothesis_words),
+        "reference_words": len(reference_words),
+        "character_edits": edit_distance(
+            reference_characters,
+            hypothesis_characters,
+        ),
+        "reference_characters": len(reference_characters),
+    }
+
+
+def make_negative_samples(directory: Path) -> list[Sample]:
+    directory.mkdir(parents=True, exist_ok=True)
+    definitions = [
+        ("silence-1s", 1.0, 0.0),
+        ("silence-5s", 5.0, 0.0),
+        ("low-white-noise-5s", 5.0, 0.003),
+    ]
+    output = []
+    for sample_id, duration, amplitude in definitions:
+        path = directory / f"{sample_id}.wav"
+        if not path.exists():
+            random_source = random.Random(42)
+            frame_count = round(16_000 * duration)
+            with wave.open(str(path), "wb") as audio:
+                audio.setnchannels(1)
+                audio.setsampwidth(2)
+                audio.setframerate(16_000)
+                frames = bytearray()
+                for _ in range(frame_count):
+                    value = (
+                        0
+                        if amplitude == 0
+                        else round(random_source.uniform(-amplitude, amplitude) * 32767)
+                    )
+                    frames.extend(struct.pack("<h", value))
+                audio.writeframes(frames)
+        output.append(
+            Sample(
+                language="negative",
+                language_hint="de",
+                sample_id=sample_id,
+                reference="",
+                audio_path=path,
+                duration_seconds=duration,
+            )
+        )
+    return output
+
+
+def powershell_json(script: str) -> Any:
+    try:
+        completed = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                script,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        output = completed.stdout.strip()
+        return json.loads(output) if output else None
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return None
+
+
+def collect_hardware() -> dict[str, Any]:
+    hardware: dict[str, Any] = {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python": platform.python_version(),
+    }
+    if os.name == "nt":
+        windows = powershell_json(
+            """
+$cpu = Get-CimInstance Win32_Processor |
+  Select-Object Name,NumberOfCores,NumberOfLogicalProcessors
+$gpu = Get-CimInstance Win32_VideoController |
+  Select-Object Name,AdapterRAM,DriverVersion
+$os = Get-CimInstance Win32_OperatingSystem |
+  Select-Object Caption,Version,BuildNumber,TotalVisibleMemorySize
+[pscustomobject]@{ cpu=$cpu; gpu=@($gpu); os=$os } |
+  ConvertTo-Json -Compress -Depth 4
+"""
+        )
+        if windows:
+            hardware["windows"] = windows
+    return hardware
+
+
+def crispasr_peak_working_set() -> int | None:
+    if os.name != "nt":
+        return None
+    value = powershell_json(
+        """
+$process = Get-Process crispasr -ErrorAction SilentlyContinue |
+  Sort-Object StartTime -Descending |
+  Select-Object -First 1
+if ($process) {
+  [long]$process.PeakWorkingSet64 | ConvertTo-Json -Compress
+}
+"""
+    )
+    return int(value) if value is not None else None
+
+
+def git_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def result_key(run: dict[str, Any]) -> tuple[str, str, str]:
+    return run["model"], run["language"], run["sample_id"]
+
+
+def initial_result(
+    args: argparse.Namespace,
+    samples: list[Sample],
+    manifest_hash: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCRIPT_VERSION,
+        "created_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "source_revision": git_revision(),
+        "api_url": args.api_url,
+        "backend": args.backend,
+        "models": args.models,
+        "languages": args.languages,
+        "samples_per_language": args.samples,
+        "sample_count": len(samples),
+        "sample_manifest_sha256": manifest_hash,
+        "datasets": {
+            EUROPE_DATASET[0]: EUROPE_DATASET[1],
+            FULL_DATASET[0]: FULL_DATASET[1],
+        },
+        "normalization": "Unicode NFKC + casefold + punctuation/symbol removal",
+        "hardware": collect_hardware(),
+        "preparation": [],
+        "warmups": [],
+        "runs": [],
+        "negative_tests": [],
+        "model_peak_working_set_bytes": {},
+        "model_runtime_status": {},
+    }
+
+
+def load_or_create_result(
+    args: argparse.Namespace,
+    samples: list[Sample],
+    manifest_hash: str,
+) -> dict[str, Any]:
+    if args.resume and args.output.exists():
+        result = json.loads(args.output.read_text(encoding="utf-8"))
+        expected = {
+            "schema_version": SCRIPT_VERSION,
+            "models": args.models,
+            "languages": args.languages,
+            "samples_per_language": args.samples,
+            "sample_manifest_sha256": manifest_hash,
+        }
+        for key, value in expected.items():
+            if result.get(key) != value:
+                raise RuntimeError(
+                    f"Cannot resume: result field {key!r} does not match this run."
+                )
+        return result
+    return initial_result(args, samples, manifest_hash)
+
+
+def aggregate_rows(result: dict[str, Any]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for run in result["runs"]:
+        if run.get("error"):
+            continue
+        grouped.setdefault((run["model"], run["language"]), []).append(run)
+
+    rows = []
+    for (model, language), runs in grouped.items():
+        word_edits = sum(run["word_edits"] for run in runs)
+        reference_words = sum(run["reference_words"] for run in runs)
+        character_edits = sum(run["character_edits"] for run in runs)
+        reference_characters = sum(run["reference_characters"] for run in runs)
+        audio_seconds = sum(run["duration_seconds"] for run in runs)
+        processing_seconds = sum(run["processing_time_seconds"] for run in runs)
+        wall_seconds = sum(run["wall_seconds"] for run in runs)
+        rows.append(
+            {
+                "model": model,
+                "language": language,
+                "primary_metric": LANGUAGES[language][2],
+                "clips": len(runs),
+                "wer": word_edits / reference_words if reference_words else math.nan,
+                "cer": (
+                    character_edits / reference_characters
+                    if reference_characters
+                    else math.nan
+                ),
+                "rtfx": (
+                    audio_seconds / processing_seconds
+                    if processing_seconds
+                    else math.inf
+                ),
+                "wall_rtfx": audio_seconds / wall_seconds if wall_seconds else math.inf,
+                "empty_results": sum(
+                    not run["normalized_hypothesis"] for run in runs
+                ),
+                "audio_seconds": audio_seconds,
+                "processing_seconds": processing_seconds,
+                "wall_seconds": wall_seconds,
+                "median_processing_seconds": statistics.median(
+                    run["processing_time_seconds"] for run in runs
+                ),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            result["models"].index(row["model"]),
+            result["languages"].index(row["language"]),
+        ),
+    )
+
+
+def percent(value: float) -> str:
+    return "n/a" if math.isnan(value) else f"{value * 100:.2f}%"
+
+
+def gibibytes(value: int | None) -> str:
+    return "n/a" if value is None else f"{value / (1024**3):.2f} GiB"
+
+
+def markdown_report(result: dict[str, Any]) -> str:
+    rows = aggregate_rows(result)
+    lines = [
+        "# Cohere Transcribe quantization benchmark",
+        "",
+        f"- Source revision: `{result.get('source_revision')}`",
+        f"- Backend: `{result['backend']}`",
+        f"- Samples: {result['samples_per_language']} per language",
+        f"- Sample manifest SHA-256: `{result['sample_manifest_sha256']}`",
+        "",
+        "## Aggregate",
+        "",
+        "| Model | Non-CJK macro WER | CJK macro CER | Weighted RTFx | Wall RTFx | Peak working set |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for model in result["models"]:
+        model_rows = [row for row in rows if row["model"] == model]
+        non_cjk = [row["wer"] for row in model_rows if row["language"] not in CJK_LANGUAGES]
+        cjk = [row["cer"] for row in model_rows if row["language"] in CJK_LANGUAGES]
+        audio_seconds = sum(row["audio_seconds"] for row in model_rows)
+        processing_seconds = sum(row["processing_seconds"] for row in model_rows)
+        wall_seconds = sum(row["wall_seconds"] for row in model_rows)
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{model}`",
+                    percent(statistics.mean(non_cjk)) if non_cjk else "n/a",
+                    percent(statistics.mean(cjk)) if cjk else "n/a",
+                    f"{audio_seconds / processing_seconds:.2f}x"
+                    if processing_seconds
+                    else "n/a",
+                    f"{audio_seconds / wall_seconds:.2f}x" if wall_seconds else "n/a",
+                    gibibytes(
+                        result["model_peak_working_set_bytes"].get(model)
+                    ),
+                ]
+            )
+            + " |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Per-language results",
+            "",
+            "| Model | Language | Primary | WER | CER | RTFx | Wall RTFx | Empty | Clips |",
+            "|---|---|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in rows:
+        primary_value = row[row["primary_metric"]]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{row['model']}`",
+                    row["language"],
+                    f"{row['primary_metric'].upper()} {percent(primary_value)}",
+                    percent(row["wer"]),
+                    percent(row["cer"]),
+                    f"{row['rtfx']:.2f}x",
+                    f"{row['wall_rtfx']:.2f}x",
+                    str(row["empty_results"]),
+                    str(row["clips"]),
+                ]
+            )
+            + " |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Silence and noise",
+            "",
+            "| Model | Input | Output | Processing time |",
+            "|---|---|---|---:|",
+        ]
+    )
+    for run in result["negative_tests"]:
+        output = run.get("text", "").replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| `{run['model']}` | {run['sample_id']} | "
+            f"`{output}` | {run['processing_time_seconds']:.3f} s |"
+        )
+
+    errors = [run for run in result["runs"] if run.get("error")]
+    lines.extend(
+        [
+            "",
+            "## Completion",
+            "",
+            f"- Successful speech clips: {len(result['runs']) - len(errors)}",
+            f"- Failed speech clips: {len(errors)}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def checkpoint(args: argparse.Namespace, result: dict[str, Any]) -> None:
+    atomic_write_json(args.output, result)
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.write_text(markdown_report(result), encoding="utf-8")
+
+
+def validate_models(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
+    response = api_request(args, "GET", "/v1/models")
+    models = {
+        model["id"]: model
+        for model in response.get("models", [])
+        if model.get("engine") == "cohere-transcribe"
+    }
+    missing = [model for model in args.models if model not in models]
+    if missing:
+        raise RuntimeError(
+            "TypeWhisper does not expose the requested Cohere models: "
+            + ", ".join(missing)
+        )
+    return models
+
+
+def validate_post_processing(args: argparse.Namespace) -> dict[str, Any]:
+    terms = api_request(args, "GET", "/v1/dictionary/terms")
+    corrections = api_request(args, "GET", "/v1/dictionary/corrections")
+    term_count = int(terms.get("count", len(terms.get("terms", []))))
+    correction_count = int(
+        corrections.get("count", len(corrections.get("corrections", [])))
+    )
+    if not args.allow_dictionary and (term_count or correction_count):
+        raise RuntimeError(
+            "The benchmark requires an empty TypeWhisper dictionary. "
+            f"Found {term_count} terms and {correction_count} corrections. "
+            "Use a clean profile or pass --allow-dictionary to record a non-standard run."
+        )
+    return {
+        "dictionary_terms": term_count,
+        "dictionary_corrections": correction_count,
+        "number_normalization": False,
+        "dictionary_override_allowed": bool(args.allow_dictionary),
+    }
+
+
+def validate_active_backend(
+    args: argparse.Namespace,
+    model: str,
+) -> dict[str, Any]:
+    status = api_request(args, "GET", "/v1/status")
+    acceleration = status.get("acceleration") or {}
+    active_backend = acceleration.get("active_backend")
+    if (
+        args.backend != "configured in TypeWhisper"
+        and active_backend != args.backend
+    ):
+        raise RuntimeError(
+            f"{model} loaded with backend {active_backend!r}, "
+            f"but {args.backend!r} was requested."
+        )
+    return status
+
+
+def benchmark(args: argparse.Namespace) -> int:
+    print("Preparing pinned FLEURS samples...", flush=True)
+    samples = prepare_samples(args)
+    manifest_hash = sample_manifest_sha256(samples)
+    result = load_or_create_result(args, samples, manifest_hash)
+    result.setdefault("model_runtime_status", {})
+    models_before = validate_models(args)
+    result["post_processing"] = validate_post_processing(args)
+    first_sample = samples[0]
+
+    prepared_models = {entry["model"] for entry in result["preparation"]}
+    if not args.no_prepare_models:
+        print("Preparing model downloads...", flush=True)
+        for model in args.models:
+            if model in prepared_models:
+                continue
+            started = time.perf_counter()
+            response, request_wall = transcribe(
+                args,
+                model,
+                first_sample,
+                await_download=True,
+            )
+            result["preparation"].append(
+                {
+                    "model": model,
+                    "downloaded_before": bool(models_before[model].get("downloaded")),
+                    "wall_seconds": time.perf_counter() - started,
+                    "request_wall_seconds": request_wall,
+                    "processing_time_seconds": response.get("processing_time"),
+                }
+            )
+            checkpoint(args, result)
+            print(f"  prepared {model}", flush=True)
+    elif args.no_prepare_models:
+        missing_downloads = [
+            model
+            for model in args.models
+            if not models_before[model].get("downloaded")
+        ]
+        if missing_downloads:
+            raise RuntimeError(
+                "Download these models in TypeWhisper first: "
+                + ", ".join(missing_downloads)
+            )
+
+    completed = {result_key(run) for run in result["runs"]}
+    completed_negative = {
+        (run["model"], run["sample_id"]) for run in result["negative_tests"]
+    }
+    negative_samples = make_negative_samples(args.cache_dir / "negative")
+
+    try:
+        for model in args.models:
+            print(f"Benchmarking {model}...", flush=True)
+            if not any(warmup["model"] == model for warmup in result["warmups"]):
+                first_response, first_wall = transcribe(
+                    args,
+                    model,
+                    first_sample,
+                    await_download=False,
+                )
+                second_response, second_wall = transcribe(
+                    args,
+                    model,
+                    first_sample,
+                    await_download=False,
+                )
+                result["warmups"].append(
+                    {
+                        "model": model,
+                        "load_and_first_inference_wall_seconds": first_wall,
+                        "first_processing_time_seconds": first_response.get(
+                            "processing_time"
+                        ),
+                        "second_warmup_wall_seconds": second_wall,
+                        "second_processing_time_seconds": second_response.get(
+                            "processing_time"
+                        ),
+                    }
+                )
+                checkpoint(args, result)
+            else:
+                transcribe(
+                    args,
+                    model,
+                    first_sample,
+                    await_download=False,
+                )
+            result["model_runtime_status"][model] = validate_active_backend(
+                args,
+                model,
+            )
+            checkpoint(args, result)
+
+            model_samples = [sample for sample in samples]
+            for index, sample in enumerate(model_samples, start=1):
+                key = (model, sample.language, sample.sample_id)
+                if key in completed:
+                    continue
+                try:
+                    response, wall_seconds = transcribe(
+                        args,
+                        model,
+                        sample,
+                        await_download=False,
+                    )
+                    metrics = score(sample.reference, response.get("text", ""))
+                    result["runs"].append(
+                        {
+                            "model": model,
+                            "language": sample.language,
+                            "language_hint": sample.language_hint,
+                            "sample_id": sample.sample_id,
+                            "reference": sample.reference,
+                            "hypothesis": response.get("text", ""),
+                            "detected_language": response.get("language"),
+                            "duration_seconds": float(
+                                response.get("duration") or sample.duration_seconds
+                            ),
+                            "processing_time_seconds": float(
+                                response.get("processing_time") or wall_seconds
+                            ),
+                            "wall_seconds": wall_seconds,
+                            **metrics,
+                        }
+                    )
+                except Exception as error:  # Continue to preserve long benchmark runs.
+                    result["runs"].append(
+                        {
+                            "model": model,
+                            "language": sample.language,
+                            "language_hint": sample.language_hint,
+                            "sample_id": sample.sample_id,
+                            "reference": sample.reference,
+                            "duration_seconds": sample.duration_seconds,
+                            "error": str(error),
+                        }
+                    )
+                completed.add(key)
+                if index % args.checkpoint_every == 0:
+                    checkpoint(args, result)
+                    print(
+                        f"  {index}/{len(model_samples)} speech clips",
+                        flush=True,
+                    )
+
+            for sample in negative_samples:
+                key = (model, sample.sample_id)
+                if key in completed_negative:
+                    continue
+                response, wall_seconds = transcribe(
+                    args,
+                    model,
+                    sample,
+                    await_download=False,
+                )
+                result["negative_tests"].append(
+                    {
+                        "model": model,
+                        "sample_id": sample.sample_id,
+                        "text": response.get("text", ""),
+                        "processing_time_seconds": float(
+                            response.get("processing_time") or wall_seconds
+                        ),
+                        "wall_seconds": wall_seconds,
+                    }
+                )
+                completed_negative.add(key)
+
+            result["model_peak_working_set_bytes"][model] = (
+                crispasr_peak_working_set()
+            )
+            checkpoint(args, result)
+    except KeyboardInterrupt:
+        checkpoint(args, result)
+        print("\nInterrupted; checkpoint saved.", file=sys.stderr)
+        return 130
+
+    checkpoint(args, result)
+    print(markdown_report(result))
+    errors = [run for run in result["runs"] if run.get("error")]
+    return 2 if errors else 0
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return benchmark(args)
+    except Exception as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eng/benchmark_cohere_quantizations.py
+++ b/eng/benchmark_cohere_quantizations.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Benchmark the local Cohere Transcribe GGUF variants through TypeWhisper.
+"""Benchmark the local Cohere Transcribe GGUF variants on Windows.
 
 The runner downloads a pinned subset of the public FLEURS test corpus, prepares
-the selected models through TypeWhisper's local API, and records accuracy,
-throughput, wall time, peak CrispASR working set, and silence/noise behavior.
-It intentionally uses only the Python standard library.
+the selected models through TypeWhisper's local API, then starts one persistent
+CrispASR process per quantization. It records accuracy, throughput, model load
+time, peak CrispASR working set, and silence/noise behavior. It intentionally
+uses only the Python standard library.
 """
 
 from __future__ import annotations
@@ -18,6 +19,8 @@ import os
 import platform
 import random
 import re
+import secrets
+import socket
 import statistics
 import struct
 import subprocess
@@ -34,7 +37,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-SCRIPT_VERSION = 1
+SCRIPT_VERSION = 2
 EUROPE_DATASET = (
     "FluidInference/fleurs",
     "8944693da251acbaf2f9686bddc4fedce8bd2edd",
@@ -49,6 +52,20 @@ DEFAULT_MODELS = [
     "cohere-transcribe-03-2026-q6_k",
     "cohere-transcribe-03-2026-q8_0",
 ]
+MODEL_FILES = {
+    "cohere-transcribe-03-2026-q4_k": "cohere-transcribe-q4_k.gguf",
+    "cohere-transcribe-03-2026-q5_0": "cohere-transcribe-q5_0.gguf",
+    "cohere-transcribe-03-2026-q6_k": "cohere-transcribe-q6_k.gguf",
+    "cohere-transcribe-03-2026-q8_0": "cohere-transcribe-q8_0.gguf",
+}
+CRISPASR_VERSION = "0.8.24"
+BACKENDS = {
+    "nvidia-cuda": ("cuda", "cuda", False),
+    "amd-vulkan": ("vulkan", "vulkan", False),
+    "cpu": ("cpu", "cpu", True),
+}
+VAD_MODEL_FILE = "ggml-silero-v6.2.0.bin"
+LANGUAGE_ID_MODEL_FILE = "ecapa-lid-107-f16.gguf"
 LANGUAGES = {
     "de_de": ("de", EUROPE_DATASET, "wer"),
     "en_us": ("en", EUROPE_DATASET, "wer"),
@@ -81,7 +98,10 @@ class Sample:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Benchmark Cohere GGUF quantizations through the TypeWhisper API."
+        description=(
+            "Benchmark Cohere GGUF quantizations with one persistent CrispASR "
+            "process per model."
+        )
     )
     parser.add_argument("--api-url", default="http://127.0.0.1:8978")
     parser.add_argument(
@@ -113,25 +133,40 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("artifacts/cohere-quantization-benchmark/results.json"),
+        default=Path("artifacts/cohere-quantization-benchmark/direct-results.json"),
     )
     parser.add_argument(
         "--markdown-output",
         type=Path,
-        default=Path("artifacts/cohere-quantization-benchmark/results.md"),
+        default=Path("artifacts/cohere-quantization-benchmark/direct-results.md"),
     )
     parser.add_argument(
-        "--backend",
-        default="configured in TypeWhisper",
+        "--asset-root",
+        type=Path,
         help=(
-            "Expected active backend reported by TypeWhisper, for example "
-            "nvidia-cuda, amd-vulkan, or cpu."
+            "Cohere plugin data root. Auto-detected from TypeWhisper Store, "
+            "desktop, or development data when exactly one candidate exists."
         ),
     )
     parser.add_argument(
-        "--allow-dictionary",
+        "--backend",
+        choices=["nvidia-cuda", "amd-vulkan", "cpu"],
+        default="nvidia-cuda",
+        help="CrispASR runtime and GPU backend to benchmark.",
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=min(max((os.cpu_count() or 2) // 2, 1), 12),
+        help="CrispASR inference threads (default matches the plugin heuristic).",
+    )
+    parser.add_argument(
+        "--stop-typewhisper-sidecar",
         action="store_true",
-        help="Allow enabled dictionary terms or corrections to modify benchmark output.",
+        help=(
+            "Stop a TypeWhisper-owned CrispASR process under the selected asset "
+            "root before starting the direct benchmark."
+        ),
     )
     parser.add_argument(
         "--no-prepare-models",
@@ -145,6 +180,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--checkpoint-every", type=int, default=10)
     parser.add_argument("--request-timeout", type=int, default=7_200)
+    parser.add_argument("--startup-timeout", type=int, default=900)
     parser.add_argument("--download-retries", type=int, default=4)
     parser.add_argument("--download-workers", type=int, default=8)
     args = parser.parse_args()
@@ -162,6 +198,10 @@ def parse_args() -> argparse.Namespace:
         parser.error("--samples must be positive.")
     if args.checkpoint_every <= 0:
         parser.error("--checkpoint-every must be positive.")
+    if args.threads <= 0:
+        parser.error("--threads must be positive.")
+    if args.startup_timeout <= 0:
+        parser.error("--startup-timeout must be positive.")
     if args.download_workers <= 0:
         parser.error("--download-workers must be positive.")
     return args
@@ -363,7 +403,7 @@ def multipart_body(
     return b"".join(chunks), boundary
 
 
-def transcribe(
+def typewhisper_transcribe(
     args: argparse.Namespace,
     model: str,
     sample: Sample,
@@ -525,23 +565,444 @@ $os = Get-CimInstance Win32_OperatingSystem |
         )
         if windows:
             hardware["windows"] = windows
+        try:
+            nvidia_smi = subprocess.run(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=name,memory.total,driver_version",
+                    "--format=csv,noheader,nounits",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).stdout.strip()
+            if nvidia_smi:
+                hardware["nvidia_smi"] = [
+                    {
+                        "name": parts[0],
+                        "memory_total_mib": int(parts[1]),
+                        "driver_version": parts[2],
+                    }
+                    for line in nvidia_smi.splitlines()
+                    if len(parts := [part.strip() for part in line.split(",")]) == 3
+                ]
+        except (OSError, subprocess.SubprocessError, ValueError):
+            pass
     return hardware
 
 
-def crispasr_peak_working_set() -> int | None:
+def crispasr_peak_working_set(process_id: int) -> int | None:
     if os.name != "nt":
         return None
     value = powershell_json(
-        """
-$process = Get-Process crispasr -ErrorAction SilentlyContinue |
-  Sort-Object StartTime -Descending |
-  Select-Object -First 1
-if ($process) {
+        f"""
+$process = Get-Process -Id {process_id} -ErrorAction SilentlyContinue
+if ($process) {{
   [long]$process.PeakWorkingSet64 | ConvertTo-Json -Compress
-}
+}}
 """
     )
     return int(value) if value is not None else None
+
+
+def is_same_or_under(path: Path, root: Path) -> bool:
+    normalized_path = os.path.normcase(str(path.resolve()))
+    normalized_root = os.path.normcase(str(root.resolve())).rstrip("\\/")
+    return normalized_path == normalized_root or normalized_path.startswith(
+        normalized_root + os.sep
+    )
+
+
+def runtime_executable(asset_root: Path, backend: str) -> Path | None:
+    runtime_id = BACKENDS[backend][0]
+    runtime_root = (
+        asset_root / "Runtimes" / "CrispASR" / CRISPASR_VERSION / runtime_id
+    )
+    return next(runtime_root.rglob("crispasr.exe"), None) if runtime_root.is_dir() else None
+
+
+def model_path(asset_root: Path, model: str) -> Path:
+    try:
+        file_name = MODEL_FILES[model]
+    except KeyError as error:
+        raise RuntimeError(f"Unknown Cohere benchmark model: {model}") from error
+    return asset_root / "Models" / model / file_name
+
+
+def auxiliary_paths(asset_root: Path) -> tuple[Path, Path, Path]:
+    auxiliary_root = (
+        asset_root
+        / "Models"
+        / "cohere-transcribe-03-2026-q5_0"
+        / "Auxiliary"
+    )
+    return (
+        auxiliary_root / LANGUAGE_ID_MODEL_FILE,
+        auxiliary_root / VAD_MODEL_FILE,
+        asset_root / "Cache" / "CrispASR",
+    )
+
+
+def asset_root_candidates() -> list[Path]:
+    local_app_data_value = os.environ.get("LOCALAPPDATA")
+    if not local_app_data_value:
+        return []
+
+    local_app_data = Path(local_app_data_value)
+    candidates = [
+        local_app_data
+        / "TypeWhisper-UserData"
+        / "PluginData"
+        / "com.typewhisper.cohere-transcribe",
+        local_app_data
+        / "TypeWhisper-DevUserData"
+        / "PluginData"
+        / "com.typewhisper.cohere-transcribe",
+    ]
+    packages_root = local_app_data / "Packages"
+    if packages_root.is_dir():
+        candidates.extend(
+            package
+            / "LocalCache"
+            / "Local"
+            / "TypeWhisper-UserData"
+            / "PluginData"
+            / "com.typewhisper.cohere-transcribe"
+            for package in packages_root.glob("TypeWhisper.TypeWhisper_*")
+        )
+
+    unique: dict[str, Path] = {}
+    for candidate in candidates:
+        if candidate.is_dir():
+            unique[os.path.normcase(str(candidate.resolve()))] = candidate.resolve()
+    return list(unique.values())
+
+
+def validate_asset_root(
+    asset_root: Path,
+    models: list[str],
+    backend: str,
+) -> list[str]:
+    missing = [
+        str(path)
+        for path in (model_path(asset_root, model) for model in models)
+        if not path.is_file()
+    ]
+    language_id_path, vad_path, _ = auxiliary_paths(asset_root)
+    missing.extend(
+        str(path) for path in (language_id_path, vad_path) if not path.is_file()
+    )
+    if runtime_executable(asset_root, backend) is None:
+        missing.append(
+            str(
+                asset_root
+                / "Runtimes"
+                / "CrispASR"
+                / CRISPASR_VERSION
+                / BACKENDS[backend][0]
+                / "**"
+                / "crispasr.exe"
+            )
+        )
+    return missing
+
+
+def discover_asset_root(
+    requested_root: Path | None,
+    models: list[str],
+    backend: str,
+) -> Path:
+    if requested_root is not None:
+        root = requested_root.expanduser().resolve()
+        if not root.is_dir():
+            raise RuntimeError(f"Cohere asset root does not exist: {root}")
+        missing = validate_asset_root(root, models, backend)
+        if missing:
+            raise RuntimeError(
+                "The selected Cohere asset root is incomplete:\n  "
+                + "\n  ".join(missing)
+            )
+        return root
+
+    candidates = [
+        candidate
+        for candidate in asset_root_candidates()
+        if not validate_asset_root(candidate, models, backend)
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    if not candidates:
+        discovered = asset_root_candidates()
+        details = "\n  ".join(str(path) for path in discovered) or "(none)"
+        raise RuntimeError(
+            "No complete Cohere asset root was found. Prepare every requested "
+            f"model and the {backend} runtime in TypeWhisper, or pass "
+            f"--asset-root explicitly. Discovered roots:\n  {details}"
+        )
+    raise RuntimeError(
+        "Multiple complete Cohere asset roots were found. Pass --asset-root "
+        "explicitly:\n  "
+        + "\n  ".join(str(path) for path in candidates)
+    )
+
+
+def matching_crispasr_processes(asset_root: Path) -> list[dict[str, Any]]:
+    if os.name != "nt":
+        return []
+    value = powershell_json(
+        """
+$processes = @(
+  Get-CimInstance Win32_Process -Filter "Name='crispasr.exe'" |
+    Select-Object ProcessId,ExecutablePath
+)
+ConvertTo-Json -InputObject $processes -Compress -Depth 3
+"""
+    )
+    if not value:
+        return []
+    processes = value if isinstance(value, list) else [value]
+    return [
+        process
+        for process in processes
+        if process.get("ExecutablePath")
+        and is_same_or_under(Path(process["ExecutablePath"]), asset_root)
+    ]
+
+
+def stop_typewhisper_sidecar(
+    asset_root: Path,
+    allow_stop: bool,
+) -> list[int]:
+    processes = matching_crispasr_processes(asset_root)
+    if not processes:
+        return []
+    process_ids = sorted(int(process["ProcessId"]) for process in processes)
+    if not allow_stop:
+        raise RuntimeError(
+            "TypeWhisper currently owns a CrispASR process under the selected "
+            "asset root. Close TypeWhisper or pass --stop-typewhisper-sidecar; "
+            "the TypeWhisper app itself remains open."
+        )
+
+    subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Stop-Process -Id "
+            + ",".join(str(process_id) for process_id in process_ids)
+            + " -Force -ErrorAction Stop",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    deadline = time.monotonic() + 10
+    while matching_crispasr_processes(asset_root):
+        if time.monotonic() >= deadline:
+            raise RuntimeError("The TypeWhisper CrispASR sidecar did not stop.")
+        time.sleep(0.25)
+    return process_ids
+
+
+class CrispAsrProcess:
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        model: str,
+    ) -> None:
+        self.args = args
+        self.model = model
+        self.api_key = secrets.token_hex(32)
+        self.base_url: str | None = None
+        self.process: subprocess.Popen[str] | None = None
+        self.log_handle: Any = None
+        self.log_path = args.output.parent / "logs" / f"{model}-{args.backend}.log"
+        self.executable = runtime_executable(args.asset_root, args.backend)
+        if self.executable is None:
+            raise RuntimeError(
+                f"The CrispASR {args.backend} runtime is missing under {args.asset_root}."
+            )
+
+    def start(self) -> dict[str, Any]:
+        model_file = model_path(self.args.asset_root, self.model)
+        language_id_file, vad_file, cache_directory = auxiliary_paths(
+            self.args.asset_root
+        )
+        cache_directory.mkdir(parents=True, exist_ok=True)
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        self.log_handle = self.log_path.open(
+            "w",
+            encoding="utf-8",
+            errors="replace",
+        )
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = int(reservation.getsockname()[1])
+        self.base_url = f"http://127.0.0.1:{port}"
+
+        _, gpu_backend, no_gpu = BACKENDS[self.args.backend]
+        command = [
+            str(self.executable),
+            "--server",
+            "--backend",
+            "cohere",
+            "--model",
+            str(model_file),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--language",
+            "auto",
+            "--lid-backend",
+            "ecapa",
+            "--lid-model",
+            str(language_id_file),
+            "--vad",
+            "--vad-model",
+            str(vad_file),
+            "--strict-pipeline",
+            "--require-vad",
+            "--threads",
+            str(self.args.threads),
+            "--gpu-backend",
+            gpu_backend,
+        ]
+        if no_gpu:
+            command.append("--no-gpu")
+
+        environment = os.environ.copy()
+        environment["CRISPASR_API_KEYS"] = self.api_key
+        environment["CRISPASR_CACHE_DIR"] = str(cache_directory)
+        creation_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        started = time.perf_counter()
+        self.process = subprocess.Popen(
+            command,
+            cwd=self.executable.parent,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=self.log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            creationflags=creation_flags,
+        )
+
+        try:
+            self._wait_until_ready()
+        except Exception:
+            exit_code = self.process.poll()
+            log_tail = self._log_tail()
+            self.stop()
+            raise RuntimeError(
+                f"CrispASR failed to start for {self.model}; "
+                f"exit code {exit_code}. Log tail:\n{log_tail}"
+            )
+        return {
+            "model": self.model,
+            "process_id": self.process.pid,
+            "executable": str(self.executable),
+            "backend": self.args.backend,
+            "threads": self.args.threads,
+            "startup_seconds": time.perf_counter() - started,
+            "log_path": str(self.log_path),
+        }
+
+    def _wait_until_ready(self) -> None:
+        assert self.process is not None
+        assert self.base_url is not None
+        deadline = time.monotonic() + self.args.startup_timeout
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                raise RuntimeError("CrispASR exited during startup.")
+            try:
+                with urllib.request.urlopen(
+                    self.base_url + "/health",
+                    timeout=2,
+                ) as response:
+                    if response.status == 200:
+                        return
+            except (OSError, urllib.error.URLError):
+                pass
+            time.sleep(0.25)
+        raise TimeoutError(
+            f"CrispASR did not become ready within {self.args.startup_timeout} seconds."
+        )
+
+    def transcribe(self, sample: Sample) -> tuple[dict[str, Any], float]:
+        if self.process is None or self.process.poll() is not None:
+            raise RuntimeError("CrispASR is not running.")
+        assert self.base_url is not None
+        fields = {
+            "model": self.model,
+            "response_format": "verbose_json",
+        }
+        if sample.language_hint != "auto":
+            fields["language"] = sample.language_hint
+        body, boundary = multipart_body(
+            fields,
+            sample.audio_path.name,
+            sample.audio_path.read_bytes(),
+        )
+        request = urllib.request.Request(
+            self.base_url + "/v1/audio/transcriptions",
+            data=body,
+            method="POST",
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": f"multipart/form-data; boundary={boundary}",
+            },
+        )
+        started = time.perf_counter()
+        try:
+            with urllib.request.urlopen(
+                request,
+                timeout=self.args.request_timeout,
+            ) as response:
+                result = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            response_body = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"CrispASR returned HTTP {error.code}: {response_body}"
+            ) from error
+        return result, time.perf_counter() - started
+
+    def peak_working_set(self) -> int | None:
+        if self.process is None:
+            return None
+        return crispasr_peak_working_set(self.process.pid)
+
+    def _log_tail(self) -> str:
+        if self.log_handle is not None:
+            self.log_handle.flush()
+        try:
+            return "\n".join(
+                self.log_path.read_text(
+                    encoding="utf-8",
+                    errors="replace",
+                ).splitlines()[-80:]
+            )
+        except OSError:
+            return "(log unavailable)"
+
+    def stop(self) -> None:
+        process = self.process
+        self.process = None
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+        if self.log_handle is not None:
+            self.log_handle.close()
+            self.log_handle = None
 
 
 def git_revision() -> str | None:
@@ -580,8 +1041,12 @@ def initial_result(
         "schema_version": SCRIPT_VERSION,
         "created_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "source_revision": git_revision(),
-        "api_url": args.api_url,
+        "mode": "direct-crispasr",
+        "typewhisper_api_url_for_preparation": args.api_url,
+        "asset_root": str(args.asset_root),
+        "crispasr_version": CRISPASR_VERSION,
         "backend": args.backend,
+        "threads": args.threads,
         "models": args.models,
         "languages": args.languages,
         "samples_per_language": args.samples,
@@ -592,8 +1057,19 @@ def initial_result(
             FULL_DATASET[0]: FULL_DATASET[1],
         },
         "normalization": "Unicode NFKC + casefold + punctuation/symbol removal",
+        "timing": (
+            "Client wall time around each direct localhost CrispASR request; "
+            "one persistent server process per model"
+        ),
+        "post_processing": {
+            "mode": "raw CrispASR response",
+            "typewhisper_dictionary": False,
+            "typewhisper_corrections": False,
+            "number_normalization": False,
+        },
         "hardware": collect_hardware(),
         "preparation": [],
+        "stopped_typewhisper_sidecar_process_ids": [],
         "warmups": [],
         "runs": [],
         "negative_tests": [],
@@ -611,6 +1087,10 @@ def load_or_create_result(
         result = json.loads(args.output.read_text(encoding="utf-8"))
         expected = {
             "schema_version": SCRIPT_VERSION,
+            "mode": "direct-crispasr",
+            "asset_root": str(args.asset_root),
+            "backend": args.backend,
+            "threads": args.threads,
             "models": args.models,
             "languages": args.languages,
             "samples_per_language": args.samples,
@@ -693,14 +1173,16 @@ def markdown_report(result: dict[str, Any]) -> str:
         "# Cohere Transcribe quantization benchmark",
         "",
         f"- Source revision: `{result.get('source_revision')}`",
-        f"- Backend: `{result['backend']}`",
+        f"- Mode: `{result.get('mode')}`",
+        f"- Runtime: CrispASR `{result.get('crispasr_version')}`",
+        f"- Backend: `{result['backend']}` with {result.get('threads')} threads",
         f"- Samples: {result['samples_per_language']} per language",
         f"- Sample manifest SHA-256: `{result['sample_manifest_sha256']}`",
         "",
         "## Aggregate",
         "",
-        "| Model | Non-CJK macro WER | CJK macro CER | Weighted RTFx | Wall RTFx | Peak working set |",
-        "|---|---:|---:|---:|---:|---:|",
+        "| Model | Model size | Non-CJK macro WER | CJK macro CER | RTFx | Startup | Peak working set |",
+        "|---|---:|---:|---:|---:|---:|---:|",
     ]
     for model in result["models"]:
         model_rows = [row for row in rows if row["model"] == model]
@@ -708,18 +1190,21 @@ def markdown_report(result: dict[str, Any]) -> str:
         cjk = [row["cer"] for row in model_rows if row["language"] in CJK_LANGUAGES]
         audio_seconds = sum(row["audio_seconds"] for row in model_rows)
         processing_seconds = sum(row["processing_seconds"] for row in model_rows)
-        wall_seconds = sum(row["wall_seconds"] for row in model_rows)
+        runtime_status = result["model_runtime_status"].get(model, {})
         lines.append(
             "| "
             + " | ".join(
                 [
                     f"`{model}`",
+                    gibibytes(runtime_status.get("model_file_size_bytes")),
                     percent(statistics.mean(non_cjk)) if non_cjk else "n/a",
                     percent(statistics.mean(cjk)) if cjk else "n/a",
                     f"{audio_seconds / processing_seconds:.2f}x"
                     if processing_seconds
                     else "n/a",
-                    f"{audio_seconds / wall_seconds:.2f}x" if wall_seconds else "n/a",
+                    f"{runtime_status['startup_seconds']:.2f} s"
+                    if runtime_status.get("startup_seconds") is not None
+                    else "n/a",
                     gibibytes(
                         result["model_peak_working_set_bytes"].get(model)
                     ),
@@ -733,8 +1218,8 @@ def markdown_report(result: dict[str, Any]) -> str:
             "",
             "## Per-language results",
             "",
-            "| Model | Language | Primary | WER | CER | RTFx | Wall RTFx | Empty | Clips |",
-            "|---|---|---|---:|---:|---:|---:|---:|---:|",
+            "| Model | Language | Primary | WER | CER | RTFx | Empty | Clips |",
+            "|---|---|---|---:|---:|---:|---:|---:|",
         ]
     )
     for row in rows:
@@ -749,7 +1234,6 @@ def markdown_report(result: dict[str, Any]) -> str:
                     percent(row["wer"]),
                     percent(row["cer"]),
                     f"{row['rtfx']:.2f}x",
-                    f"{row['wall_rtfx']:.2f}x",
                     str(row["empty_results"]),
                     str(row["clips"]),
                 ]
@@ -809,69 +1293,24 @@ def validate_models(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
     return models
 
 
-def validate_post_processing(args: argparse.Namespace) -> dict[str, Any]:
-    terms = api_request(args, "GET", "/v1/dictionary/terms")
-    corrections = api_request(args, "GET", "/v1/dictionary/corrections")
-    term_count = int(terms.get("count", len(terms.get("terms", []))))
-    correction_count = int(
-        corrections.get("count", len(corrections.get("corrections", [])))
-    )
-    if not args.allow_dictionary and (term_count or correction_count):
-        raise RuntimeError(
-            "The benchmark requires an empty TypeWhisper dictionary. "
-            f"Found {term_count} terms and {correction_count} corrections. "
-            "Use a clean profile or pass --allow-dictionary to record a non-standard run."
-        )
-    return {
-        "dictionary_terms": term_count,
-        "dictionary_corrections": correction_count,
-        "number_normalization": False,
-        "dictionary_override_allowed": bool(args.allow_dictionary),
-    }
-
-
-def validate_active_backend(
-    args: argparse.Namespace,
-    model: str,
-) -> dict[str, Any]:
-    status = api_request(args, "GET", "/v1/status")
-    acceleration = status.get("acceleration") or {}
-    active_backend = acceleration.get("active_backend")
-    if (
-        args.backend != "configured in TypeWhisper"
-        and active_backend != args.backend
-    ):
-        raise RuntimeError(
-            f"{model} loaded with backend {active_backend!r}, "
-            f"but {args.backend!r} was requested."
-        )
-    return status
-
-
 def benchmark(args: argparse.Namespace) -> int:
     print("Preparing pinned FLEURS samples...", flush=True)
     samples = prepare_samples(args)
     manifest_hash = sample_manifest_sha256(samples)
-    result = load_or_create_result(args, samples, manifest_hash)
-    result.setdefault("model_runtime_status", {})
     models_before = validate_models(args)
-    result["post_processing"] = validate_post_processing(args)
     first_sample = samples[0]
-
-    prepared_models = {entry["model"] for entry in result["preparation"]}
+    preparation: list[dict[str, Any]] = []
     if not args.no_prepare_models:
         print("Preparing model downloads...", flush=True)
         for model in args.models:
-            if model in prepared_models:
-                continue
             started = time.perf_counter()
-            response, request_wall = transcribe(
+            response, request_wall = typewhisper_transcribe(
                 args,
                 model,
                 first_sample,
                 await_download=True,
             )
-            result["preparation"].append(
+            preparation.append(
                 {
                     "model": model,
                     "downloaded_before": bool(models_before[model].get("downloaded")),
@@ -880,19 +1319,47 @@ def benchmark(args: argparse.Namespace) -> int:
                     "processing_time_seconds": response.get("processing_time"),
                 }
             )
-            checkpoint(args, result)
             print(f"  prepared {model}", flush=True)
-    elif args.no_prepare_models:
+
+    models_after = validate_models(args)
+    if args.no_prepare_models:
         missing_downloads = [
             model
             for model in args.models
-            if not models_before[model].get("downloaded")
+            if not models_after[model].get("downloaded")
         ]
         if missing_downloads:
             raise RuntimeError(
                 "Download these models in TypeWhisper first: "
                 + ", ".join(missing_downloads)
             )
+
+    args.asset_root = discover_asset_root(
+        args.asset_root,
+        args.models,
+        args.backend,
+    )
+    print(f"Using Cohere assets: {args.asset_root}", flush=True)
+    stopped_process_ids = stop_typewhisper_sidecar(
+        args.asset_root,
+        args.stop_typewhisper_sidecar,
+    )
+    if stopped_process_ids:
+        print(
+            "Stopped TypeWhisper CrispASR sidecar: "
+            + ", ".join(str(process_id) for process_id in stopped_process_ids),
+            flush=True,
+        )
+
+    result = load_or_create_result(args, samples, manifest_hash)
+    result["preparation"] = preparation
+    result["stopped_typewhisper_sidecar_process_ids"] = sorted(
+        set(result.get("stopped_typewhisper_sidecar_process_ids", []))
+        | set(stopped_process_ids)
+    )
+    result.setdefault("model_runtime_status", {})
+    result["runs"] = [run for run in result["runs"] if not run.get("error")]
+    checkpoint(args, result)
 
     completed = {result_key(run) for run in result["runs"]}
     completed_negative = {
@@ -902,126 +1369,133 @@ def benchmark(args: argparse.Namespace) -> int:
 
     try:
         for model in args.models:
+            pending_speech = any(
+                (model, sample.language, sample.sample_id) not in completed
+                for sample in samples
+            )
+            pending_negative = any(
+                (model, sample.sample_id) not in completed_negative
+                for sample in negative_samples
+            )
+            if (
+                not pending_speech
+                and not pending_negative
+                and model in result["model_peak_working_set_bytes"]
+            ):
+                print(f"Skipping completed {model}.", flush=True)
+                continue
+
             print(f"Benchmarking {model}...", flush=True)
-            if not any(warmup["model"] == model for warmup in result["warmups"]):
-                first_response, first_wall = transcribe(
-                    args,
+            server = CrispAsrProcess(args, model)
+            try:
+                runtime_status = server.start()
+                runtime_status["model_file_size_bytes"] = model_path(
+                    args.asset_root,
                     model,
-                    first_sample,
-                    await_download=False,
-                )
-                second_response, second_wall = transcribe(
-                    args,
-                    model,
-                    first_sample,
-                    await_download=False,
-                )
+                ).stat().st_size
+                result["model_runtime_status"][model] = runtime_status
+
+                first_response, first_wall = server.transcribe(first_sample)
+                second_response, second_wall = server.transcribe(first_sample)
+                result["warmups"] = [
+                    warmup
+                    for warmup in result["warmups"]
+                    if warmup["model"] != model
+                ]
                 result["warmups"].append(
                     {
                         "model": model,
-                        "load_and_first_inference_wall_seconds": first_wall,
-                        "first_processing_time_seconds": first_response.get(
-                            "processing_time"
+                        "server_startup_seconds": runtime_status[
+                            "startup_seconds"
+                        ],
+                        "load_and_first_inference_wall_seconds": (
+                            runtime_status["startup_seconds"] + first_wall
                         ),
+                        "first_inference_seconds": first_wall,
+                        "first_output": first_response.get("text", ""),
                         "second_warmup_wall_seconds": second_wall,
-                        "second_processing_time_seconds": second_response.get(
-                            "processing_time"
-                        ),
+                        "second_output": second_response.get("text", ""),
                     }
                 )
                 checkpoint(args, result)
-            else:
-                transcribe(
-                    args,
-                    model,
-                    first_sample,
-                    await_download=False,
-                )
-            result["model_runtime_status"][model] = validate_active_backend(
-                args,
-                model,
-            )
-            checkpoint(args, result)
 
-            model_samples = [sample for sample in samples]
-            for index, sample in enumerate(model_samples, start=1):
-                key = (model, sample.language, sample.sample_id)
-                if key in completed:
-                    continue
-                try:
-                    response, wall_seconds = transcribe(
-                        args,
-                        model,
-                        sample,
-                        await_download=False,
-                    )
-                    metrics = score(sample.reference, response.get("text", ""))
-                    result["runs"].append(
+                model_samples = list(samples)
+                for index, sample in enumerate(model_samples, start=1):
+                    key = (model, sample.language, sample.sample_id)
+                    if key in completed:
+                        continue
+                    try:
+                        response, wall_seconds = server.transcribe(sample)
+                        metrics = score(
+                            sample.reference,
+                            response.get("text", ""),
+                        )
+                        result["runs"].append(
+                            {
+                                "model": model,
+                                "language": sample.language,
+                                "language_hint": sample.language_hint,
+                                "sample_id": sample.sample_id,
+                                "reference": sample.reference,
+                                "hypothesis": response.get("text", ""),
+                                "detected_language": response.get("language"),
+                                "duration_seconds": float(
+                                    response.get("duration")
+                                    or sample.duration_seconds
+                                ),
+                                "processing_time_seconds": wall_seconds,
+                                "wall_seconds": wall_seconds,
+                                **metrics,
+                            }
+                        )
+                        completed.add(key)
+                    except Exception as error:
+                        result["runs"].append(
+                            {
+                                "model": model,
+                                "language": sample.language,
+                                "language_hint": sample.language_hint,
+                                "sample_id": sample.sample_id,
+                                "reference": sample.reference,
+                                "duration_seconds": sample.duration_seconds,
+                                "error": str(error),
+                            }
+                        )
+                        if (
+                            server.process is None
+                            or server.process.poll() is not None
+                        ):
+                            raise
+                    if index % args.checkpoint_every == 0:
+                        checkpoint(args, result)
+                        print(
+                            f"  {index}/{len(model_samples)} speech clips",
+                            flush=True,
+                        )
+
+                for sample in negative_samples:
+                    key = (model, sample.sample_id)
+                    if key in completed_negative:
+                        continue
+                    response, wall_seconds = server.transcribe(sample)
+                    result["negative_tests"].append(
                         {
                             "model": model,
-                            "language": sample.language,
-                            "language_hint": sample.language_hint,
                             "sample_id": sample.sample_id,
-                            "reference": sample.reference,
-                            "hypothesis": response.get("text", ""),
-                            "detected_language": response.get("language"),
-                            "duration_seconds": float(
-                                response.get("duration") or sample.duration_seconds
-                            ),
-                            "processing_time_seconds": float(
-                                response.get("processing_time") or wall_seconds
-                            ),
+                            "text": response.get("text", ""),
+                            "processing_time_seconds": wall_seconds,
                             "wall_seconds": wall_seconds,
-                            **metrics,
                         }
                     )
-                except Exception as error:  # Continue to preserve long benchmark runs.
-                    result["runs"].append(
-                        {
-                            "model": model,
-                            "language": sample.language,
-                            "language_hint": sample.language_hint,
-                            "sample_id": sample.sample_id,
-                            "reference": sample.reference,
-                            "duration_seconds": sample.duration_seconds,
-                            "error": str(error),
-                        }
-                    )
-                completed.add(key)
-                if index % args.checkpoint_every == 0:
-                    checkpoint(args, result)
-                    print(
-                        f"  {index}/{len(model_samples)} speech clips",
-                        flush=True,
-                    )
-
-            for sample in negative_samples:
-                key = (model, sample.sample_id)
-                if key in completed_negative:
-                    continue
-                response, wall_seconds = transcribe(
-                    args,
-                    model,
-                    sample,
-                    await_download=False,
-                )
-                result["negative_tests"].append(
-                    {
-                        "model": model,
-                        "sample_id": sample.sample_id,
-                        "text": response.get("text", ""),
-                        "processing_time_seconds": float(
-                            response.get("processing_time") or wall_seconds
-                        ),
-                        "wall_seconds": wall_seconds,
-                    }
-                )
-                completed_negative.add(key)
-
-            result["model_peak_working_set_bytes"][model] = (
-                crispasr_peak_working_set()
-            )
-            checkpoint(args, result)
+                    completed_negative.add(key)
+            finally:
+                peak_working_set = server.peak_working_set()
+                if peak_working_set is not None:
+                    result["model_peak_working_set_bytes"][
+                        model
+                    ] = peak_working_set
+                server.stop()
+                checkpoint(args, result)
     except KeyboardInterrupt:
         checkpoint(args, result)
         print("\nInterrupted; checkpoint saved.", file=sys.stderr)

--- a/eng/benchmark_cohere_quantizations.py
+++ b/eng/benchmark_cohere_quantizations.py
@@ -588,6 +588,7 @@ $os = Get-CimInstance Win32_OperatingSystem |
                     if len(parts := [part.strip() for part in line.split(",")]) == 3
                 ]
         except (OSError, subprocess.SubprocessError, ValueError):
+            # NVIDIA metadata is optional; the WMI hardware snapshot remains usable.
             pass
     return hardware
 
@@ -927,6 +928,7 @@ class CrispAsrProcess:
                     if response.status == 200:
                         return
             except (OSError, urllib.error.URLError):
+                # Connection failures are expected until the server binds its port.
                 pass
             time.sleep(0.25)
         raise TimeoutError(

--- a/eng/benchmark_cohere_quantizations.py
+++ b/eng/benchmark_cohere_quantizations.py
@@ -202,6 +202,10 @@ def parse_args() -> argparse.Namespace:
         parser.error("--threads must be positive.")
     if args.startup_timeout <= 0:
         parser.error("--startup-timeout must be positive.")
+    if args.request_timeout <= 0:
+        parser.error("--request-timeout must be positive.")
+    if args.download_retries <= 0:
+        parser.error("--download-retries must be positive.")
     if args.download_workers <= 0:
         parser.error("--download-workers must be positive.")
     return args
@@ -293,7 +297,13 @@ def prepare_samples(args: argparse.Namespace) -> list[Sample]:
 
         selected_entries = transcript_entries[: args.samples]
 
-        def download_audio(entry: tuple[str, str]) -> None:
+        def download_audio(
+            entry: tuple[str, str],
+            language: str = language,
+            language_dir: Path = language_dir,
+            repository: str = repository,
+            revision: str = revision,
+        ) -> None:
             sample_id, _ = entry
             audio_path = language_dir / f"{sample_id}.wav"
             download_file(
@@ -895,14 +905,14 @@ class CrispAsrProcess:
 
         try:
             self._wait_until_ready()
-        except Exception:
+        except Exception as error:
             exit_code = self.process.poll()
             log_tail = self._log_tail()
             self.stop()
             raise RuntimeError(
                 f"CrispASR failed to start for {self.model}; "
                 f"exit code {exit_code}. Log tail:\n{log_tail}"
-            )
+            ) from error
         return {
             "model": self.model,
             "process_id": self.process.pid,
@@ -1253,13 +1263,22 @@ def markdown_report(result: dict[str, Any]) -> str:
         ]
     )
     for run in result["negative_tests"]:
-        output = run.get("text", "").replace("|", "\\|").replace("\n", " ")
+        if run.get("error"):
+            output = f"ERROR: {run['error']}"
+            processing_time = "n/a"
+        else:
+            output = run.get("text") or ""
+            processing_time = f"{run['processing_time_seconds']:.3f} s"
+        output = output.replace("|", "\\|").replace("\n", " ")
         lines.append(
             f"| `{run['model']}` | {run['sample_id']} | "
-            f"`{output}` | {run['processing_time_seconds']:.3f} s |"
+            f"`{output}` | {processing_time} |"
         )
 
     errors = [run for run in result["runs"] if run.get("error")]
+    negative_errors = [
+        run for run in result["negative_tests"] if run.get("error")
+    ]
     lines.extend(
         [
             "",
@@ -1267,6 +1286,11 @@ def markdown_report(result: dict[str, Any]) -> str:
             "",
             f"- Successful speech clips: {len(result['runs']) - len(errors)}",
             f"- Failed speech clips: {len(errors)}",
+            (
+                "- Successful negative tests: "
+                f"{len(result['negative_tests']) - len(negative_errors)}"
+            ),
+            f"- Failed negative tests: {len(negative_errors)}",
             "",
         ]
     )
@@ -1361,6 +1385,9 @@ def benchmark(args: argparse.Namespace) -> int:
     )
     result.setdefault("model_runtime_status", {})
     result["runs"] = [run for run in result["runs"] if not run.get("error")]
+    result["negative_tests"] = [
+        run for run in result["negative_tests"] if not run.get("error")
+    ]
     checkpoint(args, result)
 
     completed = {result_key(run) for run in result["runs"]}
@@ -1428,9 +1455,10 @@ def benchmark(args: argparse.Namespace) -> int:
                         continue
                     try:
                         response, wall_seconds = server.transcribe(sample)
+                        hypothesis = response.get("text") or ""
                         metrics = score(
                             sample.reference,
-                            response.get("text", ""),
+                            hypothesis,
                         )
                         result["runs"].append(
                             {
@@ -1439,7 +1467,7 @@ def benchmark(args: argparse.Namespace) -> int:
                                 "language_hint": sample.language_hint,
                                 "sample_id": sample.sample_id,
                                 "reference": sample.reference,
-                                "hypothesis": response.get("text", ""),
+                                "hypothesis": hypothesis,
                                 "detected_language": response.get("language"),
                                 "duration_seconds": float(
                                     response.get("duration")
@@ -1479,12 +1507,31 @@ def benchmark(args: argparse.Namespace) -> int:
                     key = (model, sample.sample_id)
                     if key in completed_negative:
                         continue
-                    response, wall_seconds = server.transcribe(sample)
+                    try:
+                        response, wall_seconds = server.transcribe(sample)
+                    except Exception as error:
+                        result["negative_tests"].append(
+                            {
+                                "model": model,
+                                "sample_id": sample.sample_id,
+                                "error": str(error),
+                            }
+                        )
+                        print(
+                            f"  negative sample {sample.sample_id} failed: {error}",
+                            file=sys.stderr,
+                        )
+                        if (
+                            server.process is None
+                            or server.process.poll() is not None
+                        ):
+                            raise
+                        continue
                     result["negative_tests"].append(
                         {
                             "model": model,
                             "sample_id": sample.sample_id,
-                            "text": response.get("text", ""),
+                            "text": response.get("text") or "",
                             "processing_time_seconds": wall_seconds,
                             "wall_seconds": wall_seconds,
                         }
@@ -1506,7 +1553,10 @@ def benchmark(args: argparse.Namespace) -> int:
     checkpoint(args, result)
     print(markdown_report(result))
     errors = [run for run in result["runs"] if run.get("error")]
-    return 2 if errors else 0
+    negative_errors = [
+        run for run in result["negative_tests"] if run.get("error")
+    ]
+    return 2 if errors or negative_errors else 0
 
 
 def main() -> int:

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereLocalAssets.cs
@@ -21,6 +21,92 @@ internal sealed record RemoteArtifact(
     long SizeBytes,
     string Sha256);
 
+internal sealed record CohereModelDefinition(
+    string Id,
+    string DisplayName,
+    string SizeDescription,
+    long EstimatedSizeMB,
+    bool IsRecommended,
+    RemoteArtifact Artifact);
+
+internal static class CohereModelCatalog
+{
+    internal const string Revision = "2242638d5dfecc6f1dbe6c3a8713b97deb2e150f";
+    internal const string Q4KModelId = "cohere-transcribe-03-2026-q4_k";
+    internal const string DefaultModelId = "cohere-transcribe-03-2026-q5_0";
+    internal const string Q6KModelId = "cohere-transcribe-03-2026-q6_k";
+    internal const string Q8ModelId = "cohere-transcribe-03-2026-q8_0";
+
+    internal static readonly IReadOnlyList<CohereModelDefinition> All =
+    [
+        Create(
+            Q4KModelId,
+            "Cohere Transcribe 2B (Q4_K)",
+            "~1.5 GB + local runtime",
+            1_510,
+            false,
+            "cohere-transcribe-q4_k.gguf",
+            1_510_362_752,
+            "2931fc0ac6d6708eef5389aadf1ebd5eec7b8e764bac385be585e910c0e7b410"),
+        Create(
+            DefaultModelId,
+            "Cohere Transcribe 2B (Q5_0)",
+            "~1.7 GB + local runtime",
+            1_739,
+            true,
+            "cohere-transcribe-q5_0.gguf",
+            1_738_722_944,
+            "a09696c5cc2ed5052bf290c4f2beb35abc69c0d6986842042d92bebb22c9184e"),
+        Create(
+            Q6KModelId,
+            "Cohere Transcribe 2B (Q6_K)",
+            "~2.0 GB + local runtime",
+            1_982,
+            false,
+            "cohere-transcribe-q6_k.gguf",
+            1_981_355_648,
+            "0ad2634e0ba34efa38a47d4fd4cf34d7a2d738d8486d83b8d5a178f823109c52"),
+        Create(
+            Q8ModelId,
+            "Cohere Transcribe 2B (Q8_0)",
+            "~2.4 GB + local runtime",
+            2_424,
+            false,
+            "cohere-transcribe-q8_0.gguf",
+            2_423_803_520,
+            "c8620cb182a7c04e311e6c24e478b94f7ecd7f1b5230bf39fffa8daf94644f51")
+    ];
+
+    internal static bool Contains(string? modelId) =>
+        modelId is not null
+        && All.Any(model => string.Equals(model.Id, modelId, StringComparison.Ordinal));
+
+    internal static CohereModelDefinition Resolve(string modelId) =>
+        All.FirstOrDefault(model => string.Equals(model.Id, modelId, StringComparison.Ordinal))
+        ?? throw new ArgumentException($"Unknown model: {modelId}", nameof(modelId));
+
+    private static CohereModelDefinition Create(
+        string id,
+        string displayName,
+        string sizeDescription,
+        long estimatedSizeMB,
+        bool isRecommended,
+        string fileName,
+        long sizeBytes,
+        string sha256) =>
+        new(
+            id,
+            displayName,
+            sizeDescription,
+            estimatedSizeMB,
+            isRecommended,
+            new RemoteArtifact(
+                fileName,
+                $"https://huggingface.co/cstr/cohere-transcribe-03-2026-GGUF/resolve/{Revision}/{fileName}",
+                sizeBytes,
+                sha256));
+}
+
 internal sealed record RuntimePackage(
     CrispAsrBackend Backend,
     string Id,
@@ -36,21 +122,24 @@ internal readonly record struct ArtifactTransferProgress(long BytesTransferred, 
 
 internal interface ICohereLocalAssetManager
 {
-    long ModelTransferSize { get; }
-
     void SetHuggingFaceToken(string? token);
 
-    bool IsModelInstalled();
+    long GetModelTransferSize(string modelId);
+
+    bool IsModelInstalled(string modelId);
 
     bool IsRuntimeInstalled(CrispAsrBackend backend);
 
     long GetRuntimeTransferSize(CrispAsrBackend backend);
 
-    CohereModelPaths GetModelPaths();
+    CohereModelPaths GetModelPaths(string modelId);
 
     string GetRuntimeExecutablePath(CrispAsrBackend backend);
 
-    Task EnsureModelAsync(IProgress<ArtifactTransferProgress>? progress, CancellationToken cancellationToken);
+    Task EnsureModelAsync(
+        string modelId,
+        IProgress<ArtifactTransferProgress>? progress,
+        CancellationToken cancellationToken);
 
     Task EnsureRuntimeAsync(
         CrispAsrBackend backend,
@@ -67,15 +156,9 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
     private static readonly TimeSpan DefaultDownloadRetryDelay = TimeSpan.FromSeconds(1);
 
     internal const string CrispAsrVersion = "0.8.24";
-    internal const string CohereModelRevision = "2242638d5dfecc6f1dbe6c3a8713b97deb2e150f";
+    internal const string CohereModelRevision = CohereModelCatalog.Revision;
     internal const string VadModelRevision = "9ffd54a1e1ee413ddf265af9913beaf518d1639b";
     internal const string LanguageIdModelRevision = "95fb0613bf78c6e48305fccd9ce023ac15f0b5a6";
-
-    internal static readonly RemoteArtifact CohereModel = new(
-        "cohere-transcribe-q5_0.gguf",
-        $"https://huggingface.co/cstr/cohere-transcribe-03-2026-GGUF/resolve/{CohereModelRevision}/cohere-transcribe-q5_0.gguf",
-        1_738_722_944,
-        "a09696c5cc2ed5052bf290c4f2beb35abc69c0d6986842042d92bebb22c9184e");
 
     internal static readonly RemoteArtifact VadModel = new(
         "ggml-silero-v6.2.0.bin",
@@ -115,9 +198,6 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
             $"https://github.com/CrispStrobe/CrispASR/releases/download/v{CrispAsrVersion}/crispasr-windows-x86_64-vulkan.zip",
             35_580_185,
             "70956638045042b49f61f9f04ee9ceae9fc8b450f6f56a10fc98c2088207628a"));
-
-    private static readonly IReadOnlyList<RemoteArtifact> ModelArtifacts =
-        [CohereModel, VadModel, LanguageIdModel];
 
     private readonly string _assetRoot;
     private readonly HttpClient _httpClient;
@@ -161,17 +241,21 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("TypeWhisper-CohereTranscribe/1.0");
     }
 
-    public long ModelTransferSize => ModelArtifacts.Sum(static artifact => artifact.SizeBytes);
-
     public void SetHuggingFaceToken(string? token)
     {
         Volatile.Write(ref _huggingFaceToken, token);
     }
 
-    public bool IsModelInstalled()
+    public long GetModelTransferSize(string modelId) =>
+        CohereModelCatalog.Resolve(modelId).Artifact.SizeBytes
+        + VadModel.SizeBytes
+        + LanguageIdModel.SizeBytes;
+
+    public bool IsModelInstalled(string modelId)
     {
-        var paths = GetModelPaths();
-        return IsArtifactReady(CohereModel, paths.ModelPath)
+        var model = CohereModelCatalog.Resolve(modelId);
+        var paths = GetModelPaths(modelId);
+        return IsArtifactReady(model.Artifact, paths.ModelPath)
             && IsArtifactReady(VadModel, paths.VadModelPath)
             && IsArtifactReady(LanguageIdModel, paths.LanguageIdModelPath);
     }
@@ -194,13 +278,18 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
     public long GetRuntimeTransferSize(CrispAsrBackend backend) =>
         GetRuntimePackage(backend).Archive.SizeBytes;
 
-    public CohereModelPaths GetModelPaths()
+    public CohereModelPaths GetModelPaths(string modelId)
     {
-        var modelDirectory = Path.Join(_assetRoot, "Models", "cohere-transcribe-03-2026-q5_0");
-        var auxiliaryDirectory = Path.Join(modelDirectory, "Auxiliary");
+        var model = CohereModelCatalog.Resolve(modelId);
+        var modelDirectory = Path.Join(_assetRoot, "Models", model.Id);
+        var auxiliaryDirectory = Path.Join(
+            _assetRoot,
+            "Models",
+            CohereModelCatalog.DefaultModelId,
+            "Auxiliary");
 
         return new CohereModelPaths(
-            Path.Join(modelDirectory, CohereModel.FileName),
+            Path.Join(modelDirectory, model.Artifact.FileName),
             Path.Join(auxiliaryDirectory, VadModel.FileName),
             Path.Join(auxiliaryDirectory, LanguageIdModel.FileName),
             Path.Join(_assetRoot, "Cache", "CrispASR"));
@@ -215,16 +304,19 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
     }
 
     public async Task EnsureModelAsync(
+        string modelId,
         IProgress<ArtifactTransferProgress>? progress,
         CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);
         try
         {
-            var paths = GetModelPaths();
+            var model = CohereModelCatalog.Resolve(modelId);
+            var transferSize = GetModelTransferSize(modelId);
+            var paths = GetModelPaths(modelId);
             var targets = new[]
             {
-                (Artifact: CohereModel, Path: paths.ModelPath),
+                (Artifact: model.Artifact, Path: paths.ModelPath),
                 (Artifact: VadModel, Path: paths.VadModelPath),
                 (Artifact: LanguageIdModel, Path: paths.LanguageIdModelPath)
             };
@@ -238,7 +330,7 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
                     : new Progress<ArtifactTransferProgress>(value =>
                         progress.Report(new ArtifactTransferProgress(
                             completedBeforeArtifact + value.BytesTransferred,
-                            ModelTransferSize)));
+                            transferSize)));
 
                 await EnsureArtifactAsync(
                     target.Artifact,
@@ -247,7 +339,7 @@ internal sealed class CohereLocalAssetManager : ICohereLocalAssetManager, IDispo
                     cancellationToken);
 
                 completed += target.Artifact.SizeBytes;
-                progress?.Report(new ArtifactTransferProgress(completed, ModelTransferSize));
+                progress?.Report(new ArtifactTransferProgress(completed, transferSize));
             }
         }
         finally

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
@@ -60,7 +60,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.1";
 
     /// <summary>
     /// Gets the stable transcription provider identifier.

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
@@ -131,7 +131,10 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
     /// <summary>
     /// Gets the active acceleration status.
     /// </summary>
-    public TranscriptionAccelerationStatus AccelerationStatus => _accelerationStatus;
+    public TranscriptionAccelerationStatus AccelerationStatus =>
+        _loadedModelId is not null && _server?.IsRunning != true
+            ? CreatePendingStatus(_accelerationPreference)
+            : _accelerationStatus;
 
     /// <summary>
     /// Activates the plugin and prepares its isolated asset storage.
@@ -437,21 +440,60 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
             throw new NotSupportedException("Cohere Transcribe does not support speech translation.");
 
         var normalizedLanguage = NormalizeLanguage(language);
+        var restartAttempted = false;
 
-        await _gate.WaitAsync(cancellationToken);
-        try
+        while (true)
         {
-            if (_loadedModelId is null)
-                throw new InvalidOperationException("No Cohere Transcribe model is loaded.");
+            string? modelToRestart = null;
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                if (_loadedModelId is null)
+                    throw new InvalidOperationException("No Cohere Transcribe model is loaded.");
 
-            return await GetServer().TranscribeAsync(
-                wavAudio,
-                normalizedLanguage,
-                cancellationToken);
-        }
-        finally
-        {
-            _gate.Release();
+                var server = GetServer();
+                if (!server.IsRunning)
+                {
+                    if (restartAttempted)
+                        throw new InvalidOperationException("The local Cohere Transcribe model is not loaded.");
+
+                    modelToRestart = _loadedModelId;
+                    _loadedModelId = null;
+                    _accelerationStatus = CreatePendingStatus(_accelerationPreference);
+                }
+                else
+                {
+                    try
+                    {
+                        return await server.TranscribeAsync(
+                            wavAudio,
+                            normalizedLanguage,
+                            cancellationToken);
+                    }
+                    catch (Exception exception) when (
+                        exception is not OperationCanceledException
+                        && !restartAttempted
+                        && !server.IsRunning)
+                    {
+                        modelToRestart = _loadedModelId;
+                        _loadedModelId = null;
+                        _accelerationStatus = CreatePendingStatus(_accelerationPreference);
+                    }
+                }
+            }
+            finally
+            {
+                _gate.Release();
+            }
+
+            if (modelToRestart is null)
+                throw new InvalidOperationException("The local Cohere Transcribe model is not loaded.");
+
+            restartAttempted = true;
+            _host?.Log(
+                PluginLogLevel.Warning,
+                $"CrispASR stopped unexpectedly; restarting {modelToRestart} before transcription.");
+            await LoadModelAsync(modelToRestart, cancellationToken);
         }
     }
 

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CohereTranscribePlugin.cs
@@ -11,7 +11,7 @@ namespace TypeWhisper.Plugin.CohereTranscribe;
 /// </summary>
 public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
 {
-    internal const string ModelId = "cohere-transcribe-03-2026-q5_0";
+    internal const string ModelId = CohereModelCatalog.DefaultModelId;
     internal const string HuggingFaceTokenSecretName = "hugging-face-token";
 
     private static readonly IReadOnlyList<string> Languages =
@@ -83,15 +83,15 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
     /// Gets the available local Cohere transcription models.
     /// </summary>
     public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
-    [
-        new PluginModelInfo(ModelId, "Cohere Transcribe 2B (Q5_0)")
-        {
-            SizeDescription = "~1.7 GB + local runtime",
-            EstimatedSizeMB = 1_700,
-            IsRecommended = true,
-            LanguageCount = 14
-        }
-    ];
+        CohereModelCatalog.All
+            .Select(model => new PluginModelInfo(model.Id, model.DisplayName)
+            {
+                SizeDescription = model.SizeDescription,
+                EstimatedSizeMB = model.EstimatedSizeMB,
+                IsRecommended = model.IsRecommended,
+                LanguageCount = 14
+            })
+            .ToArray();
 
     /// <summary>
     /// Gets the currently selected model identifier.
@@ -170,9 +170,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
         _assets.SetHuggingFaceToken(_huggingFaceToken);
 
         var persistedModel = host.GetSetting<string>("selectedModel");
-        _selectedModelId = string.Equals(persistedModel, ModelId, StringComparison.Ordinal)
-            ? persistedModel
-            : ModelId;
+        _selectedModelId = CohereModelCatalog.Contains(persistedModel) ? persistedModel : ModelId;
 
         host.Log(
             PluginLogLevel.Info,
@@ -196,7 +194,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
     public UserControl? CreateSettingsView() => new CohereTranscribeSettingsView(this);
 
     /// <summary>
-    /// Selects the single Cohere Transcribe model.
+    /// Selects a Cohere Transcribe quantization.
     /// </summary>
     public void SelectModel(string modelId)
     {
@@ -211,7 +209,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
     public bool IsModelDownloaded(string modelId)
     {
         ValidateModelId(modelId);
-        return _assets?.IsModelInstalled() == true;
+        return _assets?.IsModelInstalled(modelId) == true;
     }
 
     /// <summary>
@@ -236,7 +234,8 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
 
             var candidates = GetBackendCandidatesForCurrentMachine(_accelerationPreference);
             var initialBackend = candidates[0];
-            var totalBytes = assets.ModelTransferSize + assets.GetRuntimeTransferSize(initialBackend);
+            var modelTransferSize = assets.GetModelTransferSize(modelId);
+            var totalBytes = modelTransferSize + assets.GetRuntimeTransferSize(initialBackend);
 
             var modelProgress = progress is null
                 ? null
@@ -245,7 +244,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
                         ? 0
                         : Math.Clamp((double)value.BytesTransferred / totalBytes, 0, 1)));
 
-            await assets.EnsureModelAsync(modelProgress, cancellationToken);
+            await assets.EnsureModelAsync(modelId, modelProgress, cancellationToken);
 
             Exception? lastError = null;
             foreach (var backend in candidates)
@@ -253,12 +252,12 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
                 try
                 {
                     var runtimeSize = assets.GetRuntimeTransferSize(backend);
-                    var runtimeTotal = assets.ModelTransferSize + runtimeSize;
+                    var runtimeTotal = modelTransferSize + runtimeSize;
                     var runtimeProgress = progress is null
                         ? null
                         : new Progress<ArtifactTransferProgress>(value =>
                             progress.Report(Math.Clamp(
-                                (double)(assets.ModelTransferSize + value.BytesTransferred) / runtimeTotal,
+                                (double)(modelTransferSize + value.BytesTransferred) / runtimeTotal,
                                 0,
                                 1)));
 
@@ -301,7 +300,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
         EnsureSupportedPlatform();
 
         var assets = GetAssets();
-        if (!assets.IsModelInstalled())
+        if (!assets.IsModelInstalled(modelId))
         {
             throw new FileNotFoundException(
                 "Cohere Transcribe model files are not downloaded. Download the model first.");
@@ -336,8 +335,9 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
                         "Starting the local Cohere Transcribe runtime.");
 
                     var configuration = new CrispAsrServerConfiguration(
+                        modelId,
                         assets.GetRuntimeExecutablePath(backend),
-                        assets.GetModelPaths(),
+                        assets.GetModelPaths(modelId),
                         backend,
                         GetRecommendedThreadCount(Environment.ProcessorCount));
 
@@ -741,7 +741,7 @@ public sealed class CohereTranscribePlugin : ITranscriptionEnginePlugin
 
     private static void ValidateModelId(string modelId)
     {
-        if (!string.Equals(modelId, ModelId, StringComparison.Ordinal))
+        if (!CohereModelCatalog.Contains(modelId))
             throw new ArgumentException($"Unknown model: {modelId}", nameof(modelId));
     }
 

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -1,9 +1,12 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
 using TypeWhisper.PluginSDK.Models;
@@ -34,6 +37,8 @@ internal interface ICrispAsrServer : IDisposable
 
 internal sealed class CrispAsrServer : ICrispAsrServer
 {
+    private const int ErrorSuccess = 0;
+    private const int ErrorInsufficientBuffer = 122;
     private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(10);
 
@@ -202,11 +207,58 @@ internal sealed class CrispAsrServer : ICrispAsrServer
         int port,
         string apiKey)
     {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var packageFamilyName = TryGetCurrentPackageFamilyName();
+        var executablePath = ResolveUnpackagedChildPath(
+            configuration.ExecutablePath,
+            localAppData,
+            packageFamilyName);
+        var modelPath = ResolveUnpackagedChildPath(
+            configuration.ModelPaths.ModelPath,
+            localAppData,
+            packageFamilyName);
+        var languageIdModelPath = ResolveUnpackagedChildPath(
+            configuration.ModelPaths.LanguageIdModelPath,
+            localAppData,
+            packageFamilyName);
+        var vadModelPath = ResolveUnpackagedChildPath(
+            configuration.ModelPaths.VadModelPath,
+            localAppData,
+            packageFamilyName);
+        var cacheDirectory = ResolveUnpackagedChildPath(
+            configuration.ModelPaths.CacheDirectory,
+            localAppData,
+            packageFamilyName);
+        var runtimeDirectory = Path.GetDirectoryName(executablePath)
+            ?? AppContext.BaseDirectory;
+        var backend = GetBackendName(configuration.Backend);
+        var command =
+            "\"\"%TYPEWHISPER_CRISPASR_EXECUTABLE%\""
+            + " --server"
+            + " --backend cohere"
+            + " --model \"%TYPEWHISPER_CRISPASR_MODEL%\""
+            + " --host 127.0.0.1"
+            + $" --port {port.ToString(CultureInfo.InvariantCulture)}"
+            + " --language auto"
+            + " --lid-backend ecapa"
+            + " --lid-model \"%TYPEWHISPER_CRISPASR_LID_MODEL%\""
+            + " --vad"
+            + " --vad-model \"%TYPEWHISPER_CRISPASR_VAD_MODEL%\""
+            + " --strict-pipeline"
+            + " --require-vad"
+            + $" --threads {configuration.ThreadCount.ToString(CultureInfo.InvariantCulture)}"
+            + $" --gpu-backend {backend}"
+            + (configuration.Backend == CrispAsrBackend.Cpu ? " --no-gpu" : string.Empty)
+            + "\"";
+
         var startInfo = new ProcessStartInfo
         {
-            FileName = configuration.ExecutablePath,
-            WorkingDirectory = Path.GetDirectoryName(configuration.ExecutablePath)
-                ?? AppContext.BaseDirectory,
+            // An executable launched directly by an MSIX desktop process inherits
+            // its packaged DLL search order. The intermediate command process makes
+            // CrispASR a grandchild, which Windows starts outside that environment.
+            FileName = Path.Join(Environment.SystemDirectory, "cmd.exe"),
+            Arguments = $"/d /s /v:off /c {command}",
+            WorkingDirectory = runtimeDirectory,
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -214,27 +266,67 @@ internal sealed class CrispAsrServer : ICrispAsrServer
             WindowStyle = ProcessWindowStyle.Hidden
         };
 
-        AddArgument(startInfo, "--server");
-        AddArgument(startInfo, "--backend", "cohere");
-        AddArgument(startInfo, "--model", configuration.ModelPaths.ModelPath);
-        AddArgument(startInfo, "--host", "127.0.0.1");
-        AddArgument(startInfo, "--port", port.ToString());
-        AddArgument(startInfo, "--language", "auto");
-        AddArgument(startInfo, "--lid-backend", "ecapa");
-        AddArgument(startInfo, "--lid-model", configuration.ModelPaths.LanguageIdModelPath);
-        AddArgument(startInfo, "--vad");
-        AddArgument(startInfo, "--vad-model", configuration.ModelPaths.VadModelPath);
-        AddArgument(startInfo, "--strict-pipeline");
-        AddArgument(startInfo, "--require-vad");
-        AddArgument(startInfo, "--threads", configuration.ThreadCount.ToString());
-        AddArgument(startInfo, "--gpu-backend", GetBackendName(configuration.Backend));
-
-        if (configuration.Backend == CrispAsrBackend.Cpu)
-            AddArgument(startInfo, "--no-gpu");
-
         startInfo.Environment["CRISPASR_API_KEYS"] = apiKey;
-        startInfo.Environment["CRISPASR_CACHE_DIR"] = configuration.ModelPaths.CacheDirectory;
+        startInfo.Environment["CRISPASR_CACHE_DIR"] = cacheDirectory;
+        startInfo.Environment["TYPEWHISPER_CRISPASR_EXECUTABLE"] = executablePath;
+        startInfo.Environment["TYPEWHISPER_CRISPASR_MODEL"] = modelPath;
+        startInfo.Environment["TYPEWHISPER_CRISPASR_LID_MODEL"] = languageIdModelPath;
+        startInfo.Environment["TYPEWHISPER_CRISPASR_VAD_MODEL"] = vadModelPath;
         return startInfo;
+    }
+
+    internal static string ResolveUnpackagedChildPath(
+        string path,
+        string localAppData,
+        string? packageFamilyName)
+    {
+        var resolvedPath = Path.GetFullPath(path);
+        if (string.IsNullOrWhiteSpace(localAppData) || string.IsNullOrWhiteSpace(packageFamilyName))
+            return resolvedPath;
+
+        var localAppDataRoot = Path.GetFullPath(localAppData);
+        var physicalLocalAppDataRoot = Path.Join(
+            localAppDataRoot,
+            "Packages",
+            packageFamilyName,
+            "LocalCache",
+            "Local");
+
+        if (IsSameOrUnderDirectory(resolvedPath, physicalLocalAppDataRoot)
+            || !IsSameOrUnderDirectory(resolvedPath, localAppDataRoot))
+        {
+            return resolvedPath;
+        }
+
+        return Path.Join(
+            physicalLocalAppDataRoot,
+            Path.GetRelativePath(localAppDataRoot, resolvedPath));
+    }
+
+    private static bool IsSameOrUnderDirectory(string path, string directory)
+    {
+        var normalizedDirectory = directory.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar);
+        return path.Equals(normalizedDirectory, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith(
+                normalizedDirectory + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? TryGetCurrentPackageFamilyName()
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        uint length = 0;
+        var result = GetCurrentPackageFamilyName(ref length, null);
+        if (result != ErrorInsufficientBuffer || length == 0)
+            return null;
+
+        var familyName = new StringBuilder((int)length);
+        result = GetCurrentPackageFamilyName(ref length, familyName);
+        return result == ErrorSuccess ? familyName.ToString() : null;
     }
 
     private async Task WaitUntilReadyAsync(
@@ -316,9 +408,8 @@ internal sealed class CrispAsrServer : ICrispAsrServer
             _ => throw new ArgumentOutOfRangeException(nameof(backend), backend, null)
         };
 
-    private static void AddArgument(ProcessStartInfo startInfo, params string[] values)
-    {
-        foreach (var value in values)
-            startInfo.ArgumentList.Add(value);
-    }
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetCurrentPackageFamilyName(
+        ref uint packageFamilyNameLength,
+        StringBuilder? packageFamilyName);
 }

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -309,6 +309,9 @@ internal sealed class CrispAsrServer : ICrispAsrServer
 
     private static string? TryGetPhysicalLocalAppData()
     {
+        if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+            return null;
+
         try
         {
             var localCachePath = ApplicationData.Current.LocalCacheFolder.Path;

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -6,10 +6,10 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Text;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
 using TypeWhisper.PluginSDK.Models;
+using Windows.Storage;
 
 namespace TypeWhisper.Plugin.CohereTranscribe;
 
@@ -37,8 +37,6 @@ internal interface ICrispAsrServer : IDisposable
 
 internal sealed class CrispAsrServer : ICrispAsrServer
 {
-    private const int ErrorSuccess = 0;
-    private const int ErrorInsufficientBuffer = 122;
     private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(10);
 
@@ -208,27 +206,27 @@ internal sealed class CrispAsrServer : ICrispAsrServer
         string apiKey)
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var packageFamilyName = TryGetCurrentPackageFamilyName();
+        var physicalLocalAppData = TryGetPhysicalLocalAppData();
         var executablePath = ResolveUnpackagedChildPath(
             configuration.ExecutablePath,
             localAppData,
-            packageFamilyName);
+            physicalLocalAppData);
         var modelPath = ResolveUnpackagedChildPath(
             configuration.ModelPaths.ModelPath,
             localAppData,
-            packageFamilyName);
+            physicalLocalAppData);
         var languageIdModelPath = ResolveUnpackagedChildPath(
             configuration.ModelPaths.LanguageIdModelPath,
             localAppData,
-            packageFamilyName);
+            physicalLocalAppData);
         var vadModelPath = ResolveUnpackagedChildPath(
             configuration.ModelPaths.VadModelPath,
             localAppData,
-            packageFamilyName);
+            physicalLocalAppData);
         var cacheDirectory = ResolveUnpackagedChildPath(
             configuration.ModelPaths.CacheDirectory,
             localAppData,
-            packageFamilyName);
+            physicalLocalAppData);
         var runtimeDirectory = Path.GetDirectoryName(executablePath)
             ?? AppContext.BaseDirectory;
         var backend = GetBackendName(configuration.Backend);
@@ -278,19 +276,14 @@ internal sealed class CrispAsrServer : ICrispAsrServer
     internal static string ResolveUnpackagedChildPath(
         string path,
         string localAppData,
-        string? packageFamilyName)
+        string? physicalLocalAppData)
     {
         var resolvedPath = Path.GetFullPath(path);
-        if (string.IsNullOrWhiteSpace(localAppData) || string.IsNullOrWhiteSpace(packageFamilyName))
+        if (string.IsNullOrWhiteSpace(localAppData) || string.IsNullOrWhiteSpace(physicalLocalAppData))
             return resolvedPath;
 
         var localAppDataRoot = Path.GetFullPath(localAppData);
-        var physicalLocalAppDataRoot = Path.Join(
-            localAppDataRoot,
-            "Packages",
-            packageFamilyName,
-            "LocalCache",
-            "Local");
+        var physicalLocalAppDataRoot = Path.GetFullPath(physicalLocalAppData);
 
         if (IsSameOrUnderDirectory(resolvedPath, physicalLocalAppDataRoot)
             || !IsSameOrUnderDirectory(resolvedPath, localAppDataRoot))
@@ -314,19 +307,20 @@ internal sealed class CrispAsrServer : ICrispAsrServer
                 StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string? TryGetCurrentPackageFamilyName()
+    private static string? TryGetPhysicalLocalAppData()
     {
-        if (!OperatingSystem.IsWindows())
+        try
+        {
+            var localCachePath = ApplicationData.Current.LocalCacheFolder.Path;
+            return string.IsNullOrWhiteSpace(localCachePath)
+                ? null
+                : Path.Join(localCachePath, "Local");
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or COMException)
+        {
             return null;
-
-        uint length = 0;
-        var result = GetCurrentPackageFamilyName(ref length, null);
-        if (result != ErrorInsufficientBuffer || length == 0)
-            return null;
-
-        var familyName = new StringBuilder((int)length);
-        result = GetCurrentPackageFamilyName(ref length, familyName);
-        return result == ErrorSuccess ? familyName.ToString() : null;
+        }
     }
 
     private async Task WaitUntilReadyAsync(
@@ -408,8 +402,4 @@ internal sealed class CrispAsrServer : ICrispAsrServer
             _ => throw new ArgumentOutOfRangeException(nameof(backend), backend, null)
         };
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-    private static extern int GetCurrentPackageFamilyName(
-        ref uint packageFamilyNameLength,
-        StringBuilder? packageFamilyName);
 }

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -240,6 +240,8 @@ internal sealed class CrispAsrServer : ICrispAsrServer
         var runtimeDirectory = Path.GetDirectoryName(executablePath)
             ?? AppContext.BaseDirectory;
         var backend = GetBackendName(configuration.Backend);
+        // cmd.exe /s strips the outermost quote pair. The doubled leading quote
+        // preserves the executable's quoted path, including paths with spaces.
         var command =
             "\"\"%TYPEWHISPER_CRISPASR_EXECUTABLE%\""
             + " --server"

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/CrispAsrServer.cs
@@ -14,6 +14,7 @@ using Windows.Storage;
 namespace TypeWhisper.Plugin.CohereTranscribe;
 
 internal sealed record CrispAsrServerConfiguration(
+    string ModelId,
     string ExecutablePath,
     CohereModelPaths ModelPaths,
     CrispAsrBackend Backend,
@@ -49,6 +50,7 @@ internal sealed class CrispAsrServer : ICrispAsrServer
     private WindowsProcessJob? _processJob;
     private string? _baseUrl;
     private string? _apiKey;
+    private string? _modelId;
 
     internal CrispAsrServer(Action<PluginLogLevel, string> log)
     {
@@ -108,6 +110,7 @@ internal sealed class CrispAsrServer : ICrispAsrServer
             await WaitUntilReadyAsync(process, _baseUrl, timeout.Token);
 
             ActiveBackend = configuration.Backend;
+            _modelId = configuration.ModelId;
             _log(
                 PluginLogLevel.Info,
                 $"CrispASR {CohereLocalAssetManager.CrispAsrVersion} is ready on loopback using {GetBackendName(configuration.Backend)}.");
@@ -134,8 +137,14 @@ internal sealed class CrispAsrServer : ICrispAsrServer
         string? language,
         CancellationToken cancellationToken)
     {
-        if (!IsRunning || _baseUrl is null || _apiKey is null || _process is null)
+        if (!IsRunning
+            || _baseUrl is null
+            || _apiKey is null
+            || _modelId is null
+            || _process is null)
+        {
             throw new InvalidOperationException("The local Cohere Transcribe model is not loaded.");
+        }
 
         if (_process.HasExited)
         {
@@ -147,7 +156,7 @@ internal sealed class CrispAsrServer : ICrispAsrServer
             _httpClient,
             _baseUrl,
             _apiKey,
-            CohereTranscribePlugin.ModelId,
+            _modelId,
             wavAudio,
             language,
             translate: false,
@@ -164,6 +173,7 @@ internal sealed class CrispAsrServer : ICrispAsrServer
         _processJob = null;
         _baseUrl = null;
         _apiKey = null;
+        _modelId = null;
         ActiveBackend = null;
 
         if (process is null)

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.19041.57</WindowsSdkPackageVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -10,6 +11,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+    <FrameworkReference Include="Microsoft.Windows.SDK.NET.Ref" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/TypeWhisper.Plugin.CohereTranscribe.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/plugins/TypeWhisper.Plugin.CohereTranscribe/manifest.json
+++ b/plugins/TypeWhisper.Plugin.CohereTranscribe/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.cohere-transcribe",
   "name": "Cohere Transcribe (Local)",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minHostVersion": "1.0.6",
   "author": "TypeWhisper",
   "description": "Offline Cohere Transcribe inference via a managed local CrispASR runtime",

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -46,14 +46,14 @@ public sealed class CohereTranscribePluginTests
 
         Assert.Equal(
             [
-                CohereModelCatalog.Q4KModelId,
-                CohereModelCatalog.DefaultModelId,
-                CohereModelCatalog.Q6KModelId,
-                CohereModelCatalog.Q8ModelId
+                "cohere-transcribe-03-2026-q4_k",
+                "cohere-transcribe-03-2026-q5_0",
+                "cohere-transcribe-03-2026-q6_k",
+                "cohere-transcribe-03-2026-q8_0"
             ],
             models.Select(model => model.Id));
         Assert.Equal(
-            CohereTranscribePlugin.ModelId,
+            "cohere-transcribe-03-2026-q5_0",
             Assert.Single(models, model => model.IsRecommended).Id);
         Assert.All(models, model => Assert.Equal(14, model.LanguageCount));
         Assert.Equal(14, sut.SupportedLanguages.Count);
@@ -65,36 +65,96 @@ public sealed class CohereTranscribePluginTests
     [Fact]
     public void DownloadDefinitions_AreRevisionPinnedAndSha256Pinned()
     {
-        Assert.Equal(4, CohereModelCatalog.All.Count);
-        Assert.All(
-            CohereModelCatalog.All,
-            model => Assert.Contains(
-                CohereLocalAssetManager.CohereModelRevision,
-                model.Artifact.DownloadUrl));
-        Assert.Contains(
-            CohereLocalAssetManager.VadModelRevision,
-            CohereLocalAssetManager.VadModel.DownloadUrl);
-        Assert.Contains(
-            CohereLocalAssetManager.LanguageIdModelRevision,
-            CohereLocalAssetManager.LanguageIdModel.DownloadUrl);
+        const string modelRoot =
+            "https://huggingface.co/cstr/cohere-transcribe-03-2026-GGUF/resolve/"
+            + "2242638d5dfecc6f1dbe6c3a8713b97deb2e150f/";
+        var expectedModels = new (string Id, RemoteArtifact Artifact)[]
+        {
+            (
+                "cohere-transcribe-03-2026-q4_k",
+                new RemoteArtifact(
+                    "cohere-transcribe-q4_k.gguf",
+                    modelRoot + "cohere-transcribe-q4_k.gguf",
+                    1_510_362_752,
+                    "2931fc0ac6d6708eef5389aadf1ebd5eec7b8e764bac385be585e910c0e7b410")),
+            (
+                "cohere-transcribe-03-2026-q5_0",
+                new RemoteArtifact(
+                    "cohere-transcribe-q5_0.gguf",
+                    modelRoot + "cohere-transcribe-q5_0.gguf",
+                    1_738_722_944,
+                    "a09696c5cc2ed5052bf290c4f2beb35abc69c0d6986842042d92bebb22c9184e")),
+            (
+                "cohere-transcribe-03-2026-q6_k",
+                new RemoteArtifact(
+                    "cohere-transcribe-q6_k.gguf",
+                    modelRoot + "cohere-transcribe-q6_k.gguf",
+                    1_981_355_648,
+                    "0ad2634e0ba34efa38a47d4fd4cf34d7a2d738d8486d83b8d5a178f823109c52")),
+            (
+                "cohere-transcribe-03-2026-q8_0",
+                new RemoteArtifact(
+                    "cohere-transcribe-q8_0.gguf",
+                    modelRoot + "cohere-transcribe-q8_0.gguf",
+                    2_423_803_520,
+                    "c8620cb182a7c04e311e6c24e478b94f7ecd7f1b5230bf39fffa8daf94644f51"))
+        };
+        var actualModels = CohereModelCatalog.All
+            .Select(model => (model.Id, model.Artifact))
+            .ToArray();
 
-        Assert.All(
-            CohereModelCatalog.All
-                .Select(model => model.Artifact)
-                .Concat(
-                [
-                    CohereLocalAssetManager.VadModel,
-                    CohereLocalAssetManager.LanguageIdModel,
-                    CohereLocalAssetManager.CpuRuntime.Archive,
-                    CohereLocalAssetManager.CudaRuntime.Archive,
-                    CohereLocalAssetManager.VulkanRuntime.Archive
-                ]),
-            artifact =>
-            {
-                Assert.Equal(64, artifact.Sha256.Length);
-                Assert.True(artifact.SizeBytes > 0);
-                Assert.StartsWith("https://", artifact.DownloadUrl);
-            });
+        Assert.Equal(expectedModels, actualModels);
+        Assert.Equal(
+            new RemoteArtifact(
+                "ggml-silero-v6.2.0.bin",
+                "https://huggingface.co/ggml-org/whisper-vad/resolve/"
+                + "9ffd54a1e1ee413ddf265af9913beaf518d1639b/"
+                + "ggml-silero-v6.2.0.bin",
+                885_098,
+                "2aa269b785eeb53a82983a20501ddf7c1d9c48e33ab63a41391ac6c9f7fb6987"),
+            CohereLocalAssetManager.VadModel);
+        Assert.Equal(
+            new RemoteArtifact(
+                "ecapa-lid-107-f16.gguf",
+                "https://huggingface.co/cstr/ecapa-lid-107-GGUF/resolve/"
+                + "95fb0613bf78c6e48305fccd9ce023ac15f0b5a6/"
+                + "ecapa-lid-107-f16.gguf",
+                42_838_944,
+                "59db30ba67cec2f36304f794420779c181124332246f75fc66c349f184110340"),
+            CohereLocalAssetManager.LanguageIdModel);
+        Assert.Equal(
+            new RuntimePackage(
+                CrispAsrBackend.Cpu,
+                "cpu",
+                new RemoteArtifact(
+                    "crispasr-windows-x86_64-cpu.zip",
+                    "https://github.com/CrispStrobe/CrispASR/releases/download/"
+                    + "v0.8.24/crispasr-windows-x86_64-cpu.zip",
+                    7_635_428,
+                    "a05456c9adac276289060ae83bd77ed7b4d87ccfd447aed804e497d76e73f8f8")),
+            CohereLocalAssetManager.CpuRuntime);
+        Assert.Equal(
+            new RuntimePackage(
+                CrispAsrBackend.Cuda,
+                "cuda",
+                new RemoteArtifact(
+                    "crispasr-windows-x86_64-cuda.zip",
+                    "https://github.com/CrispStrobe/CrispASR/releases/download/"
+                    + "v0.8.24/crispasr-windows-x86_64-cuda.zip",
+                    729_126_487,
+                    "832af6218508ac52fc71ac5653c433786bdfae81f775e2c77bfefd05df6f255b")),
+            CohereLocalAssetManager.CudaRuntime);
+        Assert.Equal(
+            new RuntimePackage(
+                CrispAsrBackend.Vulkan,
+                "vulkan",
+                new RemoteArtifact(
+                    "crispasr-windows-x86_64-vulkan.zip",
+                    "https://github.com/CrispStrobe/CrispASR/releases/download/"
+                    + "v0.8.24/crispasr-windows-x86_64-vulkan.zip",
+                    35_580_185,
+                    "70956638045042b49f61f9f04ee9ceae9fc8b450f6f56a10fc98c2088207628a")),
+            CohereLocalAssetManager.VulkanRuntime);
     }
 
     [Fact]
@@ -380,7 +440,9 @@ public sealed class CohereTranscribePluginTests
         Assert.Contains("--require-vad", arguments);
         Assert.DoesNotContain("--api-keys", arguments);
         Assert.DoesNotContain(apiKey, arguments);
+        Assert.Equal(@"C:\runtime", startInfo.WorkingDirectory);
         Assert.Equal(apiKey, startInfo.Environment["CRISPASR_API_KEYS"]);
+        Assert.Equal(paths.CacheDirectory, startInfo.Environment["CRISPASR_CACHE_DIR"]);
         Assert.Equal(
             configuration.ExecutablePath,
             startInfo.Environment["TYPEWHISPER_CRISPASR_EXECUTABLE"]);
@@ -505,6 +567,7 @@ public sealed class CohereTranscribePluginTests
         using var sut = new CohereTranscribePlugin(assets, server);
         var host = new FakePluginHostServices(temp.Path);
         var downloadProgress = new List<double>();
+        var expectedModelPath = assets.GetModelPaths(modelId).ModelPath;
 
         await sut.ActivateAsync(host);
         sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Cpu);
@@ -524,6 +587,7 @@ public sealed class CohereTranscribePluginTests
         Assert.Equal(modelId, assets.LastEnsuredModelId);
         Assert.Equal([CrispAsrBackend.Cpu], assets.EnsuredRuntimes);
         Assert.Equal(modelId, server.LastConfiguration?.ModelId);
+        Assert.Equal(expectedModelPath, server.LastConfiguration?.ModelPaths.ModelPath);
         Assert.Equal(CrispAsrBackend.Cpu, server.LastConfiguration?.Backend);
         Assert.Equal("de", server.LastLanguage);
         Assert.Equal("lokal", result.Text);

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -342,6 +342,12 @@ public sealed class CohereTranscribePluginTests
     {
         const string localAppData = @"C:\Users\tester\AppData\Local";
         const string packageFamilyName = "TypeWhisper.TypeWhisper_51tqb5623pxja";
+        var physicalLocalAppData = Path.Join(
+            localAppData,
+            "Packages",
+            packageFamilyName,
+            "LocalCache",
+            "Local");
         var logicalPath = Path.Join(
             localAppData,
             "TypeWhisper-UserData",
@@ -350,11 +356,7 @@ public sealed class CohereTranscribePluginTests
             "runtime",
             "crispasr.exe");
         var physicalPath = Path.Join(
-            localAppData,
-            "Packages",
-            packageFamilyName,
-            "LocalCache",
-            "Local",
+            physicalLocalAppData,
             Path.GetRelativePath(localAppData, logicalPath));
 
         Assert.Equal(
@@ -362,19 +364,19 @@ public sealed class CohereTranscribePluginTests
             CrispAsrServer.ResolveUnpackagedChildPath(
                 logicalPath,
                 localAppData,
-                packageFamilyName));
+                physicalLocalAppData));
         Assert.Equal(
             physicalPath,
             CrispAsrServer.ResolveUnpackagedChildPath(
                 physicalPath,
                 localAppData,
-                packageFamilyName));
+                physicalLocalAppData));
         Assert.Equal(
             @"D:\Models\cohere.gguf",
             CrispAsrServer.ResolveUnpackagedChildPath(
                 @"D:\Models\cohere.gguf",
                 localAppData,
-                packageFamilyName));
+                physicalLocalAppData));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -608,6 +608,71 @@ public sealed class CohereTranscribePluginTests
     }
 
     [Fact]
+    public async Task TranscribeAsync_RestartsUnexpectedlyStoppedSidecar()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        var server = new FakeCrispAsrServer();
+        using var sut = new CohereTranscribePlugin(assets, server);
+        var host = new FakePluginHostServices(temp.Path);
+
+        await sut.ActivateAsync(host);
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Cpu);
+        await sut.DownloadModelAsync(
+            CohereModelCatalog.DefaultModelId,
+            progress: null,
+            CancellationToken.None);
+        await sut.LoadModelAsync(CohereModelCatalog.DefaultModelId, CancellationToken.None);
+        Assert.Equal(1, server.StartCount);
+
+        await server.StopAsync();
+        Assert.Equal("Not loaded", sut.AccelerationStatus.DisplayText);
+
+        var result = await sut.TranscribeAsync(
+            [1, 2, 3],
+            "de",
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+
+        Assert.Equal("lokal", result.Text);
+        Assert.True(server.IsRunning);
+        Assert.Equal(2, server.StartCount);
+        Assert.Equal(CohereModelCatalog.DefaultModelId, server.LastConfiguration?.ModelId);
+        Assert.Equal("Using CPU", sut.AccelerationStatus.DisplayText);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_RestartsSidecarThatExitsDuringRequest()
+    {
+        using var temp = new TempDirectory();
+        var assets = new FakeAssetManager();
+        var server = new FakeCrispAsrServer();
+        using var sut = new CohereTranscribePlugin(assets, server);
+
+        await sut.ActivateAsync(new FakePluginHostServices(temp.Path));
+        sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Cpu);
+        await sut.DownloadModelAsync(
+            CohereModelCatalog.DefaultModelId,
+            progress: null,
+            CancellationToken.None);
+        await sut.LoadModelAsync(CohereModelCatalog.DefaultModelId, CancellationToken.None);
+        server.FailNextTranscriptionAndStop = true;
+
+        var result = await sut.TranscribeAsync(
+            [1, 2, 3],
+            "de",
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+
+        Assert.Equal("lokal", result.Text);
+        Assert.True(server.IsRunning);
+        Assert.Equal(2, server.StartCount);
+        Assert.Equal("Using CPU", sut.AccelerationStatus.DisplayText);
+    }
+
+    [Fact]
     public async Task PluginLifecycle_LoadsStoresAndRemovesOptionalHuggingFaceToken()
     {
         using var temp = new TempDirectory();
@@ -888,11 +953,14 @@ public sealed class CohereTranscribePluginTests
         public CrispAsrBackend? ActiveBackend { get; private set; }
         public CrispAsrServerConfiguration? LastConfiguration { get; private set; }
         public string? LastLanguage { get; private set; }
+        public int StartCount { get; private set; }
+        public bool FailNextTranscriptionAndStop { get; set; }
 
         public Task StartAsync(
             CrispAsrServerConfiguration configuration,
             CancellationToken cancellationToken)
         {
+            StartCount++;
             LastConfiguration = configuration;
             ActiveBackend = configuration.Backend;
             IsRunning = true;
@@ -905,6 +973,14 @@ public sealed class CohereTranscribePluginTests
             CancellationToken cancellationToken)
         {
             LastLanguage = language;
+            if (FailNextTranscriptionAndStop)
+            {
+                FailNextTranscriptionAndStop = false;
+                IsRunning = false;
+                ActiveBackend = null;
+                throw new HttpRequestException("CrispASR stopped during transcription.");
+            }
+
             return Task.FromResult(new PluginTranscriptionResult("lokal", language, 1, null));
         }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -39,14 +39,23 @@ public sealed class CohereTranscribePluginTests
     }
 
     [Fact]
-    public void ModelMetadata_ExposesPinnedBalancedModelAndFourteenLanguages()
+    public void ModelMetadata_ExposesFourPinnedQuantizationsAndFourteenLanguages()
     {
         var sut = new CohereTranscribePlugin();
-        var model = Assert.Single(sut.TranscriptionModels);
+        var models = sut.TranscriptionModels;
 
-        Assert.Equal(CohereTranscribePlugin.ModelId, model.Id);
-        Assert.True(model.IsRecommended);
-        Assert.Equal(14, model.LanguageCount);
+        Assert.Equal(
+            [
+                CohereModelCatalog.Q4KModelId,
+                CohereModelCatalog.DefaultModelId,
+                CohereModelCatalog.Q6KModelId,
+                CohereModelCatalog.Q8ModelId
+            ],
+            models.Select(model => model.Id));
+        Assert.Equal(
+            CohereTranscribePlugin.ModelId,
+            Assert.Single(models, model => model.IsRecommended).Id);
+        Assert.All(models, model => Assert.Equal(14, model.LanguageCount));
         Assert.Equal(14, sut.SupportedLanguages.Count);
         Assert.Contains("de", sut.SupportedLanguages);
         Assert.Contains("ja", sut.SupportedLanguages);
@@ -56,9 +65,12 @@ public sealed class CohereTranscribePluginTests
     [Fact]
     public void DownloadDefinitions_AreRevisionPinnedAndSha256Pinned()
     {
-        Assert.Contains(
-            CohereLocalAssetManager.CohereModelRevision,
-            CohereLocalAssetManager.CohereModel.DownloadUrl);
+        Assert.Equal(4, CohereModelCatalog.All.Count);
+        Assert.All(
+            CohereModelCatalog.All,
+            model => Assert.Contains(
+                CohereLocalAssetManager.CohereModelRevision,
+                model.Artifact.DownloadUrl));
         Assert.Contains(
             CohereLocalAssetManager.VadModelRevision,
             CohereLocalAssetManager.VadModel.DownloadUrl);
@@ -67,21 +79,62 @@ public sealed class CohereTranscribePluginTests
             CohereLocalAssetManager.LanguageIdModel.DownloadUrl);
 
         Assert.All(
-            new[]
-            {
-                CohereLocalAssetManager.CohereModel,
-                CohereLocalAssetManager.VadModel,
-                CohereLocalAssetManager.LanguageIdModel,
-                CohereLocalAssetManager.CpuRuntime.Archive,
-                CohereLocalAssetManager.CudaRuntime.Archive,
-                CohereLocalAssetManager.VulkanRuntime.Archive
-            },
+            CohereModelCatalog.All
+                .Select(model => model.Artifact)
+                .Concat(
+                [
+                    CohereLocalAssetManager.VadModel,
+                    CohereLocalAssetManager.LanguageIdModel,
+                    CohereLocalAssetManager.CpuRuntime.Archive,
+                    CohereLocalAssetManager.CudaRuntime.Archive,
+                    CohereLocalAssetManager.VulkanRuntime.Archive
+                ]),
             artifact =>
             {
                 Assert.Equal(64, artifact.Sha256.Length);
                 Assert.True(artifact.SizeBytes > 0);
                 Assert.StartsWith("https://", artifact.DownloadUrl);
             });
+    }
+
+    [Fact]
+    public void ModelPaths_KeepQuantizationsSeparateAndReuseAuxiliaryModels()
+    {
+        using var temp = new TempDirectory();
+        using var sut = new CohereLocalAssetManager(temp.Path);
+
+        var paths = CohereModelCatalog.All
+            .ToDictionary(model => model.Id, model => sut.GetModelPaths(model.Id));
+        var defaultPaths = paths[CohereModelCatalog.DefaultModelId];
+
+        Assert.Equal(
+            CohereModelCatalog.All.Select(model => model.Artifact.FileName),
+            CohereModelCatalog.All.Select(model => Path.GetFileName(paths[model.Id].ModelPath)));
+        Assert.Equal(
+            CohereModelCatalog.All.Count,
+            paths.Values.Select(path => path.ModelPath).Distinct(StringComparer.Ordinal).Count());
+        Assert.All(
+            paths.Values,
+            path =>
+            {
+                Assert.Equal(defaultPaths.VadModelPath, path.VadModelPath);
+                Assert.Equal(defaultPaths.LanguageIdModelPath, path.LanguageIdModelPath);
+                Assert.Equal(defaultPaths.CacheDirectory, path.CacheDirectory);
+            });
+    }
+
+    [Fact]
+    public void SelectModel_AcceptsPublishedQuantizationsAndRejectsUnknownIds()
+    {
+        using var sut = new CohereTranscribePlugin();
+
+        foreach (var model in CohereModelCatalog.All)
+        {
+            sut.SelectModel(model.Id);
+            Assert.Equal(model.Id, sut.SelectedModelId);
+        }
+
+        Assert.Throws<ArgumentException>(() => sut.SelectModel("cohere-unknown"));
     }
 
     [Fact]
@@ -302,6 +355,7 @@ public sealed class CohereTranscribePluginTests
             @"C:\models\lid.gguf",
             @"C:\models\cache");
         var configuration = new CrispAsrServerConfiguration(
+            CohereTranscribePlugin.ModelId,
             @"C:\runtime\crispasr.exe",
             paths,
             CrispAsrBackend.Cuda,
@@ -438,8 +492,12 @@ public sealed class CohereTranscribePluginTests
         Assert.False(File.Exists(escapedPath));
     }
 
-    [Fact]
-    public async Task PluginLifecycle_UsesManagedCpuRuntimeAndNormalizesLanguage()
+    [Theory]
+    [InlineData(CohereModelCatalog.Q4KModelId)]
+    [InlineData(CohereModelCatalog.DefaultModelId)]
+    [InlineData(CohereModelCatalog.Q6KModelId)]
+    [InlineData(CohereModelCatalog.Q8ModelId)]
+    public async Task PluginLifecycle_UsesSelectedQuantizationAndManagedCpuRuntime(string modelId)
     {
         using var temp = new TempDirectory();
         var assets = new FakeAssetManager();
@@ -451,10 +509,10 @@ public sealed class CohereTranscribePluginTests
         await sut.ActivateAsync(host);
         sut.SetAccelerationPreference(TranscriptionAccelerationPreference.Cpu);
         await sut.DownloadModelAsync(
-            CohereTranscribePlugin.ModelId,
+            modelId,
             new InlineProgress<double>(downloadProgress.Add),
             CancellationToken.None);
-        await sut.LoadModelAsync(CohereTranscribePlugin.ModelId, CancellationToken.None);
+        await sut.LoadModelAsync(modelId, CancellationToken.None);
         var result = await sut.TranscribeAsync(
             [1, 2, 3],
             "de-DE",
@@ -463,7 +521,9 @@ public sealed class CohereTranscribePluginTests
             CancellationToken.None);
 
         Assert.True(assets.ModelInstalled);
+        Assert.Equal(modelId, assets.LastEnsuredModelId);
         Assert.Equal([CrispAsrBackend.Cpu], assets.EnsuredRuntimes);
+        Assert.Equal(modelId, server.LastConfiguration?.ModelId);
         Assert.Equal(CrispAsrBackend.Cpu, server.LastConfiguration?.Backend);
         Assert.Equal("de", server.LastLanguage);
         Assert.Equal("lokal", result.Text);
@@ -624,8 +684,10 @@ public sealed class CohereTranscribePluginTests
 
     private sealed class FakeAssetManager : ICohereLocalAssetManager
     {
-        public long ModelTransferSize => 100;
-        public bool ModelInstalled { get; private set; }
+        private readonly HashSet<string> _installedModelIds = [];
+
+        public bool ModelInstalled => _installedModelIds.Count > 0;
+        public string? LastEnsuredModelId { get; private set; }
         public string? HuggingFaceToken { get; private set; }
         public List<CrispAsrBackend> EnsuredRuntimes { get; } = [];
 
@@ -634,12 +696,13 @@ public sealed class CohereTranscribePluginTests
             HuggingFaceToken = token;
         }
 
-        public bool IsModelInstalled() => ModelInstalled;
+        public long GetModelTransferSize(string modelId) => 100;
+        public bool IsModelInstalled(string modelId) => _installedModelIds.Contains(modelId);
         public bool IsRuntimeInstalled(CrispAsrBackend backend) =>
             EnsuredRuntimes.Contains(backend);
         public long GetRuntimeTransferSize(CrispAsrBackend backend) => 20;
-        public CohereModelPaths GetModelPaths() => new(
-            @"C:\models\cohere.gguf",
+        public CohereModelPaths GetModelPaths(string modelId) => new(
+            $@"C:\models\{modelId}.gguf",
             @"C:\models\vad.bin",
             @"C:\models\lid.gguf",
             @"C:\models\cache");
@@ -647,10 +710,12 @@ public sealed class CohereTranscribePluginTests
             @"C:\runtime\crispasr.exe";
 
         public Task EnsureModelAsync(
+            string modelId,
             IProgress<ArtifactTransferProgress>? progress,
             CancellationToken cancellationToken)
         {
-            ModelInstalled = true;
+            LastEnsuredModelId = modelId;
+            _installedModelIds.Add(modelId);
             progress?.Report(new ArtifactTransferProgress(100, 100));
             return Task.CompletedTask;
         }

--- a/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CohereTranscribePluginTests.cs
@@ -309,23 +309,72 @@ public sealed class CohereTranscribePluginTests
         const string apiKey = "not-on-the-command-line";
 
         var startInfo = CrispAsrServer.BuildStartInfo(configuration, 43123, apiKey);
-        var arguments = startInfo.ArgumentList.ToArray();
+        var arguments = startInfo.Arguments;
 
-        AssertArgumentPair(arguments, "--host", "127.0.0.1");
-        AssertArgumentPair(arguments, "--port", "43123");
-        AssertArgumentPair(arguments, "--backend", "cohere");
-        AssertArgumentPair(arguments, "--model", paths.ModelPath);
-        AssertArgumentPair(arguments, "--lid-backend", "ecapa");
-        AssertArgumentPair(arguments, "--lid-model", paths.LanguageIdModelPath);
-        AssertArgumentPair(arguments, "--vad-model", paths.VadModelPath);
-        AssertArgumentPair(arguments, "--gpu-backend", "cuda");
+        Assert.Equal(Path.Join(Environment.SystemDirectory, "cmd.exe"), startInfo.FileName);
+        Assert.StartsWith("/d /s /v:off /c ", arguments, StringComparison.Ordinal);
+        Assert.Contains("\"%TYPEWHISPER_CRISPASR_EXECUTABLE%\"", arguments);
+        Assert.Contains("--host 127.0.0.1", arguments);
+        Assert.Contains("--port 43123", arguments);
+        Assert.Contains("--backend cohere", arguments);
+        Assert.Contains("--model \"%TYPEWHISPER_CRISPASR_MODEL%\"", arguments);
+        Assert.Contains("--lid-backend ecapa", arguments);
+        Assert.Contains("--lid-model \"%TYPEWHISPER_CRISPASR_LID_MODEL%\"", arguments);
+        Assert.Contains("--vad-model \"%TYPEWHISPER_CRISPASR_VAD_MODEL%\"", arguments);
+        Assert.Contains("--gpu-backend cuda", arguments);
         Assert.Contains("--strict-pipeline", arguments);
         Assert.Contains("--require-vad", arguments);
         Assert.DoesNotContain("--api-keys", arguments);
         Assert.DoesNotContain(apiKey, arguments);
         Assert.Equal(apiKey, startInfo.Environment["CRISPASR_API_KEYS"]);
+        Assert.Equal(
+            configuration.ExecutablePath,
+            startInfo.Environment["TYPEWHISPER_CRISPASR_EXECUTABLE"]);
+        Assert.Equal(paths.ModelPath, startInfo.Environment["TYPEWHISPER_CRISPASR_MODEL"]);
+        Assert.Equal(paths.LanguageIdModelPath, startInfo.Environment["TYPEWHISPER_CRISPASR_LID_MODEL"]);
+        Assert.Equal(paths.VadModelPath, startInfo.Environment["TYPEWHISPER_CRISPASR_VAD_MODEL"]);
         Assert.True(startInfo.CreateNoWindow);
         Assert.Equal(System.Diagnostics.ProcessWindowStyle.Hidden, startInfo.WindowStyle);
+    }
+
+    [Fact]
+    public void ResolveUnpackagedChildPath_MapsMsixRedirectedLocalAppDataOnlyOnce()
+    {
+        const string localAppData = @"C:\Users\tester\AppData\Local";
+        const string packageFamilyName = "TypeWhisper.TypeWhisper_51tqb5623pxja";
+        var logicalPath = Path.Join(
+            localAppData,
+            "TypeWhisper-UserData",
+            "PluginData",
+            "com.typewhisper.cohere-transcribe",
+            "runtime",
+            "crispasr.exe");
+        var physicalPath = Path.Join(
+            localAppData,
+            "Packages",
+            packageFamilyName,
+            "LocalCache",
+            "Local",
+            Path.GetRelativePath(localAppData, logicalPath));
+
+        Assert.Equal(
+            physicalPath,
+            CrispAsrServer.ResolveUnpackagedChildPath(
+                logicalPath,
+                localAppData,
+                packageFamilyName));
+        Assert.Equal(
+            physicalPath,
+            CrispAsrServer.ResolveUnpackagedChildPath(
+                physicalPath,
+                localAppData,
+                packageFamilyName));
+        Assert.Equal(
+            @"D:\Models\cohere.gguf",
+            CrispAsrServer.ResolveUnpackagedChildPath(
+                @"D:\Models\cohere.gguf",
+                localAppData,
+                packageFamilyName));
     }
 
     [Fact]
@@ -569,17 +618,6 @@ public sealed class CohereTranscribePluginTests
             "'cohere-transcribe'  = 'TypeWhisper.Plugin.CohereTranscribe'",
             workflow,
             StringComparison.Ordinal);
-    }
-
-    private static void AssertArgumentPair(
-        IReadOnlyList<string> arguments,
-        string name,
-        string expectedValue)
-    {
-        var index = arguments.ToList().IndexOf(name);
-        Assert.True(index >= 0, $"Expected argument '{name}'.");
-        Assert.True(index + 1 < arguments.Count, $"Expected value after '{name}'.");
-        Assert.Equal(expectedValue, arguments[index + 1]);
     }
 
     private sealed class FakeAssetManager : ICohereLocalAssetManager


### PR DESCRIPTION
## Summary
- start CrispASR outside the inherited MSIX desktop runtime so native DLLs resolve from its runtime directory
- translate redirected LocalAppData paths to the physical Store package data path for the unpackaged child process
- offer Q4_K, Q5_0, Q6_K, and Q8_0 as separate, individually downloadable Cohere models while sharing auxiliary models and the selected runtime
- add a pinned, resumable FLEURS benchmark that keeps one persistent CrispASR process per quantization
- recover automatically when the app-owned CrispASR sidecar exits unexpectedly while a model is marked as loaded
- bump the Cohere Transcribe plugin to 1.0.1 and cover the launch, path, model-selection, and sidecar-recovery behavior with regression tests

## Verification
- 46 focused Cohere Transcribe tests pass
- Release plugin build passes with 0 warnings and 0 errors
- Python compilation, formatting, and diff checks pass
- installed the exact plugin build into TypeWhisper 1.0.6.0 from Microsoft Store and confirmed all four model variants are listed separately
- reused the existing Q5_0 download and completed an end-to-end CUDA transcription without a DLL error dialog
- terminated the active Q5_0 CUDA sidecar and confirmed the same request restarted it under a new process without restarting TypeWhisper
- completed the reproducible CUDA benchmark: 2,800/2,800 speech clips, 0 failures, and 0/12 silence/noise hallucinations
- confirmed the benchmark runner uses a persistent process per model and the Store app remains open when its sidecar is released
- confirmed the CrispASR process tree terminates with the Store host

Benchmark methodology and results: #339

Closes #339
