### PR TITLE
Prevent unsafe mouse-button hotkeys

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -30,6 +30,8 @@ public sealed class KeyboardHook : IDisposable
     /// </summary>
     public bool IsEnabled { get; set; } = true;
 
+    internal bool HasConfiguredHotkey => _stateMachine.HasHotkey || _mouseStateMachine.HasHotkey;
+
     /// <summary>
     /// Initializes a new instance of the KeyboardHook class.
     /// </summary>
@@ -49,6 +51,9 @@ public sealed class KeyboardHook : IDisposable
 
         if (HotkeyParser.Parse(hotkeyString, out ParsedHotkey parsed))
         {
+            if (HotkeyParser.IsUnsafeMouseBinding(parsed))
+                return;
+
             _targetKind = parsed.Kind;
             if (parsed.Kind == HotkeyTargetKind.Mouse)
                 _mouseStateMachine.SetHotkey(parsed.Modifiers, parsed.MouseButton);
@@ -862,6 +867,14 @@ internal static class HotkeyParser
 
     public static bool IsModifierOnly(string? hotkeyString) =>
         Parse(hotkeyString ?? "", out ParsedHotkey parsed) && parsed.IsModifierOnly;
+
+    public static bool IsUnsafeMouseBinding(string? hotkeyString) =>
+        Parse(hotkeyString ?? "", out ParsedHotkey parsed) && IsUnsafeMouseBinding(parsed);
+
+    internal static bool IsUnsafeMouseBinding(in ParsedHotkey parsed) =>
+        parsed.Kind == HotkeyTargetKind.Mouse
+        && parsed.Modifiers == 0
+        && parsed.MouseButton is HotkeyMouseButton.Left or HotkeyMouseButton.Right;
 
     /// <summary>
     /// Parses the supplied value into the expected representation.

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -629,6 +629,7 @@
   "Shortcuts.RemoveHotkey": "Hotkey entfernen",
   "Shortcuts.ValidationDuplicateFormat": "{0} ist bereits einem anderen Shortcut zugewiesen.",
   "Shortcuts.ValidationModifierOnlyHold": "Shortcuts nur aus Modifikatortasten können nicht für reine Halte-Diktate verwendet werden.",
+  "Hotkey.ValidationUnsafeMouseButton": "Linke und rechte Maustasten benötigen Ctrl, Shift, Alt oder Win. MouseMiddle, MouseBack und MouseForward können ohne Modifikatortaste verwendet werden.",
   "Appearance.LayoutSection": "Overlay-Layout",
   "Appearance.Style": "Indikator-Stil",
   "Appearance.StyleStatusIsland": "Status Island",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -629,6 +629,7 @@
   "Shortcuts.RemoveHotkey": "Remove hotkey",
   "Shortcuts.ValidationDuplicateFormat": "{0} is already assigned to another shortcut.",
   "Shortcuts.ValidationModifierOnlyHold": "Modifier-only shortcuts cannot be used for hold-only dictation.",
+  "Hotkey.ValidationUnsafeMouseButton": "Left and right mouse buttons require Ctrl, Shift, Alt, or Win. MouseMiddle, MouseBack, and MouseForward can be used without a modifier.",
   "Appearance.LayoutSection": "Overlay layout",
   "Appearance.Style": "Indicator style",
   "Appearance.StyleStatusIsland": "Status Island",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -618,6 +618,7 @@
   "Shortcuts.RemoveHotkey": "ホットキーを削除",
   "Shortcuts.ValidationDuplicateFormat": "{0}は別のショートカットに既に割り当てられています。",
   "Shortcuts.ValidationModifierOnlyHold": "修飾キーのみのショートカットはホールド専用の音声入力には使用できません。",
+  "Hotkey.ValidationUnsafeMouseButton": "マウスの左ボタンと右ボタンには Ctrl、Shift、Alt、または Win が必要です。MouseMiddle、MouseBack、MouseForward は修飾キーなしで使用できます。",
   "Appearance.LayoutSection": "オーバーレイレイアウト",
   "Appearance.Style": "インジケータースタイル",
   "Appearance.StyleStatusIsland": "Status Island",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -618,6 +618,7 @@
   "Shortcuts.RemoveHotkey": "Удалить горячую клавишу",
   "Shortcuts.ValidationDuplicateFormat": "{0} уже назначена другому сочетанию.",
   "Shortcuts.ValidationModifierOnlyHold": "Сочетания только из модификаторов нельзя использовать для режима удержания.",
+  "Hotkey.ValidationUnsafeMouseButton": "Для левой и правой кнопок мыши требуется Ctrl, Shift, Alt или Win. MouseMiddle, MouseBack и MouseForward можно использовать без модификатора.",
   "Appearance.LayoutSection": "Макет оверлея",
   "Appearance.Style": "Стиль индикатора",
   "Appearance.StyleStatusIsland": "Островок статуса",

--- a/src/TypeWhisper.Windows/Resources/Localization/zh-Hans.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/zh-Hans.json
@@ -618,6 +618,7 @@
   "Shortcuts.RemoveHotkey": "移除快捷键",
   "Shortcuts.ValidationDuplicateFormat": "{0} 已分配给其他快捷键。",
   "Shortcuts.ValidationModifierOnlyHold": "仅修饰键快捷键不能用于仅按住听写。",
+  "Hotkey.ValidationUnsafeMouseButton": "鼠标左键和右键需要搭配 Ctrl、Shift、Alt 或 Win。MouseMiddle、MouseBack 和 MouseForward 可以不搭配修饰键使用。",
   "Appearance.LayoutSection": "悬浮层布局",
   "Appearance.Style": "指示器样式",
   "Appearance.StyleStatusIsland": "状态岛",

--- a/src/TypeWhisper.Windows/Services/HotkeyService.cs
+++ b/src/TypeWhisper.Windows/Services/HotkeyService.cs
@@ -171,7 +171,8 @@ public sealed class HotkeyService : IDisposable
                                && workflow.Trigger.IsAutomatic
                                && workflow.Trigger.HasHotkeyBindings)
             .SelectMany(workflow => workflow.Trigger.Hotkeys
-                .Where(static hotkey => !string.IsNullOrWhiteSpace(hotkey))
+                .Where(static hotkey => !string.IsNullOrWhiteSpace(hotkey)
+                                        && !HotkeyParser.IsUnsafeMouseBinding(hotkey))
                 .Select(hotkey => new WorkflowHotkeyBinding(
                     workflow.Id,
                     hotkey,
@@ -195,7 +196,8 @@ public sealed class HotkeyService : IDisposable
         AppHotkeyAction action,
         IEnumerable<string> hotkeys) =>
         hotkeys
-            .Where(static hotkey => !string.IsNullOrWhiteSpace(hotkey))
+            .Where(static hotkey => !string.IsNullOrWhiteSpace(hotkey)
+                                    && !HotkeyParser.IsUnsafeMouseBinding(hotkey))
             .Select(hotkey => new AppHotkeyBinding(action, hotkey));
 
     private void AttachAppHotkeyHandler(KeyboardHook hook, AppHotkeyAction action)

--- a/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/SettingsViewModel.cs
@@ -890,6 +890,7 @@ public partial class SettingsViewModel : ObservableObject
         ReplaceCollection(CopyLastTranscriptionHotkeys, copyLastTranscriptionHotkeys);
         ReplaceCollection(WorkflowPaletteHotkeys, workflowPaletteHotkeys);
         ReplaceCollection(RecorderToggleHotkeys, recorderToggleHotkeys);
+        RefreshShortcutSafetyError();
 
         ToggleHotkey = mainDictationHotkey;
         PushToTalkHotkey = mainDictationHotkey;
@@ -967,8 +968,8 @@ public partial class SettingsViewModel : ObservableObject
         if (_isLoading)
             return;
 
-        ShortcutsError = "";
         SyncShortcutHotkeyPropertiesFromCollections();
+        RefreshShortcutSafetyError();
         Save();
     }
 
@@ -981,6 +982,13 @@ public partial class SettingsViewModel : ObservableObject
         var normalized = HotkeyParser.Normalize(hotkey);
         if (string.IsNullOrWhiteSpace(normalized))
             return;
+
+        if (HotkeyParser.IsUnsafeMouseBinding(normalized))
+        {
+            ShortcutsError = Loc.Instance["Hotkey.ValidationUnsafeMouseButton"];
+            setNewHotkey("");
+            return;
+        }
 
         if (rejectModifierOnly && HotkeyParser.IsModifierOnly(normalized))
         {
@@ -1025,6 +1033,13 @@ public partial class SettingsViewModel : ObservableObject
         .. NormalizeHotkeyList(WorkflowPaletteHotkeys),
         .. NormalizeHotkeyList(RecorderToggleHotkeys)
     ];
+
+    private void RefreshShortcutSafetyError()
+    {
+        ShortcutsError = GetAllShortcutHotkeys().Any(HotkeyParser.IsUnsafeMouseBinding)
+            ? Loc.Instance["Hotkey.ValidationUnsafeMouseButton"]
+            : "";
+    }
 
     private void SyncShortcutHotkeyPropertiesFromCollections()
     {
@@ -1154,6 +1169,7 @@ public partial class SettingsViewModel : ObservableObject
             OnPropertyChanged(nameof(PreviewBubbleAutoHideSecondsText));
             OnPropertyChanged(nameof(LiveTranscriptionFontSizeText));
             RefreshSpokenFeedbackProviders();
+            RefreshShortcutSafetyError();
             _isLoading = false;
         });
     }

--- a/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WelcomeViewModel.cs
@@ -79,6 +79,7 @@ public partial class WelcomeViewModel : ObservableObject
     [ObservableProperty] private bool _micWorking;
     [ObservableProperty] private string _mainDictationHotkey = "";
     [ObservableProperty] private string _newMainDictationHotkey = "";
+    [ObservableProperty] private string _hotkeyValidationMessage = "";
     [ObservableProperty] private bool _isLoadingPlugins;
     [ObservableProperty] private string _trialText = "";
     [ObservableProperty] private bool _trialSuccess;
@@ -145,6 +146,7 @@ public partial class WelcomeViewModel : ObservableObject
         _isInitializing = true;
         ReplaceCollection(MainDictationHotkeys, ResolveMainDictationHotkeys(settings.Current));
         MainDictationHotkey = FirstOrEmpty(MainDictationHotkeys);
+        RefreshHotkeyValidationMessage();
         _isInitializing = false;
 
         _pluginStateChangedHandler = (_, _) => DispatchToUi(RefreshModels);
@@ -194,7 +196,9 @@ public partial class WelcomeViewModel : ObservableObject
     /// <summary>
     /// Gets whether onboarding has at least one main dictation hotkey configured.
     /// </summary>
-    public bool HasConfiguredMainHotkey => MainDictationHotkeys.Count > 0;
+    public bool HasConfiguredMainHotkey => MainDictationHotkeys.Any(static hotkey =>
+        !string.IsNullOrWhiteSpace(HotkeyParser.Normalize(hotkey))
+        && !HotkeyParser.IsUnsafeMouseBinding(hotkey));
 
     /// <summary>
     /// Gets whether the selected local or plugin engine is ready.
@@ -368,6 +372,12 @@ public partial class WelcomeViewModel : ObservableObject
             return;
 
         var normalized = HotkeyParser.Normalize(value);
+        if (HotkeyParser.IsUnsafeMouseBinding(normalized))
+        {
+            HotkeyValidationMessage = Loc.Instance["Hotkey.ValidationUnsafeMouseButton"];
+            return;
+        }
+
         ReplaceCollection(
             MainDictationHotkeys,
             string.IsNullOrWhiteSpace(normalized) ? [] : [normalized]);
@@ -511,6 +521,7 @@ public partial class WelcomeViewModel : ObservableObject
             OnPropertyChanged(nameof(DownloadStatus));
             OnPropertyChanged(nameof(PrimaryActionLabel));
             OnPropertyChanged(nameof(MainDictationHotkeyDisplay));
+            RefreshHotkeyValidationMessage();
         });
 
     [RelayCommand]
@@ -554,6 +565,14 @@ public partial class WelcomeViewModel : ObservableObject
         if (string.IsNullOrWhiteSpace(normalized))
             return;
 
+        if (HotkeyParser.IsUnsafeMouseBinding(normalized))
+        {
+            HotkeyValidationMessage = Loc.Instance["Hotkey.ValidationUnsafeMouseButton"];
+            NewMainDictationHotkey = "";
+            NotifyMainHotkeyProperties();
+            return;
+        }
+
         if (MainDictationHotkeys.Any(hotkey =>
                 string.Equals(HotkeyParser.Normalize(hotkey), normalized, StringComparison.OrdinalIgnoreCase)))
         {
@@ -565,6 +584,7 @@ public partial class WelcomeViewModel : ObservableObject
         NewMainDictationHotkey = "";
         SyncMainDictationHotkeyFromCollection();
         PersistMainDictationHotkeys(MainDictationHotkeys);
+        RefreshHotkeyValidationMessage();
         NotifyMainHotkeyProperties();
     }
 
@@ -583,6 +603,7 @@ public partial class WelcomeViewModel : ObservableObject
         MainDictationHotkeys.Remove(existing);
         SyncMainDictationHotkeyFromCollection();
         PersistMainDictationHotkeys(MainDictationHotkeys);
+        RefreshHotkeyValidationMessage();
         NotifyMainHotkeyProperties();
     }
 
@@ -815,6 +836,13 @@ public partial class WelcomeViewModel : ObservableObject
         OnPropertyChanged(nameof(MainDictationHotkeyDisplay));
         OnPropertyChanged(nameof(HasConfiguredMainHotkey));
         OnPropertyChanged(nameof(CanTryItOut));
+    }
+
+    private void RefreshHotkeyValidationMessage()
+    {
+        HotkeyValidationMessage = MainDictationHotkeys.Any(HotkeyParser.IsUnsafeMouseBinding)
+            ? Loc.Instance["Hotkey.ValidationUnsafeMouseButton"]
+            : "";
     }
 
     private static IReadOnlyList<string> NormalizeHotkeyList(IEnumerable<string?> values) =>

--- a/src/TypeWhisper.Windows/ViewModels/WorkflowsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/WorkflowsViewModel.cs
@@ -384,6 +384,7 @@ public sealed partial class WorkflowsViewModel : ObservableObject
         _editingCreatedAt = workflow.CreatedAt;
         IsCreatingNew = false;
         PopulateEditor(workflow);
+        EditorError = ValidateUnsafeMouseBindings();
         IsEditorOpen = true;
     }
 
@@ -572,6 +573,13 @@ public sealed partial class WorkflowsViewModel : ObservableObject
         var hotkey = HotkeyParser.Normalize(value ?? NewHotkey);
         if (string.IsNullOrWhiteSpace(hotkey))
             return;
+
+        if (HotkeyParser.IsUnsafeMouseBinding(hotkey))
+        {
+            EditorError = Loc.Instance["Hotkey.ValidationUnsafeMouseButton"];
+            NewHotkey = "";
+            return;
+        }
 
         if (EditHotkeys.Any(existing => string.Equals(HotkeyParser.Normalize(existing), hotkey, StringComparison.OrdinalIgnoreCase)))
         {
@@ -1143,6 +1151,10 @@ public sealed partial class WorkflowsViewModel : ObservableObject
     private string? ValidateHotkeys()
     {
         var hotkeys = NormalizeHotkeyList(EditHotkeys);
+        var unsafeMouseValidation = ValidateUnsafeMouseBindings();
+        if (unsafeMouseValidation is not null)
+            return unsafeMouseValidation;
+
         var duplicate = hotkeys
             .GroupBy(static hotkey => hotkey, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault(static group => group.Count() > 1)
@@ -1161,6 +1173,11 @@ public sealed partial class WorkflowsViewModel : ObservableObject
 
         return null;
     }
+
+    private string? ValidateUnsafeMouseBindings() =>
+        EditHotkeys.Any(HotkeyParser.IsUnsafeMouseBinding)
+            ? Loc.Instance["Hotkey.ValidationUnsafeMouseButton"]
+            : null;
 
     private string? FindAppHotkeyConflict(string hotkey)
     {

--- a/src/TypeWhisper.Windows/Views/WelcomeWindow.xaml
+++ b/src/TypeWhisper.Windows/Views/WelcomeWindow.xaml
@@ -711,6 +711,13 @@
                                                                 AllowModifierOnly="True"
                                                                 HorizontalAlignment="Left"/>
 
+                                <TextBlock Text="{Binding HotkeyValidationMessage}"
+                                           Foreground="{StaticResource DangerBrush}"
+                                           FontSize="12"
+                                           Margin="0,8,0,0"
+                                           TextWrapping="Wrap"
+                                           Visibility="{Binding HotkeyValidationMessage, Converter={StaticResource NonEmptyToVis}}"/>
+
                                 <StackPanel Margin="0,12,0,0">
                                     <TextBlock Text="{loc:Str Welcome.MainHotkeyHint}"
                                                Style="{StaticResource PageSubtitleStyle}"

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyChipLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyChipLayoutTests.cs
@@ -129,6 +129,7 @@ public sealed class HotkeyChipLayoutTests
         Assert.Contains("ItemsSource=\"{Binding MainDictationHotkeys}\"", welcomeXaml);
         Assert.Contains("NewMainDictationHotkey", welcomeXaml);
         Assert.Contains("RecordedCommand=\"{Binding AddMainDictationHotkeyCommand}\"", welcomeXaml);
+        Assert.Contains("Text=\"{Binding HotkeyValidationMessage}\"", welcomeXaml);
         Assert.Contains("RemoveMainDictationHotkeyCommand", welcomeXaml);
         Assert.Contains("AutomationProperties.Name=\"{loc:Str Shortcuts.RemoveHotkey}\"", welcomeXaml);
         Assert.Contains("UseAddGlyph=\"True\"", welcomeXaml);

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -589,6 +589,42 @@ public class HotkeyInputTests
         Assert.Equal(hotkey, HotkeyParser.Normalize(hotkey));
     }
 
+    [Theory]
+    [InlineData("MouseLeft", true)]
+    [InlineData("MouseRight", true)]
+    [InlineData("Ctrl+MouseLeft", false)]
+    [InlineData("Shift+MouseRight", false)]
+    [InlineData("MouseMiddle", false)]
+    [InlineData("MouseBack", false)]
+    [InlineData("MouseForward", false)]
+    public void Parser_ClassifiesUnsafeMouseBindings(string hotkey, bool expectedUnsafe)
+    {
+        Assert.Equal(expectedUnsafe, HotkeyParser.IsUnsafeMouseBinding(hotkey));
+    }
+
+    [Fact]
+    public void KeyboardHook_DoesNotConfigureUnsafeMouseBinding()
+    {
+        using var sut = new KeyboardHook();
+
+        sut.SetHotkey("MouseLeft");
+
+        Assert.False(sut.HasConfiguredHotkey);
+    }
+
+    [Fact]
+    public void KeyboardHook_ConfiguresSupportedMouseBindings()
+    {
+        using var modifiedPrimary = new KeyboardHook();
+        using var auxiliary = new KeyboardHook();
+
+        modifiedPrimary.SetHotkey("Ctrl+MouseLeft");
+        auxiliary.SetHotkey("MouseBack");
+
+        Assert.True(modifiedPrimary.HasConfiguredHotkey);
+        Assert.True(auxiliary.HasConfiguredHotkey);
+    }
+
     [Fact]
     public void KeyedHotkey_RequiresExactModifiers()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyServiceTests.cs
@@ -67,6 +67,18 @@ public sealed class HotkeyServiceTests
     }
 
     [Fact]
+    public void BuildWorkflowHotkeyBindings_SkipsUnsafeMouseBindings()
+    {
+        var workflow = NewWorkflow(
+            "Mouse",
+            WorkflowTrigger.Hotkey("MouseLeft", "MouseRight", "Ctrl+MouseLeft", "MouseBack"));
+
+        var bindings = HotkeyService.BuildWorkflowHotkeyBindings([workflow]);
+
+        Assert.Equal(["Ctrl+MouseLeft", "MouseBack"], bindings.Select(binding => binding.Hotkey));
+    }
+
+    [Fact]
     public void BuildAppHotkeyBindings_IncludesMultipleHotkeysPerShortcutAction()
     {
         var settings = AppSettings.Default with
@@ -109,6 +121,22 @@ public sealed class HotkeyServiceTests
             .Where(binding => binding.Action == AppHotkeyAction.HoldOnly);
 
         Assert.Equal(["Ctrl+Alt+H"], bindings.Select(binding => binding.Hotkey));
+    }
+
+    [Fact]
+    public void BuildAppHotkeyBindings_SkipsUnsafeMouseBindings()
+    {
+        var settings = AppSettings.Default with
+        {
+            MainDictationHotkeys = ["MouseLeft", "Ctrl+MouseLeft"],
+            ToggleOnlyHotkeys = ["MouseRight", "MouseBack"]
+        };
+
+        var bindings = HotkeyService.BuildAppHotkeyBindings(settings);
+
+        Assert.DoesNotContain(bindings, binding => binding.Hotkey is "MouseLeft" or "MouseRight");
+        Assert.Contains(bindings, binding => binding.Hotkey == "Ctrl+MouseLeft");
+        Assert.Contains(bindings, binding => binding.Hotkey == "MouseBack");
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelHotkeyTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SettingsViewModelHotkeyTests.cs
@@ -118,6 +118,63 @@ public sealed class SettingsViewModelHotkeyTests
         Assert.Contains("hold-only", sut.ShortcutsError, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("MouseLeft")]
+    [InlineData("MouseRight")]
+    public void AddShortcutHotkey_RejectsUnsafeMouseBinding(string hotkey)
+    {
+        var settings = new FakeSettingsService(AppSettings.Default with
+        {
+            MainDictationHotkeys = [],
+            PushToTalkHotkey = "",
+            ToggleHotkey = ""
+        });
+        var sut = CreateSettingsViewModel(settings);
+
+        sut.AddMainDictationHotkeyCommand.Execute(hotkey);
+
+        Assert.Empty(sut.MainDictationHotkeys);
+        Assert.Empty(settings.Current.MainDictationHotkeys);
+        Assert.Contains("modifier", sut.ShortcutsError, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("", sut.NewMainDictationHotkey);
+    }
+
+    [Theory]
+    [InlineData("Ctrl+MouseLeft")]
+    [InlineData("MouseMiddle")]
+    [InlineData("MouseBack")]
+    public void AddShortcutHotkey_AcceptsSupportedMouseBinding(string hotkey)
+    {
+        var settings = new FakeSettingsService(AppSettings.Default with
+        {
+            MainDictationHotkeys = [],
+            PushToTalkHotkey = "",
+            ToggleHotkey = ""
+        });
+        var sut = CreateSettingsViewModel(settings);
+
+        sut.AddMainDictationHotkeyCommand.Execute(hotkey);
+
+        Assert.Equal([hotkey], sut.MainDictationHotkeys);
+        Assert.Equal([hotkey], settings.Current.MainDictationHotkeys);
+        Assert.Equal("", sut.ShortcutsError);
+    }
+
+    [Fact]
+    public void ExistingUnsafeMouseBinding_RemainsVisibleWithWarning()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default with
+        {
+            MainDictationHotkeys = ["MouseLeft"]
+        });
+
+        var sut = CreateSettingsViewModel(settings);
+
+        Assert.Equal(["MouseLeft"], sut.MainDictationHotkeys);
+        Assert.Equal(["MouseLeft"], settings.Current.MainDictationHotkeys);
+        Assert.Contains("modifier", sut.ShortcutsError, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void AddAndRemoveRecorderToggleHotkeys_PersistsListAndLegacyFirstValue()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/WelcomeViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WelcomeViewModelTests.cs
@@ -211,6 +211,66 @@ public sealed class WelcomeViewModelTests
         });
     }
 
+    [Theory]
+    [InlineData("MouseLeft")]
+    [InlineData("MouseRight")]
+    public void MainDictationHotkeyCommand_RejectsUnsafeMouseBinding(string hotkey)
+    {
+        RunOnStaThread(() =>
+        {
+            var plugin = new FakeTranscriptionPlugin(
+                "com.typewhisper.groq",
+                "Groq",
+                configured: true,
+                supportsModelDownload: false);
+            var sut = CreateViewModel(
+                plugin,
+                out _,
+                out var settings,
+                AppSettings.Default with
+                {
+                    MainDictationHotkeys = [],
+                    PushToTalkHotkey = "",
+                    ToggleHotkey = ""
+                });
+
+            sut.AddMainDictationHotkeyCommand.Execute(hotkey);
+
+            Assert.Empty(sut.MainDictationHotkeys);
+            Assert.Empty(settings.Current.MainDictationHotkeys);
+            Assert.False(sut.HasConfiguredMainHotkey);
+            Assert.Contains("modifier", sut.HotkeyValidationMessage, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public void ExistingUnsafeMouseBinding_RemainsVisibleButDoesNotEnableTrial()
+    {
+        RunOnStaThread(() =>
+        {
+            var plugin = new FakeTranscriptionPlugin(
+                "com.typewhisper.groq",
+                "Groq",
+                configured: true,
+                supportsModelDownload: false);
+            var sut = CreateViewModel(
+                plugin,
+                out _,
+                out var settings,
+                AppSettings.Default with
+                {
+                    MainDictationHotkeys = ["MouseLeft"],
+                    PushToTalkHotkey = "MouseLeft",
+                    ToggleHotkey = "MouseLeft"
+                });
+
+            Assert.Equal(["MouseLeft"], sut.MainDictationHotkeys);
+            Assert.Equal(["MouseLeft"], settings.Current.MainDictationHotkeys);
+            Assert.False(sut.HasConfiguredMainHotkey);
+            Assert.Contains("modifier", sut.HotkeyValidationMessage, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
     [Fact]
     public void MicTest_RaisesMicLevelOnWizardDispatcher()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowsViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowsViewModelTests.cs
@@ -171,6 +171,56 @@ public sealed class WorkflowsViewModelTests : IDisposable
         Assert.Equal("", sut.NewHotkey);
     }
 
+    [Theory]
+    [InlineData("MouseLeft")]
+    [InlineData("MouseRight")]
+    public void AddHotkeyCommand_RejectsUnsafeMouseBinding(string hotkey)
+    {
+        var sut = CreateViewModel();
+
+        sut.AddHotkeyCommand.Execute(hotkey);
+
+        Assert.Empty(sut.EditHotkeys);
+        Assert.Contains("modifier", sut.EditorError, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("", sut.NewHotkey);
+    }
+
+    [Fact]
+    public void StartEdit_PreservesUnsafeMouseBindingAndShowsWarning()
+    {
+        var workflow = NewWorkflow("Mouse", WorkflowTrigger.Hotkey("MouseLeft"));
+        var workflows = new TestWorkflowService([workflow]);
+        var sut = CreateViewModel(workflows);
+
+        sut.StartEditCommand.Execute(workflow);
+
+        Assert.Equal(["MouseLeft"], sut.EditHotkeys);
+        Assert.Contains("modifier", sut.EditorError, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(["MouseLeft"], Assert.Single(workflows.Workflows).Trigger.Hotkeys);
+    }
+
+    [Fact]
+    public void SaveEditor_RejectsExistingUnsafeMouseBindingUntilRemoved()
+    {
+        var workflow = NewWorkflow("Mouse", WorkflowTrigger.Hotkey("MouseLeft"));
+        var workflows = new TestWorkflowService([workflow]);
+        var sut = CreateViewModel(workflows);
+        sut.StartEditCommand.Execute(workflow);
+
+        sut.SaveEditorCommand.Execute(null);
+
+        Assert.True(sut.IsEditorOpen);
+        Assert.Contains("modifier", sut.EditorError, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(["MouseLeft"], Assert.Single(workflows.Workflows).Trigger.Hotkeys);
+
+        sut.RemoveHotkeyCommand.Execute("MouseLeft");
+        sut.AddHotkeyCommand.Execute("Ctrl+MouseLeft");
+        sut.SaveEditorCommand.Execute(null);
+
+        Assert.False(sut.IsEditorOpen);
+        Assert.Equal(["Ctrl+MouseLeft"], Assert.Single(workflows.Workflows).Trigger.Hotkeys);
+    }
+
     [Fact]
     public void SaveEditor_PersistsMultipleWorkflowHotkeys()
     {


### PR DESCRIPTION
## Summary

- classify bare `MouseLeft` and `MouseRight` bindings as unsafe while keeping them parseable
- prevent unsafe app and workflow bindings from reaching runtime hooks, with a second failsafe inside `KeyboardHook`
- reject newly recorded unsafe bindings in Settings, onboarding, and Workflows
- preserve legacy values for manual repair and show a localized validation message in all supported languages
- keep modified left/right clicks and bare middle/back/forward mouse buttons supported

## Root cause

The mouse recorder introduced in PR #282 can turn an accidental unmodified primary or secondary click into a global mouse binding. Once registered, that hook may consume ordinary system mouse input.

## Legacy behavior

Existing unsafe values are not migrated or deleted. They remain visible in the relevant editor, but they are never registered at runtime. Workflow saving stays blocked until an unsafe binding is removed or replaced.

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~Hotkey"` (263 passed)
- `dotnet test TypeWhisper.slnx --no-restore` (1,835 passed)
- isolated dev build completed successfully
- runtime smoke rejected bare left and right clicks, showed the localized warning, created no unsafe chip, and preserved ordinary mouse navigation after rejection, Escape, and focus loss
- verified the running development binary path as `F:\typewhisper\dev-output\typewhisper-win\Build\TypeWhisper.exe`

Closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unmodified left- and right-mouse buttons from being assigned as hotkeys.
  * Added validation warnings and localized guidance when unsafe mouse shortcuts are detected.
  * Preserved existing unsafe shortcuts for review while preventing them from being activated or saved.
  * Continued supporting modified left/right buttons and unmodified middle, back, and forward buttons.

* **Tests**
  * Added coverage for mouse hotkey validation, persistence, editing, and display behavior across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->