### PR TITLE
Use DeepInfra reasoning effort control

### DIFF
--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -60,7 +60,7 @@ public sealed class OpenAiCompatiblePlugin :
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.3";
+    public string PluginVersion => "1.0.4";
 
     /// <summary>Current profiles, including the default profile.</summary>
     public IReadOnlyList<OpenAiCompatibleProfile> Profiles => _profiles;
@@ -542,7 +542,7 @@ public sealed class OpenAiCompatiblePlugin :
     {
         if (IsDeepInfraEndpoint(baseUrl))
         {
-            body["reasoning"] = new { enabled = thinkingEnabled };
+            body["reasoning_effort"] = thinkingEnabled ? "high" : "none";
             return;
         }
 

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.openai-compatible",
   "name": "OpenAI Compatible",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "TypeWhisper",
   "description": "Connect to any OpenAI-compatible server (Ollama, LM Studio, vLLM, etc.)",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -17,6 +17,7 @@ public class OpenAiCompatiblePluginTests
         var manifest = LoadManifest();
         var sut = new OpenAiCompatiblePlugin();
 
+        Assert.Equal("1.0.4", manifest.Version);
         Assert.Equal(manifest.Version, sut.PluginVersion);
     }
 
@@ -216,6 +217,7 @@ public class OpenAiCompatiblePluginTests
                 "disabled",
                 defaultBody.RootElement.GetProperty("thinking").GetProperty("type").GetString());
             Assert.False(defaultBody.RootElement.TryGetProperty("reasoning", out _));
+            Assert.False(defaultBody.RootElement.TryGetProperty("reasoning_effort", out _));
             Assert.Equal(2048, defaultBody.RootElement.GetProperty("max_tokens").GetInt32());
             Assert.Equal(0.1, defaultBody.RootElement.GetProperty("temperature").GetDouble());
         }
@@ -227,10 +229,11 @@ public class OpenAiCompatiblePluginTests
             "enabled",
             profileBody.RootElement.GetProperty("thinking").GetProperty("type").GetString());
         Assert.False(profileBody.RootElement.TryGetProperty("reasoning", out _));
+        Assert.False(profileBody.RootElement.TryGetProperty("reasoning_effort", out _));
     }
 
     [Fact]
-    public async Task DeepInfraRequestsUseReasoningControlWithoutGenericThinking()
+    public async Task DeepInfraRequestsUseReasoningEffortWithoutOtherThinkingControls()
     {
         var requestBodies = new List<string>();
         var handler = new CapturingHandler((_, body) =>
@@ -278,7 +281,8 @@ public class OpenAiCompatiblePluginTests
         {
             var root = disabledBody.RootElement;
             Assert.Equal("google/gemma-4-E4B-it", root.GetProperty("model").GetString());
-            Assert.False(root.GetProperty("reasoning").GetProperty("enabled").GetBoolean());
+            Assert.Equal("none", root.GetProperty("reasoning_effort").GetString());
+            Assert.False(root.TryGetProperty("reasoning", out _));
             Assert.False(root.TryGetProperty("thinking", out _));
             Assert.Equal(2048, root.GetProperty("max_tokens").GetInt32());
             Assert.Equal(0.1, root.GetProperty("temperature").GetDouble());
@@ -291,7 +295,8 @@ public class OpenAiCompatiblePluginTests
         }
 
         using var enabledBody = JsonDocument.Parse(requestBodies[1]);
-        Assert.True(enabledBody.RootElement.GetProperty("reasoning").GetProperty("enabled").GetBoolean());
+        Assert.Equal("high", enabledBody.RootElement.GetProperty("reasoning_effort").GetString());
+        Assert.False(enabledBody.RootElement.TryGetProperty("reasoning", out _));
         Assert.False(enabledBody.RootElement.TryGetProperty("thinking", out _));
     }
 
@@ -319,6 +324,7 @@ public class OpenAiCompatiblePluginTests
             "disabled",
             body.RootElement.GetProperty("thinking").GetProperty("type").GetString());
         Assert.False(body.RootElement.TryGetProperty("reasoning", out _));
+        Assert.False(body.RootElement.TryGetProperty("reasoning_effort", out _));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- map the Thinking Mode toggle to DeepInfra's primary `reasoning_effort` field
- send `none` when disabled and `high` when enabled
- keep the generic `thinking.type` dialect unchanged for LM Studio, Ollama, vLLM, and other endpoints
- bump OpenAI Compatible to 1.0.4

Addresses #342

## Validation

- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter FullyQualifiedName~OpenAiCompatiblePluginTests --verbosity minimal` (10 passed)
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --verbosity minimal` (1495 passed)
- `dotnet build TypeWhisper.slnx --no-restore --verbosity minimal`
- `dotnet build plugins/TypeWhisper.Plugin.OpenAiCompatible/TypeWhisper.Plugin.OpenAiCompatible.csproj -c Release --no-restore --verbosity minimal`
- installed through the Windows plugin dev launcher; runtime loaded 1.0.4 and preserved the existing None selection and Thinking toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DeepInfra requests to use the supported reasoning effort settings, improving compatibility with thinking-mode controls.
  * Added explicit support for high and disabled reasoning effort levels.

* **Chores**
  * Updated the OpenAI-compatible plugin to version 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->