### PR TITLE
Preserve Unicode in OpenAI-compatible requests

### DIFF
--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -1,7 +1,9 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 using System.Windows.Controls;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
@@ -26,6 +28,10 @@ public sealed class OpenAiCompatiblePlugin :
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
+    };
+    private static readonly JsonSerializerOptions RequestJsonOptions = new()
+    {
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
     };
 
     private readonly HttpClient _httpClient;
@@ -60,7 +66,7 @@ public sealed class OpenAiCompatiblePlugin :
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.4";
+    public string PluginVersion => "1.0.5";
 
     /// <summary>Current profiles, including the default profile.</summary>
     public IReadOnlyList<OpenAiCompatibleProfile> Profiles => _profiles;
@@ -503,7 +509,7 @@ public sealed class OpenAiCompatiblePlugin :
             "Bearer",
             GetApiKey(profile.Id) ?? "");
         request.Content = new StringContent(
-            JsonSerializer.Serialize(body),
+            JsonSerializer.Serialize(body, RequestJsonOptions),
             Encoding.UTF8,
             "application/json");
 

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.openai-compatible",
   "name": "OpenAI Compatible",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "TypeWhisper",
   "description": "Connect to any OpenAI-compatible server (Ollama, LM Studio, vLLM, etc.)",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiCompatiblePluginTests.cs
@@ -17,7 +17,7 @@ public class OpenAiCompatiblePluginTests
         var manifest = LoadManifest();
         var sut = new OpenAiCompatiblePlugin();
 
-        Assert.Equal("1.0.4", manifest.Version);
+        Assert.Equal("1.0.5", manifest.Version);
         Assert.Equal(manifest.Version, sut.PluginVersion);
     }
 
@@ -298,6 +298,41 @@ public class OpenAiCompatiblePluginTests
         Assert.Equal("high", enabledBody.RootElement.GetProperty("reasoning_effort").GetString());
         Assert.False(enabledBody.RootElement.TryGetProperty("reasoning", out _));
         Assert.False(enabledBody.RootElement.TryGetProperty("thinking", out _));
+    }
+
+    [Theory]
+    [InlineData("https://api.deepinfra.com")]
+    [InlineData("http://localhost:1234")]
+    [InlineData("https://api.deepinfra.com.example.org")]
+    public async Task ChatRequestsWriteNonAsciiMessageContentAsUtf8(string baseUrl)
+    {
+        string? requestBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            requestBody = body;
+            return JsonResponse("""{ "choices": [ { "message": { "content": "processed" } } ] }""");
+        });
+
+        var host = new TestPluginHostServices();
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var sut = new OpenAiCompatiblePlugin(httpClient);
+        await sut.ActivateAsync(host);
+        sut.SetBaseUrl(baseUrl);
+        sut.SelectLlmModel("chat-model");
+
+        await sut.ProcessAsync(
+            "Output original input message.",
+            "今天天气很好,我们去蹓狗吧!",
+            "",
+            CancellationToken.None);
+
+        Assert.Contains("今天天气很好,我们去蹓狗吧!", requestBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\u4ECA", requestBody, StringComparison.OrdinalIgnoreCase);
+
+        using var body = JsonDocument.Parse(requestBody!);
+        Assert.Equal(
+            "今天天气很好,我们去蹓狗吧!",
+            body.RootElement.GetProperty("messages")[1].GetProperty("content").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- serialize OpenAI-compatible chat request bodies with direct UTF-8 characters instead of Unicode escape sequences
- apply the wire-format improvement consistently to DeepInfra, LM Studio, Ollama, vLLM, and other compatible endpoints
- preserve the existing provider-specific thinking controls and response handling
- bump OpenAI Compatible to 1.0.5

Addresses #342

## Validation

- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter FullyQualifiedName~OpenAiCompatiblePluginTests --verbosity minimal` (13 passed)
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-build --verbosity minimal` (1,498 passed)
- `dotnet build TypeWhisper.slnx --no-restore --verbosity minimal`
- `dotnet build plugins/TypeWhisper.Plugin.OpenAiCompatible/TypeWhisper.Plugin.OpenAiCompatible.csproj -c Release --no-restore --verbosity minimal`
- installed OpenAI Compatible 1.0.5 through the Windows plugin dev launcher and relaunched the dev app

The final DeepInfra provider confirmation remains gated on the reporter retest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI-compatible chat requests to preserve non-ASCII characters correctly during transmission.
  * Ensured Unicode content is serialized consistently across supported endpoints.

* **Chores**
  * Updated the OpenAI-compatible plugin to version 1.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->