### PR TITLE
Make clipboard restoration reliable after auto paste

### DIFF
--- a/src/TypeWhisper.Windows/Native/NativeMethods.Clipboard.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.Clipboard.cs
@@ -1,0 +1,119 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace TypeWhisper.Windows.Native;
+
+internal static partial class NativeMethods
+{
+    public const uint CF_TEXT = 1;
+    public const uint CF_BITMAP = 2;
+    public const uint CF_METAFILEPICT = 3;
+    public const uint CF_OEMTEXT = 7;
+    public const uint CF_DIB = 8;
+    public const uint CF_PALETTE = 9;
+    public const uint CF_UNICODETEXT = 13;
+    public const uint CF_ENHMETAFILE = 14;
+    public const uint CF_HDROP = 15;
+    public const uint CF_LOCALE = 16;
+    public const uint CF_DIBV5 = 17;
+    public const uint CF_OWNERDISPLAY = 0x0080;
+    public const uint CF_DSPTEXT = 0x0081;
+    public const uint CF_DSPBITMAP = 0x0082;
+    public const uint CF_DSPMETAFILEPICT = 0x0083;
+    public const uint CF_DSPENHMETAFILE = 0x008E;
+    public const uint CF_PRIVATEFIRST = 0x0200;
+    public const uint CF_PRIVATELAST = 0x02FF;
+    public const uint CF_GDIOBJFIRST = 0x0300;
+    public const uint CF_GDIOBJLAST = 0x03FF;
+
+    public const uint GMEM_MOVEABLE = 0x0002;
+    public const uint GMEM_ZEROINIT = 0x0040;
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool OpenClipboard(IntPtr hWndNewOwner);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool CloseClipboard();
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool EmptyClipboard();
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    public static partial uint EnumClipboardFormats(uint format);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    public static partial IntPtr GetClipboardData(uint format);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    public static partial IntPtr SetClipboardData(uint format, IntPtr memoryHandle);
+
+    [LibraryImport("user32.dll")]
+    public static partial uint GetClipboardSequenceNumber();
+
+    [LibraryImport("user32.dll")]
+    public static partial IntPtr GetClipboardOwner();
+
+    [LibraryImport(
+        "user32.dll",
+        EntryPoint = "RegisterClipboardFormatW",
+        StringMarshalling = StringMarshalling.Utf16,
+        SetLastError = true)]
+    public static partial uint RegisterClipboardFormat(string formatName);
+
+    [DllImport(
+        "user32.dll",
+        EntryPoint = "GetClipboardFormatNameW",
+        CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    public static extern int GetClipboardFormatName(
+        uint format,
+        StringBuilder formatName,
+        int maxCount);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    public static partial IntPtr GlobalAlloc(uint flags, nuint bytes);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    public static partial IntPtr GlobalLock(IntPtr memoryHandle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool GlobalUnlock(IntPtr memoryHandle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    public static partial IntPtr GlobalFree(IntPtr memoryHandle);
+
+    [LibraryImport("ole32.dll")]
+    public static partial IntPtr OleDuplicateData(IntPtr sourceHandle, ushort format, uint flags);
+
+    [LibraryImport(
+        "gdi32.dll",
+        EntryPoint = "CopyEnhMetaFileW",
+        StringMarshalling = StringMarshalling.Utf16,
+        SetLastError = true)]
+    public static partial IntPtr CopyEnhMetaFile(IntPtr enhancedMetafile, string? fileName);
+
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool DeleteObject(IntPtr graphicsObject);
+
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool DeleteEnhMetaFile(IntPtr enhancedMetafile);
+
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool DeleteMetaFile(IntPtr metafile);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct METAFILEPICT
+    {
+        public int MappingMode;
+        public int XExt;
+        public int YExt;
+        public IntPtr Metafile;
+    }
+}

--- a/src/TypeWhisper.Windows/Native/NativeMethods.Clipboard.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.Clipboard.cs
@@ -89,6 +89,19 @@ internal static partial class NativeMethods
     [LibraryImport("ole32.dll")]
     public static partial IntPtr OleDuplicateData(IntPtr sourceHandle, ushort format, uint flags);
 
+    [LibraryImport("edputil.dll")]
+    public static partial int EdpGetEnterpriseIdForClipboard(out IntPtr enterpriseId);
+
+    [LibraryImport("edputil.dll", StringMarshalling = StringMarshalling.Utf16)]
+    public static partial int EdpSetEnterpriseIdForClipboard(string? enterpriseId);
+
+    [LibraryImport("kernel32.dll")]
+    public static partial IntPtr GetProcessHeap();
+
+    [LibraryImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool HeapFree(IntPtr heap, uint flags, IntPtr memory);
+
     [LibraryImport(
         "gdi32.dll",
         EntryPoint = "CopyEnhMetaFileW",

--- a/src/TypeWhisper.Windows/Services/TextInsertionService.cs
+++ b/src/TypeWhisper.Windows/Services/TextInsertionService.cs
@@ -178,8 +178,18 @@ public sealed class TextInsertionService : IDisposable
     /// <summary>
     /// Performs try get clipboard text asynchronously.
     /// </summary>
-    public async Task<string?> TryGetClipboardTextAsync() =>
-        (await _platform.TryGetClipboardTextStateAsync(CancellationToken.None)).Text;
+    public async Task<string?> TryGetClipboardTextAsync()
+    {
+        await _clipboardOperationGate.WaitAsync();
+        try
+        {
+            return (await _platform.TryGetClipboardTextStateAsync(CancellationToken.None)).Text;
+        }
+        finally
+        {
+            _clipboardOperationGate.Release();
+        }
+    }
 
     /// <summary>
     /// Performs try capture selected text asynchronously.
@@ -238,6 +248,10 @@ public sealed class TextInsertionService : IDisposable
                 }
 
                 return captured.Text;
+            }
+            catch (Exception ex) when (ex is COMException or ExternalException or InvalidOperationException)
+            {
+                return null;
             }
             finally
             {
@@ -333,6 +347,7 @@ public sealed class TextInsertionService : IDisposable
             await _platform.DelayAsync(ClipboardCapturePollInterval, cancellationToken);
             var clipboardState = await _platform.TryGetClipboardTextStateAsync(cancellationToken);
             if (clipboardState.SequenceNumber != 0
+                && clipboardState.Text is not null
                 && !string.Equals(clipboardState.Text, marker, StringComparison.Ordinal))
             {
                 return clipboardState;

--- a/src/TypeWhisper.Windows/Services/TextInsertionService.cs
+++ b/src/TypeWhisper.Windows/Services/TextInsertionService.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using System.Windows;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.Windows.Native;
@@ -9,12 +8,12 @@ namespace TypeWhisper.Windows.Services;
 /// <summary>
 /// Provides text insertion service behavior.
 /// </summary>
-public sealed class TextInsertionService
+public sealed class TextInsertionService : IDisposable
 {
     private static readonly TimeSpan ModifierPollInterval = TimeSpan.FromMilliseconds(25);
     private static readonly TimeSpan FocusDelay = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan EnterDelay = TimeSpan.FromMilliseconds(50);
-    private static readonly TimeSpan ClipboardRestoreDelay = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan ClipboardRestoreDelay = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan ClipboardCapturePollInterval = TimeSpan.FromMilliseconds(50);
     private const int MaxModifierReleaseChecks = 32;
     private const int MaxModifierReleaseChecksAfterNormalization = 8;
@@ -25,12 +24,14 @@ public sealed class TextInsertionService
 
     private readonly ITextInsertionPlatform _platform;
     private readonly IErrorLogService? _errorLog;
+    private readonly bool _ownsPlatform;
+    private readonly SemaphoreSlim _clipboardOperationGate = new(1, 1);
 
     /// <summary>
     /// Initializes a new instance of the TextInsertionService class.
     /// </summary>
     public TextInsertionService()
-        : this(new WindowsTextInsertionPlatform(), null)
+        : this(new WindowsTextInsertionPlatform(), null, ownsPlatform: true)
     {
     }
 
@@ -38,14 +39,23 @@ public sealed class TextInsertionService
     /// Initializes a new instance of the TextInsertionService class.
     /// </summary>
     public TextInsertionService(IErrorLogService errorLog)
-        : this(new WindowsTextInsertionPlatform(), errorLog)
+        : this(new WindowsTextInsertionPlatform(), errorLog, ownsPlatform: true)
     {
     }
 
     internal TextInsertionService(ITextInsertionPlatform platform, IErrorLogService? errorLog = null)
+        : this(platform, errorLog, ownsPlatform: false)
+    {
+    }
+
+    private TextInsertionService(
+        ITextInsertionPlatform platform,
+        IErrorLogService? errorLog,
+        bool ownsPlatform)
     {
         _platform = platform;
         _errorLog = errorLog;
+        _ownsPlatform = ownsPlatform;
     }
 
     /// <summary>
@@ -55,156 +65,247 @@ public sealed class TextInsertionService
         string text,
         bool autoPaste = true,
         bool autoEnter = false,
-        IntPtr targetHwnd = default)
+        IntPtr targetHwnd = default,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(text))
             return InsertionResult.NoText;
 
-        var previousClipboard = await _platform.TryGetClipboardTextAsync();
-        await _platform.SetClipboardTextAsync(text);
+        await _clipboardOperationGate.WaitAsync(cancellationToken);
+        try
+        {
+            return await InsertTextCoreAsync(
+                text,
+                autoPaste,
+                autoEnter,
+                targetHwnd,
+                cancellationToken);
+        }
+        finally
+        {
+            _clipboardOperationGate.Release();
+        }
+    }
 
+    private async Task<InsertionResult> InsertTextCoreAsync(
+        string text,
+        bool autoPaste,
+        bool autoEnter,
+        IntPtr targetHwnd,
+        CancellationToken cancellationToken)
+    {
         if (!autoPaste)
-            return InsertionResult.CopiedToClipboard;
-
-        if (!await WaitForModifierKeysReleasedAsync())
         {
-            LogInsertionFallback("Auto paste fell back to clipboard: modifier keys stayed pressed before paste.");
+            await _platform.SetClipboardTextAsync(text, cancellationToken);
             return InsertionResult.CopiedToClipboard;
         }
 
-        if (!await FocusTargetWindowAsync(targetHwnd))
+        IClipboardLease? clipboardLease = null;
+        var leaseFinalized = false;
+        var pasteQueued = false;
+        try
         {
-            LogInsertionFallback("Auto paste fell back to clipboard: target window could not be focused.");
-            return InsertionResult.CopiedToClipboard;
-        }
+            clipboardLease = await _platform.BeginTemporaryClipboardTextAsync(text, cancellationToken);
 
-        var pasteInputCount = _platform.SendPasteInput();
-        if (pasteInputCount != ExpectedPasteInputCount)
-        {
-            LogInsertionFallback($"Auto paste fell back to clipboard: Ctrl+V input sent {pasteInputCount}/{ExpectedPasteInputCount} events.");
-            return InsertionResult.CopiedToClipboard;
-        }
-
-        if (autoEnter)
-        {
-            await _platform.DelayAsync(EnterDelay);
-            var enterInputCount = _platform.SendEnterInput();
-            if (enterInputCount != ExpectedEnterInputCount)
+            if (!await WaitForModifierKeysReleasedAsync(cancellationToken))
             {
-                LogInsertionFallback($"Auto paste sent Ctrl+V, but Enter input sent {enterInputCount}/{ExpectedEnterInputCount} events.");
+                var fallback = await CommitClipboardFallbackAsync(
+                    clipboardLease,
+                    text,
+                    "Auto paste fell back to clipboard: modifier keys stayed pressed before paste.",
+                    cancellationToken);
+                leaseFinalized = true;
+                return fallback;
             }
-        }
 
-        await RestorePreviousClipboardAsync(previousClipboard);
-        return InsertionResult.Pasted;
+            if (!await FocusTargetWindowAsync(targetHwnd, cancellationToken))
+            {
+                var fallback = await CommitClipboardFallbackAsync(
+                    clipboardLease,
+                    text,
+                    "Auto paste fell back to clipboard: target window could not be focused.",
+                    cancellationToken);
+                leaseFinalized = true;
+                return fallback;
+            }
+
+            var pasteInputCount = _platform.SendPasteInput();
+            if (pasteInputCount != ExpectedPasteInputCount)
+            {
+                var fallback = await CommitClipboardFallbackAsync(
+                    clipboardLease,
+                    text,
+                    $"Auto paste fell back to clipboard: Ctrl+V input sent {pasteInputCount}/{ExpectedPasteInputCount} events.",
+                    cancellationToken);
+                leaseFinalized = true;
+                return fallback;
+            }
+
+            pasteQueued = true;
+            if (autoEnter)
+            {
+                await _platform.DelayAsync(EnterDelay, cancellationToken);
+                var enterInputCount = _platform.SendEnterInput();
+                if (enterInputCount != ExpectedEnterInputCount)
+                {
+                    LogInsertionDiagnostic($"Auto paste sent Ctrl+V, but Enter input sent {enterInputCount}/{ExpectedEnterInputCount} events.");
+                }
+            }
+
+            await _platform.DelayAsync(ClipboardRestoreDelay, CancellationToken.None);
+            await TryRestoreClipboardAsync(clipboardLease);
+            leaseFinalized = true;
+            cancellationToken.ThrowIfCancellationRequested();
+            return InsertionResult.Pasted;
+        }
+        catch
+        {
+            if (clipboardLease is not null && !leaseFinalized)
+            {
+                if (pasteQueued)
+                    await _platform.DelayAsync(ClipboardRestoreDelay, CancellationToken.None);
+                await TryRestoreClipboardAsync(clipboardLease);
+            }
+
+            throw;
+        }
+        finally
+        {
+            clipboardLease?.Dispose();
+        }
     }
 
     /// <summary>
     /// Performs try get clipboard text asynchronously.
     /// </summary>
-    public Task<string?> TryGetClipboardTextAsync() => _platform.TryGetClipboardTextAsync();
+    public async Task<string?> TryGetClipboardTextAsync() =>
+        (await _platform.TryGetClipboardTextStateAsync(CancellationToken.None)).Text;
 
     /// <summary>
     /// Performs try capture selected text asynchronously.
     /// </summary>
     public async Task<string?> TryCaptureSelectedTextAsync(IntPtr targetHwnd = default)
     {
-        var previousClipboard = await _platform.TryGetClipboardTextAsync();
+        await _clipboardOperationGate.WaitAsync();
+        try
+        {
+            return await TryCaptureSelectedTextCoreAsync(targetHwnd);
+        }
+        finally
+        {
+            _clipboardOperationGate.Release();
+        }
+    }
+
+    private async Task<string?> TryCaptureSelectedTextCoreAsync(IntPtr targetHwnd)
+    {
         var marker = $"__typewhisper-selection-{Guid.NewGuid():N}__";
+        IClipboardLease? clipboardLease;
 
         try
         {
-            await _platform.SetClipboardTextAsync(marker);
+            clipboardLease = await _platform.BeginTemporaryClipboardTextAsync(
+                marker,
+                CancellationToken.None);
         }
-        catch (COMException)
-        {
-            return null;
-        }
-        catch (ExternalException)
+        catch (Exception ex) when (ex is COMException or ExternalException or InvalidOperationException)
         {
             return null;
         }
 
-        if (!await WaitForModifierKeysReleasedAsync())
+        using (clipboardLease)
         {
-            await RestorePreviousClipboardAsync(previousClipboard, clearWhenMissing: true);
-            return null;
+            try
+            {
+                if (!await WaitForModifierKeysReleasedAsync(CancellationToken.None))
+                    return null;
+
+                if (!await FocusTargetWindowAsync(targetHwnd, CancellationToken.None))
+                    return null;
+
+                if (_platform.SendCopyInput() != ExpectedCopyInputCount)
+                    return null;
+
+                var capturedState = await WaitForClipboardTextChangeAsync(marker, CancellationToken.None);
+                if (capturedState is { } state)
+                    _platform.AcceptClipboardSequence(clipboardLease, state.SequenceNumber);
+
+                if (capturedState is not { } captured
+                    || string.IsNullOrWhiteSpace(captured.Text)
+                    || string.Equals(captured.Text, marker, StringComparison.Ordinal))
+                {
+                    return null;
+                }
+
+                return captured.Text;
+            }
+            finally
+            {
+                await TryRestoreClipboardAsync(clipboardLease);
+            }
         }
-
-        if (!await FocusTargetWindowAsync(targetHwnd))
-        {
-            await RestorePreviousClipboardAsync(previousClipboard, clearWhenMissing: true);
-            return null;
-        }
-
-        if (_platform.SendCopyInput() != ExpectedCopyInputCount)
-        {
-            await RestorePreviousClipboardAsync(previousClipboard, clearWhenMissing: true);
-            return null;
-        }
-
-        var capturedText = await WaitForClipboardTextChangeAsync(marker);
-        await RestorePreviousClipboardAsync(previousClipboard, clearWhenMissing: true);
-
-        return string.IsNullOrWhiteSpace(capturedText) || string.Equals(capturedText, marker, StringComparison.Ordinal)
-            ? null
-            : capturedText;
     }
 
-    private async Task<bool> WaitForModifierKeysReleasedAsync()
+    private async Task<bool> WaitForModifierKeysReleasedAsync(CancellationToken cancellationToken)
     {
-        if (await WaitForModifierKeysReleasedAsync(MaxModifierReleaseChecks))
+        if (await WaitForModifierKeysReleasedAsync(MaxModifierReleaseChecks, cancellationToken))
             return true;
 
         var releaseInputCount = _platform.SendModifierKeyUpInputs();
         if (releaseInputCount > 0)
         {
-            await _platform.DelayAsync(ModifierPollInterval);
-            if (await WaitForModifierKeysReleasedAsync(MaxModifierReleaseChecksAfterNormalization))
+            await _platform.DelayAsync(ModifierPollInterval, cancellationToken);
+            if (await WaitForModifierKeysReleasedAsync(
+                    MaxModifierReleaseChecksAfterNormalization,
+                    cancellationToken))
                 return true;
         }
 
         return !_platform.IsAnyModifierKeyDown();
     }
 
-    private async Task<bool> WaitForModifierKeysReleasedAsync(int maxChecks)
+    private async Task<bool> WaitForModifierKeysReleasedAsync(
+        int maxChecks,
+        CancellationToken cancellationToken)
     {
         for (var attempt = 0; attempt < maxChecks; attempt++)
         {
             if (!_platform.IsAnyModifierKeyDown())
                 return true;
 
-            await _platform.DelayAsync(ModifierPollInterval);
+            await _platform.DelayAsync(ModifierPollInterval, cancellationToken);
         }
 
         return false;
     }
 
-    private async Task<bool> FocusTargetWindowAsync(IntPtr targetHwnd)
+    private async Task<bool> FocusTargetWindowAsync(
+        IntPtr targetHwnd,
+        CancellationToken cancellationToken)
     {
         if (targetHwnd == IntPtr.Zero)
         {
-            await _platform.DelayAsync(FocusDelay);
+            await _platform.DelayAsync(FocusDelay, cancellationToken);
             return true;
         }
 
         if (IsTargetForeground(targetHwnd))
         {
-            await _platform.DelayAsync(FocusDelay);
+            await _platform.DelayAsync(FocusDelay, cancellationToken);
             return true;
         }
 
         _platform.SetForegroundWindow(targetHwnd);
-        await _platform.DelayAsync(FocusDelay);
+        await _platform.DelayAsync(FocusDelay, cancellationToken);
         if (IsTargetForeground(targetHwnd))
             return true;
 
         var activationInputCount = _platform.SendForegroundActivationInput();
         if (activationInputCount > 0)
         {
-            await _platform.DelayAsync(ModifierPollInterval);
+            await _platform.DelayAsync(ModifierPollInterval, cancellationToken);
             _platform.SetForegroundWindow(targetHwnd);
-            await _platform.DelayAsync(FocusDelay);
+            await _platform.DelayAsync(FocusDelay, cancellationToken);
         }
 
         return IsTargetForeground(targetHwnd);
@@ -223,57 +324,66 @@ public sealed class TextInsertionService
         return targetRoot != IntPtr.Zero && targetRoot == _platform.GetRootWindow(foregroundHwnd);
     }
 
-    private async Task<string?> WaitForClipboardTextChangeAsync(string marker)
+    private async Task<ClipboardTextState?> WaitForClipboardTextChangeAsync(
+        string marker,
+        CancellationToken cancellationToken)
     {
         for (var attempt = 0; attempt < MaxClipboardCaptureReadAttempts; attempt++)
         {
-            await _platform.DelayAsync(ClipboardCapturePollInterval);
-            var clipboardText = await _platform.TryGetClipboardTextAsync();
-            if (!string.Equals(clipboardText, marker, StringComparison.Ordinal))
-                return clipboardText;
+            await _platform.DelayAsync(ClipboardCapturePollInterval, cancellationToken);
+            var clipboardState = await _platform.TryGetClipboardTextStateAsync(cancellationToken);
+            if (clipboardState.SequenceNumber != 0
+                && !string.Equals(clipboardState.Text, marker, StringComparison.Ordinal))
+            {
+                return clipboardState;
+            }
         }
 
         return null;
     }
 
-    private async Task RestorePreviousClipboardAsync(string? previousClipboard, bool clearWhenMissing = false)
+    private async Task<InsertionResult> CommitClipboardFallbackAsync(
+        IClipboardLease clipboardLease,
+        string text,
+        string diagnostic,
+        CancellationToken cancellationToken)
     {
-        await _platform.DelayAsync(ClipboardRestoreDelay);
-        if (previousClipboard is null)
+        var committed = await _platform.CommitTemporaryClipboardTextAsync(
+            clipboardLease,
+            text,
+            cancellationToken);
+        if (!committed)
         {
-            if (clearWhenMissing)
-            {
-                try
-                {
-                    await _platform.ClearClipboardTextAsync();
-                }
-                catch (COMException)
-                {
-                    // Best effort restore.
-                }
-                catch (ExternalException)
-                {
-                    // Best effort restore.
-                }
-            }
-            return;
+            LogInsertionDiagnostic(
+                "Auto paste fallback was skipped because the clipboard changed.");
+            throw new InvalidOperationException(
+                "The clipboard changed before TypeWhisper could complete text insertion.");
         }
 
+        LogInsertionDiagnostic(diagnostic);
+        return InsertionResult.CopiedToClipboard;
+    }
+
+    private async Task TryRestoreClipboardAsync(IClipboardLease clipboardLease)
+    {
         try
         {
-            await _platform.SetClipboardTextAsync(previousClipboard);
+            var result = await _platform.RestoreClipboardAsync(
+                clipboardLease,
+                CancellationToken.None);
+            if (result == ClipboardRestoreResult.ClipboardChanged)
+            {
+                LogInsertionDiagnostic(
+                    "Clipboard restore skipped because the clipboard changed after the temporary write.");
+            }
         }
-        catch (COMException)
+        catch (Exception ex)
         {
-            // Best effort restore.
-        }
-        catch (ExternalException)
-        {
-            // Best effort restore.
+            LogInsertionDiagnostic($"Clipboard restore failed: {ex.Message}");
         }
     }
 
-    private void LogInsertionFallback(string message)
+    private void LogInsertionDiagnostic(string message)
     {
         try
         {
@@ -284,14 +394,35 @@ public sealed class TextInsertionService
             // Diagnostics must never block dictation output.
         }
     }
+
+    /// <summary>
+    /// Releases native clipboard resources owned by this service.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_ownsPlatform && _platform is IDisposable disposablePlatform)
+            disposablePlatform.Dispose();
+
+        _clipboardOperationGate.Dispose();
+    }
 }
 
 internal interface ITextInsertionPlatform
 {
-    Task<string?> TryGetClipboardTextAsync();
-    Task SetClipboardTextAsync(string text);
-    Task ClearClipboardTextAsync();
-    Task DelayAsync(TimeSpan delay);
+    Task<ClipboardTextState> TryGetClipboardTextStateAsync(CancellationToken cancellationToken);
+    Task<IClipboardLease> BeginTemporaryClipboardTextAsync(
+        string text,
+        CancellationToken cancellationToken);
+    Task SetClipboardTextAsync(string text, CancellationToken cancellationToken);
+    Task<bool> CommitTemporaryClipboardTextAsync(
+        IClipboardLease lease,
+        string text,
+        CancellationToken cancellationToken);
+    Task<ClipboardRestoreResult> RestoreClipboardAsync(
+        IClipboardLease lease,
+        CancellationToken cancellationToken);
+    void AcceptClipboardSequence(IClipboardLease lease, uint sequenceNumber);
+    Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
     bool IsAnyModifierKeyDown();
     IntPtr GetForegroundWindow();
     bool SetForegroundWindow(IntPtr hwnd);
@@ -304,7 +435,7 @@ internal interface ITextInsertionPlatform
     uint SendEnterInput();
 }
 
-internal sealed class WindowsTextInsertionPlatform : ITextInsertionPlatform
+internal sealed class WindowsTextInsertionPlatform : ITextInsertionPlatform, IDisposable
 {
     private const uint ExpectedCopyInputCount = 4;
     private const uint ExpectedPasteInputCount = 4;
@@ -341,66 +472,66 @@ internal sealed class WindowsTextInsertionPlatform : ITextInsertionPlatform
         NativeMethods.VK_RWIN
     ];
 
+    private readonly WindowsClipboardTransaction _clipboard = new();
+
     /// <summary>
     /// Performs try get clipboard text asynchronously.
     /// </summary>
-    public async Task<string?> TryGetClipboardTextAsync()
+    public async Task<ClipboardTextState> TryGetClipboardTextStateAsync(
+        CancellationToken cancellationToken)
     {
         try
         {
-            return await Application.Current.Dispatcher.InvokeAsync(() =>
-                Clipboard.ContainsText() ? Clipboard.GetText() : null);
+            return await _clipboard.ReadTextStateAsync(cancellationToken);
         }
-        catch
+        catch (Exception ex) when (ex is COMException or ExternalException or InvalidOperationException)
         {
-            return null;
+            return new ClipboardTextState(null, NativeMethods.GetClipboardSequenceNumber());
         }
     }
 
     /// <summary>
-    /// Sets clipboard text asynchronously.
+    /// Begins a temporary clipboard text operation asynchronously.
     /// </summary>
-    public Task SetClipboardTextAsync(string text) =>
-        Application.Current.Dispatcher.InvokeAsync(() =>
-        {
-            for (var attempt = 0; attempt < 3; attempt++)
-            {
-                try
-                {
-                    Clipboard.SetText(text);
-                    return;
-                }
-                catch (COMException) when (attempt < 2)
-                {
-                    Thread.Sleep(50);
-                }
-            }
-        }).Task;
+    public Task<IClipboardLease> BeginTemporaryClipboardTextAsync(
+        string text,
+        CancellationToken cancellationToken) =>
+        _clipboard.BeginTemporaryTextAsync(text, cancellationToken);
 
     /// <summary>
-    /// Clears clipboard text asynchronously.
+    /// Sets persistent clipboard text asynchronously.
     /// </summary>
-    public Task ClearClipboardTextAsync() =>
-        Application.Current.Dispatcher.InvokeAsync(() =>
-        {
-            for (var attempt = 0; attempt < 3; attempt++)
-            {
-                try
-                {
-                    Clipboard.Clear();
-                    return;
-                }
-                catch (COMException) when (attempt < 2)
-                {
-                    Thread.Sleep(50);
-                }
-            }
-        }).Task;
+    public Task SetClipboardTextAsync(string text, CancellationToken cancellationToken) =>
+        _clipboard.SetPersistentTextAsync(text, cancellationToken);
+
+    /// <summary>
+    /// Commits temporary clipboard text as a persistent copy fallback.
+    /// </summary>
+    public Task<bool> CommitTemporaryClipboardTextAsync(
+        IClipboardLease lease,
+        string text,
+        CancellationToken cancellationToken) =>
+        _clipboard.CommitTemporaryTextAsync(lease, text, cancellationToken);
+
+    /// <summary>
+    /// Restores the clipboard represented by a temporary lease.
+    /// </summary>
+    public Task<ClipboardRestoreResult> RestoreClipboardAsync(
+        IClipboardLease lease,
+        CancellationToken cancellationToken) =>
+        _clipboard.RestoreAsync(lease, cancellationToken);
+
+    /// <summary>
+    /// Accepts an expected clipboard sequence for a temporary lease.
+    /// </summary>
+    public void AcceptClipboardSequence(IClipboardLease lease, uint sequenceNumber) =>
+        _clipboard.AcceptSequence(lease, sequenceNumber);
 
     /// <summary>
     /// Performs delay asynchronously.
     /// </summary>
-    public Task DelayAsync(TimeSpan delay) => Task.Delay(delay);
+    public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken) =>
+        Task.Delay(delay, cancellationToken);
 
     /// <summary>
     /// Returns whether any modifier key down.
@@ -508,6 +639,11 @@ internal sealed class WindowsTextInsertionPlatform : ITextInsertionPlatform
                 KeyInput(NativeMethods.VK_RETURN, keyUp: true)
             ],
             Marshal.SizeOf<NativeMethods.INPUT>());
+
+    /// <summary>
+    /// Releases native clipboard resources.
+    /// </summary>
+    public void Dispose() => _clipboard.Dispose();
 
     private static bool IsKeyDown(int virtualKey) =>
         (NativeMethods.GetAsyncKeyState(virtualKey) & unchecked((short)0x8000)) != 0;

--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -23,6 +23,7 @@ internal sealed class WindowsClipboardTransaction : IDisposable
 {
     internal const string ExcludeClipboardContentFromMonitorProcessing =
         "ExcludeClipboardContentFromMonitorProcessing";
+    internal const string EnterpriseDataProtectionId = "EnterpriseDataProtectionId";
 
     private static readonly TimeSpan ClipboardRetryDelay = TimeSpan.FromMilliseconds(50);
     private const int MaxClipboardOpenAttempts = 3;
@@ -177,7 +178,11 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         if (excludeFormat == 0)
             throw LastClipboardError("Could not register the clipboard history exclusion format.");
 
-        var snapshot = CaptureSnapshotCore();
+        var enterpriseFormat = NativeMethods.RegisterClipboardFormat(EnterpriseDataProtectionId);
+        if (enterpriseFormat == 0)
+            throw LastClipboardError("Could not register the enterprise clipboard metadata format.");
+
+        var snapshot = CaptureSnapshotCore(enterpriseFormat);
         var clipboardCleared = false;
         try
         {
@@ -212,9 +217,10 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         }
     }
 
-    private WindowsClipboardSnapshot CaptureSnapshotCore()
+    private WindowsClipboardSnapshot CaptureSnapshotCore(uint enterpriseFormat)
     {
         var entries = new List<ClipboardFormatHandle>();
+        string? enterpriseId = null;
         try
         {
             uint currentFormat = 0;
@@ -243,6 +249,15 @@ internal sealed class WindowsClipboardTransaction : IDisposable
                         $"The clipboard contains owner-managed format {nextFormat} that cannot be restored independently.");
                 }
 
+                if (nextFormat == enterpriseFormat)
+                {
+                    // CFSTR_ENTERPRISE_ID is WIP metadata exposed through the EDP APIs. It may
+                    // intentionally enumerate without a clipboard data handle.
+                    enterpriseId = ReadEnterpriseIdCore();
+                    currentFormat = nextFormat;
+                    continue;
+                }
+
                 var sourceHandle = NativeMethods.GetClipboardData(nextFormat);
                 if (sourceHandle == IntPtr.Zero)
                 {
@@ -264,13 +279,50 @@ internal sealed class WindowsClipboardTransaction : IDisposable
                 currentFormat = nextFormat;
             }
 
-            return new WindowsClipboardSnapshot(entries);
+            return new WindowsClipboardSnapshot(entries, enterpriseId);
         }
         catch
         {
             foreach (var entry in entries)
                 entry.Dispose();
             throw;
+        }
+    }
+
+    private static string? ReadEnterpriseIdCore()
+    {
+        var result = NativeMethods.EdpGetEnterpriseIdForClipboard(out var enterpriseIdPointer);
+        if (result < 0)
+        {
+            throw new COMException(
+                "Could not read Windows Information Protection clipboard metadata.",
+                result);
+        }
+
+        if (enterpriseIdPointer == IntPtr.Zero)
+            return null;
+
+        try
+        {
+            return Marshal.PtrToStringUni(enterpriseIdPointer);
+        }
+        finally
+        {
+            NativeMethods.HeapFree(
+                NativeMethods.GetProcessHeap(),
+                0,
+                enterpriseIdPointer);
+        }
+    }
+
+    private static void SetEnterpriseIdCore(string enterpriseId)
+    {
+        var result = NativeMethods.EdpSetEnterpriseIdForClipboard(enterpriseId);
+        if (result < 0)
+        {
+            throw new COMException(
+                "Could not restore Windows Information Protection clipboard metadata.",
+                result);
         }
     }
 
@@ -546,9 +598,12 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         public void Dispose() => CompleteWithoutRestore();
     }
 
-    private sealed class WindowsClipboardSnapshot(List<ClipboardFormatHandle> entries) : IDisposable
+    private sealed class WindowsClipboardSnapshot(
+        List<ClipboardFormatHandle> entries,
+        string? enterpriseId = null) : IDisposable
     {
         private readonly List<ClipboardFormatHandle> _entries = entries;
+        private readonly string? _enterpriseId = enterpriseId;
         private bool _disposed;
 
         public WindowsClipboardSnapshot DuplicateForTransfer()
@@ -560,7 +615,7 @@ internal sealed class WindowsClipboardTransaction : IDisposable
                 foreach (var entry in _entries)
                     duplicates.Add(entry.Duplicate());
 
-                return new WindowsClipboardSnapshot(duplicates);
+                return new WindowsClipboardSnapshot(duplicates, _enterpriseId);
             }
             catch
             {
@@ -575,6 +630,9 @@ internal sealed class WindowsClipboardTransaction : IDisposable
             ObjectDisposedException.ThrowIf(_disposed, this);
             foreach (var entry in _entries)
                 entry.TransferToClipboard();
+
+            if (_enterpriseId is not null)
+                SetEnterpriseIdCore(_enterpriseId);
         }
 
         public void Dispose()

--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -164,6 +164,10 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         {
             // The dispatcher may already be shutting down.
         }
+        catch (OperationCanceledException)
+        {
+            // The dispatcher shut down between the check and the invoke.
+        }
     }
 
     private WindowsClipboardLease BeginTemporaryTextCore(string text)

--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -1,0 +1,683 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Threading;
+using TypeWhisper.Windows.Native;
+
+namespace TypeWhisper.Windows.Services;
+
+internal interface IClipboardLease : IDisposable
+{
+}
+
+internal enum ClipboardRestoreResult
+{
+    Restored,
+    ClipboardChanged
+}
+
+internal readonly record struct ClipboardTextState(string? Text, uint SequenceNumber);
+
+internal sealed class WindowsClipboardTransaction : IDisposable
+{
+    internal const string ExcludeClipboardContentFromMonitorProcessing =
+        "ExcludeClipboardContentFromMonitorProcessing";
+
+    private static readonly TimeSpan ClipboardRetryDelay = TimeSpan.FromMilliseconds(50);
+    private const int MaxClipboardOpenAttempts = 3;
+    private const int MaxClipboardRestoreAttempts = 3;
+    private static readonly IntPtr MessageOnlyWindowParent = new(-3);
+
+    private readonly Dispatcher? _dispatcher;
+    private readonly Action<uint, IntPtr>? _handleReleaseObserver;
+    private HwndSource? _ownerWindow;
+    private bool _disposed;
+
+    public WindowsClipboardTransaction(
+        Dispatcher? dispatcher = null,
+        Action<uint, IntPtr>? handleReleaseObserver = null)
+    {
+        _dispatcher = dispatcher;
+        _handleReleaseObserver = handleReleaseObserver;
+    }
+
+    public Task<IClipboardLease> BeginTemporaryTextAsync(
+        string text,
+        CancellationToken cancellationToken) =>
+        WithOpenClipboardAsync<IClipboardLease>(
+            () => BeginTemporaryTextCore(text),
+            cancellationToken);
+
+    public Task SetPersistentTextAsync(string text, CancellationToken cancellationToken) =>
+        WithOpenClipboardAsync<object?>(() =>
+        {
+            ReplaceClipboardWithTextCore(text, excludeFromHistory: false);
+            return null;
+        }, cancellationToken);
+
+    public Task<bool> CommitTemporaryTextAsync(
+        IClipboardLease lease,
+        string text,
+        CancellationToken cancellationToken)
+    {
+        var windowsLease = RequireLease(lease);
+        return WithOpenClipboardAsync(() =>
+        {
+            if (windowsLease.IsCompleted)
+                return true;
+
+            if (NativeMethods.GetClipboardSequenceNumber() != windowsLease.ExpectedSequenceNumber)
+            {
+                windowsLease.CompleteWithoutRestore();
+                return false;
+            }
+
+            if (!NativeMethods.EmptyClipboard())
+                throw LastClipboardError("Could not clear the clipboard for the copy fallback.");
+
+            try
+            {
+                SetUnicodeTextCore(text);
+                windowsLease.CompleteWithoutRestore();
+                return true;
+            }
+            catch
+            {
+                TryRollbackSnapshotCore(windowsLease);
+                throw;
+            }
+        }, cancellationToken);
+    }
+
+    public Task<ClipboardRestoreResult> RestoreAsync(
+        IClipboardLease lease,
+        CancellationToken cancellationToken)
+    {
+        var windowsLease = RequireLease(lease);
+        return WithOpenClipboardAsync(() =>
+        {
+            if (windowsLease.IsCompleted)
+                return ClipboardRestoreResult.Restored;
+
+            if (NativeMethods.GetClipboardSequenceNumber() != windowsLease.ExpectedSequenceNumber)
+            {
+                windowsLease.CompleteWithoutRestore();
+                return ClipboardRestoreResult.ClipboardChanged;
+            }
+
+            RestoreSnapshotCore(windowsLease);
+            return ClipboardRestoreResult.Restored;
+        }, cancellationToken);
+    }
+
+    public Task<ClipboardTextState> ReadTextStateAsync(CancellationToken cancellationToken) =>
+        WithOpenClipboardAsync(() =>
+        {
+            string? text = null;
+            var textHandle = NativeMethods.GetClipboardData(NativeMethods.CF_UNICODETEXT);
+            if (textHandle != IntPtr.Zero)
+            {
+                var textPointer = NativeMethods.GlobalLock(textHandle);
+                if (textPointer == IntPtr.Zero)
+                    throw LastClipboardError("Could not read Unicode text from the clipboard.");
+
+                try
+                {
+                    text = Marshal.PtrToStringUni(textPointer);
+                }
+                finally
+                {
+                    NativeMethods.GlobalUnlock(textHandle);
+                }
+            }
+
+            return new ClipboardTextState(text, NativeMethods.GetClipboardSequenceNumber());
+        }, cancellationToken);
+
+    public void AcceptSequence(IClipboardLease lease, uint sequenceNumber)
+    {
+        var windowsLease = RequireLease(lease);
+        if (!windowsLease.IsCompleted)
+            windowsLease.ExpectedSequenceNumber = sequenceNumber;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        var ownerWindow = _ownerWindow;
+        _ownerWindow = null;
+        if (ownerWindow is null)
+            return;
+
+        try
+        {
+            if (ownerWindow.Dispatcher.CheckAccess())
+                ownerWindow.Dispose();
+            else if (!ownerWindow.Dispatcher.HasShutdownStarted)
+                ownerWindow.Dispatcher.Invoke(ownerWindow.Dispose);
+        }
+        catch (InvalidOperationException)
+        {
+            // The dispatcher may already be shutting down.
+        }
+    }
+
+    private WindowsClipboardLease BeginTemporaryTextCore(string text)
+    {
+        var excludeFormat = NativeMethods.RegisterClipboardFormat(
+            ExcludeClipboardContentFromMonitorProcessing);
+        if (excludeFormat == 0)
+            throw LastClipboardError("Could not register the clipboard history exclusion format.");
+
+        var snapshot = CaptureSnapshotCore();
+        var clipboardCleared = false;
+        try
+        {
+            if (!NativeMethods.EmptyClipboard())
+                throw LastClipboardError("Could not clear the clipboard for temporary text insertion.");
+
+            clipboardCleared = true;
+            SetExclusionMarkerCore(excludeFormat);
+            SetUnicodeTextCore(text);
+
+            if (NativeMethods.GetClipboardSequenceNumber() == 0)
+                throw new COMException("Could not obtain the clipboard sequence number.");
+
+            return new WindowsClipboardLease(snapshot);
+        }
+        catch
+        {
+            if (clipboardCleared)
+            {
+                try
+                {
+                    RestoreSnapshotCore(snapshot);
+                }
+                catch
+                {
+                    // Preserve the original exception. The caller logs the insertion failure.
+                }
+            }
+
+            snapshot.Dispose();
+            throw;
+        }
+    }
+
+    private WindowsClipboardSnapshot CaptureSnapshotCore()
+    {
+        var entries = new List<ClipboardFormatHandle>();
+        try
+        {
+            uint currentFormat = 0;
+            while (true)
+            {
+                Marshal.SetLastPInvokeError(0);
+                var nextFormat = NativeMethods.EnumClipboardFormats(currentFormat);
+                if (nextFormat == 0)
+                {
+                    var error = Marshal.GetLastPInvokeError();
+                    if (error != 0)
+                        throw ClipboardError("Could not enumerate all clipboard formats.", error);
+                    break;
+                }
+
+                if (nextFormat == NativeMethods.CF_OWNERDISPLAY)
+                {
+                    throw new InvalidOperationException(
+                        "The clipboard contains owner-display data that cannot be restored independently.");
+                }
+
+                if (nextFormat is >= NativeMethods.CF_PRIVATEFIRST and <= NativeMethods.CF_PRIVATELAST
+                    or >= NativeMethods.CF_GDIOBJFIRST and <= NativeMethods.CF_GDIOBJLAST)
+                {
+                    throw new InvalidOperationException(
+                        $"The clipboard contains owner-managed format {nextFormat} that cannot be restored independently.");
+                }
+
+                var sourceHandle = NativeMethods.GetClipboardData(nextFormat);
+                if (sourceHandle == IntPtr.Zero)
+                {
+                    throw LastClipboardError(
+                        $"Could not materialize clipboard format {DescribeFormat(nextFormat)}.");
+                }
+
+                var duplicateHandle = DuplicateClipboardHandle(nextFormat, sourceHandle);
+                if (duplicateHandle == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not duplicate clipboard format {DescribeFormat(nextFormat)}.");
+                }
+
+                entries.Add(new ClipboardFormatHandle(
+                    nextFormat,
+                    duplicateHandle,
+                    _handleReleaseObserver));
+                currentFormat = nextFormat;
+            }
+
+            return new WindowsClipboardSnapshot(entries);
+        }
+        catch
+        {
+            foreach (var entry in entries)
+                entry.Dispose();
+            throw;
+        }
+    }
+
+    private static string DescribeFormat(uint format)
+    {
+        if (format < 0xC000)
+            return format.ToString();
+
+        var name = new StringBuilder(256);
+        var length = NativeMethods.GetClipboardFormatName(format, name, name.Capacity);
+        return length > 0 ? $"{format} ('{name}')" : format.ToString();
+    }
+
+    private static IntPtr DuplicateClipboardHandle(uint format, IntPtr sourceHandle)
+    {
+        if (format is NativeMethods.CF_ENHMETAFILE or NativeMethods.CF_DSPENHMETAFILE)
+            return NativeMethods.CopyEnhMetaFile(sourceHandle, null);
+
+        var duplicationFormat = format switch
+        {
+            NativeMethods.CF_DSPBITMAP => NativeMethods.CF_BITMAP,
+            NativeMethods.CF_DSPMETAFILEPICT => NativeMethods.CF_METAFILEPICT,
+            _ => format
+        };
+
+        if (duplicationFormat > ushort.MaxValue)
+            return IntPtr.Zero;
+
+        return NativeMethods.OleDuplicateData(
+            sourceHandle,
+            (ushort)duplicationFormat,
+            NativeMethods.GMEM_MOVEABLE);
+    }
+
+    private static void ReplaceClipboardWithTextCore(string text, bool excludeFromHistory)
+    {
+        var exclusionFormat = 0u;
+        if (excludeFromHistory)
+        {
+            exclusionFormat = NativeMethods.RegisterClipboardFormat(
+                ExcludeClipboardContentFromMonitorProcessing);
+            if (exclusionFormat == 0)
+                throw LastClipboardError("Could not register the clipboard history exclusion format.");
+        }
+
+        if (!NativeMethods.EmptyClipboard())
+            throw LastClipboardError("Could not clear the clipboard.");
+
+        SetUnicodeTextCore(text);
+        if (excludeFromHistory)
+            SetExclusionMarkerCore(exclusionFormat);
+    }
+
+    private static void SetUnicodeTextCore(string text)
+    {
+        var byteCount = checked((nuint)((text.Length + 1) * sizeof(char)));
+        var textHandle = NativeMethods.GlobalAlloc(
+            NativeMethods.GMEM_MOVEABLE | NativeMethods.GMEM_ZEROINIT,
+            byteCount);
+        if (textHandle == IntPtr.Zero)
+            throw LastClipboardError("Could not allocate clipboard text memory.");
+
+        try
+        {
+            var textPointer = NativeMethods.GlobalLock(textHandle);
+            if (textPointer == IntPtr.Zero)
+                throw LastClipboardError("Could not lock clipboard text memory.");
+
+            try
+            {
+                Marshal.Copy(text.ToCharArray(), 0, textPointer, text.Length);
+            }
+            finally
+            {
+                NativeMethods.GlobalUnlock(textHandle);
+            }
+
+            if (NativeMethods.SetClipboardData(NativeMethods.CF_UNICODETEXT, textHandle) == IntPtr.Zero)
+                throw LastClipboardError("Could not set Unicode clipboard text.");
+
+            textHandle = IntPtr.Zero;
+        }
+        finally
+        {
+            if (textHandle != IntPtr.Zero)
+                NativeMethods.GlobalFree(textHandle);
+        }
+    }
+
+    private static void SetExclusionMarkerCore(uint exclusionFormat)
+    {
+        var markerHandle = NativeMethods.GlobalAlloc(
+            NativeMethods.GMEM_MOVEABLE | NativeMethods.GMEM_ZEROINIT,
+            4);
+        if (markerHandle == IntPtr.Zero)
+            throw LastClipboardError("Could not allocate the clipboard history exclusion marker.");
+
+        try
+        {
+            if (NativeMethods.SetClipboardData(exclusionFormat, markerHandle) == IntPtr.Zero)
+                throw LastClipboardError("Could not set the clipboard history exclusion marker.");
+
+            markerHandle = IntPtr.Zero;
+        }
+        finally
+        {
+            if (markerHandle != IntPtr.Zero)
+                NativeMethods.GlobalFree(markerHandle);
+        }
+    }
+
+    private static void RestoreSnapshotCore(WindowsClipboardLease lease)
+    {
+        RestoreSnapshotCore(lease.Snapshot);
+        lease.CompleteAfterRestore();
+    }
+
+    private static void RestoreSnapshotCore(WindowsClipboardSnapshot snapshot)
+    {
+        for (var attempt = 0; attempt < MaxClipboardRestoreAttempts; attempt++)
+        {
+            try
+            {
+                using var transferSnapshot = snapshot.DuplicateForTransfer();
+                if (!NativeMethods.EmptyClipboard())
+                {
+                    throw LastClipboardError(
+                        "Could not clear the clipboard before restoring its contents.");
+                }
+
+                transferSnapshot.TransferToClipboard();
+                return;
+            }
+            catch (ExternalException) when (attempt < MaxClipboardRestoreAttempts - 1)
+            {
+                // A fresh set of transfer handles is used for every retry. Handles already
+                // accepted by SetClipboardData remain owned by Windows.
+            }
+        }
+    }
+
+    private static void TryRollbackSnapshotCore(WindowsClipboardLease lease)
+    {
+        try
+        {
+            RestoreSnapshotCore(lease);
+        }
+        catch
+        {
+            // Preserve the copy-fallback exception.
+        }
+    }
+
+    private async Task<T> WithOpenClipboardAsync<T>(
+        Func<T> action,
+        CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        var dispatcher = _dispatcher ?? Application.Current?.Dispatcher
+            ?? throw new InvalidOperationException("The WPF application dispatcher is unavailable.");
+
+        for (var attempt = 0; attempt < MaxClipboardOpenAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (dispatcher.CheckAccess())
+                    return ExecuteWithOpenClipboardCore(action);
+
+                return await dispatcher.InvokeAsync(
+                    () => ExecuteWithOpenClipboardCore(action),
+                    DispatcherPriority.Send,
+                    cancellationToken);
+            }
+            catch (ClipboardBusyException) when (attempt < MaxClipboardOpenAttempts - 1)
+            {
+                await Task.Delay(ClipboardRetryDelay, cancellationToken);
+            }
+        }
+
+        throw new COMException("Could not open the clipboard after multiple attempts.");
+    }
+
+    private T ExecuteWithOpenClipboardCore<T>(Func<T> action)
+    {
+        var ownerHandle = EnsureOwnerWindow().Handle;
+        if (!NativeMethods.OpenClipboard(ownerHandle))
+            throw new ClipboardBusyException(Marshal.GetLastPInvokeError());
+
+        T result;
+        try
+        {
+            result = action();
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        if (result is WindowsClipboardLease lease && !lease.HasExpectedSequenceNumber)
+        {
+            var sequenceNumber = NativeMethods.GetClipboardSequenceNumber();
+            if (sequenceNumber == 0 || NativeMethods.GetClipboardOwner() != ownerHandle)
+            {
+                lease.CompleteWithoutRestore();
+                throw new InvalidOperationException(
+                    "The clipboard changed before the temporary write could be confirmed.");
+            }
+
+            lease.ExpectedSequenceNumber = sequenceNumber;
+            lease.HasExpectedSequenceNumber = true;
+        }
+
+        return result;
+    }
+
+    private HwndSource EnsureOwnerWindow()
+    {
+        if (_ownerWindow is not null)
+            return _ownerWindow;
+
+        _ownerWindow = new HwndSource(new HwndSourceParameters("TypeWhisperClipboardOwner")
+        {
+            ParentWindow = MessageOnlyWindowParent,
+            WindowStyle = 0,
+            ExtendedWindowStyle = 0,
+            Width = 0,
+            Height = 0
+        });
+        return _ownerWindow;
+    }
+
+    private static WindowsClipboardLease RequireLease(IClipboardLease lease) =>
+        lease as WindowsClipboardLease
+        ?? throw new ArgumentException("The clipboard lease belongs to a different platform.", nameof(lease));
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private static COMException LastClipboardError(string message) =>
+        ClipboardError(message, Marshal.GetLastPInvokeError());
+
+    private static COMException ClipboardError(string message, int error) =>
+        new($"{message} Win32 error: {error}.", HResultFromWin32(error));
+
+    private static int HResultFromWin32(int error) =>
+        error <= 0 ? error : unchecked((int)(0x80070000u | (uint)error));
+
+    private sealed class ClipboardBusyException(int error)
+        : ExternalException("The clipboard is currently in use.", HResultFromWin32(error));
+
+    private sealed class WindowsClipboardLease(WindowsClipboardSnapshot snapshot) : IClipboardLease
+    {
+        public WindowsClipboardSnapshot Snapshot { get; } = snapshot;
+        public uint ExpectedSequenceNumber { get; set; }
+        public bool HasExpectedSequenceNumber { get; set; }
+        public bool IsCompleted { get; private set; }
+
+        public void CompleteAfterRestore()
+        {
+            IsCompleted = true;
+            Snapshot.Dispose();
+        }
+
+        public void CompleteWithoutRestore()
+        {
+            IsCompleted = true;
+            Snapshot.Dispose();
+        }
+
+        public void Dispose() => CompleteWithoutRestore();
+    }
+
+    private sealed class WindowsClipboardSnapshot(List<ClipboardFormatHandle> entries) : IDisposable
+    {
+        private readonly List<ClipboardFormatHandle> _entries = entries;
+        private bool _disposed;
+
+        public WindowsClipboardSnapshot DuplicateForTransfer()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            var duplicates = new List<ClipboardFormatHandle>(_entries.Count);
+            try
+            {
+                foreach (var entry in _entries)
+                    duplicates.Add(entry.Duplicate());
+
+                return new WindowsClipboardSnapshot(duplicates);
+            }
+            catch
+            {
+                foreach (var duplicate in duplicates)
+                    duplicate.Dispose();
+                throw;
+            }
+        }
+
+        public void TransferToClipboard()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            foreach (var entry in _entries)
+                entry.TransferToClipboard();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            foreach (var entry in _entries)
+                entry.Dispose();
+        }
+    }
+
+    private sealed class ClipboardFormatHandle(
+        uint format,
+        IntPtr handle,
+        Action<uint, IntPtr>? releaseObserver) : IDisposable
+    {
+        private IntPtr _handle = handle;
+
+        public ClipboardFormatHandle Duplicate()
+        {
+            ObjectDisposedException.ThrowIf(_handle == IntPtr.Zero, this);
+            var duplicateHandle = DuplicateClipboardHandle(format, _handle);
+            if (duplicateHandle == IntPtr.Zero)
+            {
+                throw new COMException(
+                    $"Could not duplicate clipboard format {DescribeFormat(format)} for restoration.");
+            }
+
+            return new ClipboardFormatHandle(format, duplicateHandle, releaseObserver);
+        }
+
+        public void TransferToClipboard()
+        {
+            if (_handle == IntPtr.Zero)
+                return;
+
+            if (NativeMethods.SetClipboardData(format, _handle) == IntPtr.Zero)
+            {
+                throw LastClipboardError(
+                    $"Could not restore clipboard format {DescribeFormat(format)}.");
+            }
+
+            _handle = IntPtr.Zero;
+        }
+
+        public void Dispose()
+        {
+            var handleToRelease = Interlocked.Exchange(ref _handle, IntPtr.Zero);
+            if (handleToRelease == IntPtr.Zero)
+                return;
+
+            try
+            {
+                ReleaseClipboardHandle(format, handleToRelease);
+            }
+            finally
+            {
+                releaseObserver?.Invoke(format, handleToRelease);
+            }
+        }
+
+        private static void ReleaseClipboardHandle(uint clipboardFormat, IntPtr clipboardHandle)
+        {
+            switch (clipboardFormat)
+            {
+                case NativeMethods.CF_BITMAP:
+                case NativeMethods.CF_DSPBITMAP:
+                case NativeMethods.CF_PALETTE:
+                    NativeMethods.DeleteObject(clipboardHandle);
+                    return;
+
+                case NativeMethods.CF_ENHMETAFILE:
+                case NativeMethods.CF_DSPENHMETAFILE:
+                    NativeMethods.DeleteEnhMetaFile(clipboardHandle);
+                    return;
+
+                case NativeMethods.CF_METAFILEPICT:
+                case NativeMethods.CF_DSPMETAFILEPICT:
+                    ReleaseMetafilePict(clipboardHandle);
+                    return;
+
+                default:
+                    NativeMethods.GlobalFree(clipboardHandle);
+                    return;
+            }
+        }
+
+        private static void ReleaseMetafilePict(IntPtr clipboardHandle)
+        {
+            var dataPointer = NativeMethods.GlobalLock(clipboardHandle);
+            if (dataPointer != IntPtr.Zero)
+            {
+                try
+                {
+                    var metafile = Marshal.PtrToStructure<NativeMethods.METAFILEPICT>(dataPointer);
+                    if (metafile.Metafile != IntPtr.Zero)
+                        NativeMethods.DeleteMetaFile(metafile.Metafile);
+                }
+                finally
+                {
+                    NativeMethods.GlobalUnlock(clipboardHandle);
+                }
+            }
+
+            NativeMethods.GlobalFree(clipboardHandle);
+        }
+    }
+}

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -667,7 +667,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
             insertionText,
             _settings.Current.AutoPaste,
             autoEnter,
-            targetWindowHandle);
+            targetWindowHandle,
+            ct);
 
         var tracking = await TryStartTargetAppCorrectionLearningAsync(
             null,
@@ -2095,7 +2096,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                         insertionText,
                         _settings.Current.AutoPaste,
                         job.ActiveWorkflow?.Output.AutoEnter == true,
-                        job.CapturedWindowHandle);
+                        job.CapturedWindowHandle,
+                        ct);
                     textInsertedEventText = insertionText;
                     StartTargetAppCorrectionLearningInBackground(job, insertionText, insertResult);
                 }
@@ -2113,7 +2115,8 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                     insertionText,
                     _settings.Current.AutoPaste,
                     job.ActiveWorkflow?.Output.AutoEnter == true,
-                    job.CapturedWindowHandle);
+                    job.CapturedWindowHandle,
+                    ct);
                 textInsertedEventText = insertionText;
                 StartTargetAppCorrectionLearningInBackground(job, insertionText, insertResult);
             }

--- a/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
 using TypeWhisper.Windows.Native;
@@ -18,6 +19,8 @@ public sealed class TextInsertionServiceTests
         Assert.Equal(InsertionResult.CopiedToClipboard, result);
         Assert.Equal("dictated", platform.ClipboardText);
         Assert.Equal(0, platform.PasteInputCalls);
+        Assert.Equal(0, platform.TemporaryClipboardWrites);
+        Assert.Equal(1, platform.PersistentClipboardWrites);
     }
 
     [Fact]
@@ -231,6 +234,210 @@ public sealed class TextInsertionServiceTests
         Assert.Equal("previous", platform.ClipboardText);
         Assert.Equal(1, platform.PasteInputCalls);
         Assert.Equal(["dictated", "previous"], platform.ClipboardWrites);
+        Assert.Equal(1, platform.TemporaryClipboardWrites);
+        Assert.Equal(0, platform.PersistentClipboardWrites);
+        Assert.Equal(1, platform.RestoreClipboardCalls);
+        Assert.Contains(TimeSpan.FromMilliseconds(500), platform.Delays);
+        Assert.Equal(
+            ["temporary-write", "delay:100", "paste", "delay:500", "restore"],
+            platform.InsertionEvents);
+    }
+
+    [Fact]
+    public async Task SuccessfulPaste_KeepsTransientTextAvailableForSlowTargetUntilRestoreDelay()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            ReadClipboardDuringRestoreDelay = true,
+            SimulatedTargetReadOffset = TimeSpan.FromMilliseconds(400)
+        };
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal("dictated", platform.TextReadByTarget);
+        Assert.Equal(TimeSpan.FromMilliseconds(400), platform.TargetReadOffsetObserved);
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.True(platform.LastTemporaryWriteExcludedFromHistory);
+    }
+
+    [Fact]
+    public async Task AutoEnter_RestoresOnlyAfterPasteEnterAndFullRestoreDelay()
+    {
+        var platform = new FakeTextInsertionPlatform { ClipboardText = "previous" };
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated", autoEnter: true);
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal(
+            [
+                "temporary-write",
+                "delay:100",
+                "paste",
+                "delay:50",
+                "enter",
+                "delay:500",
+                "restore"
+            ],
+            platform.InsertionEvents);
+    }
+
+    [Fact]
+    public async Task ConcurrentClipboardOperations_AreSerializedAcrossTheRestoreWindow()
+    {
+        var restoreDelayEntered = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueRestoreDelay = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            RestoreDelayEntered = restoreDelayEntered,
+            ContinueRestoreDelay = continueRestoreDelay
+        };
+        var sut = new TextInsertionService(platform);
+
+        var paste = sut.InsertTextAsync("dictated");
+        await restoreDelayEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var copy = sut.InsertTextAsync("copied", autoPaste: false);
+
+        try
+        {
+            await Task.Yield();
+            Assert.False(copy.IsCompleted);
+        }
+        finally
+        {
+            continueRestoreDelay.TrySetResult(true);
+        }
+
+        Assert.Equal(InsertionResult.Pasted, await paste);
+        Assert.Equal(InsertionResult.CopiedToClipboard, await copy);
+        Assert.Equal("copied", platform.ClipboardText);
+        Assert.True(
+            platform.InsertionEvents.IndexOf("restore")
+            < platform.InsertionEvents.IndexOf("persistent-write"));
+    }
+
+    [Fact]
+    public async Task SuccessfulPaste_RestoresAllClipboardFormats()
+    {
+        var platform = new FakeTextInsertionPlatform();
+        platform.ClipboardFormats["UnicodeText"] = "previous";
+        platform.ClipboardFormats["HTML Format"] = "<b>previous</b>";
+        platform.ClipboardFormats["Rich Text Format"] = "{\\rtf1 previous}";
+        platform.ClipboardFormats["FileDrop"] = "C:\\temp\\previous.txt";
+        platform.ClipboardFormats["Bitmap"] = "bitmap-bytes";
+        platform.ClipboardFormats["TypeWhisper.Test.Custom"] = "custom-bytes";
+        var expected = platform.ClipboardFormats.ToDictionary(static pair => pair.Key, static pair => pair.Value);
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal(expected, platform.ClipboardFormats);
+    }
+
+    [Fact]
+    public async Task SuccessfulPaste_DoesNotOverwriteNewerClipboardChange()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            ChangeClipboardDuringRestoreDelay = true
+        };
+        var errorLog = new FakeErrorLogService();
+        var sut = new TextInsertionService(platform, errorLog);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Equal("newer", platform.ClipboardText);
+        Assert.Equal(1, platform.RestoreClipboardCalls);
+        Assert.Contains(errorLog.Entries, entry =>
+            entry.Category == ErrorCategory.Insertion
+            && entry.Message.Contains("changed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SnapshotFailure_LeavesOriginalClipboardUntouched()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            BeginTemporaryClipboardException = new InvalidOperationException("unsupported format")
+        };
+        platform.ClipboardFormats["OwnerDisplay"] = "owner-dependent";
+        var expected = platform.ClipboardFormats.ToDictionary(static pair => pair.Key, static pair => pair.Value);
+        var sut = new TextInsertionService(platform);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.InsertTextAsync("dictated"));
+
+        Assert.Equal(expected, platform.ClipboardFormats);
+        Assert.Equal(0, platform.TemporaryClipboardWrites);
+    }
+
+    [Fact]
+    public async Task CancellationBeforePaste_RestoresClipboardImmediately()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            CancellationSource = cancellation,
+            CancelDuringFocusDelay = true
+        };
+        var sut = new TextInsertionService(platform);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.InsertTextAsync("dictated", cancellationToken: cancellation.Token));
+
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.Equal(0, platform.PasteInputCalls);
+        Assert.DoesNotContain(TimeSpan.FromMilliseconds(500), platform.Delays);
+    }
+
+    [Fact]
+    public async Task CancellationAfterPaste_WaitsBeforeRestoringClipboard()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            CancellationSource = cancellation,
+            CancelDuringRestoreDelay = true,
+            ReadClipboardDuringRestoreDelay = true
+        };
+        var sut = new TextInsertionService(platform);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.InsertTextAsync("dictated", cancellationToken: cancellation.Token));
+
+        Assert.Equal("dictated", platform.TextReadByTarget);
+        Assert.Equal("previous", platform.ClipboardText);
+        Assert.Contains(TimeSpan.FromMilliseconds(500), platform.Delays);
+    }
+
+    [Fact]
+    public async Task RestoreFailure_StillReportsPasteAndLogsDiagnostic()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            RestoreClipboardException = new ExternalException("restore failed")
+        };
+        var errorLog = new FakeErrorLogService();
+        var sut = new TextInsertionService(platform, errorLog);
+
+        var result = await sut.InsertTextAsync("dictated");
+
+        Assert.Equal(InsertionResult.Pasted, result);
+        Assert.Contains(errorLog.Entries, entry =>
+            entry.Category == ErrorCategory.Insertion
+            && entry.Message.Contains("restore", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -275,6 +482,9 @@ public sealed class TextInsertionServiceTests
             CapturedSelectionText = "selected text",
             MarkerReadsBeforeSelection = 1
         };
+        platform.ClipboardFormats["HTML Format"] = "<b>previous</b>";
+        platform.ClipboardFormats["Bitmap"] = "bitmap-bytes";
+        var expected = platform.ClipboardFormats.ToDictionary(static pair => pair.Key, static pair => pair.Value);
         var sut = new TextInsertionService(platform);
 
         var result = await sut.TryCaptureSelectedTextAsync(new IntPtr(321));
@@ -285,6 +495,7 @@ public sealed class TextInsertionServiceTests
         Assert.Equal(new IntPtr(321), platform.LastSetForegroundWindow);
         Assert.Contains(platform.ClipboardWrites, value => value.StartsWith("__typewhisper-selection-", StringComparison.Ordinal));
         Assert.Equal("previous", platform.ClipboardWrites[^1]);
+        Assert.Equal(expected, platform.ClipboardFormats);
     }
 
     [Fact]
@@ -316,10 +527,65 @@ public sealed class TextInsertionServiceTests
         Assert.Equal(1, platform.ClearClipboardCalls);
     }
 
+    [Fact]
+    public async Task TryCaptureSelectedTextAsync_CopyInputFailureRestoresAllFormats()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            CopyInputResult = 0
+        };
+        platform.ClipboardFormats["HTML Format"] = "<b>previous</b>";
+        platform.ClipboardFormats["TypeWhisper.Test.Custom"] = "custom-bytes";
+        var expected = platform.ClipboardFormats.ToDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value);
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.TryCaptureSelectedTextAsync();
+
+        Assert.Null(result);
+        Assert.Equal(expected, platform.ClipboardFormats);
+        Assert.Equal(1, platform.RestoreClipboardCalls);
+    }
+
+    [Fact]
+    public async Task TryCaptureSelectedTextAsync_ReadErrorStillRestoresAllFormats()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            ClipboardReadException = new ExternalException("read failed")
+        };
+        platform.ClipboardFormats["Bitmap"] = "bitmap-bytes";
+        var expected = platform.ClipboardFormats.ToDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value);
+        var sut = new TextInsertionService(platform);
+
+        await Assert.ThrowsAsync<ExternalException>(() => sut.TryCaptureSelectedTextAsync());
+
+        Assert.Equal(expected, platform.ClipboardFormats);
+        Assert.Equal(1, platform.RestoreClipboardCalls);
+    }
+
     private sealed class FakeTextInsertionPlatform : ITextInsertionPlatform
     {
-        public string? ClipboardText { get; set; }
+        public Dictionary<string, string> ClipboardFormats { get; } = [];
+        public string? ClipboardText
+        {
+            get => ClipboardFormats.GetValueOrDefault("UnicodeText");
+            set
+            {
+                if (value is null)
+                    ClipboardFormats.Remove("UnicodeText");
+                else
+                    ClipboardFormats["UnicodeText"] = value;
+            }
+        }
         public List<string> ClipboardWrites { get; } = [];
+        public List<TimeSpan> Delays { get; } = [];
+        public List<string> InsertionEvents { get; } = [];
         public Queue<bool> ModifierStates { get; } = [];
         public bool ModifierDefaultState { get; set; }
         public bool ModifierKeyUpInputClearsState { get; set; }
@@ -345,37 +611,77 @@ public sealed class TextInsertionServiceTests
         public int SetForegroundWindowCalls { get; private set; }
         public int ClearClipboardCalls { get; private set; }
         public int DelayCalls { get; private set; }
+        public int TemporaryClipboardWrites { get; private set; }
+        public int PersistentClipboardWrites { get; private set; }
+        public int RestoreClipboardCalls { get; private set; }
+        public bool LastTemporaryWriteExcludedFromHistory { get; private set; }
+        public bool ReadClipboardDuringRestoreDelay { get; set; }
+        public TimeSpan? SimulatedTargetReadOffset { get; set; }
+        public TimeSpan? TargetReadOffsetObserved { get; private set; }
+        public bool ChangeClipboardDuringRestoreDelay { get; set; }
+        public string? TextReadByTarget { get; private set; }
+        public CancellationTokenSource? CancellationSource { get; set; }
+        public bool CancelDuringFocusDelay { get; set; }
+        public bool CancelDuringRestoreDelay { get; set; }
+        public TaskCompletionSource<bool>? RestoreDelayEntered { get; set; }
+        public TaskCompletionSource<bool>? ContinueRestoreDelay { get; set; }
+        public Exception? RestoreClipboardException { get; set; }
+        public Exception? BeginTemporaryClipboardException { get; set; }
+        public Exception? ClipboardReadException { get; set; }
         private string? SelectionMarker { get; set; }
         private int MarkerReadsCompleted { get; set; }
+        private uint ClipboardSequenceNumber { get; set; } = 1;
+        private bool RestoreDelayActionsCompleted { get; set; }
 
-        public Task<string?> TryGetClipboardTextAsync()
+        public Task<ClipboardTextState> TryGetClipboardTextStateAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ClipboardReadException is not null)
+                throw ClipboardReadException;
+
             if (SelectionMarker is not null && CopyInputCalls > 0)
             {
                 if (CapturedSelectionText is null)
                 {
                     ClipboardText = SelectionMarker;
-                    return Task.FromResult<string?>(ClipboardText);
+                    return Task.FromResult(new ClipboardTextState(ClipboardText, ClipboardSequenceNumber));
                 }
 
                 if (MarkerReadsCompleted < MarkerReadsBeforeSelection)
                 {
                     MarkerReadsCompleted++;
                     ClipboardText = SelectionMarker;
-                    return Task.FromResult<string?>(ClipboardText);
+                    return Task.FromResult(new ClipboardTextState(ClipboardText, ClipboardSequenceNumber));
                 }
 
+                ClipboardFormats.Clear();
                 ClipboardText = CapturedSelectionText;
                 SelectionMarker = null;
+                ClipboardSequenceNumber++;
             }
 
-            return Task.FromResult<string?>(ClipboardText);
+            return Task.FromResult(new ClipboardTextState(ClipboardText, ClipboardSequenceNumber));
         }
 
-        public Task SetClipboardTextAsync(string text)
+        public Task<IClipboardLease> BeginTemporaryClipboardTextAsync(
+            string text,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (BeginTemporaryClipboardException is not null)
+                throw BeginTemporaryClipboardException;
+
+            var lease = new FakeClipboardLease(
+                ClipboardFormats.ToDictionary(static pair => pair.Key, static pair => pair.Value));
+            ClipboardFormats.Clear();
             ClipboardText = text;
+            ClipboardFormats[WindowsClipboardTransaction.ExcludeClipboardContentFromMonitorProcessing] = "1";
             ClipboardWrites.Add(text);
+            TemporaryClipboardWrites++;
+            InsertionEvents.Add("temporary-write");
+            LastTemporaryWriteExcludedFromHistory = true;
+            ClipboardSequenceNumber++;
+            lease.ExpectedSequenceNumber = ClipboardSequenceNumber;
             if (text.StartsWith("__typewhisper-selection-", StringComparison.Ordinal))
             {
                 SelectionMarker = text;
@@ -385,21 +691,121 @@ public sealed class TextInsertionServiceTests
             {
                 SelectionMarker = null;
             }
-            return Task.CompletedTask;
+            return Task.FromResult<IClipboardLease>(lease);
         }
 
-        public Task ClearClipboardTextAsync()
+        public Task SetClipboardTextAsync(string text, CancellationToken cancellationToken)
         {
-            ClipboardText = null;
+            cancellationToken.ThrowIfCancellationRequested();
+            ClipboardFormats.Clear();
+            ClipboardText = text;
+            ClipboardWrites.Add(text);
+            PersistentClipboardWrites++;
+            InsertionEvents.Add("persistent-write");
+            ClipboardSequenceNumber++;
             SelectionMarker = null;
-            ClearClipboardCalls++;
             return Task.CompletedTask;
         }
 
-        public Task DelayAsync(TimeSpan delay)
+        public Task<bool> CommitTemporaryClipboardTextAsync(
+            IClipboardLease lease,
+            string text,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var fakeLease = Assert.IsType<FakeClipboardLease>(lease);
+            if (fakeLease.ExpectedSequenceNumber != ClipboardSequenceNumber)
+            {
+                fakeLease.Completed = true;
+                return Task.FromResult(false);
+            }
+
+            ClipboardFormats.Clear();
+            ClipboardText = text;
+            ClipboardWrites.Add(text);
+            PersistentClipboardWrites++;
+            InsertionEvents.Add("fallback-write");
+            ClipboardSequenceNumber++;
+            SelectionMarker = null;
+            fakeLease.Completed = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<ClipboardRestoreResult> RestoreClipboardAsync(
+            IClipboardLease lease,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RestoreClipboardCalls++;
+            InsertionEvents.Add("restore");
+            if (RestoreClipboardException is not null)
+                throw RestoreClipboardException;
+
+            var fakeLease = Assert.IsType<FakeClipboardLease>(lease);
+            if (fakeLease.Completed)
+                return Task.FromResult(ClipboardRestoreResult.Restored);
+
+            if (fakeLease.ExpectedSequenceNumber != ClipboardSequenceNumber)
+            {
+                fakeLease.Completed = true;
+                return Task.FromResult(ClipboardRestoreResult.ClipboardChanged);
+            }
+
+            ClipboardFormats.Clear();
+            foreach (var pair in fakeLease.Snapshot)
+                ClipboardFormats[pair.Key] = pair.Value;
+
+            ClipboardSequenceNumber++;
+            fakeLease.Completed = true;
+            SelectionMarker = null;
+            if (ClipboardText is { } restoredText)
+                ClipboardWrites.Add(restoredText);
+            else
+                ClearClipboardCalls++;
+
+            return Task.FromResult(ClipboardRestoreResult.Restored);
+        }
+
+        public void AcceptClipboardSequence(IClipboardLease lease, uint sequenceNumber)
+        {
+            var fakeLease = Assert.IsType<FakeClipboardLease>(lease);
+            fakeLease.ExpectedSequenceNumber = sequenceNumber;
+        }
+
+        public async Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
         {
             DelayCalls++;
-            return Task.CompletedTask;
+            Delays.Add(delay);
+            InsertionEvents.Add($"delay:{delay.TotalMilliseconds:0}");
+
+            if (delay == TimeSpan.FromMilliseconds(100) && CancelDuringFocusDelay)
+                CancellationSource?.Cancel();
+
+            if (delay == TimeSpan.FromMilliseconds(500) && !RestoreDelayActionsCompleted)
+            {
+                RestoreDelayActionsCompleted = true;
+                RestoreDelayEntered?.TrySetResult(true);
+                if (ContinueRestoreDelay is not null)
+                    await ContinueRestoreDelay.Task.WaitAsync(cancellationToken);
+
+                if (ReadClipboardDuringRestoreDelay)
+                {
+                    var readOffset = SimulatedTargetReadOffset ?? TimeSpan.Zero;
+                    Assert.True(readOffset <= delay);
+                    TextReadByTarget = ClipboardText;
+                    TargetReadOffsetObserved = readOffset;
+                }
+                if (ChangeClipboardDuringRestoreDelay)
+                {
+                    ClipboardFormats.Clear();
+                    ClipboardText = "newer";
+                    ClipboardSequenceNumber++;
+                }
+                if (CancelDuringRestoreDelay)
+                    CancellationSource?.Cancel();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         public bool IsAnyModifierKeyDown() =>
@@ -444,6 +850,7 @@ public sealed class TextInsertionServiceTests
         public uint SendPasteInput()
         {
             PasteInputCalls++;
+            InsertionEvents.Add("paste");
             return PasteInputResult;
         }
 
@@ -456,7 +863,16 @@ public sealed class TextInsertionServiceTests
         public uint SendEnterInput()
         {
             EnterInputCalls++;
+            InsertionEvents.Add("enter");
             return EnterInputResult;
+        }
+
+        private sealed class FakeClipboardLease(Dictionary<string, string> snapshot) : IClipboardLease
+        {
+            public Dictionary<string, string> Snapshot { get; } = snapshot;
+            public uint ExpectedSequenceNumber { get; set; }
+            public bool Completed { get; set; }
+            public void Dispose() => Completed = true;
         }
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/TextInsertionServiceTests.cs
@@ -323,6 +323,39 @@ public sealed class TextInsertionServiceTests
     }
 
     [Fact]
+    public async Task TryGetClipboardTextAsync_WaitsForActiveTemporaryLease()
+    {
+        var restoreDelayEntered = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueRestoreDelay = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            RestoreDelayEntered = restoreDelayEntered,
+            ContinueRestoreDelay = continueRestoreDelay
+        };
+        var sut = new TextInsertionService(platform);
+
+        var paste = sut.InsertTextAsync("dictated");
+        await restoreDelayEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var clipboardRead = sut.TryGetClipboardTextAsync();
+
+        try
+        {
+            await Task.Yield();
+            Assert.False(clipboardRead.IsCompleted);
+        }
+        finally
+        {
+            continueRestoreDelay.TrySetResult(true);
+        }
+
+        Assert.Equal(InsertionResult.Pasted, await paste);
+        Assert.Equal("previous", await clipboardRead);
+    }
+
+    [Fact]
     public async Task SuccessfulPaste_RestoresAllClipboardFormats()
     {
         var platform = new FakeTextInsertionPlatform();
@@ -563,9 +596,28 @@ public sealed class TextInsertionServiceTests
             static pair => pair.Value);
         var sut = new TextInsertionService(platform);
 
-        await Assert.ThrowsAsync<ExternalException>(() => sut.TryCaptureSelectedTextAsync());
+        var result = await sut.TryCaptureSelectedTextAsync();
 
+        Assert.Null(result);
         Assert.Equal(expected, platform.ClipboardFormats);
+        Assert.Equal(1, platform.RestoreClipboardCalls);
+    }
+
+    [Fact]
+    public async Task TryCaptureSelectedTextAsync_RetriesTransientNullClipboardReads()
+    {
+        var platform = new FakeTextInsertionPlatform
+        {
+            ClipboardText = "previous",
+            CapturedSelectionText = "selected text",
+            ClipboardNullReadsRemaining = 1
+        };
+        var sut = new TextInsertionService(platform);
+
+        var result = await sut.TryCaptureSelectedTextAsync();
+
+        Assert.Equal("selected text", result);
+        Assert.Equal("previous", platform.ClipboardText);
         Assert.Equal(1, platform.RestoreClipboardCalls);
     }
 
@@ -628,6 +680,7 @@ public sealed class TextInsertionServiceTests
         public Exception? RestoreClipboardException { get; set; }
         public Exception? BeginTemporaryClipboardException { get; set; }
         public Exception? ClipboardReadException { get; set; }
+        public int ClipboardNullReadsRemaining { get; set; }
         private string? SelectionMarker { get; set; }
         private int MarkerReadsCompleted { get; set; }
         private uint ClipboardSequenceNumber { get; set; } = 1;
@@ -638,6 +691,12 @@ public sealed class TextInsertionServiceTests
             cancellationToken.ThrowIfCancellationRequested();
             if (ClipboardReadException is not null)
                 throw ClipboardReadException;
+
+            if (ClipboardNullReadsRemaining > 0)
+            {
+                ClipboardNullReadsRemaining--;
+                return Task.FromResult(new ClipboardTextState(null, ClipboardSequenceNumber));
+            }
 
             if (SelectionMarker is not null && CopyInputCalls > 0)
             {

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -164,6 +164,47 @@ public sealed class WindowsClipboardTransactionTests
     }
 
     [Fact]
+    public void TemporaryText_HandlesEmptyWindowsInformationProtectionMarker()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                using var transaction = new WindowsClipboardTransaction(Dispatcher.CurrentDispatcher);
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    using var enterpriseOwner = SeedEmptyEnterpriseClipboardMarker();
+                    var enterpriseFormat = NativeMethods.RegisterClipboardFormat(
+                        WindowsClipboardTransaction.EnterpriseDataProtectionId);
+                    Assert.Contains(enterpriseFormat, EnumerateClipboardFormats());
+                    Assert.Equal(IntPtr.Zero, ReadClipboardHandle(enterpriseFormat));
+                    Assert.True(string.IsNullOrEmpty(ReadEnterpriseClipboardId()));
+
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    Assert.Equal("dictated", ReadUnicodeText());
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    Assert.Equal("previous", ReadUnicodeText());
+                    Assert.True(string.IsNullOrEmpty(ReadEnterpriseClipboardId()));
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
+    [Fact]
     public void UnsupportedOleFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
     {
         lock (ClipboardTestLock)
@@ -245,6 +286,76 @@ public sealed class WindowsClipboardTransactionTests
         finally
         {
             NativeMethods.CloseClipboard();
+        }
+    }
+
+    private static HwndSource SeedEmptyEnterpriseClipboardMarker()
+    {
+        var enterpriseFormat = NativeMethods.RegisterClipboardFormat(
+            WindowsClipboardTransaction.EnterpriseDataProtectionId);
+        Assert.NotEqual(0u, enterpriseFormat);
+
+        var owner = new HwndSource(new HwndSourceParameters(
+            "TypeWhisper enterprise clipboard test owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+            SetGlobalData(
+                NativeMethods.CF_UNICODETEXT,
+                Encoding.Unicode.GetBytes("previous\0"));
+            Marshal.SetLastPInvokeError(0);
+            Assert.Equal(
+                IntPtr.Zero,
+                NativeMethods.SetClipboardData(enterpriseFormat, IntPtr.Zero));
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        return owner;
+    }
+
+    private static IntPtr ReadClipboardHandle(uint format)
+    {
+        Assert.True(NativeMethods.OpenClipboard(IntPtr.Zero));
+        try
+        {
+            Marshal.SetLastPInvokeError(0);
+            var handle = NativeMethods.GetClipboardData(format);
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
+            return handle;
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+    }
+
+    private static string? ReadEnterpriseClipboardId()
+    {
+        var result = NativeMethods.EdpGetEnterpriseIdForClipboard(out var enterpriseIdPointer);
+        Assert.True(result >= 0);
+        if (enterpriseIdPointer == IntPtr.Zero)
+            return null;
+
+        try
+        {
+            return Marshal.PtrToStringUni(enterpriseIdPointer);
+        }
+        finally
+        {
+            Assert.True(NativeMethods.HeapFree(
+                NativeMethods.GetProcessHeap(),
+                0,
+                enterpriseIdPointer));
         }
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -76,9 +76,9 @@ public sealed class WindowsClipboardTransactionTests
                     Assert.True(Clipboard.ContainsData(DataFormats.Rtf));
                     Assert.True(Clipboard.ContainsImage());
                     Assert.Equal(temporaryFile, Assert.Single(Clipboard.GetFileDropList().Cast<string>()));
-                    Assert.Equal(htmlBytes, ReadGlobalBytes(formats.Html));
-                    Assert.Equal(rtfBytes, ReadGlobalBytes(formats.Rtf));
-                    Assert.Equal(customBytes, ReadGlobalBytes(formats.Custom));
+                    AssertGlobalBytesStartWith(htmlBytes, formats.Html);
+                    AssertGlobalBytesStartWith(rtfBytes, formats.Rtf);
+                    AssertGlobalBytesStartWith(customBytes, formats.Custom);
                     Assert.False(Clipboard.ContainsData(
                         WindowsClipboardTransaction.ExcludeClipboardContentFromMonitorProcessing));
 
@@ -193,12 +193,11 @@ public sealed class WindowsClipboardTransactionTests
                     Clipboard.SetDataObject(seedData, copy: true);
                     releasedFormats.Clear();
 
-                    var error = Assert.Throws<COMException>(() =>
+                    Assert.Throws<COMException>(() =>
                         transaction.BeginTemporaryTextAsync("dictated", CancellationToken.None)
                             .GetAwaiter()
                             .GetResult());
 
-                    Assert.Contains("System.Drawing.Bitmap", error.Message, StringComparison.Ordinal);
                     Assert.Equal("previous", Clipboard.GetText());
                     Assert.True(Clipboard.ContainsImage());
                     Assert.NotEmpty(releasedFormats);
@@ -400,6 +399,13 @@ public sealed class WindowsClipboardTransactionTests
         {
             NativeMethods.CloseClipboard();
         }
+    }
+
+    private static void AssertGlobalBytesStartWith(byte[] expected, uint format)
+    {
+        var actual = ReadGlobalBytes(format);
+        Assert.True(actual.Length >= expected.Length);
+        Assert.Equal(expected, actual.AsSpan(0, expected.Length).ToArray());
     }
 
     private static string? ReadUnicodeText()

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -1,0 +1,463 @@
+using System.IO;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Threading;
+using TypeWhisper.Windows.Native;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class WindowsClipboardTransactionTests
+{
+    private const string CustomFormat = "TypeWhisper.Test.CustomClipboardFormat";
+    private static readonly object ClipboardTestLock = new();
+
+    [Fact]
+    public void TemporaryText_RestoresCommonAndRegisteredFormatsAndHonorsSequenceGuard()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                var temporaryFile = Path.GetTempFileName();
+                var releasedFormats = new List<uint>();
+                using var transaction = new WindowsClipboardTransaction(
+                    Dispatcher.CurrentDispatcher,
+                    (format, _) => releasedFormats.Add(format));
+                IClipboardLease? originalClipboard = null;
+                try
+                {
+                    originalClipboard = transaction.BeginTemporaryTextAsync(
+                            "__typewhisper-test-backup__",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    var htmlBytes = Encoding.UTF8.GetBytes("<b>previous</b>\0");
+                    var rtfBytes = Encoding.ASCII.GetBytes("{\\rtf1 previous}\0");
+                    var customBytes = new byte[] { 1, 2, 3, 4 };
+                    var formats = SeedNativeClipboard(
+                        temporaryFile,
+                        htmlBytes,
+                        rtfBytes,
+                        customBytes);
+                    var originalFormatOrder = EnumerateClipboardFormats();
+                    releasedFormats.Clear();
+
+                    using (var lease = transaction.BeginTemporaryTextAsync(
+                                   "dictated",
+                                   CancellationToken.None)
+                               .GetAwaiter()
+                               .GetResult())
+                    {
+                        Assert.Equal("dictated", ReadUnicodeText());
+                        var exclusionFormat = NativeMethods.RegisterClipboardFormat(
+                            WindowsClipboardTransaction.ExcludeClipboardContentFromMonitorProcessing);
+                        var temporaryFormats = EnumerateClipboardFormats().ToList();
+                        Assert.Contains(exclusionFormat, temporaryFormats);
+                        Assert.True(
+                            temporaryFormats.IndexOf(exclusionFormat) <
+                            temporaryFormats.IndexOf(NativeMethods.CF_UNICODETEXT));
+
+                        var restoreResult = transaction.RestoreAsync(lease, CancellationToken.None)
+                            .GetAwaiter()
+                            .GetResult();
+
+                        Assert.Equal(ClipboardRestoreResult.Restored, restoreResult);
+                    }
+
+                    Assert.Equal(originalFormatOrder, releasedFormats);
+                    Assert.Equal(originalFormatOrder, EnumerateClipboardFormats());
+                    Assert.Equal("previous", Clipboard.GetText());
+                    Assert.True(Clipboard.ContainsData(DataFormats.Html));
+                    Assert.True(Clipboard.ContainsData(DataFormats.Rtf));
+                    Assert.True(Clipboard.ContainsImage());
+                    Assert.Equal(temporaryFile, Assert.Single(Clipboard.GetFileDropList().Cast<string>()));
+                    Assert.Equal(htmlBytes, ReadGlobalBytes(formats.Html));
+                    Assert.Equal(rtfBytes, ReadGlobalBytes(formats.Rtf));
+                    Assert.Equal(customBytes, ReadGlobalBytes(formats.Custom));
+                    Assert.False(Clipboard.ContainsData(
+                        WindowsClipboardTransaction.ExcludeClipboardContentFromMonitorProcessing));
+
+                    using (var guardedLease = transaction.BeginTemporaryTextAsync(
+                                   "dictated-again",
+                                   CancellationToken.None)
+                               .GetAwaiter()
+                               .GetResult())
+                    {
+                        Clipboard.SetText("newer");
+
+                        var guardedResult = transaction.RestoreAsync(
+                                guardedLease,
+                                CancellationToken.None)
+                            .GetAwaiter()
+                            .GetResult();
+
+                        Assert.Equal(ClipboardRestoreResult.ClipboardChanged, guardedResult);
+                        Assert.Equal("newer", Clipboard.GetText());
+                    }
+
+                    transaction.SetPersistentTextAsync("copied", CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    var persistentExclusionFormat = NativeMethods.RegisterClipboardFormat(
+                        WindowsClipboardTransaction.ExcludeClipboardContentFromMonitorProcessing);
+                    Assert.Equal("copied", ReadUnicodeText());
+                    Assert.DoesNotContain(persistentExclusionFormat, EnumerateClipboardFormats());
+                }
+                finally
+                {
+                    if (originalClipboard is not null)
+                    {
+                        transaction.AcceptSequence(
+                            originalClipboard,
+                            NativeMethods.GetClipboardSequenceNumber());
+                        transaction.RestoreAsync(originalClipboard, CancellationToken.None)
+                            .GetAwaiter()
+                            .GetResult();
+                        originalClipboard.Dispose();
+                    }
+
+                    File.Delete(temporaryFile);
+                }
+            });
+        }
+    }
+
+    [Fact]
+    public void TemporaryText_RestoresAnOriginallyEmptyClipboard()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                using var transaction = new WindowsClipboardTransaction(Dispatcher.CurrentDispatcher);
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    EmptyNativeClipboard();
+                    Assert.Empty(EnumerateClipboardFormats());
+
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    Assert.Equal("dictated", ReadUnicodeText());
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    Assert.Empty(EnumerateClipboardFormats());
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
+    [Fact]
+    public void UnsupportedOleFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                var releasedFormats = new List<uint>();
+                using var transaction = new WindowsClipboardTransaction(
+                    Dispatcher.CurrentDispatcher,
+                    (format, _) => releasedFormats.Add(format));
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    var bitmap = System.Windows.Media.Imaging.BitmapSource.Create(
+                        1,
+                        1,
+                        96,
+                        96,
+                        System.Windows.Media.PixelFormats.Bgra32,
+                        null,
+                        new byte[] { 0x11, 0x22, 0x33, 0xFF },
+                        4);
+                    bitmap.Freeze();
+                    var seedData = new DataObject();
+                    seedData.SetData(DataFormats.UnicodeText, "previous", autoConvert: false);
+                    seedData.SetImage(bitmap);
+                    Clipboard.SetDataObject(seedData, copy: true);
+                    releasedFormats.Clear();
+
+                    var error = Assert.Throws<COMException>(() =>
+                        transaction.BeginTemporaryTextAsync("dictated", CancellationToken.None)
+                            .GetAwaiter()
+                            .GetResult());
+
+                    Assert.Contains("System.Drawing.Bitmap", error.Message, StringComparison.Ordinal);
+                    Assert.Equal("previous", Clipboard.GetText());
+                    Assert.True(Clipboard.ContainsImage());
+                    Assert.NotEmpty(releasedFormats);
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
+    private static IClipboardLease BackupClipboard(WindowsClipboardTransaction transaction) =>
+        transaction.BeginTemporaryTextAsync(
+                "__typewhisper-test-backup__",
+                CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+
+    private static void RestoreClipboardBackup(
+        WindowsClipboardTransaction transaction,
+        IClipboardLease originalClipboard)
+    {
+        transaction.AcceptSequence(
+            originalClipboard,
+            NativeMethods.GetClipboardSequenceNumber());
+        transaction.RestoreAsync(originalClipboard, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+        originalClipboard.Dispose();
+    }
+
+    private static void EmptyNativeClipboard()
+    {
+        using var owner = new HwndSource(new HwndSourceParameters("TypeWhisper empty clipboard test owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+    }
+
+    private static ClipboardFormats SeedNativeClipboard(
+        string filePath,
+        byte[] htmlBytes,
+        byte[] rtfBytes,
+        byte[] customBytes)
+    {
+        var html = NativeMethods.RegisterClipboardFormat(DataFormats.Html);
+        var rtf = NativeMethods.RegisterClipboardFormat(DataFormats.Rtf);
+        var custom = NativeMethods.RegisterClipboardFormat(CustomFormat);
+        Assert.NotEqual(0u, html);
+        Assert.NotEqual(0u, rtf);
+        Assert.NotEqual(0u, custom);
+
+        using var owner = new HwndSource(new HwndSourceParameters("TypeWhisper clipboard test owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+            SetGlobalData(
+                NativeMethods.CF_UNICODETEXT,
+                Encoding.Unicode.GetBytes("previous\0"));
+            SetGlobalData(html, htmlBytes);
+            SetGlobalData(rtf, rtfBytes);
+            SetGlobalData(NativeMethods.CF_HDROP, CreateFileDropBytes(filePath));
+
+            var bitmap = CreateBitmap(
+                1,
+                1,
+                1,
+                32,
+                new byte[] { 0x11, 0x22, 0x33, 0xFF });
+            Assert.NotEqual(IntPtr.Zero, bitmap);
+            if (NativeMethods.SetClipboardData(NativeMethods.CF_BITMAP, bitmap) == IntPtr.Zero)
+            {
+                NativeMethods.DeleteObject(bitmap);
+                throw new ExternalException(
+                    "Could not seed the native bitmap clipboard format.",
+                    Marshal.GetLastPInvokeError());
+            }
+
+            SetGlobalData(custom, customBytes);
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        return new ClipboardFormats(html, rtf, custom);
+    }
+
+    private static void SetGlobalData(uint format, byte[] bytes)
+    {
+        var handle = NativeMethods.GlobalAlloc(
+            NativeMethods.GMEM_MOVEABLE | NativeMethods.GMEM_ZEROINIT,
+            (nuint)bytes.Length);
+        if (handle == IntPtr.Zero)
+            throw new OutOfMemoryException();
+
+        var pointer = NativeMethods.GlobalLock(handle);
+        if (pointer == IntPtr.Zero)
+        {
+            NativeMethods.GlobalFree(handle);
+            throw new ExternalException("Could not lock test clipboard memory.");
+        }
+
+        try
+        {
+            Marshal.Copy(bytes, 0, pointer, bytes.Length);
+        }
+        finally
+        {
+            NativeMethods.GlobalUnlock(handle);
+        }
+
+        if (NativeMethods.SetClipboardData(format, handle) != IntPtr.Zero)
+            return;
+
+        var error = Marshal.GetLastPInvokeError();
+        NativeMethods.GlobalFree(handle);
+        throw new ExternalException(
+            $"Could not seed clipboard format {format}.",
+            error);
+    }
+
+    private static byte[] CreateFileDropBytes(string filePath)
+    {
+        const int dropFilesSize = 20;
+        var paths = Encoding.Unicode.GetBytes(filePath + "\0\0");
+        var result = new byte[dropFilesSize + paths.Length];
+        BitConverter.GetBytes(dropFilesSize).CopyTo(result, 0);
+        BitConverter.GetBytes(1).CopyTo(result, 16);
+        paths.CopyTo(result, dropFilesSize);
+        return result;
+    }
+
+    private static IReadOnlyList<uint> EnumerateClipboardFormats()
+    {
+        Assert.True(NativeMethods.OpenClipboard(IntPtr.Zero));
+        try
+        {
+            var formats = new List<uint>();
+            uint current = 0;
+            while (true)
+            {
+                Marshal.SetLastPInvokeError(0);
+                current = NativeMethods.EnumClipboardFormats(current);
+                if (current == 0)
+                {
+                    Assert.Equal(0, Marshal.GetLastPInvokeError());
+                    return formats;
+                }
+
+                formats.Add(current);
+            }
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+    }
+
+    private static byte[] ReadGlobalBytes(uint format)
+    {
+        Assert.True(NativeMethods.OpenClipboard(IntPtr.Zero));
+        try
+        {
+            var handle = NativeMethods.GetClipboardData(format);
+            Assert.NotEqual(IntPtr.Zero, handle);
+            var length = checked((int)GlobalSize(handle));
+            var pointer = NativeMethods.GlobalLock(handle);
+            Assert.NotEqual(IntPtr.Zero, pointer);
+            try
+            {
+                var bytes = new byte[length];
+                Marshal.Copy(pointer, bytes, 0, length);
+                return bytes;
+            }
+            finally
+            {
+                NativeMethods.GlobalUnlock(handle);
+            }
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+    }
+
+    private static string? ReadUnicodeText()
+    {
+        Assert.True(NativeMethods.OpenClipboard(IntPtr.Zero));
+        try
+        {
+            var handle = NativeMethods.GetClipboardData(NativeMethods.CF_UNICODETEXT);
+            Assert.NotEqual(IntPtr.Zero, handle);
+            var pointer = NativeMethods.GlobalLock(handle);
+            Assert.NotEqual(IntPtr.Zero, pointer);
+            try
+            {
+                return Marshal.PtrToStringUni(pointer);
+            }
+            finally
+            {
+                NativeMethods.GlobalUnlock(handle);
+            }
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+    }
+
+    private static void RunOnStaThread(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    private static extern IntPtr CreateBitmap(
+        int width,
+        int height,
+        uint planes,
+        uint bitsPerPixel,
+        byte[] bits);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern nuint GlobalSize(IntPtr memoryHandle);
+
+    private sealed record ClipboardFormats(uint Html, uint Rtf, uint Custom);
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowPaletteServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowPaletteServiceTests.cs
@@ -321,34 +321,44 @@ public sealed class WorkflowPaletteServiceTests : IDisposable
         public int CopyInputCalls { get; private set; }
         private string? SelectionMarker { get; set; }
         private int MarkerReadsCompleted { get; set; }
+        private uint ClipboardSequenceNumber { get; set; } = 1;
 
-        public Task<string?> TryGetClipboardTextAsync()
+        public Task<ClipboardTextState> TryGetClipboardTextStateAsync(
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (SelectionMarker is not null && CopyInputCalls > 0)
             {
                 if (CapturedSelectionText is null)
                 {
                     ClipboardText = SelectionMarker;
-                    return Task.FromResult<string?>(ClipboardText);
+                    return Task.FromResult(new ClipboardTextState(ClipboardText, ClipboardSequenceNumber));
                 }
 
                 if (MarkerReadsCompleted < MarkerReadsBeforeSelection)
                 {
                     MarkerReadsCompleted++;
                     ClipboardText = SelectionMarker;
-                    return Task.FromResult<string?>(ClipboardText);
+                    return Task.FromResult(new ClipboardTextState(ClipboardText, ClipboardSequenceNumber));
                 }
 
                 ClipboardText = CapturedSelectionText;
                 SelectionMarker = null;
+                ClipboardSequenceNumber++;
             }
 
-            return Task.FromResult<string?>(ClipboardText);
+            return Task.FromResult(new ClipboardTextState(ClipboardText, ClipboardSequenceNumber));
         }
 
-        public Task SetClipboardTextAsync(string text)
+        public Task<IClipboardLease> BeginTemporaryClipboardTextAsync(
+            string text,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            var lease = new FakeClipboardLease(ClipboardText);
             ClipboardText = text;
+            ClipboardSequenceNumber++;
+            lease.ExpectedSequenceNumber = ClipboardSequenceNumber;
             if (text.StartsWith("__typewhisper-selection-", StringComparison.Ordinal))
             {
                 SelectionMarker = text;
@@ -359,17 +369,59 @@ public sealed class WorkflowPaletteServiceTests : IDisposable
                 SelectionMarker = null;
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult<IClipboardLease>(lease);
         }
 
-        public Task ClearClipboardTextAsync()
+        public Task SetClipboardTextAsync(string text, CancellationToken cancellationToken)
         {
-            ClipboardText = null;
+            cancellationToken.ThrowIfCancellationRequested();
+            ClipboardText = text;
+            ClipboardSequenceNumber++;
             SelectionMarker = null;
             return Task.CompletedTask;
         }
 
-        public Task DelayAsync(TimeSpan delay) => Task.CompletedTask;
+        public Task<bool> CommitTemporaryClipboardTextAsync(
+            IClipboardLease lease,
+            string text,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ClipboardText = text;
+            ClipboardSequenceNumber++;
+            ((FakeClipboardLease)lease).Completed = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<ClipboardRestoreResult> RestoreClipboardAsync(
+            IClipboardLease lease,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var fakeLease = (FakeClipboardLease)lease;
+            if (fakeLease.Completed)
+                return Task.FromResult(ClipboardRestoreResult.Restored);
+            if (fakeLease.ExpectedSequenceNumber != ClipboardSequenceNumber)
+            {
+                fakeLease.Completed = true;
+                return Task.FromResult(ClipboardRestoreResult.ClipboardChanged);
+            }
+
+            ClipboardText = fakeLease.PreviousText;
+            ClipboardSequenceNumber++;
+            fakeLease.Completed = true;
+            SelectionMarker = null;
+            return Task.FromResult(ClipboardRestoreResult.Restored);
+        }
+
+        public void AcceptClipboardSequence(IClipboardLease lease, uint sequenceNumber) =>
+            ((FakeClipboardLease)lease).ExpectedSequenceNumber = sequenceNumber;
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
 
         public bool IsAnyModifierKeyDown() => false;
 
@@ -401,5 +453,13 @@ public sealed class WorkflowPaletteServiceTests : IDisposable
         public uint SendPasteInput() => PasteInputResult;
 
         public uint SendEnterInput() => EnterInputResult;
+
+        private sealed class FakeClipboardLease(string? previousText) : IClipboardLease
+        {
+            public string? PreviousText { get; } = previousText;
+            public uint ExpectedSequenceNumber { get; set; }
+            public bool Completed { get; set; }
+            public void Dispose() => Completed = true;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- preserve and restore the complete native clipboard payload around temporary auto-paste operations, including text, HTML/RTF, images, file drops, and registered formats
- mark temporary auto-paste content with `ExcludeClipboardContentFromMonitorProcessing` before publishing text so it is excluded from Clipboard History and Cloud Clipboard processing
- wait 500 ms after queued paste input and restore only while the clipboard sequence still belongs to TypeWhisper
- keep explicit copy and paste-fallback writes as normal history-capable clipboard entries
- propagate cancellation through insertion while preserving the required pre-paste and post-paste restore timing
- use the same full-format lease for selected-text capture and serialize overlapping clipboard operations
- handle Windows `EnterpriseDataProtectionId` metadata through the documented EDP APIs when it enumerates without a transferable clipboard handle

## Root cause

The previous path restored text-only clipboard state after a fixed 200 ms. `SendInput` only confirms that Ctrl+V events were queued, so slower target applications could read the restored old value instead of the transcription. The text-only backup also discarded non-text clipboard formats.

## Compatibility

- no settings, localization, migration, API response, or plugin SDK changes
- explicit copy and existing copy-fallback behavior remain history-capable
- newer clipboard writes are preserved instead of being overwritten

## Validation

- targeted clipboard and insertion tests: 37 passed
- `dotnet test TypeWhisper.slnx --no-restore`: 382 Core and 1,705 PluginSystem tests passed
- `dotnet format TypeWhisper.slnx --no-restore --verify-no-changes --include ...`
- `git diff --check`
- live dev runtime: 20 automation insert requests completed with the 500 ms restore window
- live Clipboard History stress check confirmed zero temporary marker entries after publishing the exclusion marker first
- forced clipboard change during the restore window remained intact
- native regression reproduced format 49329 (`EnterpriseDataProtectionId`) with a null handle and passed after the EDP metadata fix
- fresh Codex Desktop smoke inserted dictated text, restored `ALT-CLIPBOARD-359`, and produced no new materialization error

## Manual validation

The earlier Notepad run used an unsupported `/new` argument and remains discarded. A fresh Codex Desktop run on the rebuilt dev app copied `ALT-CLIPBOARD-359`, dictated successfully, and confirmed with Ctrl+V that the original marker remained available. A separate fresh Notepad smoke is not claimed.

Addresses #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporarily replaces and reliably restores existing clipboard content during text insertion.
  * Preserves supported text, images, file drops, and other clipboard data.
  * Added cancellation support for text insertion operations.

* **Bug Fixes**
  * Prevents overwriting newer clipboard content.
  * Improves reliability when the clipboard is busy or restoration temporarily fails.

* **Tests**
  * Expanded coverage for clipboard preservation, concurrency, cancellation, and restoration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->