### PR TITLE
Fix DeepInfra reasoning control in OpenAI Compatible

### DIFF
--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -60,7 +60,7 @@ public sealed class OpenAiCompatiblePlugin :
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.2";
+    public string PluginVersion => "1.0.3";
 
     /// <summary>Current profiles, including the default profile.</summary>
     public IReadOnlyList<OpenAiCompatibleProfile> Profiles => _profiles;
@@ -492,12 +492,9 @@ public sealed class OpenAiCompatiblePlugin :
                 new { role = "user", content = userText }
             },
             ["temperature"] = 0.1,
-            ["max_tokens"] = 2048,
-            ["thinking"] = new
-            {
-                type = profile.ThinkingEnabled ? "enabled" : "disabled"
-            }
+            ["max_tokens"] = 2048
         };
+        AddThinkingConfiguration(body, profile.BaseUrl, profile.ThinkingEnabled);
 
         using var request = new HttpRequestMessage(
             HttpMethod.Post,
@@ -537,6 +534,27 @@ public sealed class OpenAiCompatiblePlugin :
             "OpenAI-compatible chat completion response did not contain a string "
             + "choices[0].message.content value.");
     }
+
+    private static void AddThinkingConfiguration(
+        Dictionary<string, object?> body,
+        string baseUrl,
+        bool thinkingEnabled)
+    {
+        if (IsDeepInfraEndpoint(baseUrl))
+        {
+            body["reasoning"] = new { enabled = thinkingEnabled };
+            return;
+        }
+
+        body["thinking"] = new
+        {
+            type = thinkingEnabled ? "enabled" : "disabled"
+        };
+    }
+
+    private static bool IsDeepInfraEndpoint(string baseUrl) =>
+        Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri)
+        && string.Equals(uri.Host, "api.deepinfra.com", StringComparison.OrdinalIgnoreCase);
 
     private static string SecretKey(string profileId) =>
         IsDefaultProfile(profileId) ? "api-key" : $"api-key.{profileId}";

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.openai-compatible",
   "name": "OpenAI Compatible",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "TypeWhisper",
   "description": "Connect to any OpenAI-compatible server (Ollama, LM Studio, vLLM, etc.)",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -215,6 +215,7 @@ public class OpenAiCompatiblePluginTests
             Assert.Equal(
                 "disabled",
                 defaultBody.RootElement.GetProperty("thinking").GetProperty("type").GetString());
+            Assert.False(defaultBody.RootElement.TryGetProperty("reasoning", out _));
             Assert.Equal(2048, defaultBody.RootElement.GetProperty("max_tokens").GetInt32());
             Assert.Equal(0.1, defaultBody.RootElement.GetProperty("temperature").GetDouble());
         }
@@ -225,6 +226,99 @@ public class OpenAiCompatiblePluginTests
         Assert.Equal(
             "enabled",
             profileBody.RootElement.GetProperty("thinking").GetProperty("type").GetString());
+        Assert.False(profileBody.RootElement.TryGetProperty("reasoning", out _));
+    }
+
+    [Fact]
+    public async Task DeepInfraRequestsUseReasoningControlWithoutGenericThinking()
+    {
+        var requestBodies = new List<string>();
+        var handler = new CapturingHandler((_, body) =>
+        {
+            requestBodies.Add(body!);
+            return JsonResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "  processed  ",
+                        "reasoning_content": "internal reasoning that must not be returned"
+                      }
+                    }
+                  ]
+                }
+                """);
+        });
+
+        var host = new TestPluginHostServices();
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new OpenAiCompatiblePlugin(httpClient);
+        await sut.ActivateAsync(host);
+        sut.SetBaseUrl("https://API.DEEPINFRA.COM/custom-path");
+        sut.SelectLlmModel("google/gemma-4-E4B-it");
+
+        var disabledResult = await sut.ProcessAsync(
+            "Return only the final text.",
+            "input",
+            "",
+            CancellationToken.None);
+
+        sut.SetThinkingEnabled(true);
+        var enabledResult = await sut.ProcessAsync(
+            "Return only the final text.",
+            "input",
+            "",
+            CancellationToken.None);
+
+        Assert.Equal("processed", disabledResult);
+        Assert.Equal("processed", enabledResult);
+        Assert.Equal(2, requestBodies.Count);
+
+        using (var disabledBody = JsonDocument.Parse(requestBodies[0]))
+        {
+            var root = disabledBody.RootElement;
+            Assert.Equal("google/gemma-4-E4B-it", root.GetProperty("model").GetString());
+            Assert.False(root.GetProperty("reasoning").GetProperty("enabled").GetBoolean());
+            Assert.False(root.TryGetProperty("thinking", out _));
+            Assert.Equal(2048, root.GetProperty("max_tokens").GetInt32());
+            Assert.Equal(0.1, root.GetProperty("temperature").GetDouble());
+
+            var messages = root.GetProperty("messages");
+            Assert.Equal("system", messages[0].GetProperty("role").GetString());
+            Assert.Equal("Return only the final text.", messages[0].GetProperty("content").GetString());
+            Assert.Equal("user", messages[1].GetProperty("role").GetString());
+            Assert.Equal("input", messages[1].GetProperty("content").GetString());
+        }
+
+        using var enabledBody = JsonDocument.Parse(requestBodies[1]);
+        Assert.True(enabledBody.RootElement.GetProperty("reasoning").GetProperty("enabled").GetBoolean());
+        Assert.False(enabledBody.RootElement.TryGetProperty("thinking", out _));
+    }
+
+    [Fact]
+    public async Task DeepInfraLookalikeHostUsesGenericThinkingControl()
+    {
+        string? requestBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            requestBody = body;
+            return JsonResponse("""{ "choices": [ { "message": { "content": "processed" } } ] }""");
+        });
+
+        var host = new TestPluginHostServices();
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new OpenAiCompatiblePlugin(httpClient);
+        await sut.ActivateAsync(host);
+        sut.SetBaseUrl("https://api.deepinfra.com.example.org");
+        sut.SelectLlmModel("chat-model");
+
+        await sut.ProcessAsync("system", "user", "", CancellationToken.None);
+
+        using var body = JsonDocument.Parse(requestBody!);
+        Assert.Equal(
+            "disabled",
+            body.RootElement.GetProperty("thinking").GetProperty("type").GetString());
+        Assert.False(body.RootElement.TryGetProperty("reasoning", out _));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- map the OpenAI Compatible Thinking Mode toggle to DeepInfra's supported `reasoning.enabled` request shape
- preserve the existing `thinking.type` request shape for all other compatible backends
- release the plugin source and manifest as version 1.0.3

## Root cause

OpenAI Compatible 1.0.2 always sent `thinking.type`. DeepInfra accepts the request but expects `reasoning.enabled` for models such as `google/gemma-4-E4B-it`, so disabled thinking was ignored and the reasoning trace remained in normal response content.

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~OpenAiCompatiblePluginTests" --verbosity minimal` (10 passed)
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --verbosity minimal` (1,495 passed)
- `dotnet build TypeWhisper.slnx --no-restore --verbosity minimal` (0 warnings, 0 errors)
- OpenAI Compatible Release build (0 warnings, 0 errors)
- local dev plugin discovery and launch verified with plugin version 1.0.3

Addresses #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved thinking-mode support for DeepInfra-compatible endpoints using the appropriate reasoning controls.
  * Preserved existing thinking controls for other compatible endpoints.
* **Bug Fixes**
  * Prevented generic thinking parameters from being sent to DeepInfra.
* **Tests**
  * Added coverage for DeepInfra endpoint detection and lookalike host handling.
* **Chores**
  * Updated the OpenAI-compatible plugin to version 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->