### PR TITLE
Fix OpenAI-compatible thinking output and model selection

### DIFF
--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/de.json
@@ -13,6 +13,8 @@
   "Settings.Refresh": "\uD83D\uDD04 Aktualisieren",
   "Settings.TranscriptionModel": "Transkriptions-Modell",
   "Settings.LlmModel": "LLM-Modell",
+  "Settings.None": "Keine",
+  "Settings.ThinkingMode": "Denkmodus",
   "Settings.NoModelsFound": "\u26A0 Keine Modelle über die API gefunden. Du kannst die Modellnamen manuell eingeben.",
   "Settings.Connecting": "Verbinde...",
   "Settings.TryingConnection": "Versuche Verbindung zu {0}...",

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/Localization/en.json
@@ -13,6 +13,8 @@
   "Settings.Refresh": "\uD83D\uDD04 Refresh",
   "Settings.TranscriptionModel": "Transcription Model",
   "Settings.LlmModel": "LLM Model",
+  "Settings.None": "None",
+  "Settings.ThinkingMode": "Thinking Mode",
   "Settings.NoModelsFound": "\u26A0 No models found via the API. You can enter model names manually.",
   "Settings.Connecting": "Connecting...",
   "Settings.TryingConnection": "Trying to connect to {0}...",

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Windows.Controls;
 using TypeWhisper.PluginSDK;
@@ -59,7 +60,7 @@ public sealed class OpenAiCompatiblePlugin :
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.1";
+    public string PluginVersion => "1.0.2";
 
     /// <summary>Current profiles, including the default profile.</summary>
     public IReadOnlyList<OpenAiCompatibleProfile> Profiles => _profiles;
@@ -286,6 +287,17 @@ public sealed class OpenAiCompatiblePlugin :
         PersistProfiles();
     }
 
+    /// <summary>Enables or disables thinking mode for the default profile.</summary>
+    public void SetThinkingEnabled(bool enabled) =>
+        SetThinkingEnabledForProfile(DefaultProfileId, enabled);
+
+    /// <summary>Enables or disables thinking mode for a profile.</summary>
+    public void SetThinkingEnabledForProfile(string profileId, bool enabled)
+    {
+        RequireProfile(profileId).ThinkingEnabled = enabled;
+        PersistProfiles();
+    }
+
     /// <summary>Stores fetched models for the default profile.</summary>
     public void SetFetchedModels(List<FetchedModel> models) =>
         SetFetchedModelsForProfile(DefaultProfileId, models);
@@ -386,8 +398,7 @@ public sealed class OpenAiCompatiblePlugin :
         !string.IsNullOrWhiteSpace(FindProfile(profileId)?.BaseUrl);
 
     internal bool IsProfileLlmAvailable(string profileId) =>
-        IsProfileConfigured(profileId)
-        && !string.IsNullOrWhiteSpace(FindProfile(profileId)?.SelectedLlmModelId);
+        IsProfileConfigured(profileId);
 
     internal IReadOnlyList<PluginModelInfo> GetTranscriptionModels(string profileId)
     {
@@ -457,14 +468,72 @@ public sealed class OpenAiCompatiblePlugin :
         if (string.IsNullOrEmpty(modelId))
             throw new InvalidOperationException("Kein LLM-Modell ausgewählt");
 
-        return await OpenAiChatHelper.SendChatCompletionAsync(
-            _httpClient,
-            profile.BaseUrl,
-            GetApiKey(profile.Id) ?? "",
+        return await SendChatCompletionAsync(
+            profile,
             modelId,
             systemPrompt,
             userText,
             ct);
+    }
+
+    private async Task<string> SendChatCompletionAsync(
+        OpenAiCompatibleProfile profile,
+        string modelId,
+        string systemPrompt,
+        string userText,
+        CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["model"] = modelId,
+            ["messages"] = new object[]
+            {
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = userText }
+            },
+            ["temperature"] = 0.1,
+            ["max_tokens"] = 2048,
+            ["thinking"] = new
+            {
+                type = profile.ThinkingEnabled ? "enabled" : "disabled"
+            }
+        };
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"{profile.BaseUrl}/v1/chat/completions");
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            GetApiKey(profile.Id) ?? "");
+        request.Content = new StringContent(
+            JsonSerializer.Serialize(body),
+            Encoding.UTF8,
+            "application/json");
+
+        using var response = await OpenAiApiHelper.SendWithErrorHandlingAsync(
+            _httpClient,
+            request,
+            ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseChatCompletionResponse(json);
+    }
+
+    private static string ParseChatCompletionResponse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("choices", out var choices)
+            && choices.ValueKind == JsonValueKind.Array
+            && choices.GetArrayLength() > 0
+            && choices[0].TryGetProperty("message", out var message)
+            && message.TryGetProperty("content", out var content)
+            && content.ValueKind == JsonValueKind.String)
+        {
+            return content.GetString()?.Trim() ?? "";
+        }
+
+        return "";
     }
 
     private static string SecretKey(string profileId) =>
@@ -679,6 +748,8 @@ public sealed class OpenAiCompatibleProfile
     public string? SelectedModelId { get; set; }
     /// <summary>Selected LLM model ID.</summary>
     public string? SelectedLlmModelId { get; set; }
+    /// <summary>Whether compatible chat requests should enable model thinking mode.</summary>
+    public bool ThinkingEnabled { get; set; }
     /// <summary>Models fetched from the provider. API keys are never stored here.</summary>
     public List<FetchedModel> FetchedModels { get; set; } = [];
     /// <summary>Display name with a fallback for unnamed profiles.</summary>

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -533,7 +533,9 @@ public sealed class OpenAiCompatiblePlugin :
             return content.GetString()?.Trim() ?? "";
         }
 
-        return "";
+        throw new InvalidOperationException(
+            "OpenAI-compatible chat completion response did not contain a string "
+            + "choices[0].message.content value.");
     }
 
     private static string SecretKey(string profileId) =>

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml
@@ -93,13 +93,13 @@
                            Foreground="{StaticResource PluginHintBrush}" Margin="0,0,0,4"/>
                 <ComboBox x:Name="TranscriptionModelPicker"
                           SelectionChanged="OnTranscriptionModelChanged"
-                          DisplayMemberPath="Id" Margin="0,0,0,12"/>
+                          DisplayMemberPath="DisplayName" Margin="0,0,0,12"/>
 
                 <TextBlock x:Name="LlmModelLabel1" FontSize="12"
                            Foreground="{StaticResource PluginHintBrush}" Margin="0,0,0,4"/>
                 <ComboBox x:Name="LlmModelPicker"
                           SelectionChanged="OnLlmModelChanged"
-                          DisplayMemberPath="Id"/>
+                          DisplayMemberPath="DisplayName"/>
             </StackPanel>
 
             <!-- Manual entry fallback -->
@@ -133,6 +133,11 @@
                             Click="OnSaveManualLlm"/>
                 </Grid>
             </StackPanel>
+
+            <Separator Margin="0,16,0,12"/>
+            <CheckBox x:Name="ThinkingModeCheckBox"
+                      Checked="OnThinkingModeChanged"
+                      Unchecked="OnThinkingModeChanged"/>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml.cs
@@ -37,6 +37,7 @@ public partial class OpenAiCompatibleSettingsView : UserControl
         SaveTranscriptionButton.Content = L("Settings.Save");
         LlmModelLabel2.Text = L("Settings.LlmModel");
         SaveLlmButton.Content = L("Settings.Save");
+        ThinkingModeCheckBox.Content = L("Settings.ThinkingMode");
 
         Loaded += OnLoaded;
     }
@@ -83,6 +84,7 @@ public partial class OpenAiCompatibleSettingsView : UserControl
             ApiKeyBox.Password = _plugin.GetApiKey(profile.Id) ?? "";
             ManualTranscriptionBox.Text = profile.SelectedModelId ?? "";
             ManualLlmBox.Text = profile.SelectedLlmModelId ?? "";
+            ThinkingModeCheckBox.IsChecked = profile.ThinkingEnabled;
             DeleteProfileButton.IsEnabled = profile.Id != OpenAiCompatiblePlugin.DefaultProfileId;
 
             ConnectionStatusPanel.Visibility = Visibility.Collapsed;
@@ -244,14 +246,22 @@ public partial class OpenAiCompatibleSettingsView : UserControl
             PickerSection.Visibility = Visibility.Visible;
             ManualSection.Visibility = Visibility.Collapsed;
 
-            TranscriptionModelPicker.ItemsSource = models;
-            LlmModelPicker.ItemsSource = models;
+            var options = new List<ModelPickerOption>
+            {
+                new("", L("Settings.None"))
+            };
+            options.AddRange(models.Select(model => new ModelPickerOption(model.Id, model.Id)));
 
-            var selectedTranscription = models.FirstOrDefault(m => m.Id == profile.SelectedModelId);
-            TranscriptionModelPicker.SelectedItem = selectedTranscription ?? models.FirstOrDefault();
+            TranscriptionModelPicker.ItemsSource = options;
+            LlmModelPicker.ItemsSource = options;
 
-            var selectedLlm = models.FirstOrDefault(m => m.Id == profile.SelectedLlmModelId);
-            LlmModelPicker.SelectedItem = selectedLlm ?? models.FirstOrDefault();
+            var selectedTranscription = options.FirstOrDefault(option =>
+                string.Equals(option.Id, profile.SelectedModelId ?? "", StringComparison.OrdinalIgnoreCase));
+            TranscriptionModelPicker.SelectedItem = selectedTranscription ?? options[0];
+
+            var selectedLlm = options.FirstOrDefault(option =>
+                string.Equals(option.Id, profile.SelectedLlmModelId ?? "", StringComparison.OrdinalIgnoreCase));
+            LlmModelPicker.SelectedItem = selectedLlm ?? options[0];
         }
         else
         {
@@ -266,8 +276,8 @@ public partial class OpenAiCompatibleSettingsView : UserControl
         if (_isLoadingProfile)
             return;
 
-        if (SelectedProfile() is { } profile && TranscriptionModelPicker.SelectedItem is FetchedModel model)
-            _plugin.SelectModelForProfile(profile.Id, model.Id);
+        if (SelectedProfile() is { } profile && TranscriptionModelPicker.SelectedItem is ModelPickerOption option)
+            _plugin.SelectModelForProfile(profile.Id, option.Id);
     }
 
     private void OnLlmModelChanged(object sender, SelectionChangedEventArgs e)
@@ -276,8 +286,22 @@ public partial class OpenAiCompatibleSettingsView : UserControl
         if (_isLoadingProfile)
             return;
 
-        if (SelectedProfile() is { } profile && LlmModelPicker.SelectedItem is FetchedModel model)
-            _plugin.SelectLlmModelForProfile(profile.Id, model.Id);
+        if (SelectedProfile() is { } profile && LlmModelPicker.SelectedItem is ModelPickerOption option)
+            _plugin.SelectLlmModelForProfile(profile.Id, option.Id);
+    }
+
+    private void OnThinkingModeChanged(object sender, RoutedEventArgs e)
+    {
+        e.Handled = true;
+        if (_isLoadingProfile)
+            return;
+
+        if (SelectedProfile() is { } profile)
+        {
+            _plugin.SetThinkingEnabledForProfile(
+                profile.Id,
+                ThinkingModeCheckBox.IsChecked == true);
+        }
     }
 
     private void OnSaveManualTranscription(object sender, RoutedEventArgs e)
@@ -348,4 +372,6 @@ public partial class OpenAiCompatibleSettingsView : UserControl
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
     private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
+
+    private sealed record ModelPickerOption(string Id, string DisplayName);
 }

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatibleSettingsView.xaml.cs
@@ -300,7 +300,7 @@ public partial class OpenAiCompatibleSettingsView : UserControl
         {
             _plugin.SetThinkingEnabledForProfile(
                 profile.Id,
-                ThinkingModeCheckBox.IsChecked == true);
+                ThinkingModeCheckBox.IsChecked.GetValueOrDefault());
         }
     }
 

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.openai-compatible",
   "name": "OpenAI Compatible",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TypeWhisper",
   "description": "Connect to any OpenAI-compatible server (Ollama, LM Studio, vLLM, etc.)",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -289,6 +289,37 @@ public class OpenAiCompatiblePluginTests
         Assert.Equal("Kein LLM-Modell ausgewählt", error.Message);
     }
 
+    [Fact]
+    public async Task ProcessAsync_ThrowsWhenResponseContainsOnlyReasoningContent()
+    {
+        var handler = new CapturingHandler((_, _) => JsonResponse("""
+            {
+              "choices": [
+                {
+                  "message": {
+                    "reasoning_content": "internal reasoning"
+                  }
+                }
+              ]
+            }
+            """));
+
+        var host = new TestPluginHostServices();
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new OpenAiCompatiblePlugin(httpClient);
+        await sut.ActivateAsync(host);
+        sut.SetBaseUrl("https://reasoning-only.example/v1");
+        sut.SelectLlmModel("chat-model");
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ProcessAsync("system", "user", "", CancellationToken.None));
+
+        Assert.Equal(
+            "OpenAI-compatible chat completion response did not contain a string "
+            + "choices[0].message.content value.",
+            error.Message);
+    }
+
     private static PluginManifest LoadManifest()
     {
         var basePath = Path.GetFullPath(AppContext.BaseDirectory);

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -12,18 +12,19 @@ namespace TypeWhisper.PluginSystem.Tests;
 public class OpenAiCompatiblePluginTests
 {
     [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifest = LoadManifest();
+        var sut = new OpenAiCompatiblePlugin();
+
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
     public void Manifest_AdvertisesTranscriptionAndLlmCategories()
     {
-        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
-        var relativeManifestPath = Path.Join(
-            "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.OpenAiCompatible", "manifest.json");
-        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
-        var manifest = JsonSerializer.Deserialize<PluginManifest>(
-            File.ReadAllText(manifestPath),
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var manifest = LoadManifest();
 
-        Assert.NotNull(manifest);
         Assert.Equal("transcription", manifest.Category);
         Assert.Equal(["transcription", "llm"], manifest.Categories);
     }
@@ -51,6 +52,7 @@ public class OpenAiCompatiblePluginTests
         Assert.Equal("https://legacy.example", profile.BaseUrl);
         Assert.Equal("whisper-legacy", profile.SelectedModelId);
         Assert.Equal("gpt-legacy", profile.SelectedLlmModelId);
+        Assert.False(profile.ThinkingEnabled);
         Assert.Equal(["gpt-legacy", "whisper-legacy"], profile.FetchedModels.Select(model => model.Id).Order().ToArray());
         Assert.Equal("legacy-token", sut.GetApiKey());
 
@@ -60,6 +62,32 @@ public class OpenAiCompatiblePluginTests
         Assert.Equal("https://legacy.example", host.GetSetting<string>("baseUrl"));
         Assert.Equal("whisper-legacy", host.GetSetting<string>("selectedModel"));
         Assert.Equal("gpt-legacy", host.GetSetting<string>("selectedLlmModel"));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_LoadsSavedProfilesWithoutThinkingModeAsDisabled()
+    {
+        var host = new TestPluginHostServices();
+        host.SetSetting("profiles", new[]
+        {
+            new
+            {
+                id = OpenAiCompatiblePlugin.DefaultProfileId,
+                name = "OpenAI Compatible",
+                baseUrl = "https://saved.example",
+                selectedModelId = "whisper-saved",
+                selectedLlmModelId = "chat-saved",
+                fetchedModels = Array.Empty<object>()
+            }
+        });
+
+        var sut = new OpenAiCompatiblePlugin();
+        await sut.ActivateAsync(host);
+
+        var profile = Assert.Single(sut.Profiles);
+        Assert.False(profile.ThinkingEnabled);
+        using var persisted = JsonDocument.Parse(host.GetRawSettingJson("profiles"));
+        Assert.False(persisted.RootElement[0].GetProperty("ThinkingEnabled").GetBoolean());
     }
 
     [Fact]
@@ -73,6 +101,7 @@ public class OpenAiCompatiblePluginTests
         sut.SetBaseUrl("https://local.example/v1", profile.Id);
         sut.SelectModelForProfile(profile.Id, "whisper-local");
         sut.SelectLlmModelForProfile(profile.Id, "gpt-local");
+        sut.SetThinkingEnabledForProfile(profile.Id, true);
         await sut.SetApiKeyAsync("local-token", profile.Id);
 
         var transcriptionRole = Assert.Single(((IAdditionalTranscriptionEnginesProvider)sut).AdditionalTranscriptionEngines);
@@ -87,6 +116,8 @@ public class OpenAiCompatiblePluginTests
         Assert.Equal("Local Gateway", llmRole.ProviderName);
         Assert.Equal("whisper-local", transcriptionRole.SelectedModelId);
         Assert.Equal("gpt-local", llmRole.SupportedModels.Single().Id);
+        Assert.False(sut.Profiles.Single(item => item.Id == OpenAiCompatiblePlugin.DefaultProfileId).ThinkingEnabled);
+        Assert.True(profile.ThinkingEnabled);
         Assert.Equal("local-token", host.Secrets[$"api-key.{profile.Id}"]);
         Assert.DoesNotContain("local-token", host.GetRawSettingJson("profiles"));
 
@@ -123,7 +154,8 @@ public class OpenAiCompatiblePluginTests
                   "choices": [
                     {
                       "message": {
-                        "content": "processed"
+                        "content": "  processed  ",
+                        "reasoning_content": "internal reasoning that must not be returned"
                       }
                     }
                   ]
@@ -145,6 +177,7 @@ public class OpenAiCompatiblePluginTests
         sut.SetBaseUrl("https://profile.example/v1", profile.Id);
         sut.SelectModelForProfile(profile.Id, "whisper-profile");
         sut.SelectLlmModelForProfile(profile.Id, "gpt-profile");
+        sut.SetThinkingEnabledForProfile(profile.Id, true);
         await sut.SetApiKeyAsync("profile-token", profile.Id);
 
         var profileTranscription = ((IAdditionalTranscriptionEnginesProvider)sut).AdditionalTranscriptionEngines.Single();
@@ -152,8 +185,11 @@ public class OpenAiCompatiblePluginTests
 
         await sut.TranscribeAsync([1, 2, 3], "en", translate: false, prompt: null, CancellationToken.None);
         await profileTranscription.TranscribeAsync([4, 5, 6], "de", translate: false, prompt: "terms", CancellationToken.None);
-        await sut.ProcessAsync("system", "user", "", CancellationToken.None);
-        await profileLlm.ProcessAsync("system", "user", "", CancellationToken.None);
+        var defaultResult = await sut.ProcessAsync("system", "user", "", CancellationToken.None);
+        var profileResult = await profileLlm.ProcessAsync("system", "user", "", CancellationToken.None);
+
+        Assert.Equal("processed", defaultResult);
+        Assert.Equal("processed", profileResult);
 
         Assert.Contains(requests, request =>
             request.Url == "https://default.example/v1/audio/transcriptions"
@@ -171,6 +207,99 @@ public class OpenAiCompatiblePluginTests
             request.Url == "https://profile.example/v1/chat/completions"
             && request.Authorization == "Bearer profile-token"
             && request.Body?.Contains("\"model\":\"gpt-profile\"", StringComparison.Ordinal) == true);
+
+        var defaultChat = requests.Single(request =>
+            request.Url == "https://default.example/v1/chat/completions");
+        using (var defaultBody = JsonDocument.Parse(defaultChat.Body!))
+        {
+            Assert.Equal(
+                "disabled",
+                defaultBody.RootElement.GetProperty("thinking").GetProperty("type").GetString());
+            Assert.Equal(2048, defaultBody.RootElement.GetProperty("max_tokens").GetInt32());
+            Assert.Equal(0.1, defaultBody.RootElement.GetProperty("temperature").GetDouble());
+        }
+
+        var profileChat = requests.Single(request =>
+            request.Url == "https://profile.example/v1/chat/completions");
+        using var profileBody = JsonDocument.Parse(profileChat.Body!);
+        Assert.Equal(
+            "enabled",
+            profileBody.RootElement.GetProperty("thinking").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task ClearedDefaultsKeepConfiguredProfileAvailableForWorkflowModelOverrides()
+    {
+        string? chatBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            chatBody = body;
+            return JsonResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "workflow result",
+                        "reasoning_content": "ignored"
+                      }
+                    }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new OpenAiCompatiblePlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        sut.SetBaseUrl("https://workflow.example/v1");
+        sut.SetFetchedModels([
+            new FetchedModel("whisper-workflow", "provider"),
+            new FetchedModel("chat-workflow", "provider")
+        ]);
+        sut.SelectModel("whisper-workflow");
+        sut.SelectLlmModel("chat-workflow");
+
+        sut.SelectModel("");
+        sut.SelectLlmModel("");
+
+        Assert.Null(sut.SelectedModelId);
+        Assert.Null(Assert.Single(sut.Profiles).SelectedLlmModelId);
+        Assert.True(sut.IsAvailable);
+        Assert.Equal(
+            ["chat-workflow", "whisper-workflow"],
+            sut.SupportedModels.Select(model => model.Id).ToArray());
+
+        var result = await sut.ProcessAsync(
+            "system",
+            "user",
+            "chat-workflow",
+            CancellationToken.None);
+
+        Assert.Equal("workflow result", result);
+        using var body = JsonDocument.Parse(chatBody!);
+        Assert.Equal("chat-workflow", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal(
+            "disabled",
+            body.RootElement.GetProperty("thinking").GetProperty("type").GetString());
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ProcessAsync("system", "user", "", CancellationToken.None));
+        Assert.Equal("Kein LLM-Modell ausgewählt", error.Message);
+    }
+
+    private static PluginManifest LoadManifest()
+    {
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.OpenAiCompatible", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
+        return JsonSerializer.Deserialize<PluginManifest>(
+                   File.ReadAllText(manifestPath),
+                   new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+               ?? throw new InvalidOperationException("OpenAI Compatible manifest could not be parsed.");
     }
 
     private static HttpResponseMessage JsonResponse(string json) =>


### PR DESCRIPTION
## Summary

- add per-profile Thinking Mode control and send explicit `thinking.type` values with every OpenAI-compatible chat request
- keep reasoning metadata separate from the returned assistant content
- add persistent None selections for transcription and LLM defaults while preserving workflow model overrides
- release the OpenAI Compatible plugin as version 1.0.2 and keep manifest/runtime versions aligned

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~OpenAiCompatiblePluginTests|FullyQualifiedName~OpenAiChatHelperTests"` (9 passed)
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore` (1,492 passed)
- `dotnet build TypeWhisper.slnx --no-restore --verbosity minimal` (0 warnings, 0 errors)
- OpenAI Compatible plugin Release build (0 warnings, 0 errors)
- isolated dev plugin install and launch verified with plugin manifest version 1.0.2

Addresses #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Thinking Mode per profile with localized settings labels.
  * Model selectors now show friendly names and include a localized “None” option.
  * Improved support for UTF-8 request content and reasoning responses.
* **Bug Fixes**
  * Improved handling of API errors, cleared model selections, and unavailable models.
  * Profiles remain available for workflow overrides without a default model.
* **Updates**
  * Updated the OpenAI-compatible plugin to version 1.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->