### PR TITLE
Start dictation recording before model preparation

### DIFF
--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -7,6 +7,13 @@ using TypeWhisper.PluginSDK;
 
 namespace TypeWhisper.Windows.Services;
 
+internal sealed record StreamingModelPreparation(
+    string RequestedModelId,
+    string? ActiveModelId,
+    ITranscriptionEngine? Engine,
+    ITranscriptionEnginePlugin? Plugin,
+    bool IsReady);
+
 /// <summary>
 /// Provides live transcription during recording. Uses real-time WebSocket streaming
 /// when the plugin supports it, otherwise falls back to polling-based transcription.
@@ -99,11 +106,11 @@ public sealed class StreamingHandler : IDisposable
     /// Starts buffering live-preview audio immediately and opens the provider path
     /// after the requested model is ready.
     /// </summary>
-    public void StartWhenReadyWithLanguageHints(
+    internal void StartWhenReadyWithLanguageHints(
         IReadOnlyList<string> languageHints,
         TranscriptionTask task,
         Func<bool> isStillRecording,
-        Task<bool> modelReady,
+        Task<StreamingModelPreparation> modelPreparation,
         bool allowOnlineBatchPolling)
     {
         Stop();
@@ -120,7 +127,7 @@ public sealed class StreamingHandler : IDisposable
             languageHints,
             task,
             isStillRecording,
-            modelReady,
+            modelPreparation,
             allowOnlineBatchPolling,
             sessionVersion,
             ct);
@@ -183,14 +190,15 @@ public sealed class StreamingHandler : IDisposable
         IReadOnlyList<string> languageHints,
         TranscriptionTask task,
         Func<bool> isStillRecording,
-        Task<bool> modelReady,
+        Task<StreamingModelPreparation> modelPreparation,
         bool allowOnlineBatchPolling,
         int sessionVersion,
         CancellationToken ct)
     {
         try
         {
-            if (!await modelReady.WaitAsync(ct)
+            var preparation = await modelPreparation.WaitAsync(ct);
+            if (!IsCurrentPreparation(preparation)
                 || !_transcriptState.IsCurrentSession(sessionVersion)
                 || ct.IsCancellationRequested)
             {
@@ -198,7 +206,7 @@ public sealed class StreamingHandler : IDisposable
                 return;
             }
 
-            var plugin = _modelManager.ActiveTranscriptionPlugin;
+            var plugin = preparation.Plugin!;
             var prompt = plugin?.SupportsDictionaryTerms == true
                 ? _dictionary.GetTermsForPrompt()
                 : null;
@@ -220,7 +228,8 @@ public sealed class StreamingHandler : IDisposable
                     task,
                     isStillRecording,
                     sessionVersion,
-                    ct);
+                    ct,
+                    preparation.Engine);
             }
         }
         catch (OperationCanceledException)
@@ -233,6 +242,20 @@ public sealed class StreamingHandler : IDisposable
             StopPreviewBuffering(sessionVersion);
         }
     }
+
+    private bool IsCurrentPreparation(StreamingModelPreparation preparation) =>
+        preparation.IsReady
+        && preparation.Engine?.IsModelLoaded == true
+        && preparation.Plugin is not null
+        && string.Equals(
+            preparation.RequestedModelId,
+            preparation.ActiveModelId,
+            StringComparison.Ordinal)
+        && string.Equals(
+            _modelManager.ActiveModelId,
+            preparation.ActiveModelId,
+            StringComparison.Ordinal)
+        && ReferenceEquals(_modelManager.ActiveTranscriptionPlugin, preparation.Plugin);
 
     private void StopPreviewBuffering(int sessionVersion)
     {
@@ -457,9 +480,10 @@ public sealed class StreamingHandler : IDisposable
 
     private async Task RunPollingFallbackAsync(
         IReadOnlyList<string> languageHints, TranscriptionTask task,
-        Func<bool> isStillRecording, int sessionVersion, CancellationToken ct)
+        Func<bool> isStillRecording, int sessionVersion, CancellationToken ct,
+        ITranscriptionEngine? preparedEngine = null)
     {
-        var engine = _modelManager.Engine;
+        var engine = preparedEngine ?? _modelManager.Engine;
         var pollInterval = TimeSpan.FromSeconds(3.0);
 
         try

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -96,6 +96,37 @@ public sealed class StreamingHandler : IDisposable
     }
 
     /// <summary>
+    /// Starts buffering live-preview audio immediately and opens the provider path
+    /// after the requested model is ready.
+    /// </summary>
+    public void StartWhenReadyWithLanguageHints(
+        IReadOnlyList<string> languageHints,
+        TranscriptionTask task,
+        Func<bool> isStillRecording,
+        Task<bool> modelReady,
+        bool allowOnlineBatchPolling)
+    {
+        Stop();
+        ClearPendingStreamingAudio();
+
+        var sessionVersion = _transcriptState.StartSession();
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+
+        // Subscribe before capture starts so a slow model or provider cannot lose
+        // the beginning of a real-time preview session.
+        _audio.SamplesAvailable += OnStreamingSamplesAvailable;
+        _streamingTask = RunWhenReadyAsync(
+            languageHints,
+            task,
+            isStillRecording,
+            modelReady,
+            allowOnlineBatchPolling,
+            sessionVersion,
+            ct);
+    }
+
+    /// <summary>
     /// Stops the service or session.
     /// </summary>
     public string Stop()
@@ -147,6 +178,70 @@ public sealed class StreamingHandler : IDisposable
     }
 
     // ── WebSocket streaming path ──
+
+    private async Task RunWhenReadyAsync(
+        IReadOnlyList<string> languageHints,
+        TranscriptionTask task,
+        Func<bool> isStillRecording,
+        Task<bool> modelReady,
+        bool allowOnlineBatchPolling,
+        int sessionVersion,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (!await modelReady.WaitAsync(ct)
+                || !_transcriptState.IsCurrentSession(sessionVersion)
+                || ct.IsCancellationRequested)
+            {
+                StopPreviewBuffering(sessionVersion);
+                return;
+            }
+
+            var plugin = _modelManager.ActiveTranscriptionPlugin;
+            var prompt = plugin?.SupportsDictionaryTerms == true
+                ? _dictionary.GetTermsForPrompt()
+                : null;
+
+            if (plugin is not null && plugin.SupportsStreamingForPrompt(prompt))
+            {
+                await RunWebSocketStreamingAsync(plugin, languageHints, sessionVersion, ct);
+                return;
+            }
+
+            // Polling reads the recorder's complete growing buffer directly. The
+            // bounded preview-only packet queue is unnecessary on this path.
+            StopPreviewBuffering(sessionVersion);
+            if (plugin is not null
+                && (plugin.SupportsModelDownload || allowOnlineBatchPolling))
+            {
+                await RunPollingFallbackAsync(
+                    languageHints,
+                    task,
+                    isStillRecording,
+                    sessionVersion,
+                    ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            StopPreviewBuffering(sessionVersion);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Delayed streaming startup error: {ex.Message}");
+            StopPreviewBuffering(sessionVersion);
+        }
+    }
+
+    private void StopPreviewBuffering(int sessionVersion)
+    {
+        if (!_transcriptState.IsCurrentSession(sessionVersion))
+            return;
+
+        _audio.SamplesAvailable -= OnStreamingSamplesAvailable;
+        ClearPendingStreamingAudio();
+    }
 
     private async Task RunWebSocketStreamingAsync(
         ITranscriptionEnginePlugin plugin,

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -207,11 +207,11 @@ public sealed class StreamingHandler : IDisposable
             }
 
             var plugin = preparation.Plugin!;
-            var prompt = plugin?.SupportsDictionaryTerms == true
+            var prompt = plugin.SupportsDictionaryTerms
                 ? _dictionary.GetTermsForPrompt()
                 : null;
 
-            if (plugin is not null && plugin.SupportsStreamingForPrompt(prompt))
+            if (plugin.SupportsStreamingForPrompt(prompt))
             {
                 await RunWebSocketStreamingAsync(plugin, languageHints, sessionVersion, ct);
                 return;
@@ -220,8 +220,7 @@ public sealed class StreamingHandler : IDisposable
             // Polling reads the recorder's complete growing buffer directly. The
             // bounded preview-only packet queue is unnecessary on this path.
             StopPreviewBuffering(sessionVersion);
-            if (plugin is not null
-                && (plugin.SupportsModelDownload || allowOnlineBatchPolling))
+            if (plugin.SupportsModelDownload || allowOnlineBatchPolling)
             {
                 await RunPollingFallbackAsync(
                     languageHints,
@@ -251,11 +250,11 @@ public sealed class StreamingHandler : IDisposable
             preparation.RequestedModelId,
             preparation.ActiveModelId,
             StringComparison.Ordinal)
+        && ReferenceEquals(_modelManager.ActiveTranscriptionPlugin, preparation.Plugin)
         && string.Equals(
             _modelManager.ActiveModelId,
             preparation.ActiveModelId,
-            StringComparison.Ordinal)
-        && ReferenceEquals(_modelManager.ActiveTranscriptionPlugin, preparation.Plugin);
+            StringComparison.Ordinal);
 
     private void StopPreviewBuffering(int sessionVersion)
     {

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -227,7 +227,7 @@ public sealed class StreamingHandler : IDisposable
         {
             StopPreviewBuffering(sessionVersion);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             Debug.WriteLine($"Delayed streaming startup error: {ex.Message}");
             StopPreviewBuffering(sessionVersion);

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -972,7 +972,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 IsCancelled: true,
                 Error: null);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             return new ModelPreparationOutcome(
                 recordingId,
@@ -1264,7 +1264,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         var preparationOutcome = await modelPreparation;
         if (!ReferenceEquals(_activeRecordingSession, session)
             || session.IsInvalidated
-            || _isStoppingRecording
+            || session.StopRequested
             || !_isRecording)
         {
             return;
@@ -1293,6 +1293,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             return;
         }
 
+        session.StopRequested = true;
         _isStoppingRecording = true;
 
         try
@@ -2825,6 +2826,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         public bool PreparationFailureHandled { get; set; }
         public bool CancelledByUser { get; set; }
         public bool JobEnqueued { get; set; }
+        public bool StopRequested { get; set; }
 
         public void Invalidate()
         {

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using System.Windows;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TypeWhisper.Core;
@@ -81,6 +82,15 @@ public enum ApiDictationSessionStatus
     /// </summary>
     Failed
 }
+
+internal sealed record ModelPreparationOutcome(
+    Guid RecordingId,
+    string RequestedModelId,
+    string? ActiveModelId,
+    ITranscriptionEngine? Engine,
+    bool IsReady,
+    bool IsCancelled,
+    Exception? Error);
 
 /// <summary>
 /// API-facing dictation control surface.
@@ -165,6 +175,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     private Guid? _activeApiDictationSessionId;
     // Identifies the current recording session; stamped on all related events.
     private Guid? _currentRecordingId;
+    private RecordingSession? _activeRecordingSession;
 
     private readonly Channel<TranscriptionJob> _jobChannel =
         Channel.CreateBounded<TranscriptionJob>(new BoundedChannelOptions(5)
@@ -184,6 +195,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     private SimpleVoiceActivityDetector? _vad;
     private readonly List<string> _partialSegments = [];
     private readonly SemaphoreSlim _vadLock = new(1, 1);
+    private readonly SemaphoreSlim _modelPreparationLock = new(1, 1);
     private bool _disposed;
     private int _lastVadFlushedSegmentCount;
     private int _lastVadDiscardedShortSegmentCount;
@@ -295,13 +307,21 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         _consumerTask = Task.Run(() => ProcessJobsAsync(_consumerCts.Token));
 
         _audio.AudioLevelChanged += OnAudioLevelChanged;
-        _audio.DeviceLost += (_, _) => Application.Current?.Dispatcher.InvokeAsync(async () =>
+        _audio.DeviceLost += (_, _) => Application.Current?.Dispatcher.InvokeAsync(() =>
         {
-            if (_isRecording)
+            var session = _activeRecordingSession;
+            if (session is not null && (_isRecording || _isStoppingRecording))
             {
+                var durationSeconds = _audio.RecordingDuration.TotalSeconds;
                 _isRecording = false;
-                _audio.StopRecording();
+                StopAudioOnce(session);
                 StopActiveRecordingInfrastructure();
+                PublishRecordingStoppedOnce(session, durationSeconds);
+                FailApiDictationSession(session.Context.ApiSessionId, Loc.Instance["Status.NoMicrophone"]);
+                PublishTranscriptionFailureOnce(session, Loc.Instance["Status.NoMicrophone"]);
+                session.Invalidate();
+                _activeRecordingSession = null;
+                _currentRecordingId = null;
             }
 
             ApplyTransientIdleFeedback(Loc.Instance["Status.NoMicrophone"], feedbackIsError: true);
@@ -548,7 +568,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         _workflowHotkeyOverrideId = workflowId;
         await StartRecording();
 
-        if (!_isRecording)
+        if (!_isRecording
+            && GetApiDictationSession(sessionId)?.Status == ApiDictationSessionStatus.Recording)
             FailApiDictationSession(sessionId, StatusText);
 
         return sessionId;
@@ -901,10 +922,206 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         ApplyTransientIdleFeedback(feedback, feedbackIsError: true);
     }
 
+    private async Task<ModelPreparationOutcome> PrepareModelAsync(
+        Guid recordingId,
+        string desiredModelId,
+        Task<bool> captureStarted,
+        CancellationToken cancellationToken)
+    {
+        var lockAcquired = false;
+        try
+        {
+            if (!await captureStarted.WaitAsync(cancellationToken))
+            {
+                return new ModelPreparationOutcome(
+                    recordingId,
+                    desiredModelId,
+                    null,
+                    null,
+                    IsReady: false,
+                    IsCancelled: true,
+                    Error: null);
+            }
+
+            await YieldForRecordingPresentationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await _modelPreparationLock.WaitAsync(cancellationToken);
+            lockAcquired = true;
+            var loaded = await _modelManager.EnsureModelLoadedAsync(desiredModelId, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            var activeModelId = _modelManager.ActiveModelId;
+            var engine = _modelManager.Engine;
+            return new ModelPreparationOutcome(
+                recordingId,
+                desiredModelId,
+                activeModelId,
+                engine,
+                IsReady: loaded && engine.IsModelLoaded,
+                IsCancelled: false,
+                Error: null);
+        }
+        catch (OperationCanceledException)
+        {
+            return new ModelPreparationOutcome(
+                recordingId,
+                desiredModelId,
+                null,
+                null,
+                IsReady: false,
+                IsCancelled: true,
+                Error: null);
+        }
+        catch (Exception ex)
+        {
+            return new ModelPreparationOutcome(
+                recordingId,
+                desiredModelId,
+                null,
+                null,
+                IsReady: false,
+                IsCancelled: false,
+                Error: ex);
+        }
+        finally
+        {
+            if (lockAcquired)
+                _modelPreparationLock.Release();
+        }
+    }
+
+    private static async Task YieldForRecordingPresentationAsync()
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null)
+        {
+            await Task.Yield();
+            return;
+        }
+
+        await dispatcher.InvokeAsync(static () => { }, DispatcherPriority.Background);
+    }
+
+    private static async Task<bool> AwaitModelReadyAsync(Task<ModelPreparationOutcome> preparation) =>
+        (await preparation).IsReady;
+
+    private void PublishRecordingStartedOnce(RecordingSession session)
+    {
+        if (session.RecordingStartedPublished)
+            return;
+
+        session.RecordingStartedPublished = true;
+        _eventBus.Publish(new RecordingStartedEvent
+        {
+            AppName = session.Context.CapturedWindowTitle,
+            AppProcessName = session.Context.CapturedProcessName,
+            RecordingId = session.Context.RecordingId
+        });
+    }
+
+    private void PublishRecordingStoppedOnce(RecordingSession session, double durationSeconds)
+    {
+        if (session.RecordingStoppedPublished)
+            return;
+
+        session.RecordingStoppedPublished = true;
+        _eventBus.Publish(new RecordingStoppedEvent
+        {
+            DurationSeconds = durationSeconds,
+            RecordingId = session.Context.RecordingId
+        });
+    }
+
+    private void PublishTranscriptionFailureOnce(
+        RecordingSession session,
+        string message,
+        string? modelId = null)
+    {
+        if (session.TerminalTranscriptionEventPublished)
+            return;
+
+        session.TerminalTranscriptionEventPublished = true;
+        _eventBus.Publish(new TranscriptionFailedEvent
+        {
+            ErrorMessage = message,
+            ModelId = modelId ?? session.Context.DesiredModelId,
+            AppName = session.Context.CapturedWindowTitle,
+            RecordingId = session.Context.RecordingId
+        });
+    }
+
+    private void StopAudioOnce(RecordingSession session)
+    {
+        if (session.AudioStopped)
+            return;
+
+        session.AudioStopped = true;
+        _audio.StopRecording();
+    }
+
+    private async Task<float[]> StopAudioOnceAsync(RecordingSession session)
+    {
+        if (session.AudioStopped)
+            return [];
+
+        session.AudioStopped = true;
+        return await _audio.StopRecordingAsync() ?? [];
+    }
+
+    private void EndRecordingAfterPreparationCancellation(RecordingSession session)
+    {
+        if (!ReferenceEquals(_activeRecordingSession, session))
+            return;
+
+        var durationSeconds = _audio.RecordingDuration.TotalSeconds;
+        _isRecording = false;
+        StopAudioOnce(session);
+        StopActiveRecordingInfrastructure();
+        PublishRecordingStoppedOnce(session, durationSeconds);
+        FailApiDictationSession(session.Context.ApiSessionId, Loc.Instance["Status.Cancelled"]);
+        session.Invalidate();
+        _activeRecordingSession = null;
+        _currentRecordingId = null;
+        ResetSessionToIdle(clearFeedback: false, forceHotkeyStop: true);
+    }
+
+    private void EndRecordingAfterPreparationFailure(
+        RecordingSession session,
+        ModelPreparationOutcome outcome)
+    {
+        if (!ReferenceEquals(_activeRecordingSession, session) || session.PreparationFailureHandled)
+            return;
+
+        session.PreparationFailureHandled = true;
+        var durationSeconds = _audio.RecordingDuration.TotalSeconds;
+        _isRecording = false;
+        StopAudioOnce(session);
+        StopActiveRecordingInfrastructure();
+        PublishRecordingStoppedOnce(session, durationSeconds);
+
+        var feedback = outcome.Error is null
+            ? Loc.Instance["Status.NoModelLoaded"]
+            : Loc.Instance.GetString("Status.ModelErrorFormat", outcome.Error.Message);
+        FailApiDictationSession(session.Context.ApiSessionId, feedback);
+        PublishTranscriptionFailureOnce(session, feedback, outcome.ActiveModelId);
+        session.Invalidate();
+        _activeRecordingSession = null;
+        _currentRecordingId = null;
+        ApplyModelUnavailableFeedback(session.Context.DesiredModelId, outcome.Error);
+    }
+
     private async Task StartRecording()
     {
-        if (_isRecording || _isStoppingRecording) return;
-        _isRecording = true;
+        if (_isRecording)
+            return;
+
+        if (_isStoppingRecording)
+        {
+            _workflowHotkeyOverrideId = null;
+            _hotkey.ForceStop();
+            return;
+        }
+
         CancelTargetAppCorrectionLearning();
         ClearFeedbackAction();
         FeedbackText = null;
@@ -926,48 +1143,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             _activeWorkflow = _workflows.MatchWorkflow(_capturedProcessName, _capturedUrl)?.Workflow;
         }
 
-        var desiredModelId = EffectiveModelId ?? _settings.Current.SelectedModelId;
+        var settingsSnapshot = _settings.Current;
+        var desiredModelId = _activeWorkflow?.Behavior.TranscriptionModelOverride
+            ?? settingsSnapshot.SelectedModelId;
         if (string.IsNullOrWhiteSpace(desiredModelId))
-        {
-            ApplyModelUnavailableFeedback(desiredModelId);
-            return;
-        }
-
-        try
-        {
-            if (!await _modelManager.EnsureModelLoadedAsync(desiredModelId))
-            {
-                ApplyModelUnavailableFeedback(desiredModelId);
-                return;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            _isRecording = false;
-            return;
-        }
-        catch (InvalidOperationException ex)
-        {
-            ApplyModelUnavailableFeedback(desiredModelId, ex);
-            return;
-        }
-        catch (IOException ex)
-        {
-            ApplyModelUnavailableFeedback(desiredModelId, ex);
-            return;
-        }
-        catch (ArgumentException ex)
-        {
-            ApplyModelUnavailableFeedback(desiredModelId, ex);
-            return;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            ApplyModelUnavailableFeedback(desiredModelId, ex);
-            return;
-        }
-
-        if (!_modelManager.Engine.IsModelLoaded)
         {
             ApplyModelUnavailableFeedback(desiredModelId);
             return;
@@ -975,71 +1154,93 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
         if (!_audio.HasDevice)
         {
-            _isRecording = false;
             ApplyTransientIdleFeedback(Loc.Instance["Status.NoMicrophone"], feedbackIsError: true);
             return;
         }
 
+        var languageHints = (_activeWorkflow?.Behavior.GetLanguageHints(settingsSnapshot.GetLanguageHints())
+            ?? settingsSnapshot.GetLanguageHints()).ToList();
+        var effectiveLanguage = languageHints.FirstOrDefault() ?? "auto";
+        var effectiveTask = (_activeWorkflow?.Behavior.SelectedTask ?? settingsSnapshot.TranscriptionTask) == "translate"
+            ? TranscriptionTask.Translate
+            : TranscriptionTask.Transcribe;
+        var effectiveWhisperMode = _activeWorkflow?.Behavior.WhisperModeOverride
+            ?? settingsSnapshot.WhisperModeEnabled;
+        var recordingId = Guid.NewGuid();
+        var captureStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var preparationCts = new CancellationTokenSource();
+        var modelPreparation = PrepareModelAsync(
+            recordingId,
+            desiredModelId,
+            captureStarted.Task,
+            preparationCts.Token);
+        var context = new RecordingContext(
+            recordingId,
+            desiredModelId,
+            _activeWorkflow,
+            _capturedWindowHandle,
+            _capturedProcessName,
+            _capturedWindowTitle,
+            _capturedUrl,
+            effectiveLanguage,
+            languageHints,
+            effectiveTask,
+            effectiveWhisperMode,
+            settingsSnapshot.TranscribeShortQuietClipsAggressively,
+            _activeApiDictationSessionId);
+        var session = new RecordingSession(
+            context,
+            captureStarted,
+            preparationCts,
+            modelPreparation);
+        _activeRecordingSession = session;
+        _currentRecordingId = recordingId;
+
         ActiveProcessName = _capturedProcessName;
         ActiveWorkflowName = _activeWorkflow?.Name;
 
-        _audio.WhisperModeEnabled = EffectiveWhisperMode;
+        _audio.WhisperModeEnabled = effectiveWhisperMode;
 
-        // Live transcription: streaming handler polls growing buffer periodically
+        // Prepare live preview before capture so the first audio packet can be buffered.
         _partialSegments.Clear();
         PartialText = "";
         _vad?.Dispose();
         _vad = null;
         _streamingHandler.Stop();
 
-        var isPluginModel = _modelManager.ActiveModelId is not null
-            && ModelManagerService.IsPluginModel(_modelManager.ActiveModelId);
-        var activeTranscriptionPlugin = _modelManager.ActiveTranscriptionPlugin;
-        var dictionaryPrompt = activeTranscriptionPlugin?.SupportsDictionaryTerms == true
-            ? _dictionary.GetTermsForPrompt()
-            : null;
-
-        var liveTranscriptionMode = LiveTranscriptionStartupPolicy.Select(
-            _settings.Current,
-            isPluginModel,
-            activeTranscriptionPlugin,
-            dictionaryPrompt);
-
-        if (liveTranscriptionMode is LiveTranscriptionStartupMode.PluginStreaming
-            or LiveTranscriptionStartupMode.PluginPollingFallback)
+        if (settingsSnapshot.LiveTranscriptionEnabled
+            && ModelManagerService.IsPluginModel(desiredModelId))
         {
-            _streamingHandler.StartWithLanguageHints(EffectiveLanguageHints, EffectiveTask, () => _isRecording);
-        }
-        else if (liveTranscriptionMode == LiveTranscriptionStartupMode.LegacyVad)
-        {
-            // VAD fallback for non-plugin models
-            _vad = CreateVoiceActivityDetector();
-            _audio.SamplesAvailable += OnSamplesAvailable;
+            _streamingHandler.StartWhenReadyWithLanguageHints(
+                languageHints,
+                effectiveTask,
+                () => ReferenceEquals(_activeRecordingSession, session) && _isRecording,
+                AwaitModelReadyAsync(modelPreparation),
+                settingsSnapshot.OnlineAsrBatchLiveTranscriptionEnabled);
         }
 
         _audio.StartRecording();
         if (!_audio.IsRecording)
         {
-            _isRecording = false;
+            session.Invalidate();
+            if (ReferenceEquals(_activeRecordingSession, session))
+                _activeRecordingSession = null;
+            _currentRecordingId = null;
             StopActiveRecordingInfrastructure();
             ApplyTransientIdleFeedback(Loc.Instance["Status.NoMicrophone"], feedbackIsError: true);
             return;
         }
 
+        _isRecording = true;
+
         _sound.PlayStartSound();
 
-        if (_settings.Current.AudioDuckingEnabled)
-            _audioDucking.DuckAudio(_settings.Current.AudioDuckingLevel);
-        if (_settings.Current.PauseMediaDuringRecording)
+        if (settingsSnapshot.AudioDuckingEnabled)
+            _audioDucking.DuckAudio(settingsSnapshot.AudioDuckingLevel);
+        if (settingsSnapshot.PauseMediaDuringRecording)
             _mediaPause.PauseMedia();
 
-        _currentRecordingId = Guid.NewGuid();
-        _eventBus.Publish(new RecordingStartedEvent
-        {
-            AppName = _activeWindow.GetActiveWindowTitle(),
-            AppProcessName = _activeWindow.GetActiveWindowProcessName(),
-            RecordingId = _currentRecordingId
-        });
+        PublishRecordingStartedOnce(session);
 
         State = DictationState.Recording;
         CurrentHotkeyMode = _hotkey.CurrentMode;
@@ -1058,12 +1259,40 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 CurrentHotkeyMode = mode;
         };
         _durationTimer.Start();
+
+        captureStarted.TrySetResult(true);
+        var preparationOutcome = await modelPreparation;
+        if (!ReferenceEquals(_activeRecordingSession, session)
+            || session.IsInvalidated
+            || _isStoppingRecording
+            || !_isRecording)
+        {
+            return;
+        }
+
+        if (preparationOutcome.IsReady)
+            return;
+
+        if (preparationOutcome.IsCancelled)
+        {
+            EndRecordingAfterPreparationCancellation(session);
+            return;
+        }
+
+        EndRecordingAfterPreparationFailure(session, preparationOutcome);
     }
 
     [RelayCommand]
     private async Task StopRecording()
     {
         if (!_isRecording || _isStoppingRecording) return;
+        var session = _activeRecordingSession;
+        if (session is null)
+        {
+            _hotkey.ForceStop();
+            return;
+        }
+
         _isStoppingRecording = true;
 
         try
@@ -1072,13 +1301,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             var streamingText = _streamingHandler.Stop();
             _audio.SamplesAvailable -= OnSamplesAvailable;
 
-            var samples = await _audio.StopRecordingAsync();
+            var samples = await StopAudioOnceAsync(session);
             _isRecording = false;
             var audioTailSnapshot = _audio.CaptureTailSnapshot();
-            var originalSamples = samples ?? [];
+            var originalSamples = samples;
             var rawPeakRmsLevel = _audio.PreGainPeakRmsLevel;
             var rawDuration = originalSamples.Length / 16000.0;
-            _eventBus.Publish(new RecordingStoppedEvent { DurationSeconds = rawDuration, RecordingId = _currentRecordingId });
+            PublishRecordingStoppedOnce(session, rawDuration);
             _durationTimer?.Stop();
             _durationTimer?.Dispose();
             _durationTimer = null;
@@ -1086,6 +1315,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             _mediaPause.ResumeMedia();
             RecordingSeconds = 0;
             CurrentHotkeyMode = null;
+            State = DictationState.Processing;
+            StatusText = Loc.Instance["Status.Processing"];
+            IsOverlayVisible = true;
+            _hotkey.IsCancelShortcutEnabled = true;
 
             // Flush remaining VAD segments
             _lastVadFlushedSegmentCount = 0;
@@ -1117,7 +1350,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 ? [trustedLiveText]
                 : [.. _partialSegments];
 
-            var aggressiveShortQuietHandling = _settings.Current.TranscribeShortQuietClipsAggressively;
+            var aggressiveShortQuietHandling = session.Context.TranscribeShortQuietClipsAggressively;
             var shortSpeechDecision = DictationShortSpeechPolicy.Classify(
                 rawDuration,
                 rawPeakRmsLevel,
@@ -1126,56 +1359,67 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
             if (shortSpeechDecision == ShortSpeechDecision.DiscardTooShort)
             {
-                FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.TooShort"]);
-                _eventBus.Publish(new TranscriptionFailedEvent
-                {
-                    ErrorMessage = Loc.Instance["Status.TooShort"],
-                    ModelId = _modelManager.ActiveModelId,
-                    AppName = _capturedWindowTitle,
-                    RecordingId = _currentRecordingId
-                });
+                FailApiDictationSession(session.Context.ApiSessionId, Loc.Instance["Status.TooShort"]);
+                PublishTranscriptionFailureOnce(session, Loc.Instance["Status.TooShort"]);
+                session.Invalidate();
                 ApplyTransientIdleFeedback(Loc.Instance["Status.TooShort"]);
                 return;
             }
 
             if (shortSpeechDecision == ShortSpeechDecision.DiscardNoSpeech)
             {
-                FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.NoSpeech"]);
-                PublishNoSpeechFailure(_modelManager.ActiveModelId, _capturedWindowTitle, _currentRecordingId);
+                FailApiDictationSession(session.Context.ApiSessionId, Loc.Instance["Status.NoSpeech"]);
+                PublishTranscriptionFailureOnce(session, Loc.Instance["Status.NoSpeech"]);
+                session.Invalidate();
                 ApplyTransientIdleFeedback(Loc.Instance["Status.NoSpeech"]);
                 return;
             }
 
-            var apiSessionId = _activeApiDictationSessionId;
+            var preparationOutcome = await session.ModelPreparation;
+            if (!ReferenceEquals(_activeRecordingSession, session) || session.IsInvalidated)
+                return;
+
+            if (!preparationOutcome.IsReady)
+            {
+                if (preparationOutcome.IsCancelled)
+                    EndRecordingAfterPreparationCancellation(session);
+                else
+                    EndRecordingAfterPreparationFailure(session, preparationOutcome);
+                return;
+            }
+
+            var apiSessionId = session.Context.ApiSessionId;
             if (apiSessionId is not null)
             {
                 MarkApiDictationSessionProcessing(apiSessionId.Value);
                 _activeApiDictationSessionId = null;
             }
 
-            // Snapshot all context and enqueue — returns immediately
+            // Snapshot all context and enqueue, then return immediately.
             var transcriptionSamples = DictationShortSpeechPolicy.PadSamplesForFinalTranscription(originalSamples, rawDuration);
-            var activeModelIdAtCapture = _modelManager.ActiveModelId;
+            var activeModelIdAtCapture = preparationOutcome.ActiveModelId
+                ?? session.Context.DesiredModelId;
             var transcriptionIdentity = _modelManager.ResolveTranscriptionIdentity(activeModelIdAtCapture);
             var job = new TranscriptionJob(
                 transcriptionSamples,
                 originalSamples,
                 partialSnapshot,
-                _activeWorkflow,
-                _capturedWindowHandle,
-                _capturedProcessName,
-                _capturedWindowTitle,
-                _capturedUrl,
-                EffectiveLanguage,
-                EffectiveLanguageHints.ToList(),
-                EffectiveTask,
+                session.Context.ActiveWorkflow,
+                session.Context.CapturedWindowHandle,
+                session.Context.CapturedProcessName,
+                session.Context.CapturedWindowTitle,
+                session.Context.CapturedUrl,
+                session.Context.EffectiveLanguage,
+                session.Context.EffectiveLanguageHints,
+                session.Context.EffectiveTask,
+                preparationOutcome.Engine!,
                 activeModelIdAtCapture,
                 transcriptionIdentity?.EngineId,
                 transcriptionIdentity?.ModelId,
                 apiSessionId,
                 aggressiveShortQuietHandling,
                 new RecordingTailDiagnosticSnapshot(
-                    _modelManager.ActiveModelId,
+                    activeModelIdAtCapture,
                     "local",
                     stopRequestedAtUtc,
                     rawDuration,
@@ -1196,8 +1440,9 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                     null,
                     null,
                     null),
-                _currentRecordingId);
+                session.Context.RecordingId);
 
+            session.JobEnqueued = true;
             Interlocked.Increment(ref _pendingJobCount);
             await _jobChannel.Writer.WriteAsync(job);
             UpdateVisualState();
@@ -1206,29 +1451,43 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         {
             _isRecording = false;
             _isStoppingRecording = false;
+            if (ReferenceEquals(_activeRecordingSession, session))
+                _activeRecordingSession = null;
+            if (!session.JobEnqueued && _currentRecordingId == session.Context.RecordingId)
+                _currentRecordingId = null;
+            session.DisposePreparationResources();
             _hotkey.ForceStop();
         }
     }
 
     private Task AbortActiveOperation()
     {
-        if (_isStoppingRecording)
-            return Task.CompletedTask;
-
-        if (_isRecording)
+        var session = _activeRecordingSession;
+        if (_isStoppingRecording && session is not null)
         {
-            var recordingId = _currentRecordingId;
+            session.CancelledByUser = true;
+            session.Invalidate();
+            FailApiDictationSession(session.Context.ApiSessionId, Loc.Instance["Status.Cancelled"]);
+            PublishTranscriptionFailureOnce(session, Loc.Instance["Status.Cancelled"]);
+            _activeRecordingSession = null;
+            _currentRecordingId = null;
+            ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]);
+            return Task.CompletedTask;
+        }
+
+        if (_isRecording && session is not null)
+        {
             var durationSeconds = _audio.RecordingDuration.TotalSeconds;
             _isRecording = false;
-            _audio.StopRecording();
+            StopAudioOnce(session);
             StopActiveRecordingInfrastructure();
-            FailApiDictationSession(_activeApiDictationSessionId, Loc.Instance["Status.Cancelled"]);
-            _eventBus.Publish(new RecordingStoppedEvent
-            {
-                DurationSeconds = durationSeconds,
-                RecordingId = recordingId
-            });
-            PublishCancelledFailure(_modelManager.ActiveModelId, _capturedWindowTitle, recordingId);
+            PublishRecordingStoppedOnce(session, durationSeconds);
+            FailApiDictationSession(session.Context.ApiSessionId, Loc.Instance["Status.Cancelled"]);
+            PublishTranscriptionFailureOnce(session, Loc.Instance["Status.Cancelled"]);
+            session.CancelledByUser = true;
+            session.Invalidate();
+            _activeRecordingSession = null;
+            _currentRecordingId = null;
             ApplyTransientIdleFeedback(Loc.Instance["Status.Cancelled"]);
             return Task.CompletedTask;
         }
@@ -1290,7 +1549,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     {
         await foreach (var job in _jobChannel.Reader.ReadAllAsync(ct))
         {
-            await Application.Current.Dispatcher.InvokeAsync(() => UpdateVisualState());
+            await DispatchToUiAsync(UpdateVisualState);
             try
             {
                 await ProcessSingleJobAsync(job, ct);
@@ -1298,7 +1557,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             finally
             {
                 DecrementPendingJobCount();
-                await Application.Current.Dispatcher.InvokeAsync(() => UpdateVisualState());
+                await DispatchToUiAsync(UpdateVisualState);
             }
         }
     }
@@ -1307,7 +1566,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     {
         try
         {
-            await Application.Current.Dispatcher.InvokeAsync(() =>
+            await DispatchToUiAsync(() =>
             {
                 State = DictationState.Processing;
                 StatusText = Loc.Instance["Status.Processing"];
@@ -1334,7 +1593,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             TranscriptionResult? result = null;
             try
             {
-                result = await _modelManager.Engine.TranscribeWithLanguageHintsAsync(
+                result = await job.EngineAtCapture.TranscribeWithLanguageHintsAsync(
                     decodeSamples, job.EffectiveLanguageHints, job.EffectiveTask, ct);
                 fullDecodeText = result.Text ?? "";
                 fullDecodeDetectedLanguage = result.DetectedLanguage;
@@ -1440,7 +1699,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 if (!tailHardeningEnabled)
                 {
                     var compareStartedAt = DateTime.UtcNow;
-                    var compareResult = await _modelManager.Engine.TranscribeWithLanguageHintsAsync(
+                    var compareResult = await job.EngineAtCapture.TranscribeWithLanguageHintsAsync(
                         ParakeetTailHelper.AppendTailGuard(job.Samples),
                         job.EffectiveLanguageHints,
                         job.EffectiveTask,
@@ -2314,6 +2573,18 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         dispatcher.InvokeAsync(action);
     }
 
+    private static async Task DispatchToUiAsync(Action action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        await dispatcher.InvokeAsync(action);
+    }
+
     private void UpdateVisualState()
     {
         if (_isRecording)
@@ -2368,8 +2639,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
             try
             {
+                var languageHints = _activeRecordingSession?.Context.EffectiveLanguageHints
+                    ?? EffectiveLanguageHints;
                 var result = await _modelManager.Engine.TranscribeWithLanguageHintsAsync(
-                    segment.Samples, EffectiveLanguageHints);
+                    segment.Samples, languageHints);
                 if (!string.IsNullOrWhiteSpace(result.Text))
                 {
                     _partialSegments.Add(result.Text);
@@ -2452,6 +2725,12 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     {
         if (!_disposed)
         {
+            var recordingSession = _activeRecordingSession;
+            recordingSession?.Invalidate();
+            if (_isRecording && recordingSession is not null)
+                StopAudioOnce(recordingSession);
+            _activeRecordingSession = null;
+            _isRecording = false;
             _audioDucking.RestoreAudio();
             _mediaPause.ResumeMedia();
             _jobChannel.Writer.TryComplete();
@@ -2511,6 +2790,71 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         _errorLog.AddEntry(JsonSerializer.Serialize(payload), "parakeet-tail");
     }
 
+    private sealed record RecordingContext(
+        Guid RecordingId,
+        string DesiredModelId,
+        Workflow? ActiveWorkflow,
+        IntPtr CapturedWindowHandle,
+        string? CapturedProcessName,
+        string? CapturedWindowTitle,
+        string? CapturedUrl,
+        string EffectiveLanguage,
+        IReadOnlyList<string> EffectiveLanguageHints,
+        TranscriptionTask EffectiveTask,
+        bool EffectiveWhisperMode,
+        bool TranscribeShortQuietClipsAggressively,
+        Guid? ApiSessionId);
+
+    private sealed class RecordingSession(
+        RecordingContext context,
+        TaskCompletionSource<bool> captureStarted,
+        CancellationTokenSource preparationCts,
+        Task<ModelPreparationOutcome> modelPreparation)
+    {
+        private int _preparationResourcesDisposed;
+
+        public RecordingContext Context { get; } = context;
+        public TaskCompletionSource<bool> CaptureStarted { get; } = captureStarted;
+        public CancellationTokenSource PreparationCts { get; } = preparationCts;
+        public Task<ModelPreparationOutcome> ModelPreparation { get; } = modelPreparation;
+        public bool IsInvalidated { get; private set; }
+        public bool AudioStopped { get; set; }
+        public bool RecordingStartedPublished { get; set; }
+        public bool RecordingStoppedPublished { get; set; }
+        public bool TerminalTranscriptionEventPublished { get; set; }
+        public bool PreparationFailureHandled { get; set; }
+        public bool CancelledByUser { get; set; }
+        public bool JobEnqueued { get; set; }
+
+        public void Invalidate()
+        {
+            if (IsInvalidated)
+                return;
+
+            IsInvalidated = true;
+            CaptureStarted.TrySetResult(false);
+            PreparationCts.Cancel();
+        }
+
+        public void DisposePreparationResources()
+        {
+            if (Interlocked.Exchange(ref _preparationResourcesDisposed, 1) != 0)
+                return;
+
+            if (ModelPreparation.IsCompleted)
+            {
+                PreparationCts.Dispose();
+                return;
+            }
+
+            _ = ModelPreparation.ContinueWith(
+                _ => PreparationCts.Dispose(),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+
     private sealed record TranscriptionJob(
         float[] Samples,
         float[] OriginalSamples,
@@ -2523,6 +2867,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         string? EffectiveLanguage,
         IReadOnlyList<string> EffectiveLanguageHints,
         TranscriptionTask EffectiveTask,
+        ITranscriptionEngine EngineAtCapture,
         string? ActiveModelIdAtCapture,
         string? EngineIdAtCapture,
         string? TranscriptionModelIdAtCapture,

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -575,7 +575,12 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
         if (!_isRecording
             && GetApiDictationSession(sessionId)?.Status == ApiDictationSessionStatus.Recording)
-            FailApiDictationSession(sessionId, StatusText);
+        {
+            var startupError = string.IsNullOrWhiteSpace(FeedbackText)
+                ? StatusText
+                : FeedbackText;
+            FailApiDictationSession(sessionId, startupError);
+        }
 
         return sessionId;
     }
@@ -1381,6 +1386,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
         session.StopRequested = true;
         _isStoppingRecording = true;
+        CancellationTokenSource? jobCancellation = null;
 
         try
         {
@@ -1487,6 +1493,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             var activeModelIdAtCapture = preparationOutcome.ActiveModelId
                 ?? session.Context.DesiredModelId;
             var transcriptionIdentity = _modelManager.ResolveTranscriptionIdentity(activeModelIdAtCapture);
+            jobCancellation = session.CreateJobCancellation();
             var job = new TranscriptionJob(
                 transcriptionSamples,
                 originalSamples,
@@ -1527,11 +1534,21 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                     null,
                     null,
                     null),
+                session,
+                jobCancellation,
                 session.Context.RecordingId);
+
+            try
+            {
+                await _jobChannel.Writer.WriteAsync(job, jobCancellation.Token);
+            }
+            catch (OperationCanceledException) when (jobCancellation.IsCancellationRequested)
+            {
+                return;
+            }
 
             session.JobEnqueued = true;
             Interlocked.Increment(ref _pendingJobCount);
-            await _jobChannel.Writer.WriteAsync(job);
             UpdateVisualState();
         }
         finally
@@ -1542,6 +1559,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 _activeRecordingSession = null;
             if (!session.JobEnqueued && _currentRecordingId == session.Context.RecordingId)
                 _currentRecordingId = null;
+            if (!session.JobEnqueued && jobCancellation is not null)
+                session.ReleaseJobCancellation(jobCancellation);
             session.DisposePreparationResources();
             _hotkey.ForceStop();
         }
@@ -1639,10 +1658,14 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             await DispatchToUiAsync(UpdateVisualState);
             try
             {
-                await ProcessSingleJobAsync(job, ct);
+                using var jobCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    ct,
+                    job.SessionCancellationSource.Token);
+                await ProcessSingleJobAsync(job, jobCts.Token);
             }
             finally
             {
+                job.Session.ReleaseJobCancellation(job.SessionCancellationSource);
                 DecrementPendingJobCount();
                 await DispatchToUiAsync(UpdateVisualState);
             }
@@ -1653,11 +1676,13 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     {
         try
         {
+            ct.ThrowIfCancellationRequested();
             await DispatchToUiAsync(() =>
             {
                 State = DictationState.Processing;
                 StatusText = Loc.Instance["Status.Processing"];
             });
+            ct.ThrowIfCancellationRequested();
 
             string rawText = "";
             string? detectedLanguage = null;
@@ -1712,6 +1737,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             {
                 fullDecodeDurationMs = (long)(DateTime.UtcNow - decodeStartedAt).TotalMilliseconds;
             }
+            ct.ThrowIfCancellationRequested();
 
             if (result is not null && isParakeetJob)
             {
@@ -1915,6 +1941,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             };
 
             var pipelineResult = await _pipeline.ProcessAsync(rawText, pipelineOptions, ct);
+            ct.ThrowIfCancellationRequested();
             var finalText = pipelineResult.Text;
 
             var timestamp = DateTime.UtcNow;
@@ -2101,6 +2128,9 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         }
         catch (OperationCanceledException)
         {
+            if (job.SessionCancellationSource.IsCancellationRequested)
+                return;
+
             FailApiDictationSession(job.ApiSessionId, Loc.Instance["Status.Cancelled"]);
             PublishCancelledFailure(job.ActiveModelIdAtCapture, job.CapturedWindowTitle, job.RecordingId);
             await Application.Current.Dispatcher.InvokeAsync(() =>
@@ -2761,6 +2791,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 pendingJob.ActiveModelIdAtCapture,
                 pendingJob.CapturedWindowTitle,
                 pendingJob.RecordingId);
+            pendingJob.Session.ReleaseJobCancellation(pendingJob.SessionCancellationSource);
             DecrementPendingJobCount();
         }
 
@@ -2825,6 +2856,11 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             CancelTargetAppCorrectionLearning();
             _consumerCts.Cancel();
             try { _consumerTask?.Wait(TimeSpan.FromSeconds(3)); } catch { /* shutting down */ }
+            while (_jobChannel.Reader.TryRead(out var pendingJob))
+            {
+                pendingJob.Session.ReleaseJobCancellation(pendingJob.SessionCancellationSource);
+                DecrementPendingJobCount();
+            }
             _consumerCts.Dispose();
             _durationTimer?.Dispose();
             _feedbackTimer?.Dispose();
@@ -2900,12 +2936,15 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         Task<ModelPreparationOutcome> modelPreparation)
     {
         private int _preparationResourcesDisposed;
+        private int _isInvalidated;
+        private readonly object _jobCancellationGate = new();
+        private CancellationTokenSource? _jobCancellation;
 
         public RecordingContext Context { get; } = context;
         public TaskCompletionSource<bool> CaptureStarted { get; } = captureStarted;
         public CancellationTokenSource PreparationCts { get; } = preparationCts;
         public Task<ModelPreparationOutcome> ModelPreparation { get; } = modelPreparation;
-        public bool IsInvalidated { get; private set; }
+        public bool IsInvalidated => Volatile.Read(ref _isInvalidated) != 0;
         public bool AudioStopped { get; set; }
         public bool RecordingStartedPublished { get; set; }
         public bool RecordingStoppedPublished { get; set; }
@@ -2917,13 +2956,40 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
         public void Invalidate()
         {
-            if (IsInvalidated)
+            if (Interlocked.Exchange(ref _isInvalidated, 1) != 0)
                 return;
 
-            IsInvalidated = true;
             CaptureStarted.TrySetResult(false);
             PreparationCts.Cancel();
+            lock (_jobCancellationGate)
+                _jobCancellation?.Cancel();
             DisposePreparationResources();
+        }
+
+        public CancellationTokenSource CreateJobCancellation()
+        {
+            lock (_jobCancellationGate)
+            {
+                if (_jobCancellation is not null)
+                    throw new InvalidOperationException("A recording session can enqueue only one transcription job.");
+
+                _jobCancellation = new CancellationTokenSource();
+                if (IsInvalidated)
+                    _jobCancellation.Cancel();
+                return _jobCancellation;
+            }
+        }
+
+        public void ReleaseJobCancellation(CancellationTokenSource cancellation)
+        {
+            lock (_jobCancellationGate)
+            {
+                if (!ReferenceEquals(_jobCancellation, cancellation))
+                    return;
+
+                _jobCancellation = null;
+                cancellation.Dispose();
+            }
         }
 
         public void DisposePreparationResources()
@@ -2964,6 +3030,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         Guid? ApiSessionId,
         bool TranscribeShortQuietClipsAggressively,
         RecordingTailDiagnosticSnapshot Diagnostic,
+        RecordingSession Session,
+        CancellationTokenSource SessionCancellationSource,
         Guid? RecordingId);
 
     internal static Func<string, string>? CreateSpokenFormatter(

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -88,6 +88,7 @@ internal sealed record ModelPreparationOutcome(
     string RequestedModelId,
     string? ActiveModelId,
     ITranscriptionEngine? Engine,
+    ITranscriptionEnginePlugin? Plugin,
     bool IsReady,
     bool IsCancelled,
     Exception? Error);
@@ -196,6 +197,10 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     private readonly List<string> _partialSegments = [];
     private readonly SemaphoreSlim _vadLock = new(1, 1);
     private readonly SemaphoreSlim _modelPreparationLock = new(1, 1);
+    private readonly object _modelPreparationLifetimeGate = new();
+    private int _activeModelPreparationOperations;
+    private bool _modelPreparationLockDisposeRequested;
+    private bool _modelPreparationLockDisposed;
     private bool _disposed;
     private int _lastVadFlushedSegmentCount;
     private int _lastVadDiscardedShortSegmentCount;
@@ -928,6 +933,19 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         Task<bool> captureStarted,
         CancellationToken cancellationToken)
     {
+        if (!TryBeginModelPreparationOperation())
+        {
+            return new ModelPreparationOutcome(
+                recordingId,
+                desiredModelId,
+                null,
+                null,
+                null,
+                IsReady: false,
+                IsCancelled: true,
+                Error: null);
+        }
+
         var lockAcquired = false;
         try
         {
@@ -936,6 +954,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 return new ModelPreparationOutcome(
                     recordingId,
                     desiredModelId,
+                    null,
                     null,
                     null,
                     IsReady: false,
@@ -952,12 +971,18 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             cancellationToken.ThrowIfCancellationRequested();
             var activeModelId = _modelManager.ActiveModelId;
             var engine = _modelManager.Engine;
+            var plugin = _modelManager.ActiveTranscriptionPlugin;
+            var requestedModelIsActive = string.Equals(
+                desiredModelId,
+                activeModelId,
+                StringComparison.Ordinal);
             return new ModelPreparationOutcome(
                 recordingId,
                 desiredModelId,
                 activeModelId,
                 engine,
-                IsReady: loaded && engine.IsModelLoaded,
+                plugin,
+                IsReady: loaded && requestedModelIsActive && engine.IsModelLoaded,
                 IsCancelled: false,
                 Error: null);
         }
@@ -966,6 +991,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             return new ModelPreparationOutcome(
                 recordingId,
                 desiredModelId,
+                null,
                 null,
                 null,
                 IsReady: false,
@@ -979,6 +1005,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 desiredModelId,
                 null,
                 null,
+                null,
                 IsReady: false,
                 IsCancelled: false,
                 Error: ex);
@@ -987,7 +1014,49 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         {
             if (lockAcquired)
                 _modelPreparationLock.Release();
+            CompleteModelPreparationOperation();
         }
+    }
+
+    private void CompleteModelPreparationOperation()
+    {
+        lock (_modelPreparationLifetimeGate)
+        {
+            _activeModelPreparationOperations--;
+            if (_activeModelPreparationOperations == 0 && _modelPreparationLockDisposeRequested)
+                DisposeModelPreparationLockOnce();
+        }
+    }
+
+    private bool TryBeginModelPreparationOperation()
+    {
+        lock (_modelPreparationLifetimeGate)
+        {
+            if (_modelPreparationLockDisposeRequested)
+                return false;
+
+            _activeModelPreparationOperations++;
+            return true;
+        }
+    }
+
+    private void RequestModelPreparationLockDisposal()
+    {
+        lock (_modelPreparationLifetimeGate)
+        {
+            _modelPreparationLockDisposeRequested = true;
+            if (_activeModelPreparationOperations == 0)
+                DisposeModelPreparationLockOnce();
+        }
+    }
+
+    private void DisposeModelPreparationLockOnce()
+    {
+        if (_modelPreparationLockDisposed)
+            return;
+
+        _modelPreparationLockDisposed = true;
+        _modelPreparationLock.Dispose();
     }
 
     private static async Task YieldForRecordingPresentationAsync()
@@ -1002,8 +1071,17 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         await dispatcher.InvokeAsync(static () => { }, DispatcherPriority.Background);
     }
 
-    private static async Task<bool> AwaitModelReadyAsync(Task<ModelPreparationOutcome> preparation) =>
-        (await preparation).IsReady;
+    private static async Task<StreamingModelPreparation> AwaitStreamingModelPreparationAsync(
+        Task<ModelPreparationOutcome> preparation)
+    {
+        var outcome = await preparation;
+        return new StreamingModelPreparation(
+            outcome.RequestedModelId,
+            outcome.ActiveModelId,
+            outcome.Engine,
+            outcome.Plugin,
+            outcome.IsReady);
+    }
 
     private void PublishRecordingStartedOnce(RecordingSession session)
     {
@@ -1112,7 +1190,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
 
     private async Task StartRecording()
     {
-        if (_isRecording)
+        if (_disposed || _isRecording)
             return;
 
         if (_isStoppingRecording)
@@ -1206,17 +1284,25 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
         PartialText = "";
         _vad?.Dispose();
         _vad = null;
+        _audio.SamplesAvailable -= OnSamplesAvailable;
         _streamingHandler.Stop();
 
-        if (settingsSnapshot.LiveTranscriptionEnabled
-            && ModelManagerService.IsPluginModel(desiredModelId))
+        if (settingsSnapshot.LiveTranscriptionEnabled)
         {
-            _streamingHandler.StartWhenReadyWithLanguageHints(
-                languageHints,
-                effectiveTask,
-                () => ReferenceEquals(_activeRecordingSession, session) && _isRecording,
-                AwaitModelReadyAsync(modelPreparation),
-                settingsSnapshot.OnlineAsrBatchLiveTranscriptionEnabled);
+            if (ModelManagerService.IsPluginModel(desiredModelId))
+            {
+                _streamingHandler.StartWhenReadyWithLanguageHints(
+                    languageHints,
+                    effectiveTask,
+                    () => ReferenceEquals(_activeRecordingSession, session) && _isRecording,
+                    AwaitStreamingModelPreparationAsync(modelPreparation),
+                    settingsSnapshot.OnlineAsrBatchLiveTranscriptionEnabled);
+            }
+            else
+            {
+                _vad = CreateVoiceActivityDetector();
+                _audio.SamplesAvailable += OnSamplesAvailable;
+            }
         }
 
         _audio.StartRecording();
@@ -2726,6 +2812,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
     {
         if (!_disposed)
         {
+            _disposed = true;
             var recordingSession = _activeRecordingSession;
             recordingSession?.Invalidate();
             if (_isRecording && recordingSession is not null)
@@ -2744,9 +2831,9 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             _streamingHandler.Dispose();
             _vad?.Dispose();
             _vadLock.Dispose();
+            RequestModelPreparationLockDisposal();
             _audio.AudioLevelChanged -= OnAudioLevelChanged;
             _audio.SamplesAvailable -= OnSamplesAvailable;
-            _disposed = true;
         }
     }
 
@@ -2836,6 +2923,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             IsInvalidated = true;
             CaptureStarted.TrySetResult(false);
             PreparationCts.Cancel();
+            DisposePreparationResources();
         }
 
         public void DisposePreparationResources()

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -2960,7 +2960,6 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 return;
 
             CaptureStarted.TrySetResult(false);
-            PreparationCts.Cancel();
             lock (_jobCancellationGate)
                 _jobCancellation?.Cancel();
             DisposePreparationResources();
@@ -2997,6 +2996,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             if (Interlocked.Exchange(ref _preparationResourcesDisposed, 1) != 0)
                 return;
 
+            PreparationCts.Cancel();
             if (ModelPreparation.IsCompleted)
             {
                 PreparationCts.Dispose();

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
@@ -93,4 +93,35 @@ public class DictationOverlayPresentationTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void LegacyLivePreview_PreparesVadBeforeAudioCaptureStarts()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "ViewModels",
+            "DictationViewModel.cs");
+        var startRecording = TestFile.ExtractBlock(source, "private async Task StartRecording()", 8500);
+
+        var pluginBranchIndex = startRecording.IndexOf(
+            "if (ModelManagerService.IsPluginModel(desiredModelId))",
+            StringComparison.Ordinal);
+        var vadIndex = startRecording.IndexOf(
+            "_vad = CreateVoiceActivityDetector();",
+            StringComparison.Ordinal);
+        var samplesSubscriptionIndex = startRecording.IndexOf(
+            "_audio.SamplesAvailable += OnSamplesAvailable;",
+            StringComparison.Ordinal);
+        var captureStartIndex = startRecording.IndexOf("_audio.StartRecording();", StringComparison.Ordinal);
+
+        Assert.True(pluginBranchIndex >= 0, "Expected separate plugin and legacy preview paths.");
+        Assert.True(vadIndex > pluginBranchIndex, "Expected the legacy preview path to create its VAD.");
+        Assert.True(
+            samplesSubscriptionIndex > vadIndex,
+            "Expected legacy audio samples to feed the VAD.");
+        Assert.True(
+            captureStartIndex > samplesSubscriptionIndex,
+            "Expected live preview subscriptions before audio capture starts.");
+    }
+
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/DictationOverlayPresentationTests.cs
@@ -76,14 +76,21 @@ public class DictationOverlayPresentationTests
             source,
             "private void ApplyModelUnavailableFeedback(string? modelId, Exception? error = null)",
             900);
-        var startRecording = TestFile.ExtractBlock(source, "private async Task StartRecording()", 4200);
+        var preparation = TestFile.ExtractBlock(
+            source,
+            "private async Task<ModelPreparationOutcome> PrepareModelAsync(",
+            3200);
+        var startRecording = TestFile.ExtractBlock(source, "private async Task StartRecording()", 8500);
 
         Assert.Contains("_errorLog.AddEntry(diagnostic, ErrorCategory.Transcription);", helper, StringComparison.Ordinal);
         Assert.Contains("ApplyTransientIdleFeedback(feedback, feedbackIsError: true);", helper, StringComparison.Ordinal);
         Assert.Contains("ApplyModelUnavailableFeedback(desiredModelId);", startRecording, StringComparison.Ordinal);
-        Assert.Equal(4, TestFile.CountOccurrences(
+        Assert.Contains("catch (Exception ex)", preparation, StringComparison.Ordinal);
+        Assert.Contains("Error: ex", preparation, StringComparison.Ordinal);
+        Assert.Contains(
+            "EndRecordingAfterPreparationFailure(session, preparationOutcome);",
             startRecording,
-            "ApplyModelUnavailableFeedback(desiredModelId, ex);"));
+            StringComparison.Ordinal);
     }
 
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -852,6 +852,11 @@ public class ModelManagerViewModelTests
         var startTask = fixture.ViewModel.StartRecordingAsync();
         Assert.True(await plugin.WaitForLoadCountAsync(1, TimeSpan.FromSeconds(2)));
         Assert.True(fixture.Audio.IsRecording);
+        var recordingSession = GetPrivateField(fixture.ViewModel, "_activeRecordingSession");
+        var preparationCts = Assert.IsType<CancellationTokenSource>(
+            recordingSession.GetType()
+                .GetProperty("PreparationCts")
+                ?.GetValue(recordingSession));
 
         await fixture.ViewModel.HandleCancelRequested();
         await fixture.ViewModel.HandleCancelRequested();
@@ -867,12 +872,45 @@ public class ModelManagerViewModelTests
         Assert.False(fixture.Audio.IsRecording);
         Assert.Equal(DictationState.Idle, fixture.ViewModel.State);
         Assert.Equal(0, plugin.TranscribeCallCount);
+        Assert.Throws<ObjectDisposedException>(() => preparationCts.Cancel());
         lock (startedEvents)
             Assert.Single(startedEvents);
         lock (stoppedEvents)
             Assert.Single(stoppedEvents);
         lock (failedEvents)
             Assert.Single(failedEvents);
+    }
+
+    [Fact]
+    public async Task Dispose_DefersModelPreparationLockDisposalUntilBlockedLoadReturns()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Parakeet",
+            modelId,
+            "Parakeet TDT",
+            configured: true,
+            supportsModelDownload: true);
+        plugin.BlockNextLoadIgnoringCancellation();
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with { SelectedModelId = fullModelId },
+            plugin);
+
+        var startTask = fixture.ViewModel.StartRecordingAsync();
+        Assert.True(await plugin.WaitForLoadCountAsync(1, TimeSpan.FromSeconds(2)));
+        var preparationLock = Assert.IsType<SemaphoreSlim>(
+            GetPrivateField(fixture.ViewModel, "_modelPreparationLock"));
+
+        fixture.ViewModel.Dispose();
+
+        Assert.False(preparationLock.Wait(0));
+        plugin.ReleaseBlockedLoad();
+        await startTask;
+
+        Assert.Throws<ObjectDisposedException>(() => preparationLock.Wait(0));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -578,7 +578,26 @@ public class ModelManagerViewModelTests
             recentTranscriptions,
             workflowPalette);
 
-        await sut.StartRecordingAsync();
+        plugin.BlockNextLoad();
+        var startTask = sut.StartRecordingAsync();
+
+        try
+        {
+            Assert.True(
+                await plugin.WaitForLoadCountAsync(2, TimeSpan.FromSeconds(1)),
+                "Starting dictation should begin preparing the changed model.");
+            Assert.True(sut.IsRecording);
+            Assert.True(audio.IsRecording);
+            Assert.True(sut.IsOverlayVisible);
+            Assert.Equal(DictationState.Recording, sut.State);
+            Assert.False(startTask.IsCompleted);
+        }
+        finally
+        {
+            plugin.ReleaseBlockedLoad();
+        }
+
+        await startTask;
 
         Assert.Equal(
             [TranscriptionAccelerationPreference.Cpu, TranscriptionAccelerationPreference.NvidiaCuda],
@@ -665,6 +684,281 @@ public class ModelManagerViewModelTests
         Assert.False(sut.IsRecording);
         Assert.False(sut.ShowFeedback);
         Assert.False(sut.FeedbackIsError);
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_WaitsInProcessingForModelAndTranscribesCompleteAudioOnce()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Parakeet",
+            modelId,
+            "Parakeet TDT",
+            configured: true,
+            supportsModelDownload: true)
+        {
+            ResponseText = ""
+        };
+        plugin.BlockNextLoad();
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with
+            {
+                SelectedModelId = fullModelId,
+                LocalModelAcceleration = AppSettings.LocalModelAccelerationCpu,
+                TranscribeShortQuietClipsAggressively = true,
+                SaveToHistoryEnabled = false,
+                AutoPaste = false
+            },
+            plugin);
+
+        var startedEvents = new List<RecordingStartedEvent>();
+        var stoppedEvents = new List<RecordingStoppedEvent>();
+        using var startedSubscription = _eventBus.Subscribe<RecordingStartedEvent>(evt =>
+        {
+            lock (startedEvents)
+                startedEvents.Add(evt);
+            return Task.CompletedTask;
+        });
+        using var stoppedSubscription = _eventBus.Subscribe<RecordingStoppedEvent>(evt =>
+        {
+            lock (stoppedEvents)
+                stoppedEvents.Add(evt);
+            return Task.CompletedTask;
+        });
+
+        var startTask = fixture.ViewModel.StartRecordingAsync();
+        Assert.True(await plugin.WaitForLoadCountAsync(1, TimeSpan.FromSeconds(2)));
+        var capture = Assert.Single(fixture.Captures.Created);
+        var initialAudio = BuildSpeechPcm16Chunk();
+        capture.RaiseData(initialAudio, initialAudio.Length);
+
+        var stopTask = fixture.ViewModel.StopRecordingAsync();
+        Assert.True(await WaitForConditionAsync(
+            () => !fixture.Audio.IsRecording
+                && fixture.ViewModel.State == DictationState.Processing
+                && fixture.ViewModel.IsOverlayVisible,
+            TimeSpan.FromSeconds(2)));
+        Assert.False(stopTask.IsCompleted);
+
+        plugin.ReleaseBlockedLoad();
+        await Task.WhenAll(startTask, stopTask);
+        Assert.True(await WaitForConditionAsync(
+            () => plugin.TranscribeCallCount == 1,
+            TimeSpan.FromSeconds(2)));
+
+        Assert.Equal(1, plugin.TranscribeCallCount);
+        AssertWavContainsInitialAudio(plugin.LastTranscriptionAudio, initialAudio.Length);
+        Assert.Equal(1, capture.StopCount);
+        lock (startedEvents)
+            Assert.Single(startedEvents);
+        lock (stoppedEvents)
+            Assert.Single(stoppedEvents);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CloudBatchProvider_FinalRequestIncludesAudioFromRecordingStart(
+        bool liveTranscriptionEnabled)
+    {
+        const string pluginId = "com.typewhisper.cloud-batch";
+        const string modelId = "batch";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Cloud Batch",
+            modelId,
+            "Batch",
+            configured: true)
+        {
+            ResponseText = ""
+        };
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with
+            {
+                SelectedModelId = fullModelId,
+                LiveTranscriptionEnabled = liveTranscriptionEnabled,
+                TranscribeShortQuietClipsAggressively = true,
+                SaveToHistoryEnabled = false,
+                AutoPaste = false
+            },
+            plugin);
+
+        await fixture.ViewModel.StartRecordingAsync();
+        var capture = Assert.Single(fixture.Captures.Created);
+        var initialAudio = BuildSpeechPcm16Chunk();
+        capture.RaiseData(initialAudio, initialAudio.Length);
+        if (!liveTranscriptionEnabled)
+        {
+            var streamingHandler = GetPrivateField(fixture.ViewModel, "_streamingHandler");
+            Assert.Equal(0, (int)GetPrivateField(streamingHandler, "_pendingStreamingAudioBytes"));
+        }
+
+        await fixture.ViewModel.StopRecordingAsync();
+        Assert.True(await WaitForConditionAsync(
+            () => plugin.TranscribeCallCount == 1,
+            TimeSpan.FromSeconds(2)));
+
+        Assert.Equal(1, plugin.TranscribeCallCount);
+        AssertWavContainsInitialAudio(plugin.LastTranscriptionAudio, initialAudio.Length);
+        Assert.Equal(1, capture.StopCount);
+    }
+
+    [Fact]
+    public async Task LateModelContinuationAfterAbort_DoesNotRestartInvalidatedSession()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Parakeet",
+            modelId,
+            "Parakeet TDT",
+            configured: true,
+            supportsModelDownload: true)
+        {
+            ResponseText = ""
+        };
+        plugin.BlockNextLoadIgnoringCancellation();
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with { SelectedModelId = fullModelId },
+            plugin);
+        var startedEvents = new List<RecordingStartedEvent>();
+        var stoppedEvents = new List<RecordingStoppedEvent>();
+        var failedEvents = new List<TranscriptionFailedEvent>();
+        using var startedSubscription = _eventBus.Subscribe<RecordingStartedEvent>(evt =>
+        {
+            lock (startedEvents)
+                startedEvents.Add(evt);
+            return Task.CompletedTask;
+        });
+        using var stoppedSubscription = _eventBus.Subscribe<RecordingStoppedEvent>(evt =>
+        {
+            lock (stoppedEvents)
+                stoppedEvents.Add(evt);
+            return Task.CompletedTask;
+        });
+        using var failedSubscription = _eventBus.Subscribe<TranscriptionFailedEvent>(evt =>
+        {
+            lock (failedEvents)
+                failedEvents.Add(evt);
+            return Task.CompletedTask;
+        });
+
+        var startTask = fixture.ViewModel.StartRecordingAsync();
+        Assert.True(await plugin.WaitForLoadCountAsync(1, TimeSpan.FromSeconds(2)));
+        Assert.True(fixture.Audio.IsRecording);
+
+        await fixture.ViewModel.HandleCancelRequested();
+        await fixture.ViewModel.HandleCancelRequested();
+
+        Assert.False(fixture.Audio.IsRecording);
+        Assert.False(fixture.ViewModel.IsRecording);
+        Assert.False(fixture.ViewModel.IsOverlayVisible);
+
+        plugin.ReleaseBlockedLoad();
+        await startTask;
+        await Task.Delay(100);
+
+        Assert.False(fixture.Audio.IsRecording);
+        Assert.Equal(DictationState.Idle, fixture.ViewModel.State);
+        Assert.Equal(0, plugin.TranscribeCallCount);
+        lock (startedEvents)
+            Assert.Single(startedEvents);
+        lock (stoppedEvents)
+            Assert.Single(stoppedEvents);
+        lock (failedEvents)
+            Assert.Single(failedEvents);
+    }
+
+    [Fact]
+    public async Task DelayedModelFailure_StopsAudioAndPublishesOneFailure()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Parakeet",
+            modelId,
+            "Parakeet TDT",
+            configured: true,
+            supportsModelDownload: true)
+        {
+            LoadExceptionAfterBlock = new InvalidOperationException("Delayed load failed")
+        };
+        plugin.BlockNextLoad();
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with { SelectedModelId = fullModelId },
+            plugin);
+        var failedEvents = new List<TranscriptionFailedEvent>();
+        using var failedSubscription = _eventBus.Subscribe<TranscriptionFailedEvent>(evt =>
+        {
+            lock (failedEvents)
+                failedEvents.Add(evt);
+            return Task.CompletedTask;
+        });
+
+        var startTask = fixture.ViewModel.StartRecordingAsync();
+        Assert.True(await plugin.WaitForLoadCountAsync(1, TimeSpan.FromSeconds(2)));
+        Assert.True(fixture.Audio.IsRecording);
+        Assert.True(fixture.ViewModel.IsOverlayVisible);
+
+        plugin.ReleaseBlockedLoad();
+        await startTask;
+        Assert.True(await WaitForConditionAsync(
+            () =>
+            {
+                lock (failedEvents)
+                    return failedEvents.Count == 1;
+            },
+            TimeSpan.FromSeconds(2)));
+
+        Assert.False(fixture.Audio.IsRecording);
+        Assert.False(fixture.ViewModel.IsRecording);
+        Assert.False(fixture.ViewModel.IsOverlayVisible);
+        Assert.True(fixture.ViewModel.ShowFeedback);
+        Assert.True(fixture.ViewModel.FeedbackIsError);
+        Assert.Equal(0, plugin.TranscribeCallCount);
+        Assert.Equal(1, Assert.Single(fixture.Captures.Created).StopCount);
+        fixture.History.Verify(h => h.AddRecord(It.IsAny<TranscriptionRecord>()), Times.Never);
+        lock (failedEvents)
+            Assert.Single(failedEvents);
+    }
+
+    [Fact]
+    public async Task AlreadyLoadedModel_StartsWithoutReloading()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Parakeet",
+            modelId,
+            "Parakeet TDT",
+            configured: true,
+            supportsModelDownload: true);
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with { SelectedModelId = fullModelId },
+            plugin);
+        await fixture.ModelManager.LoadModelAsync(fullModelId);
+
+        await fixture.ViewModel.StartRecordingAsync();
+
+        Assert.True(fixture.ViewModel.IsRecording);
+        Assert.True(fixture.Audio.IsRecording);
+        Assert.True(fixture.ViewModel.IsOverlayVisible);
+        Assert.Equal(1, plugin.LoadCallCount);
+
+        await fixture.ViewModel.HandleCancelRequested();
+        await fixture.ViewModel.HandleCancelRequested();
+        Assert.False(fixture.Audio.IsRecording);
+        Assert.Equal(1, Assert.Single(fixture.Captures.Created).StopCount);
     }
 
     [Fact]
@@ -1088,6 +1382,106 @@ public class ModelManagerViewModelTests
         Assert.False(sut.IsActiveModelBusy);
     }
 
+    private DictationFixture CreateDictationFixture(
+        AppSettings initialSettings,
+        FakeTranscriptionPlugin plugin)
+    {
+        var settings = new FakeSettingsService(initialSettings);
+        var pluginManager = CreatePluginManager(settings, plugin);
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var errorLog = new Mock<IErrorLogService>();
+        var captures = new FakeAudioInputCaptureFactory();
+        var audio = new AudioRecordingService(
+            new FakeAudioInputDeviceProvider("USB Microphone"),
+            captures,
+            Timeout.InfiniteTimeSpan);
+        var speechFeedback = new SpeechFeedbackService(
+            settings,
+            pluginManager,
+            new FakeTtsProvider("windows-sapi", "System Voice"));
+        var textInsertion = new TextInsertionService(errorLog.Object);
+        var history = new Mock<IHistoryService>();
+        history.Setup(h => h.Records).Returns([]);
+        var workflowTextProcessor = new Mock<IWorkflowTextProcessor>();
+        var recentTranscriptions = new RecentTranscriptionsService(
+            history.Object,
+            new RecentTranscriptionStore(),
+            textInsertion,
+            settings);
+        var workflowPalette = new WorkflowPaletteService(
+            _workflows.Object,
+            _activeWindow.Object,
+            textInsertion,
+            settings,
+            workflowTextProcessor.Object,
+            pluginManager,
+            new NoOpWorkflowPalettePresenter());
+        var hotkey = new HotkeyService(settings, _workflows.Object);
+        var viewModel = new DictationViewModel(
+            settings,
+            modelManager,
+            audio,
+            hotkey,
+            textInsertion,
+            _activeWindow.Object,
+            new SoundService { IsEnabled = false },
+            history.Object,
+            Mock.Of<IDictionaryService>(),
+            Mock.Of<IVocabularyBoostingService>(),
+            Mock.Of<ISnippetService>(),
+            _workflows.Object,
+            Mock.Of<ITranslationService>(),
+            Mock.Of<IAudioDuckingService>(),
+            Mock.Of<IMediaPauseService>(),
+            workflowTextProcessor.Object,
+            new PostProcessingPipeline(),
+            errorLog.Object,
+            speechFeedback,
+            recentTranscriptions,
+            workflowPalette);
+
+        return new DictationFixture(
+            viewModel,
+            audio,
+            captures,
+            modelManager,
+            pluginManager,
+            hotkey,
+            speechFeedback,
+            history,
+            plugin);
+    }
+
+    private static byte[] BuildSpeechPcm16Chunk()
+    {
+        var samples = Enumerable.Repeat((short)8192, 1600).ToArray();
+        var bytes = new byte[samples.Length * sizeof(short)];
+        Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    private static void AssertWavContainsInitialAudio(byte[]? wavAudio, int expectedInitialBytes)
+    {
+        Assert.NotNull(wavAudio);
+        var dataOffset = -1;
+        for (var i = 12; i <= wavAudio.Length - 8; i++)
+        {
+            if (wavAudio[i] == (byte)'d'
+                && wavAudio[i + 1] == (byte)'a'
+                && wavAudio[i + 2] == (byte)'t'
+                && wavAudio[i + 3] == (byte)'a')
+            {
+                dataOffset = i + 8;
+                break;
+            }
+        }
+
+        Assert.True(dataOffset > 0, "The final transcription request should contain a WAV data chunk.");
+        var dataLength = BitConverter.ToInt32(wavAudio, dataOffset - sizeof(int));
+        Assert.True(dataLength >= expectedInitialBytes);
+        Assert.Contains(wavAudio.AsSpan(dataOffset, expectedInitialBytes).ToArray(), value => value != 0);
+    }
+
     private PluginManager CreatePluginManager(ISettingsService settings, params ITranscriptionEnginePlugin[] transcriptionEngines)
     {
         var pluginManager = new PluginManager(
@@ -1102,11 +1496,48 @@ public class ModelManagerViewModelTests
         return pluginManager;
     }
 
+    private sealed class DictationFixture(
+        DictationViewModel viewModel,
+        AudioRecordingService audio,
+        FakeAudioInputCaptureFactory captures,
+        ModelManagerService modelManager,
+        PluginManager pluginManager,
+        HotkeyService hotkey,
+        SpeechFeedbackService speechFeedback,
+        Mock<IHistoryService> history,
+        FakeTranscriptionPlugin plugin) : IDisposable
+    {
+        public DictationViewModel ViewModel { get; } = viewModel;
+        public AudioRecordingService Audio { get; } = audio;
+        public FakeAudioInputCaptureFactory Captures { get; } = captures;
+        public ModelManagerService ModelManager { get; } = modelManager;
+        public Mock<IHistoryService> History { get; } = history;
+
+        public void Dispose()
+        {
+            plugin.ReleaseBlockedLoad();
+            ViewModel.Dispose();
+            hotkey.Dispose();
+            speechFeedback.Dispose();
+            Audio.Dispose();
+            ModelManager.Dispose();
+            pluginManager.Dispose();
+        }
+    }
+
     private static void SetPrivateField(object target, string fieldName, object value)
     {
         var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
         field.SetValue(target, value);
+    }
+
+    private static object GetPrivateField(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+        return field.GetValue(target)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' was unexpectedly null.");
     }
 
     private static async Task<bool> WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
@@ -1214,9 +1645,14 @@ public class ModelManagerViewModelTests
             TranscriptionAccelerationPreference.Auto;
         public int LoadCallCount { get; private set; }
         public Exception? LoadException { get; set; }
+        public Exception? LoadExceptionAfterBlock { get; set; }
+        public string ResponseText { get; set; } = "ok";
+        public int TranscribeCallCount { get; private set; }
+        public byte[]? LastTranscriptionAudio { get; private set; }
         public List<TranscriptionAccelerationPreference> AccelerationPreferencesAtLoad { get; } = [];
         private TaskCompletionSource? _nextLoadBlocker;
         private TaskCompletionSource? _activeLoadBlocker;
+        private bool _nextLoadIgnoresCancellation;
         private readonly Func<TranscriptionAccelerationPreference, TranscriptionAccelerationStatus>? _accelerationStatusFactory;
 
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
@@ -1233,6 +1669,12 @@ public class ModelManagerViewModelTests
         public void BlockNextLoad() =>
             _nextLoadBlocker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public void BlockNextLoadIgnoringCancellation()
+        {
+            BlockNextLoad();
+            _nextLoadIgnoresCancellation = true;
+        }
+
         public void ReleaseBlockedLoad() =>
             (_activeLoadBlocker ?? _nextLoadBlocker)?.TrySetResult();
 
@@ -1244,13 +1686,18 @@ public class ModelManagerViewModelTests
                 throw LoadException;
 
             var blocker = _nextLoadBlocker;
+            var ignoresCancellation = _nextLoadIgnoresCancellation;
             _nextLoadBlocker = null;
+            _nextLoadIgnoresCancellation = false;
             if (blocker is not null)
             {
                 _activeLoadBlocker = blocker;
                 try
                 {
-                    await blocker.Task.WaitAsync(ct);
+                    if (ignoresCancellation)
+                        await blocker.Task;
+                    else
+                        await blocker.Task.WaitAsync(ct);
                 }
                 finally
                 {
@@ -1258,6 +1705,9 @@ public class ModelManagerViewModelTests
                         _activeLoadBlocker = null;
                 }
             }
+
+            if (LoadExceptionAfterBlock is not null)
+                throw LoadExceptionAfterBlock;
 
             SelectedModelId = modelId;
         }
@@ -1288,8 +1738,12 @@ public class ModelManagerViewModelTests
             string? language,
             bool translate,
             string? prompt,
-            CancellationToken ct) =>
-            Task.FromResult(new PluginTranscriptionResult("ok", language ?? "en", 1));
+            CancellationToken ct)
+        {
+            TranscribeCallCount++;
+            LastTranscriptionAudio = wavAudio;
+            return Task.FromResult(new PluginTranscriptionResult(ResponseText, language ?? "en", 1));
+        }
 
         public void Dispose() { }
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -914,6 +914,108 @@ public class ModelManagerViewModelTests
     }
 
     [Fact]
+    public async Task ApiStartFailure_PreservesMissingModelReason()
+    {
+        const string pluginId = "com.typewhisper.sherpa-onnx";
+        const string modelId = "parakeet";
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Parakeet",
+            modelId,
+            "Parakeet TDT",
+            configured: true,
+            supportsModelDownload: true);
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with { SelectedModelId = "" },
+            plugin);
+
+        var sessionId = await fixture.ViewModel.StartRecordingForApiAsync();
+        var session = Assert.IsType<ApiDictationSessionSnapshot>(
+            fixture.ViewModel.GetApiDictationSession(sessionId));
+
+        Assert.Equal(ApiDictationSessionStatus.Failed, session.Status);
+        Assert.Equal(Loc.Instance["Status.NoModelLoaded"], session.Error);
+        Assert.False(fixture.Audio.IsRecording);
+    }
+
+    [Fact]
+    public async Task CancelWhileJobQueueIsFull_DoesNotEnqueueCancelledRecording()
+    {
+        const string pluginId = "com.typewhisper.cloud-batch";
+        const string modelId = "batch";
+        var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
+        var plugin = new FakeTranscriptionPlugin(
+            pluginId,
+            "Cloud Batch",
+            modelId,
+            "Batch",
+            configured: true)
+        {
+            ResponseText = ""
+        };
+        plugin.BlockNextTranscription();
+        using var fixture = CreateDictationFixture(
+            AppSettings.Default with
+            {
+                SelectedModelId = fullModelId,
+                LiveTranscriptionEnabled = false,
+                TranscribeShortQuietClipsAggressively = true,
+                SaveToHistoryEnabled = false,
+                AutoPaste = false
+            },
+            plugin);
+
+        async Task RecordSpeechAsync()
+        {
+            await fixture.ViewModel.StartRecordingAsync();
+            var capture = fixture.Captures.Created.Last();
+            var audio = BuildSpeechPcm16Chunk();
+            capture.RaiseData(audio, audio.Length);
+            await fixture.ViewModel.StopRecordingAsync();
+        }
+
+        await RecordSpeechAsync();
+        Assert.True(await WaitForConditionAsync(
+            () => plugin.TranscribeCallCount == 1,
+            TimeSpan.FromSeconds(2)));
+
+        for (var index = 0; index < 5; index++)
+            await RecordSpeechAsync();
+
+        Assert.Equal(6, (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount"));
+
+        await fixture.ViewModel.StartRecordingAsync();
+        var blockedCapture = fixture.Captures.Created.Last();
+        var blockedAudio = BuildSpeechPcm16Chunk();
+        blockedCapture.RaiseData(blockedAudio, blockedAudio.Length);
+        var blockedStop = fixture.ViewModel.StopRecordingAsync();
+        Assert.True(await WaitForConditionAsync(
+            () => !blockedStop.IsCompleted
+                && (bool)GetPrivateField(fixture.ViewModel, "_isStoppingRecording"),
+            TimeSpan.FromSeconds(2)));
+
+        await fixture.ViewModel.HandleCancelRequested();
+        await fixture.ViewModel.HandleCancelRequested();
+
+        Assert.True(await WaitForConditionAsync(
+            () => blockedStop.IsCompleted,
+            TimeSpan.FromSeconds(2)));
+        await blockedStop;
+        Assert.Equal(6, (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount"));
+        Assert.Equal(1, plugin.TranscribeCallCount);
+
+        fixture.ViewModel.CancelProcessingCommand.Execute(null);
+        var queueDrained = await WaitForConditionAsync(
+            () => (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount") == 0,
+            TimeSpan.FromSeconds(5));
+
+        Assert.True(
+            queueDrained,
+            $"Expected an empty queue, but observed {GetPrivateField(fixture.ViewModel, "_pendingJobCount")} pending jobs.");
+        Assert.Equal(1, plugin.TranscribeCallCount);
+    }
+
+    [Fact]
     public async Task DelayedModelFailure_StopsAudioAndPublishesOneFailure()
     {
         const string pluginId = "com.typewhisper.sherpa-onnx";
@@ -1554,6 +1656,7 @@ public class ModelManagerViewModelTests
         public void Dispose()
         {
             plugin.ReleaseBlockedLoad();
+            plugin.ReleaseBlockedTranscription();
             ViewModel.Dispose();
             hotkey.Dispose();
             speechFeedback.Dispose();
@@ -1685,12 +1788,15 @@ public class ModelManagerViewModelTests
         public Exception? LoadException { get; set; }
         public Exception? LoadExceptionAfterBlock { get; set; }
         public string ResponseText { get; set; } = "ok";
-        public int TranscribeCallCount { get; private set; }
+        public int TranscribeCallCount => Volatile.Read(ref _transcribeCallCount);
         public byte[]? LastTranscriptionAudio { get; private set; }
         public List<TranscriptionAccelerationPreference> AccelerationPreferencesAtLoad { get; } = [];
         private TaskCompletionSource? _nextLoadBlocker;
         private TaskCompletionSource? _activeLoadBlocker;
+        private TaskCompletionSource? _nextTranscriptionBlocker;
+        private TaskCompletionSource? _activeTranscriptionBlocker;
         private bool _nextLoadIgnoresCancellation;
+        private int _transcribeCallCount;
         private readonly Func<TranscriptionAccelerationPreference, TranscriptionAccelerationStatus>? _accelerationStatusFactory;
 
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
@@ -1715,6 +1821,13 @@ public class ModelManagerViewModelTests
 
         public void ReleaseBlockedLoad() =>
             (_activeLoadBlocker ?? _nextLoadBlocker)?.TrySetResult();
+
+        public void BlockNextTranscription() =>
+            _nextTranscriptionBlocker = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseBlockedTranscription() =>
+            (_activeTranscriptionBlocker ?? _nextTranscriptionBlocker)?.TrySetResult();
 
         public async Task LoadModelAsync(string modelId, CancellationToken ct)
         {
@@ -1771,16 +1884,32 @@ public class ModelManagerViewModelTests
             return LoadCallCount >= expectedLoadCount;
         }
 
-        public Task<PluginTranscriptionResult> TranscribeAsync(
+        public async Task<PluginTranscriptionResult> TranscribeAsync(
             byte[] wavAudio,
             string? language,
             bool translate,
             string? prompt,
             CancellationToken ct)
         {
-            TranscribeCallCount++;
+            Interlocked.Increment(ref _transcribeCallCount);
             LastTranscriptionAudio = wavAudio;
-            return Task.FromResult(new PluginTranscriptionResult(ResponseText, language ?? "en", 1));
+            var blocker = _nextTranscriptionBlocker;
+            _nextTranscriptionBlocker = null;
+            if (blocker is not null)
+            {
+                _activeTranscriptionBlocker = blocker;
+                try
+                {
+                    await blocker.Task.WaitAsync(ct);
+                }
+                finally
+                {
+                    if (ReferenceEquals(_activeTranscriptionBlocker, blocker))
+                        _activeTranscriptionBlocker = null;
+                }
+            }
+
+            return new PluginTranscriptionResult(ResponseText, language ?? "en", 1);
         }
 
         public void Dispose() { }

--- a/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ModelManagerViewModelTests.cs
@@ -941,6 +941,9 @@ public class ModelManagerViewModelTests
     [Fact]
     public async Task CancelWhileJobQueueIsFull_DoesNotEnqueueCancelledRecording()
     {
+        // Keep this in sync with DictationViewModel's bounded transcription channel capacity.
+        const int jobQueueCapacity = 5;
+        const int activeAndQueuedJobCount = jobQueueCapacity + 1;
         const string pluginId = "com.typewhisper.cloud-batch";
         const string modelId = "batch";
         var fullModelId = ModelManagerService.GetPluginModelId(pluginId, modelId);
@@ -979,10 +982,12 @@ public class ModelManagerViewModelTests
             () => plugin.TranscribeCallCount == 1,
             TimeSpan.FromSeconds(2)));
 
-        for (var index = 0; index < 5; index++)
+        for (var index = 0; index < jobQueueCapacity; index++)
             await RecordSpeechAsync();
 
-        Assert.Equal(6, (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount"));
+        Assert.Equal(
+            activeAndQueuedJobCount,
+            (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount"));
 
         await fixture.ViewModel.StartRecordingAsync();
         var blockedCapture = fixture.Captures.Created.Last();
@@ -1001,7 +1006,9 @@ public class ModelManagerViewModelTests
             () => blockedStop.IsCompleted,
             TimeSpan.FromSeconds(2)));
         await blockedStop;
-        Assert.Equal(6, (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount"));
+        Assert.Equal(
+            activeAndQueuedJobCount,
+            (int)GetPrivateField(fixture.ViewModel, "_pendingJobCount"));
         Assert.Equal(1, plugin.TranscribeCallCount);
 
         fixture.ViewModel.CancelProcessingCommand.Execute(null);

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -210,10 +210,11 @@ public class StreamingTranscriptionTests
         var settings = new FakeSettingsService(AppSettings.Default);
         using var pluginManager = TestPluginManagerFactory.Create(settings);
         var plugin = new DelayedStreamingPlugin();
+        var changedPlugin = new DelayedStreamingPlugin("com.test.changed-streaming");
         TestPluginManagerFactory.SetPrivateField(
             pluginManager,
             "_transcriptionEngines",
-            new List<ITranscriptionEnginePlugin> { plugin });
+            new List<ITranscriptionEnginePlugin> { plugin, changedPlugin });
 
         var modelManager = new ModelManagerService(pluginManager, settings);
         var fullModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "stream");
@@ -237,12 +238,14 @@ public class StreamingTranscriptionTests
         var capture = Assert.Single(captures.Created);
         capture.RaiseData([0, 0, 0, 0], 4);
 
-        modelManager.UnloadModel();
+        await modelManager.LoadModelAsync(
+            ModelManagerService.GetPluginModelId(changedPlugin.PluginId, "stream"));
         readiness.SetResult(preparedModel);
 
         await WaitUntilAsync(() => (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")! == 0);
 
         Assert.Equal(0, plugin.StartCallCount);
+        Assert.Equal(0, changedPlugin.StartCallCount);
     }
 
     [Fact]
@@ -456,16 +459,17 @@ public class StreamingTranscriptionTests
         return field.GetValue(target);
     }
 
-    private sealed class DelayedStreamingPlugin : ITranscriptionEnginePlugin
+    private sealed class DelayedStreamingPlugin(
+        string pluginId = "com.test.delayed-streaming") : ITranscriptionEnginePlugin
     {
         private readonly TaskCompletionSource<IStreamingSession> _startCompletion =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _startCallCount;
 
-        public string PluginId => "com.test.delayed-streaming";
+        public string PluginId => pluginId;
         public string PluginName => "Delayed Streaming";
         public string PluginVersion => "1.0.0";
-        public string ProviderId => "delayed-streaming";
+        public string ProviderId => pluginId;
         public string ProviderDisplayName => "Delayed Streaming";
         public bool IsConfigured => true;
         public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -171,13 +171,15 @@ public class StreamingTranscriptionTests
             new List<ITranscriptionEnginePlugin> { plugin });
 
         var modelManager = new ModelManagerService(pluginManager, settings);
-        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+        var fullModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "stream");
+        await modelManager.LoadModelAsync(fullModelId);
 
         var devices = new FakeAudioInputDeviceProvider("Test Microphone");
         var captures = new FakeAudioInputCaptureFactory();
         using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
         using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
-        var modelReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var modelReady = new TaskCompletionSource<StreamingModelPreparation>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         handler.StartWhenReadyWithLanguageHints(
             ["en"],
@@ -191,7 +193,7 @@ public class StreamingTranscriptionTests
         capture.RaiseData([0, 0, 0, 0], 4);
         Assert.Equal(4, (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")!);
 
-        modelReady.SetResult(true);
+        modelReady.SetResult(CreateReadyPreparation(modelManager, fullModelId));
         var session = new CapturingStreamingSession();
         plugin.CompleteStart(session);
 
@@ -200,6 +202,47 @@ public class StreamingTranscriptionTests
 
         Assert.Equal(4, session.SentAudio.Single().Length);
         Assert.Single(session.SentAudio);
+    }
+
+    [Fact]
+    public async Task StreamingHandler_DoesNotStartPreviewForChangedModelIdentity()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var fullModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "stream");
+        await modelManager.LoadModelAsync(fullModelId);
+        var preparedModel = CreateReadyPreparation(modelManager, fullModelId);
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+        var readiness = new TaskCompletionSource<StreamingModelPreparation>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.StartWhenReadyWithLanguageHints(
+            ["en"],
+            TranscriptionTask.Transcribe,
+            () => audio.IsRecording,
+            readiness.Task,
+            allowOnlineBatchPolling: false);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+        capture.RaiseData([0, 0, 0, 0], 4);
+
+        modelManager.UnloadModel();
+        readiness.SetResult(preparedModel);
+
+        await WaitUntilAsync(() => (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")! == 0);
+
+        Assert.Equal(0, plugin.StartCallCount);
     }
 
     [Fact]
@@ -214,13 +257,15 @@ public class StreamingTranscriptionTests
             new List<ITranscriptionEnginePlugin> { plugin });
 
         var modelManager = new ModelManagerService(pluginManager, settings);
-        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+        var fullModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "stream");
+        await modelManager.LoadModelAsync(fullModelId);
 
         var devices = new FakeAudioInputDeviceProvider("Test Microphone");
         var captures = new FakeAudioInputCaptureFactory();
         using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
         using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
-        var firstReadiness = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstReadiness = new TaskCompletionSource<StreamingModelPreparation>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         handler.StartWhenReadyWithLanguageHints(
             ["en"],
@@ -236,7 +281,7 @@ public class StreamingTranscriptionTests
             ["en"],
             TranscriptionTask.Transcribe,
             () => audio.IsRecording,
-            Task.FromResult(true),
+            Task.FromResult(CreateReadyPreparation(modelManager, fullModelId)),
             allowOnlineBatchPolling: false);
         var staleCleanup = typeof(StreamingHandler).GetMethod(
             "StopPreviewBuffering",
@@ -394,6 +439,16 @@ public class StreamingTranscriptionTests
         return await Task.WhenAny(task, delay) == task;
     }
 
+    private static StreamingModelPreparation CreateReadyPreparation(
+        ModelManagerService modelManager,
+        string requestedModelId) =>
+        new(
+            requestedModelId,
+            modelManager.ActiveModelId,
+            modelManager.Engine,
+            modelManager.ActiveTranscriptionPlugin,
+            IsReady: true);
+
     private static object? GetPrivateField(object target, string fieldName)
     {
         var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
@@ -405,6 +460,7 @@ public class StreamingTranscriptionTests
     {
         private readonly TaskCompletionSource<IStreamingSession> _startCompletion =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _startCallCount;
 
         public string PluginId => "com.test.delayed-streaming";
         public string PluginName => "Delayed Streaming";
@@ -418,14 +474,18 @@ public class StreamingTranscriptionTests
         public bool SupportsTranslation => false;
         public bool SupportsStreaming => true;
         public string? LastLanguage { get; private set; }
+        public int StartCallCount => Volatile.Read(ref _startCallCount);
 
         public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
         public Task DeactivateAsync() => Task.CompletedTask;
         public System.Windows.Controls.UserControl? CreateSettingsView() => null;
         public void Dispose() { }
         public void SelectModel(string modelId) => SelectedModelId = modelId;
-        public Task<IStreamingSession> StartStreamingAsync(string? language, CancellationToken ct) =>
-            _startCompletion.Task.WaitAsync(ct);
+        public Task<IStreamingSession> StartStreamingAsync(string? language, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _startCallCount);
+            return _startCompletion.Task.WaitAsync(ct);
+        }
         public void CompleteStart(IStreamingSession session) => _startCompletion.SetResult(session);
 
         public Task<PluginTranscriptionResult> TranscribeAsync(

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -160,6 +160,102 @@ public class StreamingTranscriptionTests
     }
 
     [Fact]
+    public async Task StreamingHandler_BuffersAudioCapturedBeforeModelBecomesReady()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+        var modelReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.StartWhenReadyWithLanguageHints(
+            ["en"],
+            TranscriptionTask.Transcribe,
+            () => audio.IsRecording,
+            modelReady.Task,
+            allowOnlineBatchPolling: false);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+
+        capture.RaiseData([0, 0, 0, 0], 4);
+        Assert.Equal(4, (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")!);
+
+        modelReady.SetResult(true);
+        var session = new CapturingStreamingSession();
+        plugin.CompleteStart(session);
+
+        await WaitUntilAsync(() => session.SentAudio.Count == 1);
+        await Task.Delay(50);
+
+        Assert.Equal(4, session.SentAudio.Single().Length);
+        Assert.Single(session.SentAudio);
+    }
+
+    [Fact]
+    public async Task StreamingHandler_StaleReadinessCleanupCannotDetachNewSession()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new DelayedStreamingPlugin();
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        await modelManager.LoadModelAsync(ModelManagerService.GetPluginModelId(plugin.PluginId, "stream"));
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+        var firstReadiness = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.StartWhenReadyWithLanguageHints(
+            ["en"],
+            TranscriptionTask.Transcribe,
+            () => audio.IsRecording,
+            firstReadiness.Task,
+            allowOnlineBatchPolling: false);
+        var transcriptState = GetPrivateField(handler, "_transcriptState")!;
+        var staleVersion = (int)GetPrivateField(transcriptState, "_sessionVersion")!;
+        handler.Stop();
+
+        handler.StartWhenReadyWithLanguageHints(
+            ["en"],
+            TranscriptionTask.Transcribe,
+            () => audio.IsRecording,
+            Task.FromResult(true),
+            allowOnlineBatchPolling: false);
+        var staleCleanup = typeof(StreamingHandler).GetMethod(
+            "StopPreviewBuffering",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(staleCleanup);
+        staleCleanup.Invoke(handler, [staleVersion]);
+
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+        capture.RaiseData([0, 0, 0, 0], 4);
+        var session = new CapturingStreamingSession();
+        plugin.CompleteStart(session);
+
+        await WaitUntilAsync(() => session.SentAudio.Count == 1);
+
+        Assert.Single(session.SentAudio);
+    }
+
+    [Fact]
     public async Task StreamingHandler_SerializesRealtimeAudioWrites()
     {
         var settings = new FakeSettingsService(AppSettings.Default);


### PR DESCRIPTION
## Summary

- Start microphone capture, recording UI, timer, audio feedback, and ducking before local or cloud model preparation completes.
- Capture immutable per-session model, workflow, target app, and language context so late preparation cannot mutate a newer session.
- Buffer live-preview audio until streaming providers are ready while preserving the recorder's complete final audio for every provider path.
- Coordinate stop, cancellation, device loss, and delayed failures so each session produces at most one transcription, history entry, text insertion, and overlay completion.

## Root cause

Dictation startup awaited model and provider readiness before starting audio capture and exposing the recording state. Cold local model loads therefore appeared unresponsive, encouraged a second toggle, and could miss audio spoken while the model was still loading.

## Compatibility

- Applies consistently to local models, cloud batch providers, and cloud streaming providers.
- Keeps lazy loading and the existing streaming preview buffer limit.
- Adds no settings, localization keys, dictation states, HTTP schema changes, or plugin SDK changes.

## Validation

- `dotnet test TypeWhisper.slnx --no-restore`
  - Core: 365 passed
  - PluginSystem: 1,614 passed
- Focused dictation, model manager, and streaming regression tests: 60 passed
- Cold and warm Parakeet dev-app smoke, including stop-before-ready and rapid start/stop sequences
- Speaker-to-microphone TTS smoke: 2 of 2 recordings contained measurable signal, with 2 capture starts and 2 releases
- Cloud batch and streaming behavior covered with fake providers
- Manual cloud-provider dictation smoke passed with complete, single output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Recording can begin while models load, preserving audio captured during startup.
  * Streaming can switch to fallback transcription when needed.
  * Recording sessions retain their selected language and model settings.

* **Bug Fixes**
  * Improved handling of microphone loss, cancellation, model failures, and stopped recordings.
  * Prevented stale sessions from affecting new recordings.
  * Ensured captured audio is transcribed once with consistent lifecycle updates.

* **Tests**
  * Expanded coverage for delayed loading, cancellation, failure recovery, audio preservation, and streaming readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->