### PR TITLE
Restore immediate microphone capture startup

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,3 +8,18 @@ The Windows plugin logo PNGs in `src/TypeWhisper.Windows/Resources/PluginLogos/`
 - https://github.com/pheralb/svgl
 
 SVGL is distributed under the MIT License. The included brand logos remain trademarks or registered trademarks of their respective owners. TypeWhisper uses them only to identify the corresponding plugin provider in the local app UI.
+
+## NAudio WASAPI Capture
+
+The prepare-once WASAPI capture implementation in `src/TypeWhisper.Windows/Services/WasapiAudioInputCapture.cs` adapts capture initialization and packet-reading logic from NAudio 2.2.1:
+
+- https://github.com/naudio/NAudio/blob/v2.2.1/NAudio.Wasapi/WasapiCapture.cs
+- Copyright (c) 2020 Mark Heath
+
+NAudio is distributed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/TypeWhisper.Windows/Services/AudioCaptureDiagnostics.cs
+++ b/src/TypeWhisper.Windows/Services/AudioCaptureDiagnostics.cs
@@ -19,8 +19,11 @@ internal static class AudioCaptureDiagnostics
         SafePathSegment("Logs"),
         SafePathSegment("audio-capture-diagnostics.log"));
 
+    internal static event Action<string>? MessageLogged;
+
     public static void Log(string message)
     {
+        NotifyObservers(message);
         if (!Enabled)
             return;
 
@@ -58,6 +61,16 @@ internal static class AudioCaptureDiagnostics
         {
             Debug.WriteLine($"Audio capture diagnostics logging failed: {ex.Message}");
         }
+    }
+
+    private static void NotifyObservers(string message)
+    {
+        var observers = MessageLogged;
+        if (observers is null)
+            return;
+
+        foreach (var observer in observers.GetInvocationList().Cast<Action<string>>())
+            observer(message);
     }
 
     public static void Reset()

--- a/src/TypeWhisper.Windows/Services/AudioCaptureDiagnostics.cs
+++ b/src/TypeWhisper.Windows/Services/AudioCaptureDiagnostics.cs
@@ -70,7 +70,16 @@ internal static class AudioCaptureDiagnostics
             return;
 
         foreach (var observer in observers.GetInvocationList().Cast<Action<string>>())
-            observer(message);
+        {
+            try
+            {
+                observer(message);
+            }
+            catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+            {
+                Debug.WriteLine($"Audio capture diagnostics observer failed: {ex.Message}");
+            }
+        }
     }
 
     public static void Reset()

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -34,6 +34,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     private readonly TimeSpan _devicePollInterval;
     private readonly object _deviceInfoCacheLock = new();
     private readonly object _deviceChangeCheckLock = new();
+    private readonly object _captureLifecycleLock = new();
     private IAudioInputCapture? _waveIn;
     private IAudioInputCapture? _previewWaveIn;
     private List<float>? _sampleBuffer;
@@ -66,6 +67,11 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     private readonly Queue<AudioChunkTelemetry> _recentChunks = new();
     private DateTime? _lastSamplesAvailableUtc;
     private int _diagnosticDataAvailableCount;
+    private long _recordingStartTimestamp;
+    private long _recordingSequence;
+    private long _activeRecordingSequence;
+    private long _captureGeneration;
+    private long _activeCaptureGeneration;
 
     /// <summary>
     /// Initializes a new instance of the AudioRecordingService class.
@@ -206,53 +212,57 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// </summary>
     public bool WarmUp()
     {
-        AudioCaptureDiagnostics.Log(
-            $"WarmUp enter warmed={_isWarmedUp} disposed={_disposed} deviceCount={SafeDeviceCount()} sync={SynchronizationContext.Current?.GetType().FullName ?? "<null>"}");
-        if (_disposed) return false;
-        if (_isWarmedUp && _waveIn is not null) return true;
-
-        if (_deviceProvider.DeviceCount == 0)
-        {
-            AudioCaptureDiagnostics.Log("WarmUp no devices");
-            System.Diagnostics.Debug.WriteLine("WarmUp: No audio input devices available.");
-            StartDevicePolling();
-            return false;
-        }
-
-        _activeDeviceNumber = ResolvePreferredDeviceNumber(allowFallback: true);
-        if (_activeDeviceNumber < 0)
-        {
-            AudioCaptureDiagnostics.Log("WarmUp no active device after resolve");
-            StartDevicePolling();
-            return false;
-        }
-
-        try
+        lock (_captureLifecycleLock)
         {
             AudioCaptureDiagnostics.Log(
-                $"WarmUp creating capture active={_activeDeviceNumber}:{TryGetDeviceName(_activeDeviceNumber) ?? "<unknown>"}");
-            _waveIn = _captureFactory.Create(
-                _activeDeviceNumber,
-                new WaveFormat(SampleRate, BitsPerSample, Channels),
-                bufferMilliseconds: 30);
+                $"WarmUp enter warmed={_isWarmedUp} disposed={_disposed} deviceCount={SafeDeviceCount()} sync={SynchronizationContext.Current?.GetType().FullName ?? "<null>"}");
+            if (_disposed) return false;
+            if (_isWarmedUp && _waveIn is not null) return true;
 
-            _waveIn.DataAvailable += OnDataAvailable;
-            _waveIn.RecordingStopped += OnRecordingStopped;
+            if (_deviceProvider.DeviceCount == 0)
+            {
+                AudioCaptureDiagnostics.Log("WarmUp no devices");
+                System.Diagnostics.Debug.WriteLine("WarmUp: No audio input devices available.");
+                StartDevicePolling();
+                return false;
+            }
 
-            SetActiveDeviceIdentity(_activeDeviceNumber);
-            _isWarmedUp = true;
-            AudioCaptureDiagnostics.Log(
-                $"WarmUp prepared active={_activeDeviceNumber}:{_activeDeviceName ?? "<unknown>"} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
+            _activeDeviceNumber = ResolvePreferredDeviceNumber(allowFallback: true);
+            if (_activeDeviceNumber < 0)
+            {
+                AudioCaptureDiagnostics.Log("WarmUp no active device after resolve");
+                StartDevicePolling();
+                return false;
+            }
+
+            try
+            {
+                AudioCaptureDiagnostics.Log(
+                    $"WarmUp creating capture active={_activeDeviceNumber}:{TryGetDeviceName(_activeDeviceNumber) ?? "<unknown>"}");
+                _waveIn = _captureFactory.Create(
+                    _activeDeviceNumber,
+                    new WaveFormat(SampleRate, BitsPerSample, Channels),
+                    bufferMilliseconds: 30);
+                _waveIn.Prepare();
+                _waveIn.DataAvailable += OnDataAvailable;
+                _waveIn.RecordingStopped += OnRecordingStopped;
+
+                SetActiveDeviceIdentity(_activeDeviceNumber);
+                _isWarmedUp = true;
+                _activeCaptureGeneration = ++_captureGeneration;
+                AudioCaptureDiagnostics.Log(
+                    $"WarmUp prepared captureGeneration={_activeCaptureGeneration} reusable={_waveIn.CanRestartAfterStop} active={_activeDeviceNumber}:{_activeDeviceName ?? "<unknown>"} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
+            }
+            catch (Exception ex) when (IsNonFatalAudioException(ex))
+            {
+                AudioCaptureDiagnostics.Log($"WarmUp failed {ex.GetType().Name}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"WarmUp failed: {ex.Message}");
+                DisposeWaveIn(stopRecording: false, reason: "prepare failure");
+            }
+
+            StartDevicePolling();
+            return _isWarmedUp;
         }
-        catch (Exception ex) when (IsNonFatalAudioException(ex))
-        {
-            AudioCaptureDiagnostics.Log($"WarmUp failed {ex.GetType().Name}: {ex.Message}");
-            System.Diagnostics.Debug.WriteLine($"WarmUp failed: {ex.Message}");
-            DisposeWaveIn(stopRecording: false);
-        }
-
-        StartDevicePolling();
-        return _isWarmedUp;
     }
 
     /// <summary>
@@ -293,53 +303,60 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// </summary>
     public void StartRecording()
     {
-        AudioCaptureDiagnostics.Log(
-            $"StartRecording enter serviceRecording={_isRecording} warmed={_isWarmedUp} previewing={_isPreviewing} waveIn={_waveIn is not null}");
-        if (_isRecording) return;
-
-        // The settings microphone preview uses its own WaveIn instance and can
-        // block real capture while the settings window stays open on Dictation.
-        // Always stop preview before entering recording mode.
-        if (_isPreviewing)
-            StopPreview();
-
-        if ((!_isWarmedUp || _waveIn is null) && !WarmUp())
+        var startTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+        lock (_captureLifecycleLock)
         {
-            AudioCaptureDiagnostics.Log("StartRecording warmup failed");
-            return;
-        }
-
-        if (_waveIn is null)
-        {
-            AudioCaptureDiagnostics.Log("StartRecording no capture");
-            return;
-        }
-
-        _sampleBuffer = new List<float>(SampleRate * 60); // Pre-alloc ~1 min
-        _peakRmsLevel = 0;
-        _preGainPeakRms = 0;
-        _currentRmsLevel = 0;
-        lock (_bufferLock)
-        {
-            _recentChunks.Clear();
-            _lastSamplesAvailableUtc = null;
-        }
-        _recordingStartTime = DateTime.UtcNow;
-        _isRecording = true;
-        _diagnosticDataAvailableCount = 0;
-
-        try
-        {
-            _waveIn.StartRecording();
             AudioCaptureDiagnostics.Log(
-                $"StartRecording active isRecording={_isRecording} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
-        }
-        catch (Exception ex) when (IsNonFatalAudioException(ex))
-        {
-            AudioCaptureDiagnostics.Log($"StartRecording failed {ex.GetType().Name}: {ex.Message}");
-            System.Diagnostics.Debug.WriteLine($"StartRecording failed: {ex.Message}");
-            ClearRecordingState();
-            DisposeWaveIn();
+                $"StartRecording enter serviceRecording={_isRecording} warmed={_isWarmedUp} previewing={_isPreviewing} waveIn={_waveIn is not null}");
+            if (_isRecording) return;
+
+            // The settings microphone preview uses its own WaveIn instance and can
+            // block real capture while the settings window stays open on Dictation.
+            // Always stop preview before entering recording mode.
+            if (_isPreviewing)
+                StopPreview();
+
+            if ((!_isWarmedUp || _waveIn is null) && !WarmUp())
+            {
+                AudioCaptureDiagnostics.Log("StartRecording warmup failed");
+                return;
+            }
+
+            if (_waveIn is null)
+            {
+                AudioCaptureDiagnostics.Log("StartRecording no capture");
+                return;
+            }
+
+            _sampleBuffer = new List<float>(SampleRate * 60); // Pre-alloc ~1 min
+            _peakRmsLevel = 0;
+            _preGainPeakRms = 0;
+            _currentRmsLevel = 0;
+            lock (_bufferLock)
+            {
+                _recentChunks.Clear();
+                _lastSamplesAvailableUtc = null;
+            }
+            _recordingStartTime = DateTime.UtcNow;
+            _recordingStartTimestamp = startTimestamp;
+            _activeRecordingSequence = ++_recordingSequence;
+            _isRecording = true;
+            Interlocked.Exchange(ref _diagnosticDataAvailableCount, 0);
+
+            try
+            {
+                _waveIn.StartRecording();
+                AudioCaptureDiagnostics.Log(
+                    $"StartRecording active sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} isRecording={_isRecording} format={DescribeWaveFormat(_waveIn.WaveFormat)}");
+            }
+            catch (Exception ex) when (IsNonFatalAudioException(ex))
+            {
+                AudioCaptureDiagnostics.Log(
+                    $"StartRecording failed sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} {ex.GetType().Name}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"StartRecording failed: {ex.Message}");
+                ClearRecordingState();
+                DisposeWaveIn(reason: "start failure");
+            }
         }
     }
 
@@ -357,41 +374,48 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// </summary>
     public float[]? StopRecording()
     {
-        AudioCaptureDiagnostics.Log(
-            $"StopRecording enter serviceRecording={_isRecording} waveIn={_waveIn is not null} bufferCount={_sampleBuffer?.Count ?? -1} peak={_peakRmsLevel:F6} preGain={_preGainPeakRms:F6}");
-        if (!_isRecording)
-            return null;
-
-        if (_waveIn is null)
+        lock (_captureLifecycleLock)
         {
-            AudioCaptureDiagnostics.Log("StopRecording no capture");
-            ClearRecordingState();
-            return null;
+            AudioCaptureDiagnostics.Log(
+                $"StopRecording enter sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} serviceRecording={_isRecording} waveIn={_waveIn is not null} bufferCount={_sampleBuffer?.Count ?? -1} peak={_peakRmsLevel:F6} preGain={_preGainPeakRms:F6}");
+            if (!_isRecording)
+                return null;
+
+            if (_waveIn is null)
+            {
+                AudioCaptureDiagnostics.Log("StopRecording no capture");
+                ClearRecordingState();
+                return null;
+            }
+
+            _isRecording = false;
+
+            float[]? samples;
+            lock (_bufferLock)
+            {
+                samples = _sampleBuffer?.ToArray();
+                _sampleBuffer = null;
+            }
+
+            if (_waveIn.CanRestartAfterStop)
+                StopAndRetainWaveIn(_waveIn);
+            else
+                DisposeWaveIn(resetWarmUp: false, reason: "fallback recreated");
+
+            if (samples is null || samples.Length == 0)
+            {
+                AudioCaptureDiagnostics.Log(
+                    $"StopRecording returning empty sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration}");
+                return null;
+            }
+
+            if (NormalizationEnabled)
+                NormalizeAudio(samples);
+
+            AudioCaptureDiagnostics.Log(
+                $"StopRecording returning sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} samples={samples.Length} duration={samples.Length / 16000.0:F3}");
+            return samples;
         }
-
-        _isRecording = false;
-
-        float[]? samples;
-        lock (_bufferLock)
-        {
-            samples = _sampleBuffer?.ToArray();
-            _sampleBuffer = null;
-        }
-
-        DisposeWaveIn(resetWarmUp: false);
-
-        if (samples is null || samples.Length == 0)
-        {
-            AudioCaptureDiagnostics.Log("StopRecording returning empty");
-            return null;
-        }
-
-        if (NormalizationEnabled)
-            NormalizeAudio(samples);
-
-        AudioCaptureDiagnostics.Log(
-            $"StopRecording returning samples={samples.Length} duration={samples.Length / 16000.0:F3}");
-        return samples;
     }
 
     /// <summary>
@@ -435,11 +459,20 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             e.BytesRecorded,
             capture.WaveFormat);
         var sampleCount = decodedSamples.Length;
-        _diagnosticDataAvailableCount++;
-        if (_diagnosticDataAvailableCount <= 5 || _diagnosticDataAvailableCount % 50 == 0)
+        var dataAvailableCount = Interlocked.Increment(ref _diagnosticDataAvailableCount);
+        if (dataAvailableCount == 1)
+        {
+            var startLatency = System.Diagnostics.Stopwatch.GetElapsedTime(_recordingStartTimestamp);
+            var startLatencyMilliseconds = startLatency.TotalMilliseconds.ToString(
+                "F1",
+                System.Globalization.CultureInfo.InvariantCulture);
+            AudioCaptureDiagnostics.Log(
+                $"FirstDataAvailable sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} startLatencyMs={startLatencyMilliseconds} bytes={e.BytesRecorded} decoded={sampleCount}");
+        }
+        if (dataAvailableCount <= 5 || dataAvailableCount % 50 == 0)
         {
             AudioCaptureDiagnostics.Log(
-                $"DataAvailable accepted count={_diagnosticDataAvailableCount} bytes={e.BytesRecorded} decoded={sampleCount} format={DescribeWaveFormat(capture.WaveFormat)} recording={_isRecording}");
+                $"DataAvailable accepted sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} count={dataAvailableCount} bytes={e.BytesRecorded} decoded={sampleCount} format={DescribeWaveFormat(capture.WaveFormat)} recording={_isRecording}");
         }
         if (sampleCount == 0) return;
 
@@ -506,24 +539,27 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private void OnRecordingStopped(object? sender, AudioInputRecordingStoppedEventArgs e)
     {
-        if (_waveIn is null || !ReferenceEquals(sender, _waveIn))
-            return;
+        lock (_captureLifecycleLock)
+        {
+            if (_waveIn is null || !ReferenceEquals(sender, _waveIn))
+                return;
 
-        var captureFailed = e.Exception is not null;
-        var activeDeviceAvailable = IsActiveDeviceAvailable(GetDeviceSnapshot(refresh: true));
-        AudioCaptureDiagnostics.Log(
-            $"RecordingStopped captureFailed={captureFailed} activeAvailable={activeDeviceAvailable} exception={e.Exception?.GetType().Name}:{e.Exception?.Message}");
+            var captureFailed = e.Exception is not null;
+            var activeDeviceAvailable = IsActiveDeviceAvailable(GetDeviceSnapshot(refresh: true));
+            AudioCaptureDiagnostics.Log(
+                $"RecordingStopped unexpected sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} captureFailed={captureFailed} activeAvailable={activeDeviceAvailable} exception={e.Exception?.GetType().Name}:{e.Exception?.Message}");
 
-        System.Diagnostics.Debug.WriteLine(captureFailed
-            ? $"Audio input capture stopped unexpectedly: {e.Exception!.Message}"
-            : "Audio input capture stopped.");
+            System.Diagnostics.Debug.WriteLine(captureFailed
+                ? $"Audio input capture stopped unexpectedly: {e.Exception!.Message}"
+                : "Audio input capture stopped unexpectedly without an exception.");
 
-        ClearRecordingState();
-        DisposeWaveIn(stopRecording: false);
-        StartDevicePolling();
+            ClearRecordingState();
+            DisposeWaveIn(stopRecording: false, reason: "unexpected stop");
+            StartDevicePolling();
 
-        if (captureFailed && !activeDeviceAvailable)
-            RaiseDeviceLost();
+            if (captureFailed && !activeDeviceAvailable)
+                RaiseDeviceLost();
+        }
     }
 
     private static void NormalizeAudio(float[] samples)
@@ -607,20 +643,23 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private void ApplyPreferredDeviceChange()
     {
-        if (!_isWarmedUp)
-            return;
+        lock (_captureLifecycleLock)
+        {
+            if (!_isWarmedUp)
+                return;
 
-        var newDevice = ResolvePreferredDeviceNumber(allowFallback: true);
-        if (!ActiveDeviceMatches(newDevice))
-        {
-            DisposeWaveIn();
-            if (newDevice >= 0)
-                WarmUp();
-        }
-        else if (newDevice >= 0)
-        {
-            _activeDeviceNumber = newDevice;
-            SetActiveDeviceIdentity(newDevice);
+            var newDevice = ResolvePreferredDeviceNumber(allowFallback: true);
+            if (!ActiveDeviceMatches(newDevice))
+            {
+                DisposeWaveIn(reason: "device change");
+                if (newDevice >= 0)
+                    WarmUp();
+            }
+            else if (newDevice >= 0)
+            {
+                _activeDeviceNumber = newDevice;
+                SetActiveDeviceIdentity(newDevice);
+            }
         }
     }
 
@@ -918,22 +957,25 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private void EnsureActiveDeviceIsPreferred(IReadOnlyList<AudioInputDeviceSnapshot> snapshot)
     {
-        if (!_isWarmedUp)
-            return;
-
-        if (!IsPreferredDeviceAvailable(snapshot) || IsActiveDevicePreferred())
-            return;
-
-        if (_isRecording)
+        lock (_captureLifecycleLock)
         {
-            // Never tear down an in-flight recording just to migrate to a
-            // preferred device; complete the migration on a later check once
-            // recording has stopped.
-            return;
-        }
+            if (!_isWarmedUp)
+                return;
 
-        DisposeWaveIn();
-        WarmUp();
+            if (!IsPreferredDeviceAvailable(snapshot) || IsActiveDevicePreferred())
+                return;
+
+            if (_isRecording)
+            {
+                // Never tear down an in-flight recording just to migrate to a
+                // preferred device; complete the migration on a later check once
+                // recording has stopped.
+                return;
+            }
+
+            DisposeWaveIn(reason: "device change");
+            WarmUp();
+        }
     }
 
     private void RaiseAudioLevelChanged(float peak, float rms) =>
@@ -989,9 +1031,12 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 
     private void HandleDeviceLost()
     {
-        ClearRecordingState();
-        DisposeWaveIn();
-        RaiseDeviceLost();
+        lock (_captureLifecycleLock)
+        {
+            ClearRecordingState();
+            DisposeWaveIn(reason: "device loss");
+            RaiseDeviceLost();
+        }
     }
 
     private void RaiseDeviceLost()
@@ -1122,33 +1167,34 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// </summary>
     public void StartPreview(int? deviceNumber)
     {
-        if (_isRecording)
-            return;
-
-        StopPreview();
-        if (_disposed || _deviceProvider.DeviceCount == 0) return;
-
-        var deviceIndex = deviceNumber.HasValue
-            ? TryGetDeviceName(deviceNumber.Value) is not null
-                ? deviceNumber.Value
-                : ResolvePreferredDeviceNumber(allowFallback: true)
-            : FindBestMicrophoneDevice();
-        if (deviceIndex < 0) return;
-
-        try
+        lock (_captureLifecycleLock)
         {
-            _previewWaveIn = _captureFactory.Create(
-                deviceIndex,
-                new WaveFormat(SampleRate, BitsPerSample, Channels),
-                bufferMilliseconds: 50);
-            _previewWaveIn.DataAvailable += OnPreviewDataAvailable;
-            _previewWaveIn.StartRecording();
-            _isPreviewing = true;
-        }
-        catch (Exception ex) when (IsNonFatalAudioException(ex))
-        {
-            System.Diagnostics.Debug.WriteLine($"StartPreview failed: {ex.Message}");
             StopPreview();
+            if (_isRecording || _disposed || _deviceProvider.DeviceCount == 0) return;
+
+            var deviceIndex = deviceNumber.HasValue
+                ? TryGetDeviceName(deviceNumber.Value) is not null
+                    ? deviceNumber.Value
+                    : ResolvePreferredDeviceNumber(allowFallback: true)
+                : FindBestMicrophoneDevice();
+            if (deviceIndex < 0) return;
+
+            try
+            {
+                _previewWaveIn = _captureFactory.Create(
+                    deviceIndex,
+                    new WaveFormat(SampleRate, BitsPerSample, Channels),
+                    bufferMilliseconds: 50);
+                _previewWaveIn.DataAvailable += OnPreviewDataAvailable;
+                _previewWaveIn.Prepare();
+                _previewWaveIn.StartRecording();
+                _isPreviewing = true;
+            }
+            catch (Exception ex) when (IsNonFatalAudioException(ex))
+            {
+                System.Diagnostics.Debug.WriteLine($"StartPreview failed: {ex.Message}");
+                StopPreview();
+            }
         }
     }
 
@@ -1157,14 +1203,17 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// </summary>
     public void StopPreview()
     {
-        if (_previewWaveIn is not null)
+        lock (_captureLifecycleLock)
         {
-            _previewWaveIn.DataAvailable -= OnPreviewDataAvailable;
-            StopRecordingForCleanup(_previewWaveIn);
-            _previewWaveIn.Dispose();
-            _previewWaveIn = null;
+            if (_previewWaveIn is not null)
+            {
+                _previewWaveIn.DataAvailable -= OnPreviewDataAvailable;
+                StopRecordingForCleanup(_previewWaveIn);
+                _previewWaveIn.Dispose();
+                _previewWaveIn = null;
+            }
+            _isPreviewing = false;
         }
-        _isPreviewing = false;
     }
 
     private static void StopRecordingForCleanup(IAudioInputCapture waveIn)
@@ -1173,7 +1222,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         {
             waveIn.StopRecording();
         }
-        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or MmException)
+        catch (Exception ex) when (IsNonFatalAudioException(ex))
         {
             System.Diagnostics.Debug.WriteLine($"StopRecording during audio cleanup failed: {ex.Message}");
         }
@@ -1211,30 +1260,87 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         RaisePreviewLevelChanged(peak, rms);
     }
 
-    private void DisposeWaveIn(bool stopRecording = true, bool resetWarmUp = true)
+    private void StopAndRetainWaveIn(IAudioInputCapture waveIn)
     {
-        if (_waveIn is not null)
+        waveIn.DataAvailable -= OnDataAvailable;
+        waveIn.RecordingStopped -= OnRecordingStopped;
+
+        try
         {
-            var waveIn = _waveIn;
-            _waveIn = null;
+            waveIn.StopRecording();
+            waveIn.DataAvailable += OnDataAvailable;
+            waveIn.RecordingStopped += OnRecordingStopped;
             AudioCaptureDiagnostics.Log(
-                $"DisposeWaveIn release stopRecording={stopRecording} resetWarmUp={resetWarmUp}");
-            waveIn.DataAvailable -= OnDataAvailable;
-            waveIn.RecordingStopped -= OnRecordingStopped;
-            if (stopRecording)
-            {
-                StopRecordingForCleanup(waveIn);
-            }
-            waveIn.Dispose();
+                $"Capture stopped and retained sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration}");
+            AudioCaptureDiagnostics.Log(
+                $"DisposeWaveIn release stopRecording=True resetWarmUp=False retained=True sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration}");
         }
+        catch (Exception ex) when (IsNonFatalAudioException(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Capture disposed after failure sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} reason=stop failure exception={ex.GetType().Name}:{ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"Reusable audio capture stop failed: {ex.Message}");
+            if (ReferenceEquals(_waveIn, waveIn))
+                _waveIn = null;
+            try
+            {
+                waveIn.Dispose();
+            }
+            catch (Exception disposeException) when (IsNonFatalAudioException(disposeException))
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"Reusable audio capture cleanup failed: {disposeException.Message}");
+            }
 
-        if (!resetWarmUp)
-            return;
+            _isWarmedUp = false;
+            _activeDeviceNumber = -1;
+            _activeDeviceId = null;
+            _activeDeviceName = null;
+        }
+    }
 
-        _isWarmedUp = false;
-        _activeDeviceNumber = -1;
-        _activeDeviceId = null;
-        _activeDeviceName = null;
+    private void DisposeWaveIn(
+        bool stopRecording = true,
+        bool resetWarmUp = true,
+        string reason = "cleanup")
+    {
+        lock (_captureLifecycleLock)
+        {
+            if (_waveIn is not null)
+            {
+                var waveIn = _waveIn;
+                _waveIn = null;
+                AudioCaptureDiagnostics.Log(
+                    $"DisposeWaveIn release stopRecording={stopRecording} resetWarmUp={resetWarmUp} reason={reason} captureGeneration={_activeCaptureGeneration}");
+                waveIn.DataAvailable -= OnDataAvailable;
+                waveIn.RecordingStopped -= OnRecordingStopped;
+                if (stopRecording)
+                {
+                    StopRecordingForCleanup(waveIn);
+                }
+                waveIn.Dispose();
+                if (reason.Contains("failure", StringComparison.Ordinal)
+                    || reason.Contains("loss", StringComparison.Ordinal)
+                    || reason.Contains("unexpected", StringComparison.Ordinal))
+                {
+                    AudioCaptureDiagnostics.Log(
+                        $"Capture disposed after failure captureGeneration={_activeCaptureGeneration} reason={reason}");
+                }
+                else if (reason == "fallback recreated")
+                {
+                    AudioCaptureDiagnostics.Log(
+                        $"WaveIn fallback released; fallback recreated on next recording captureGeneration={_activeCaptureGeneration}");
+                }
+            }
+
+            if (!resetWarmUp)
+                return;
+
+            _isWarmedUp = false;
+            _activeDeviceNumber = -1;
+            _activeDeviceId = null;
+            _activeDeviceName = null;
+        }
     }
 
     /// <summary>
@@ -1242,20 +1348,23 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (!_disposed)
+        lock (_captureLifecycleLock)
         {
-            _disposed = true;
-            _devicePollTimer?.Dispose();
-            _devicePollTimer = null;
-            if (_deviceChangeNotifier is not null)
+            if (!_disposed)
             {
-                if (_deviceNotificationsStarted)
-                    _deviceChangeNotifier.DevicesChanged -= OnDeviceChangeNotification;
-                _deviceChangeNotifier.Dispose();
+                _disposed = true;
+                _devicePollTimer?.Dispose();
+                _devicePollTimer = null;
+                if (_deviceChangeNotifier is not null)
+                {
+                    if (_deviceNotificationsStarted)
+                        _deviceChangeNotifier.DevicesChanged -= OnDeviceChangeNotification;
+                    _deviceChangeNotifier.Dispose();
+                }
+                _isRecording = false;
+                StopPreview();
+                DisposeWaveIn();
             }
-            _isRecording = false;
-            StopPreview();
-            DisposeWaveIn();
         }
     }
 
@@ -1381,7 +1490,9 @@ internal interface IAudioInputCapture : IDisposable
 {
     event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
     event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+    bool CanRestartAfterStop { get; }
     WaveFormat WaveFormat { get; }
+    void Prepare();
     void StartRecording();
     void StopRecording();
 }
@@ -1709,7 +1820,13 @@ internal sealed class WaveInAudioInputCapture : IAudioInputCapture
     /// </summary>
     public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
 
+    public bool CanRestartAfterStop => false;
+
     public WaveFormat WaveFormat => _waveIn.WaveFormat;
+
+    public void Prepare()
+    {
+    }
 
     /// <summary>
     /// Starts recording.
@@ -1878,8 +1995,27 @@ internal sealed class FallbackAudioInputCapture : IAudioInputCapture
     public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
     public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
 
+    public bool CanRestartAfterStop => _capture?.CanRestartAfterStop ?? false;
+
     public WaveFormat WaveFormat =>
         _capture?.WaveFormat ?? throw new ObjectDisposedException(nameof(FallbackAudioInputCapture));
+
+    public void Prepare()
+    {
+        ThrowIfDisposed();
+
+        try
+        {
+            _capture!.Prepare();
+        }
+        catch (Exception ex) when (!_usingFallback && NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"Primary microphone capture prepare failed; using fallback {ex.GetType().Name}: {ex.Message}");
+            SwitchToFallback();
+            _capture!.Prepare();
+        }
+    }
 
     public void StartRecording()
     {
@@ -1942,6 +2078,8 @@ internal sealed class FallbackAudioInputCapture : IAudioInputCapture
                 _requestedWaveFormat,
                 _bufferMilliseconds);
             AttachCapture();
+            AudioCaptureDiagnostics.Log(
+                $"WaveIn fallback recreated deviceNumber={_deviceNumber} bufferMs={_bufferMilliseconds}");
         }
         catch
         {
@@ -2092,53 +2230,4 @@ internal static class WasapiAudioInputDeviceOrdering
         return wasapiDeviceName.StartsWith(trimmedWaveInName, StringComparison.OrdinalIgnoreCase)
             || trimmedWaveInName.StartsWith(wasapiDeviceName, StringComparison.OrdinalIgnoreCase);
     }
-}
-
-internal sealed class WasapiAudioInputCapture : IAudioInputCapture
-{
-    private readonly MMDevice _device;
-    private readonly WasapiCapture _capture;
-
-    public WasapiAudioInputCapture(MMDevice device, int bufferMilliseconds)
-    {
-        _device = device;
-        AudioCaptureDiagnostics.Log(
-            $"WasapiCapture ctor device={device.FriendlyName} bufferMs={bufferMilliseconds} sync={SynchronizationContext.Current?.GetType().FullName ?? "<null>"}");
-        _capture = new WasapiCapture(device, useEventSync: true, bufferMilliseconds);
-        _capture.DataAvailable += OnDataAvailable;
-        _capture.RecordingStopped += OnRecordingStopped;
-        AudioCaptureDiagnostics.Log($"WasapiCapture ctor format={AudioRecordingService.DescribeWaveFormat(_capture.WaveFormat)}");
-    }
-
-    public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
-    public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
-
-    public WaveFormat WaveFormat => _capture.WaveFormat;
-
-    public void StartRecording()
-    {
-        AudioCaptureDiagnostics.Log($"WasapiCapture StartRecording state={_capture.CaptureState}");
-        _capture.StartRecording();
-        AudioCaptureDiagnostics.Log($"WasapiCapture StartRecording returned state={_capture.CaptureState}");
-    }
-
-    public void StopRecording()
-    {
-        AudioCaptureDiagnostics.Log($"WasapiCapture StopRecording state={_capture.CaptureState}");
-        _capture.StopRecording();
-    }
-
-    public void Dispose()
-    {
-        _capture.DataAvailable -= OnDataAvailable;
-        _capture.RecordingStopped -= OnRecordingStopped;
-        _capture.Dispose();
-        _device.Dispose();
-    }
-
-    private void OnDataAvailable(object? sender, WaveInEventArgs e) =>
-        DataAvailable?.Invoke(this, new AudioInputDataAvailableEventArgs(e.Buffer, e.BytesRecorded));
-
-    private void OnRecordingStopped(object? sender, StoppedEventArgs e) =>
-        RecordingStopped?.Invoke(this, new AudioInputRecordingStoppedEventArgs(e.Exception));
 }

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -11,6 +11,13 @@ namespace TypeWhisper.Windows.Services;
 /// </summary>
 public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
 {
+    private enum CaptureDisposalClassification
+    {
+        Routine,
+        Failure,
+        FallbackRecreated
+    }
+
     private const int SampleRate = 16000;
     private const int BitsPerSample = 16;
     private const int Channels = 1;
@@ -257,7 +264,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             {
                 AudioCaptureDiagnostics.Log($"WarmUp failed {ex.GetType().Name}: {ex.Message}");
                 System.Diagnostics.Debug.WriteLine($"WarmUp failed: {ex.Message}");
-                DisposeWaveIn(stopRecording: false, reason: "prepare failure");
+                DisposeWaveIn(
+                    stopRecording: false,
+                    reason: "prepare failure",
+                    classification: CaptureDisposalClassification.Failure);
             }
 
             StartDevicePolling();
@@ -355,7 +365,9 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
                     $"StartRecording failed sequence={_activeRecordingSequence} captureGeneration={_activeCaptureGeneration} {ex.GetType().Name}: {ex.Message}");
                 System.Diagnostics.Debug.WriteLine($"StartRecording failed: {ex.Message}");
                 ClearRecordingState();
-                DisposeWaveIn(reason: "start failure");
+                DisposeWaveIn(
+                    reason: "start failure",
+                    classification: CaptureDisposalClassification.Failure);
             }
         }
     }
@@ -400,7 +412,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             if (_waveIn.CanRestartAfterStop)
                 StopAndRetainWaveIn(_waveIn);
             else
-                DisposeWaveIn(resetWarmUp: false, reason: "fallback recreated");
+                DisposeWaveIn(
+                    resetWarmUp: false,
+                    reason: "fallback recreated",
+                    classification: CaptureDisposalClassification.FallbackRecreated);
 
             if (samples is null || samples.Length == 0)
             {
@@ -554,7 +569,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
                 : "Audio input capture stopped unexpectedly without an exception.");
 
             ClearRecordingState();
-            DisposeWaveIn(stopRecording: false, reason: "unexpected stop");
+            DisposeWaveIn(
+                stopRecording: false,
+                reason: "unexpected stop",
+                classification: CaptureDisposalClassification.Failure);
             StartDevicePolling();
 
             if (captureFailed && !activeDeviceAvailable)
@@ -1034,7 +1052,9 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         lock (_captureLifecycleLock)
         {
             ClearRecordingState();
-            DisposeWaveIn(reason: "device loss");
+            DisposeWaveIn(
+                reason: "device loss",
+                classification: CaptureDisposalClassification.Failure);
             RaiseDeviceLost();
         }
     }
@@ -1296,13 +1316,15 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             _activeDeviceNumber = -1;
             _activeDeviceId = null;
             _activeDeviceName = null;
+            StartDevicePolling();
         }
     }
 
     private void DisposeWaveIn(
         bool stopRecording = true,
         bool resetWarmUp = true,
-        string reason = "cleanup")
+        string reason = "cleanup",
+        CaptureDisposalClassification classification = CaptureDisposalClassification.Routine)
     {
         lock (_captureLifecycleLock)
         {
@@ -1319,14 +1341,12 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
                     StopRecordingForCleanup(waveIn);
                 }
                 waveIn.Dispose();
-                if (reason.Contains("failure", StringComparison.Ordinal)
-                    || reason.Contains("loss", StringComparison.Ordinal)
-                    || reason.Contains("unexpected", StringComparison.Ordinal))
+                if (classification == CaptureDisposalClassification.Failure)
                 {
                     AudioCaptureDiagnostics.Log(
                         $"Capture disposed after failure captureGeneration={_activeCaptureGeneration} reason={reason}");
                 }
-                else if (reason == "fallback recreated")
+                else if (classification == CaptureDisposalClassification.FallbackRecreated)
                 {
                     AudioCaptureDiagnostics.Log(
                         $"WaveIn fallback released; fallback recreated on next recording captureGeneration={_activeCaptureGeneration}");

--- a/src/TypeWhisper.Windows/Services/WasapiAudioInputCapture.cs
+++ b/src/TypeWhisper.Windows/Services/WasapiAudioInputCapture.cs
@@ -1,0 +1,492 @@
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
+using NAudio.Wave;
+
+namespace TypeWhisper.Windows.Services;
+
+/// <summary>
+/// A prepare-once WASAPI capture that releases the endpoint between recording sessions.
+/// The buffer setup and packet-reading structure are adapted from NAudio 2.2.1 WasapiCapture.
+/// </summary>
+internal sealed class WasapiAudioInputCapture : IAudioInputCapture
+{
+    private const long ReferenceTimesPerSecond = 10_000_000;
+    private const long ReferenceTimesPerMillisecond = 10_000;
+    private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly object _lifecycleLock = new();
+    private readonly MMDevice _device;
+    private readonly int _bufferMilliseconds;
+    private readonly ManualResetEventSlim _captureStopped = new(initialState: true);
+
+    private AudioClient? _audioClient;
+    private AudioCaptureClient? _captureClient;
+    private EventWaitHandle? _frameEvent;
+    private WaveFormat? _waveFormat;
+    private byte[]? _recordBuffer;
+    private int _bytesPerFrame;
+    private int _waitMilliseconds;
+    private Thread? _captureThread;
+    private CaptureState _captureState = CaptureState.Stopped;
+    private Exception? _terminalException;
+    private bool _disposed;
+    private bool _disposeAfterCaptureThread;
+    private bool _stopTimedOut;
+    private bool _resourcesDisposed;
+    private bool _stoppedSignalDisposed;
+
+    public WasapiAudioInputCapture(MMDevice device, int bufferMilliseconds)
+    {
+        _device = device;
+        _bufferMilliseconds = bufferMilliseconds;
+        AudioCaptureDiagnostics.Log(
+            $"WasapiCapture created device={device.FriendlyName} bufferMs={bufferMilliseconds}");
+    }
+
+    public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
+    public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+
+    public bool CanRestartAfterStop => true;
+
+    public WaveFormat WaveFormat
+    {
+        get
+        {
+            lock (_lifecycleLock)
+            {
+                ThrowIfDisposed();
+                return (_waveFormat
+                    ?? throw new InvalidOperationException("WASAPI capture has not been prepared."))
+                    .AsStandardWaveFormat();
+            }
+        }
+    }
+
+    public void Prepare()
+    {
+        lock (_lifecycleLock)
+        {
+            ThrowIfDisposed();
+            if (_audioClient is not null)
+                return;
+
+            AudioClient? audioClient = null;
+            EventWaitHandle? frameEvent = null;
+            try
+            {
+                audioClient = _device.AudioClient;
+                var waveFormat = audioClient.MixFormat;
+                var requestedDuration = ReferenceTimesPerMillisecond * _bufferMilliseconds;
+                var streamFlags = AudioClientStreamFlags.EventCallback
+                    | AudioClientStreamFlags.AutoConvertPcm
+                    | AudioClientStreamFlags.SrcDefaultQuality;
+
+                audioClient.Initialize(
+                    AudioClientShareMode.Shared,
+                    streamFlags,
+                    requestedDuration,
+                    periodicity: 0,
+                    waveFormat,
+                    Guid.Empty);
+
+                frameEvent = new EventWaitHandle(false, EventResetMode.AutoReset);
+                audioClient.SetEventHandle(frameEvent.SafeWaitHandle.DangerousGetHandle());
+
+                var bufferFrameCount = audioClient.BufferSize;
+                var bytesPerFrame = waveFormat.Channels * waveFormat.BitsPerSample / 8;
+                var actualDuration = (long)(
+                    (double)ReferenceTimesPerSecond * bufferFrameCount / waveFormat.SampleRate);
+
+                _audioClient = audioClient;
+                _captureClient = audioClient.AudioCaptureClient;
+                _frameEvent = frameEvent;
+                _waveFormat = waveFormat;
+                _bytesPerFrame = bytesPerFrame;
+                _recordBuffer = new byte[bufferFrameCount * bytesPerFrame];
+                _waitMilliseconds = Math.Max(
+                    1,
+                    (int)(3 * actualDuration / ReferenceTimesPerMillisecond));
+
+                audioClient = null;
+                frameEvent = null;
+                AudioCaptureDiagnostics.Log(
+                    $"WasapiCapture prepared startIssued=False bufferMs={_bufferMilliseconds} format={AudioRecordingService.DescribeWaveFormat(WaveFormat)}");
+            }
+            catch
+            {
+                frameEvent?.Dispose();
+                audioClient?.Dispose();
+                throw;
+            }
+        }
+    }
+
+    public void StartRecording()
+    {
+        Prepare();
+
+        Thread captureThread;
+        AudioClient audioClient;
+        lock (_lifecycleLock)
+        {
+            ThrowIfDisposed();
+            if (_stopTimedOut)
+            {
+                throw new InvalidOperationException(
+                    "WASAPI capture must be recreated after a stop timeout.");
+            }
+            if (_captureState != CaptureState.Stopped || _captureThread is not null)
+                throw new InvalidOperationException("Previous WASAPI recording is still in progress.");
+
+            audioClient = _audioClient!;
+            _terminalException = null;
+            _captureStopped.Reset();
+            _captureState = CaptureState.Starting;
+
+            try
+            {
+                audioClient.Start();
+            }
+            catch
+            {
+                _captureState = CaptureState.Stopped;
+                _captureStopped.Set();
+                throw;
+            }
+
+            _captureState = CaptureState.Capturing;
+            var captureClient = _captureClient!;
+            var frameEvent = _frameEvent!;
+            var recordBuffer = _recordBuffer!;
+            var bytesPerFrame = _bytesPerFrame;
+            var waitMilliseconds = _waitMilliseconds;
+            captureThread = new Thread(() => CaptureThread(
+                audioClient,
+                captureClient,
+                frameEvent,
+                recordBuffer,
+                bytesPerFrame,
+                waitMilliseconds))
+            {
+                IsBackground = true,
+                Name = "TypeWhisper WASAPI capture"
+            };
+            _captureThread = captureThread;
+        }
+
+        try
+        {
+            captureThread.Start();
+            AudioCaptureDiagnostics.Log("WasapiCapture started preparedClient=True");
+        }
+        catch
+        {
+            lock (_lifecycleLock)
+                _captureState = CaptureState.Stopping;
+
+            var cleanupException = StopAndResetClient(audioClient);
+            lock (_lifecycleLock)
+            {
+                _captureThread = null;
+                _captureState = CaptureState.Stopped;
+                _terminalException = cleanupException;
+                _captureStopped.Set();
+            }
+
+            throw;
+        }
+    }
+
+    public void StopRecording()
+    {
+        Thread? captureThread;
+        lock (_lifecycleLock)
+        {
+            ThrowIfDisposed();
+            if (_captureState == CaptureState.Stopped && _captureThread is null)
+                return;
+
+            _captureState = CaptureState.Stopping;
+            captureThread = _captureThread;
+            _frameEvent?.Set();
+        }
+
+        if (captureThread is not null && ReferenceEquals(Thread.CurrentThread, captureThread))
+            return;
+
+        if (!_captureStopped.Wait(StopTimeout))
+        {
+            lock (_lifecycleLock)
+                _stopTimedOut = true;
+            throw new TimeoutException(
+                $"WASAPI capture did not stop within {StopTimeout.TotalSeconds:F0} seconds.");
+        }
+
+        Exception? terminalException;
+        lock (_lifecycleLock)
+            terminalException = _terminalException;
+
+        if (terminalException is not null)
+        {
+            throw new InvalidOperationException(
+                "WASAPI capture failed while stopping.",
+                terminalException);
+        }
+
+        AudioCaptureDiagnostics.Log("WasapiCapture stopped and reset preparedClient=True");
+    }
+
+    public void Dispose()
+    {
+        Thread? captureThread;
+        bool stopTimedOut;
+        lock (_lifecycleLock)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            captureThread = _captureThread;
+            stopTimedOut = _stopTimedOut;
+            if (captureThread is not null)
+            {
+                _captureState = CaptureState.Stopping;
+                _frameEvent?.Set();
+                if (stopTimedOut)
+                {
+                    _disposeAfterCaptureThread = true;
+                }
+                else if (ReferenceEquals(Thread.CurrentThread, captureThread))
+                {
+                    _disposeAfterCaptureThread = true;
+                    return;
+                }
+            }
+        }
+
+        if (captureThread is not null && stopTimedOut)
+        {
+            AudioCaptureDiagnostics.Log("WasapiCapture discarding client after stop timeout");
+            DisposePreparedResources();
+            return;
+        }
+
+        if (captureThread is not null && !_captureStopped.Wait(StopTimeout))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"WasapiCapture dispose continuing after stop timeoutMs={StopTimeout.TotalMilliseconds:F0}");
+            lock (_lifecycleLock)
+                _disposeAfterCaptureThread = true;
+            DisposePreparedResources();
+            return;
+        }
+
+        DisposePreparedResources();
+        DisposeStoppedSignal();
+    }
+
+    private void CaptureThread(
+        AudioClient audioClient,
+        AudioCaptureClient captureClient,
+        EventWaitHandle frameEvent,
+        byte[] recordBuffer,
+        int bytesPerFrame,
+        int waitMilliseconds)
+    {
+        Exception? captureException = null;
+        try
+        {
+            while (IsCapturing())
+            {
+                frameEvent.WaitOne(waitMilliseconds, exitContext: false);
+                if (!IsCapturing())
+                    break;
+
+                ReadNextPacket(captureClient, recordBuffer, bytesPerFrame);
+            }
+        }
+        catch (Exception ex)
+        {
+            captureException = ex;
+        }
+        finally
+        {
+            var cleanupException = StopAndResetClient(audioClient);
+            captureException ??= cleanupException;
+
+            lock (_lifecycleLock)
+            {
+                _captureState = CaptureState.Stopped;
+                _terminalException = captureException;
+            }
+
+            try
+            {
+                RecordingStopped?.Invoke(
+                    this,
+                    new AudioInputRecordingStoppedEventArgs(captureException));
+            }
+            catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"WASAPI RecordingStopped subscriber failed: {ex.Message}");
+            }
+            finally
+            {
+                bool disposeAfterCaptureThread;
+                lock (_lifecycleLock)
+                {
+                    _captureThread = null;
+                    disposeAfterCaptureThread = _disposeAfterCaptureThread;
+                }
+                _captureStopped.Set();
+                if (disposeAfterCaptureThread)
+                {
+                    DisposePreparedResources();
+                    DisposeStoppedSignal();
+                }
+            }
+        }
+    }
+
+    private bool IsCapturing()
+    {
+        lock (_lifecycleLock)
+            return _captureState == CaptureState.Capturing;
+    }
+
+    private void ReadNextPacket(
+        AudioCaptureClient captureClient,
+        byte[] recordBuffer,
+        int bytesPerFrame)
+    {
+        var packetSize = captureClient.GetNextPacketSize();
+        var recordBufferOffset = 0;
+
+        while (packetSize != 0)
+        {
+            var buffer = captureClient.GetBuffer(
+                out var framesAvailable,
+                out var flags);
+            try
+            {
+                var bytesAvailable = framesAvailable * bytesPerFrame;
+                var spaceRemaining = Math.Max(0, recordBuffer.Length - recordBufferOffset);
+                if (spaceRemaining < bytesAvailable && recordBufferOffset > 0)
+                {
+                    RaiseDataAvailable(recordBuffer, recordBufferOffset);
+                    recordBufferOffset = 0;
+                }
+
+                if (bytesAvailable > recordBuffer.Length)
+                {
+                    throw new InvalidOperationException(
+                        "WASAPI returned more audio data than the initialized capture buffer can hold.");
+                }
+
+                if ((flags & AudioClientBufferFlags.Silent) == 0)
+                    Marshal.Copy(buffer, recordBuffer, recordBufferOffset, bytesAvailable);
+                else
+                    Array.Clear(recordBuffer, recordBufferOffset, bytesAvailable);
+
+                recordBufferOffset += bytesAvailable;
+            }
+            finally
+            {
+                captureClient.ReleaseBuffer(framesAvailable);
+            }
+            packetSize = captureClient.GetNextPacketSize();
+        }
+
+        if (recordBufferOffset > 0)
+            RaiseDataAvailable(recordBuffer, recordBufferOffset);
+    }
+
+    private void RaiseDataAvailable(byte[] buffer, int bytesRecorded) =>
+        DataAvailable?.Invoke(
+            this,
+            new AudioInputDataAvailableEventArgs(buffer, bytesRecorded));
+
+    private static Exception? StopAndResetClient(AudioClient audioClient)
+    {
+        Exception? failure = null;
+        try
+        {
+            audioClient.Stop();
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+
+        try
+        {
+            audioClient.Reset();
+        }
+        catch (Exception ex)
+        {
+            failure ??= ex;
+        }
+
+        return failure;
+    }
+
+    private void DisposePreparedResources()
+    {
+        AudioClient? audioClient;
+        EventWaitHandle? frameEvent;
+        lock (_lifecycleLock)
+        {
+            if (_resourcesDisposed)
+                return;
+
+            _resourcesDisposed = true;
+            audioClient = _audioClient;
+            frameEvent = _frameEvent;
+            _audioClient = null;
+            _captureClient = null;
+            _frameEvent = null;
+            _waveFormat = null;
+            _recordBuffer = null;
+        }
+
+        DisposeSafely(frameEvent, "frame event");
+        DisposeSafely(audioClient, "audio client");
+        DisposeSafely(_device, "device");
+    }
+
+    private void DisposeStoppedSignal()
+    {
+        lock (_lifecycleLock)
+        {
+            if (_stoppedSignalDisposed)
+                return;
+            _stoppedSignalDisposed = true;
+        }
+
+        DisposeSafely(_captureStopped, "stop signal");
+    }
+
+    private static void DisposeSafely(IDisposable? resource, string resourceName)
+    {
+        if (resource is null)
+            return;
+
+        try
+        {
+            resource.Dispose();
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            AudioCaptureDiagnostics.Log(
+                $"WasapiCapture {resourceName} disposal failed {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(WasapiAudioInputCapture));
+    }
+}

--- a/src/TypeWhisper.Windows/Services/WasapiAudioInputCapture.cs
+++ b/src/TypeWhisper.Windows/Services/WasapiAudioInputCapture.cs
@@ -268,7 +268,6 @@ internal sealed class WasapiAudioInputCapture : IAudioInputCapture
         if (captureThread is not null && stopTimedOut)
         {
             AudioCaptureDiagnostics.Log("WasapiCapture discarding client after stop timeout");
-            DisposePreparedResources();
             return;
         }
 
@@ -278,7 +277,6 @@ internal sealed class WasapiAudioInputCapture : IAudioInputCapture
                 $"WasapiCapture dispose continuing after stop timeoutMs={StopTimeout.TotalMilliseconds:F0}");
             lock (_lifecycleLock)
                 _disposeAfterCaptureThread = true;
-            DisposePreparedResources();
             return;
         }
 
@@ -306,7 +304,7 @@ internal sealed class WasapiAudioInputCapture : IAudioInputCapture
                 ReadNextPacket(captureClient, recordBuffer, bytesPerFrame);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             captureException = ex;
         }
@@ -415,7 +413,7 @@ internal sealed class WasapiAudioInputCapture : IAudioInputCapture
         {
             audioClient.Stop();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             failure = ex;
         }
@@ -424,7 +422,7 @@ internal sealed class WasapiAudioInputCapture : IAudioInputCapture
         {
             audioClient.Reset();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             failure ??= ex;
         }

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -33,6 +33,28 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
+    public void PreparedWasapiCapture_SeparatesInitializeStartAndSynchronousReset()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Services",
+            "WasapiAudioInputCapture.cs");
+        var prepare = TestFile.ExtractBlock(source, "public void Prepare()", 2600);
+        var start = TestFile.ExtractBlock(source, "public void StartRecording()", 2600);
+        var stop = TestFile.ExtractBlock(source, "public void StopRecording()", 1900);
+        var reset = TestFile.ExtractBlock(source, "private static Exception? StopAndResetClient", 1200);
+
+        Assert.Contains("audioClient.Initialize(", prepare);
+        Assert.DoesNotContain("audioClient.Start()", prepare);
+        Assert.Contains("audioClient.Start()", start);
+        Assert.Contains("_captureStopped.Wait(StopTimeout)", stop);
+        Assert.Contains("audioClient.Stop()", reset);
+        Assert.Contains("audioClient.Reset()", reset);
+        Assert.Contains("public bool CanRestartAfterStop => true;", source);
+    }
+
+    [Fact]
     public void FallbackCapture_UsesWaveInWhenWasapiStartFails()
     {
         var wasapi = new FakeAudioInputCaptureFactory
@@ -50,6 +72,28 @@ public sealed class AudioRecordingServiceDeviceChangeTests
 
         Assert.True(Assert.Single(wasapi.Created).Disposed);
         Assert.True(Assert.Single(waveIn.Created).Started);
+    }
+
+    [Fact]
+    public void FallbackCapture_UsesWaveInWhenWasapiPrepareFails()
+    {
+        var wasapi = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true,
+            PrepareException = new InvalidOperationException("WASAPI initialization failed.")
+        };
+        var waveIn = new FakeAudioInputCaptureFactory();
+        var factory = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
+        using var capture = factory.Create(
+            deviceNumber: 0,
+            new WaveFormat(16000, 16, 1),
+            bufferMilliseconds: 30);
+
+        capture.Prepare();
+
+        Assert.True(Assert.Single(wasapi.Created).Disposed);
+        Assert.True(Assert.Single(waveIn.Created).Prepared);
+        Assert.False(capture.CanRestartAfterStop);
     }
 
     [Fact]
@@ -280,23 +324,31 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
-    public void WarmUp_DoesNotStartMicrophoneCapture()
+    public void WarmUp_PreparesMicrophoneCaptureWithoutStartingIt()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
-        var captures = new FakeAudioInputCaptureFactory();
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
         using var sut = CreateService(devices, captures);
 
         Assert.True(sut.WarmUp());
 
         var capture = Assert.Single(captures.Created);
+        Assert.True(capture.Prepared);
+        Assert.Equal(1, capture.PrepareCount);
         Assert.False(capture.Started);
     }
 
     [Fact]
-    public void StopRecording_StopsAndDisposesMicrophoneCapture_WhenNoAudioWasReceived()
+    public void StopRecording_StopsAndRetainsRestartableCapture_WhenNoAudioWasReceived()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
-        var captures = new FakeAudioInputCaptureFactory();
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
         using var sut = CreateService(devices, captures);
         Assert.True(sut.WarmUp());
         sut.StartRecording();
@@ -306,14 +358,17 @@ public sealed class AudioRecordingServiceDeviceChangeTests
 
         Assert.Null(samples);
         Assert.True(capture.Stopped);
-        Assert.True(capture.Disposed);
+        Assert.False(capture.Disposed);
     }
 
     [Fact]
-    public async Task StopRecordingAsync_ReleasesMicrophoneCapture_WhenCancellationIsRequested()
+    public async Task StopRecordingAsync_StopsAndRetainsRestartableCapture_WhenCancellationIsRequested()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
-        var captures = new FakeAudioInputCaptureFactory();
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
         using var sut = CreateService(devices, captures);
         sut.StartRecording();
         var capture = Assert.Single(captures.Created);
@@ -324,34 +379,234 @@ public sealed class AudioRecordingServiceDeviceChangeTests
 
         Assert.Null(samples);
         Assert.True(capture.Stopped);
+        Assert.False(capture.Disposed);
+    }
+
+    [Fact]
+    public void ConsecutiveRecordings_ReusePreparedCaptureWithoutLeakingSamples()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
+        using var sut = CreateService(devices, captures);
+        sut.NormalizationEnabled = false;
+        var firstBytes = new byte[sizeof(short) * 2];
+        Buffer.BlockCopy(new short[] { 1000, 2000 }, 0, firstBytes, 0, firstBytes.Length);
+        var secondBytes = new byte[sizeof(short) * 2];
+        Buffer.BlockCopy(new short[] { 3000, 4000 }, 0, secondBytes, 0, secondBytes.Length);
+
+        sut.StartRecording();
+        var capture = Assert.Single(captures.Created);
+        capture.RaiseData(firstBytes, firstBytes.Length);
+        var firstSamples = sut.StopRecording();
+
+        sut.StartRecording();
+        Assert.Same(capture, Assert.Single(captures.Created));
+        capture.RaiseData(secondBytes, secondBytes.Length);
+        var secondSamples = sut.StopRecording();
+
+        Assert.Equal(2, capture.StartCount);
+        Assert.Equal(2, capture.StopCount);
+        Assert.False(capture.Disposed);
+        Assert.NotNull(firstSamples);
+        Assert.NotNull(secondSamples);
+        Assert.Equal([1000 / 32768f, 2000 / 32768f], firstSamples);
+        Assert.Equal([3000 / 32768f, 4000 / 32768f], secondSamples);
+    }
+
+    [Fact]
+    public void WaveInFallback_RecreatesFreshCaptureForEachRecording()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var wasapi = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true,
+            PrepareException = new InvalidOperationException("WASAPI initialization failed.")
+        };
+        var waveIn = new FakeAudioInputCaptureFactory();
+        var captures = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
+        using var sut = new AudioRecordingService(
+            devices,
+            captures,
+            Timeout.InfiniteTimeSpan);
+
+        sut.StartRecording();
+        sut.StopRecording();
+        sut.StartRecording();
+        sut.StopRecording();
+
+        Assert.Equal(2, waveIn.Created.Count);
+        Assert.All(waveIn.Created, capture => Assert.True(capture.Disposed));
+        Assert.Equal(2, wasapi.Created.Count);
+        Assert.All(wasapi.Created, capture => Assert.True(capture.Disposed));
+    }
+
+    [Fact]
+    public void WarmUp_DisposesCaptureAfterPrepareFailureAndRecovers()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true,
+            PrepareException = new InvalidOperationException("WASAPI initialization failed.")
+        };
+        using var sut = CreateService(devices, captures);
+
+        Assert.False(sut.WarmUp());
+        Assert.True(Assert.Single(captures.Created).Disposed);
+
+        captures.PrepareException = null;
+
+        Assert.True(sut.WarmUp());
+        Assert.Equal(2, captures.Created.Count);
+        Assert.True(captures.Created.Last().Prepared);
+    }
+
+    [Fact]
+    public void StartRecording_DisposesRestartableCaptureAfterStartFailureAndRecovers()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true,
+            StartException = new InvalidOperationException("WASAPI start failed.")
+        };
+        using var sut = CreateService(devices, captures);
+
+        sut.StartRecording();
+        var failedCapture = Assert.Single(captures.Created);
+
+        Assert.False(sut.IsRecording);
+        Assert.True(failedCapture.Disposed);
+
+        captures.StartException = null;
+        sut.StartRecording();
+
+        Assert.True(sut.IsRecording);
+        Assert.Equal(2, captures.Created.Count);
+    }
+
+    [Fact]
+    public void StopRecording_DisposesRestartableCaptureAfterStopFailureAndRecovers()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true,
+            StopException = new InvalidOperationException("Capture stop failed.")
+        };
+        using var sut = CreateService(devices, captures);
+
+        sut.StartRecording();
+        var failedCapture = Assert.Single(captures.Created);
+        var exception = Record.Exception(() => sut.StopRecording());
+
+        Assert.Null(exception);
+        Assert.True(failedCapture.Disposed);
+
+        captures.StopException = null;
+        sut.StartRecording();
+
+        Assert.Equal(2, captures.Created.Count);
+        Assert.NotSame(failedCapture, captures.Created.Last());
+    }
+
+    [Fact]
+    public void StopRecording_DisposesRestartableCaptureAfterStopTimeoutAndRecovers()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true,
+            StopException = new TimeoutException("Capture stop timed out.")
+        };
+        using var sut = CreateService(devices, captures);
+
+        sut.StartRecording();
+        var failedCapture = Assert.Single(captures.Created);
+        sut.StopRecording();
+
+        Assert.True(failedCapture.Disposed);
+
+        captures.StopException = null;
+        sut.StartRecording();
+
+        Assert.Equal(2, captures.Created.Count);
+    }
+
+    [Fact]
+    public void RecordingStopped_UnexpectedlyDisposesRestartableCapture()
+    {
+        var devices = new FakeAudioInputDeviceProvider("USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
+        using var sut = CreateService(devices, captures);
+        sut.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        capture.RaiseStopped(new InvalidOperationException("Device removed."));
+
+        Assert.False(sut.IsRecording);
         Assert.True(capture.Disposed);
     }
 
     [Fact]
-    public void ConsecutiveRecordings_UseFreshMicrophoneCaptures()
+    public void DeviceChange_DisposesPreparedRestartableCaptureAndCreatesNewGeneration()
+    {
+        var devices = new FakeAudioInputDeviceProvider(
+            "Microphone Array",
+            "USB Microphone");
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
+        using var sut = CreateService(devices, captures);
+        Assert.True(sut.WarmUp());
+        var firstCapture = Assert.Single(captures.Created);
+
+        sut.SetMicrophoneDevice(1);
+
+        Assert.True(firstCapture.Disposed);
+        Assert.Equal(2, captures.Created.Count);
+        Assert.True(captures.Created.Last().Prepared);
+        Assert.Equal(1, captures.Created.Last().DeviceNumber);
+    }
+
+    [Fact]
+    public void FirstDataAvailable_LogsStartLatencyOncePerRecording()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
-        var captures = new FakeAudioInputCaptureFactory();
+        var captures = new FakeAudioInputCaptureFactory
+        {
+            CanRestartAfterStop = true
+        };
         using var sut = CreateService(devices, captures);
-        var bytes = new byte[sizeof(short) * 2];
+        var messages = new List<string>();
+        void Observe(string message) => messages.Add(message);
+        AudioCaptureDiagnostics.MessageLogged += Observe;
 
-        sut.StartRecording();
-        var firstCapture = Assert.Single(captures.Created);
-        Assert.True(firstCapture.Started);
-        firstCapture.RaiseData(bytes, bytes.Length);
-        Assert.NotNull(sut.StopRecording());
+        try
+        {
+            sut.StartRecording();
+            var capture = Assert.Single(captures.Created);
+            var bytes = new byte[sizeof(short) * 2];
+            capture.RaiseData(bytes, bytes.Length);
+            capture.RaiseData(bytes, bytes.Length);
+        }
+        finally
+        {
+            AudioCaptureDiagnostics.MessageLogged -= Observe;
+        }
 
-        sut.StartRecording();
-        var secondCapture = Assert.Single(captures.Created.Skip(1));
-        Assert.NotSame(firstCapture, secondCapture);
-        Assert.True(secondCapture.Started);
-        secondCapture.RaiseData(bytes, bytes.Length);
-        Assert.NotNull(sut.StopRecording());
-
-        Assert.True(firstCapture.Stopped);
-        Assert.True(firstCapture.Disposed);
-        Assert.True(secondCapture.Stopped);
-        Assert.True(secondCapture.Disposed);
+        var latencyMessage = Assert.Single(messages, message =>
+            message.StartsWith("FirstDataAvailable", StringComparison.Ordinal));
+        Assert.Contains("sequence=1", latencyMessage);
+        Assert.Contains("captureGeneration=1", latencyMessage);
+        Assert.Matches("startLatencyMs=[0-9]+\\.[0-9]", latencyMessage);
     }
 
     [Fact]
@@ -1477,7 +1732,10 @@ internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
     public List<FakeAudioInputCapture> Created { get; } = [];
     public WaveFormat? ActualWaveFormat { get; set; }
     public Exception? CreateException { get; set; }
+    public Exception? PrepareException { get; set; }
     public Exception? StartException { get; set; }
+    public Exception? StopException { get; set; }
+    public bool CanRestartAfterStop { get; set; }
 
     public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
     {
@@ -1486,7 +1744,10 @@ internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
 
         var capture = new FakeAudioInputCapture(deviceNumber, ActualWaveFormat ?? waveFormat)
         {
-            StartException = StartException
+            CanRestartAfterStop = CanRestartAfterStop,
+            PrepareException = PrepareException,
+            StartException = StartException,
+            StopException = StopException
         };
         Created.Add(capture);
         return capture;
@@ -1497,23 +1758,42 @@ internal sealed class FakeAudioInputCapture(int deviceNumber, WaveFormat waveFor
 {
     public int DeviceNumber { get; } = deviceNumber;
     public WaveFormat WaveFormat { get; } = waveFormat;
-    public bool Started { get; private set; }
-    public bool Stopped { get; private set; }
+    public bool CanRestartAfterStop { get; init; }
+    public bool Prepared => PrepareCount > 0;
+    public bool Started => StartCount > 0;
+    public bool Stopped => StopCount > 0;
     public bool Disposed { get; private set; }
+    public int PrepareCount { get; private set; }
+    public int StartCount { get; private set; }
+    public int StopCount { get; private set; }
+    public Exception? PrepareException { get; init; }
     public Exception? StartException { get; init; }
+    public Exception? StopException { get; init; }
 
     public event EventHandler<AudioInputDataAvailableEventArgs>? DataAvailable;
     public event EventHandler<AudioInputRecordingStoppedEventArgs>? RecordingStopped;
+
+    public void Prepare()
+    {
+        PrepareCount++;
+        if (PrepareException is not null)
+            throw PrepareException;
+    }
 
     public void StartRecording()
     {
         if (StartException is not null)
             throw StartException;
 
-        Started = true;
+        StartCount++;
     }
 
-    public void StopRecording() => Stopped = true;
+    public void StopRecording()
+    {
+        StopCount++;
+        if (StopException is not null)
+            throw StopException;
+    }
 
     public void RaiseStopped(Exception? exception = null) =>
         RecordingStopped?.Invoke(this, new AudioInputRecordingStoppedEventArgs(exception));

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -610,6 +610,30 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
+    public void DiagnosticsObserverFailure_DoesNotInterruptRemainingObservers()
+    {
+        var notifications = 0;
+        Action<string> throwingObserver = _ => throw new InvalidOperationException("Observer failed.");
+        Action<string> succeedingObserver = _ => notifications++;
+        AudioCaptureDiagnostics.MessageLogged += throwingObserver;
+        AudioCaptureDiagnostics.MessageLogged += succeedingObserver;
+
+        Exception? exception;
+        try
+        {
+            exception = Record.Exception(() => AudioCaptureDiagnostics.Log("observer isolation"));
+        }
+        finally
+        {
+            AudioCaptureDiagnostics.MessageLogged -= throwingObserver;
+            AudioCaptureDiagnostics.MessageLogged -= succeedingObserver;
+        }
+
+        Assert.Null(exception);
+        Assert.Equal(1, notifications);
+    }
+
+    [Fact]
     public void RecordingStopped_WithoutException_DoesNotRaiseDeviceLost_WhenCaptureStopsCleanly()
     {
         var devices = new FakeAudioInputDeviceProvider("USB Microphone");
@@ -1514,7 +1538,9 @@ public sealed class RecorderAudioPipelineTests
         Assert.Contains("Path.GetFileName(segment)", method);
         Assert.Contains("string.IsNullOrEmpty(fileName) ? string.Empty : fileName", method);
         Assert.DoesNotContain("?? segment", method);
-        Assert.DoesNotContain("catch (Exception ex)", source);
+        Assert.DoesNotMatch(
+            @"catch\s*\(\s*Exception\s+\w+\s*\)(?!\s+when\b)",
+            source);
         Assert.Contains("catch (IOException ex)", source);
         Assert.Contains("catch (UnauthorizedAccessException ex)", source);
     }
@@ -1782,10 +1808,9 @@ internal sealed class FakeAudioInputCapture(int deviceNumber, WaveFormat waveFor
 
     public void StartRecording()
     {
+        StartCount++;
         if (StartException is not null)
             throw StartException;
-
-        StartCount++;
     }
 
     public void StopRecording()


### PR DESCRIPTION
## Summary

- prepare and reuse a stopped WASAPI client so microphone capture starts immediately
- keep the microphone released between dictations while recreating capture after failures and device changes
- retain the WaveIn fallback's fresh-instance behavior
- add capture generation/start-latency diagnostics and regression coverage
- document the adapted NAudio 2.2.1 WASAPI capture code

## Validation

- 42 focused `AudioRecordingServiceDeviceChangeTests`
- `dotnet build TypeWhisper.slnx -c Release --no-restore -m:1`
- `dotnet test TypeWhisper.slnx --no-restore -m:1` (1,811 passed)
- prepare-only warm-up did not activate Windows microphone usage
- three consecutive hardware capture cycles delivered first audio in 69.1 ms, 43.0 ms, and 41.9 ms
- Windows reported the microphone released within 729 ms, 575 ms, and 559 ms after stop, and it remained released for at least five seconds after every cycle
- local hotkey smoke test confirmed immediate capture behavior

Refs #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved audio recording startup and recovery across repeated sessions.
  * Added reusable capture sessions to reduce delays before recording begins.
  * Added more reliable handling for device changes, interruptions, and capture failures.
  * Added detailed recording diagnostics, including startup latency and recovery information.

* **Bug Fixes**
  * Improved cleanup and recovery after unexpected stops and timeouts.
  * Improved fallback handling when preferred audio capture cannot start.

* **Documentation**
  * Added third-party attribution and license information for the audio capture implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->