### PR TITLE
Normalize spoken numbers when language metadata is missing

### DIFF
--- a/src/TypeWhisper.Core/Services/NumberNormalization/NumberWordNormalizer.cs
+++ b/src/TypeWhisper.Core/Services/NumberNormalization/NumberWordNormalizer.cs
@@ -8,8 +8,11 @@ namespace TypeWhisper.Core.Services.NumberNormalization;
 /// </summary>
 public static class NumberWordNormalizer
 {
-    private static readonly HashSet<string> SupportedLanguageCodes = ["en", "de", "fr", "es", "zh", "ja"];
+    private static readonly string[] SupportedLanguageCodeOrder = ["en", "de", "fr", "es", "zh", "ja"];
+    private static readonly HashSet<string> SupportedLanguageCodes = [.. SupportedLanguageCodeOrder];
     private static readonly HashSet<char> CjkNumberCharacters = ['零', '〇', '一', '二', '两', '兩', '三', '四', '五', '六', '七', '八', '九', '十', '百', '千', '万', '萬', '亿', '億', '点', '點', '負', '负'];
+
+    internal static IReadOnlyList<string> SupportedLanguages => SupportedLanguageCodeOrder;
 
     /// <summary>
     /// Normalizes supported number words in the supplied text for the requested language.
@@ -54,6 +57,8 @@ public static class NumberWordNormalizer
         var normalized = primary.Trim().ToLowerInvariant();
         return normalized.Length == 0 ? null : normalized;
     }
+
+    internal static bool IsSupportedLanguage(string language) => SupportedLanguageCodes.Contains(language);
 
     internal sealed record ParsedWords(string Value, int ConsumedWords);
 

--- a/src/TypeWhisper.Core/Services/NumberNormalization/TranscriptionNumberNormalizationService.cs
+++ b/src/TypeWhisper.Core/Services/NumberNormalization/TranscriptionNumberNormalizationService.cs
@@ -105,9 +105,13 @@ public static class TranscriptionNumberNormalizationService
         if (transcriptionTask == TranscriptionTask.Translate)
             return ["en"];
 
-        return PrioritizedLanguages(
+        var languages = PrioritizedLanguages(
             detectedLanguage,
             [.. new[] { configuredLanguage }.Where(static language => language is not null).Select(static language => language!), .. configuredLanguageCandidates]);
+
+        return languages.Count > 0
+            ? languages
+            : NumberWordNormalizer.SupportedLanguages;
     }
 
     private static string NormalizeText(
@@ -149,7 +153,9 @@ public static class TranscriptionNumberNormalizationService
         foreach (var rawLanguage in new[] { primary }.Where(static language => language is not null).Select(static language => language!).Concat(candidates))
         {
             var normalized = NumberWordNormalizer.NormalizeLanguageCode(rawLanguage);
-            if (normalized is null || !seen.Add(normalized))
+            if (normalized is null ||
+                !NumberWordNormalizer.IsSupportedLanguage(normalized) ||
+                !seen.Add(normalized))
                 continue;
 
             result.Add(normalized);

--- a/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/PostProcessingPipelineTests.cs
@@ -342,6 +342,19 @@ public class PostProcessingPipelineTests
     }
 
     [Fact]
+    public async Task ProcessAsync_NumberNormalization_AutoWithoutDetectedLanguage_NormalizesGermanSentence()
+    {
+        var options = new PipelineOptions
+        {
+            TranscriptionNumberNormalizationEnabled = true
+        };
+
+        var result = await _sut.ProcessAsync("Ein Tag hat vierundzwanzig Stunden.", options);
+
+        Assert.Equal("Ein Tag hat 24 Stunden.", result.Text);
+    }
+
+    [Fact]
     public async Task ProcessAsync_NumberNormalization_UsesEnglishForTranslateTask()
     {
         var options = new PipelineOptions
@@ -552,6 +565,7 @@ public class PostProcessingPipelineTests
     {
         var options = new PipelineOptions
         {
+            TranscriptionNumberNormalizationEnabled = false,
             AppFormatter = AppFormatterService.Format,
             TargetProcessName = "OUTLOOK"
         };

--- a/tests/TypeWhisper.Core.Tests/Services/TranscriptionNumberNormalizationServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/TranscriptionNumberNormalizationServiceTests.cs
@@ -61,6 +61,33 @@ public class TranscriptionNumberNormalizationServiceTests
     }
 
     [Fact]
+    public void NormalizeText_AutoWithoutDetectedLanguage_NormalizesGermanCompoundInSentence()
+    {
+        var result = TranscriptionNumberNormalizationService.NormalizeText(
+            "Ein Tag hat vierundzwanzig Stunden.",
+            TranscriptionTask.Transcribe,
+            detectedLanguage: null,
+            configuredLanguage: null,
+            configuredLanguageCandidates: []);
+
+        Assert.Equal("Ein Tag hat 24 Stunden.", result);
+    }
+
+    [Fact]
+    public void NormalizeText_AutoWithoutDetectedLanguage_GlobalOffPreservesNumberWords()
+    {
+        var result = TranscriptionNumberNormalizationService.NormalizeText(
+            "Ein Tag hat vierundzwanzig Stunden.",
+            TranscriptionTask.Transcribe,
+            detectedLanguage: null,
+            configuredLanguage: null,
+            configuredLanguageCandidates: [],
+            globalEnabled: false);
+
+        Assert.Equal("Ein Tag hat vierundzwanzig Stunden.", result);
+    }
+
+    [Fact]
     public void NormalizeResult_NormalizesTextAndSegments()
     {
         var transcription = new TranscriptionResult

--- a/tests/TypeWhisper.Core.Tests/Services/TranscriptionNumberNormalizationServiceTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/TranscriptionNumberNormalizationServiceTests.cs
@@ -74,6 +74,19 @@ public class TranscriptionNumberNormalizationServiceTests
     }
 
     [Fact]
+    public void NormalizeText_UnsupportedDetectedLanguage_UsesSupportedLanguageFallback()
+    {
+        var result = TranscriptionNumberNormalizationService.NormalizeText(
+            "Ein Tag hat vierundzwanzig Stunden.",
+            TranscriptionTask.Transcribe,
+            detectedLanguage: "xx",
+            configuredLanguage: null,
+            configuredLanguageCandidates: []);
+
+        Assert.Equal("Ein Tag hat 24 Stunden.", result);
+    }
+
+    [Fact]
     public void NormalizeText_AutoWithoutDetectedLanguage_GlobalOffPreservesNumberWords()
     {
         var result = TranscriptionNumberNormalizationService.NormalizeText(


### PR DESCRIPTION
## Summary

- fall back to the supported number normalizers when transcription provides no usable language metadata
- preserve detected and configured language priority when available
- keep number words unchanged when normalization is disabled
- add regression coverage for German compound numbers in complete sentences

## Root cause

Some engines, including Parakeet TDT, can return transcription text without a detected language. In automatic language mode this left the normalization language list empty, so valid number words were never processed.

## Validation

- `dotnet test tests\TypeWhisper.Core.Tests\TypeWhisper.Core.Tests.csproj --filter "FullyQualifiedName~NumberNormalization" --no-restore` (19 passed)
- `dotnet test TypeWhisper.slnx --no-restore` (386 Core tests and 1,717 PluginSystem tests passed)
- reproduced with German TTS through the local recorder API using Parakeet TDT
- verified a TTS WAV with no language metadata returns `Ein Tag hat 24 Stunden.`

Fixes #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic number normalization when no language is detected or configured.
  - German number words, including compound forms, are now normalized reliably.
  - Unsupported, duplicate, or invalid language settings are ignored.
  - Number normalization falls back to all supported languages when needed.
  - Disabling normalization continues to preserve original number words.

- **Tests**
  - Added coverage for automatic German normalization, unsupported language fallback, and disabled normalization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->