### PR TITLE
Preserve bitmap clipboard content across temporary paste

### DIFF
--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -220,6 +220,8 @@ internal sealed class WindowsClipboardTransaction : IDisposable
     private WindowsClipboardSnapshot CaptureSnapshotCore(uint enterpriseFormat)
     {
         var entries = new List<ClipboardFormatHandle>();
+        var capturedFormats = new HashSet<uint>();
+        var unavailableFormats = new List<UnavailableClipboardFormat>();
         string? enterpriseId = null;
         try
         {
@@ -261,8 +263,11 @@ internal sealed class WindowsClipboardTransaction : IDisposable
                 var sourceHandle = NativeMethods.GetClipboardData(nextFormat);
                 if (sourceHandle == IntPtr.Zero)
                 {
-                    throw LastClipboardError(
-                        $"Could not materialize clipboard format {DescribeFormat(nextFormat)}.");
+                    unavailableFormats.Add(new UnavailableClipboardFormat(
+                        nextFormat,
+                        Marshal.GetLastPInvokeError()));
+                    currentFormat = nextFormat;
+                    continue;
                 }
 
                 var duplicateHandle = DuplicateClipboardHandle(nextFormat, sourceHandle);
@@ -276,7 +281,21 @@ internal sealed class WindowsClipboardTransaction : IDisposable
                     nextFormat,
                     duplicateHandle,
                     _handleReleaseObserver));
+                capturedFormats.Add(nextFormat);
                 currentFormat = nextFormat;
+            }
+
+            foreach (var unavailableFormat in unavailableFormats)
+            {
+                if (CanRestoreFromCapturedBitmapRepresentation(
+                        unavailableFormat.Format,
+                        capturedFormats))
+                    continue;
+
+                throw ClipboardError(
+                    $"Could not materialize clipboard format " +
+                    $"{DescribeFormat(unavailableFormat.Format)}.",
+                    unavailableFormat.Error);
             }
 
             return new WindowsClipboardSnapshot(entries, enterpriseId);
@@ -334,6 +353,41 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         var name = new StringBuilder(256);
         var length = NativeMethods.GetClipboardFormatName(format, name, name.Capacity);
         return length > 0 ? $"{format} ('{name}')" : format.ToString();
+    }
+
+    private static bool CanRestoreFromCapturedBitmapRepresentation(
+        uint unavailableFormat,
+        IReadOnlySet<uint> capturedFormats)
+    {
+        var hasBitmapRepresentation =
+            capturedFormats.Contains(NativeMethods.CF_BITMAP) ||
+            capturedFormats.Contains(NativeMethods.CF_DIB) ||
+            capturedFormats.Contains(NativeMethods.CF_DIBV5);
+        if (!hasBitmapRepresentation)
+            return false;
+
+        // EnumClipboardFormats includes bitmap formats synthesized from another available
+        // bitmap representation. Windows recreates those alternatives after restoration.
+        if (unavailableFormat is NativeMethods.CF_BITMAP
+            or NativeMethods.CF_DIB
+            or NativeMethods.CF_DIBV5)
+            return true;
+
+        if (unavailableFormat < 0xC000)
+            return false;
+
+        var name = new StringBuilder(256);
+        var length = NativeMethods.GetClipboardFormatName(
+            unavailableFormat,
+            name,
+            name.Capacity);
+
+        // OLE image providers can advertise this managed bitmap alias without exposing a
+        // native handle. The captured standard bitmap formats preserve the same image.
+        return length > 0 && string.Equals(
+            name.ToString(),
+            "System.Drawing.Bitmap",
+            StringComparison.Ordinal);
     }
 
     private static IntPtr DuplicateClipboardHandle(uint format, IntPtr sourceHandle)
@@ -575,6 +629,8 @@ internal sealed class WindowsClipboardTransaction : IDisposable
 
     private sealed class ClipboardBusyException(int error)
         : ExternalException("The clipboard is currently in use.", HResultFromWin32(error));
+
+    private readonly record struct UnavailableClipboardFormat(uint Format, int Error);
 
     private sealed class WindowsClipboardLease(WindowsClipboardSnapshot snapshot) : IClipboardLease
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -13,6 +13,7 @@ namespace TypeWhisper.PluginSystem.Tests;
 public sealed class WindowsClipboardTransactionTests
 {
     private const string CustomFormat = "TypeWhisper.Test.CustomClipboardFormat";
+    private const string UnavailableFormat = "TypeWhisper.Test.UnavailableClipboardFormat";
     private static readonly object ClipboardTestLock = new();
 
     [Fact]
@@ -205,7 +206,7 @@ public sealed class WindowsClipboardTransactionTests
     }
 
     [Fact]
-    public void UnsupportedOleFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
+    public void OleBitmap_RestoresImageWhenRegisteredBitmapAliasCannotBeMaterialized()
     {
         lock (ClipboardTestLock)
         {
@@ -234,13 +235,98 @@ public sealed class WindowsClipboardTransactionTests
                     Clipboard.SetDataObject(seedData, copy: true);
                     releasedFormats.Clear();
 
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    Assert.Equal("dictated", Clipboard.GetText());
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    Assert.Equal("previous", Clipboard.GetText());
+                    var restoredBitmap = Clipboard.GetImage();
+                    Assert.NotNull(restoredBitmap);
+                    Assert.Equal(1, restoredBitmap.PixelWidth);
+                    Assert.Equal(1, restoredBitmap.PixelHeight);
+                    Assert.NotEmpty(releasedFormats);
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
+    [Fact]
+    public void DelayedDib_RestoresAvailableBitmapRepresentation()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                using var transaction = new WindowsClipboardTransaction(Dispatcher.CurrentDispatcher);
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    using var bitmapOwner = SeedBitmapWithUnavailableDib();
+                    Assert.Contains(NativeMethods.CF_BITMAP, EnumerateClipboardFormats());
+                    Assert.Contains(NativeMethods.CF_DIB, EnumerateClipboardFormats());
+                    Assert.NotEqual(IntPtr.Zero, ReadClipboardHandle(NativeMethods.CF_BITMAP));
+                    Assert.Equal(IntPtr.Zero, ReadClipboardHandle(NativeMethods.CF_DIB));
+
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    Assert.Equal("dictated", Clipboard.GetText());
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    var restoredBitmap = Clipboard.GetImage();
+                    Assert.NotNull(restoredBitmap);
+                    Assert.Equal(1, restoredBitmap.PixelWidth);
+                    Assert.Equal(1, restoredBitmap.PixelHeight);
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
+    [Fact]
+    public void UnavailableUniqueFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                var releasedFormats = new List<uint>();
+                using var transaction = new WindowsClipboardTransaction(
+                    Dispatcher.CurrentDispatcher,
+                    (format, _) => releasedFormats.Add(format));
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    using var owner = SeedUnavailableUniqueFormat();
+                    releasedFormats.Clear();
+
                     Assert.Throws<COMException>(() =>
                         transaction.BeginTemporaryTextAsync("dictated", CancellationToken.None)
                             .GetAwaiter()
                             .GetResult());
 
                     Assert.Equal("previous", Clipboard.GetText());
-                    Assert.True(Clipboard.ContainsImage());
                     Assert.NotEmpty(releasedFormats);
                 }
                 finally
@@ -337,6 +423,78 @@ public sealed class WindowsClipboardTransactionTests
         {
             NativeMethods.CloseClipboard();
         }
+    }
+
+    private static HwndSource SeedBitmapWithUnavailableDib()
+    {
+        var owner = new HwndSource(new HwndSourceParameters("TypeWhisper delayed bitmap owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+            var bitmap = CreateBitmap(
+                1,
+                1,
+                1,
+                32,
+                new byte[] { 0x11, 0x22, 0x33, 0xFF });
+            Assert.NotEqual(IntPtr.Zero, bitmap);
+            if (NativeMethods.SetClipboardData(NativeMethods.CF_BITMAP, bitmap) == IntPtr.Zero)
+            {
+                NativeMethods.DeleteObject(bitmap);
+                throw new ExternalException(
+                    "Could not seed the delayed native bitmap clipboard format.",
+                    Marshal.GetLastPInvokeError());
+            }
+
+            Marshal.SetLastPInvokeError(0);
+            Assert.Equal(
+                IntPtr.Zero,
+                NativeMethods.SetClipboardData(NativeMethods.CF_DIB, IntPtr.Zero));
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        return owner;
+    }
+
+    private static HwndSource SeedUnavailableUniqueFormat()
+    {
+        var unavailableFormat = NativeMethods.RegisterClipboardFormat(UnavailableFormat);
+        Assert.NotEqual(0u, unavailableFormat);
+        var owner = new HwndSource(new HwndSourceParameters("TypeWhisper delayed format owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+            SetGlobalData(
+                NativeMethods.CF_UNICODETEXT,
+                Encoding.Unicode.GetBytes("previous\0"));
+            Marshal.SetLastPInvokeError(0);
+            Assert.Equal(
+                IntPtr.Zero,
+                NativeMethods.SetClipboardData(unavailableFormat, IntPtr.Zero));
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        return owner;
     }
 
     private static string? ReadEnterpriseClipboardId()

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -219,6 +219,9 @@ public sealed class WindowsClipboardTransactionTests
                 var originalClipboard = BackupClipboard(transaction);
                 try
                 {
+                    var bitmapAliasFormat = NativeMethods.RegisterClipboardFormat(
+                        "System.Drawing.Bitmap");
+                    Assert.NotEqual(0u, bitmapAliasFormat);
                     var bitmap = System.Windows.Media.Imaging.BitmapSource.Create(
                         1,
                         1,
@@ -233,6 +236,10 @@ public sealed class WindowsClipboardTransactionTests
                     seedData.SetData(DataFormats.UnicodeText, "previous", autoConvert: false);
                     seedData.SetImage(bitmap);
                     Clipboard.SetDataObject(seedData, copy: true);
+                    Assert.Contains(bitmapAliasFormat, EnumerateClipboardFormats());
+                    Assert.Equal(
+                        IntPtr.Zero,
+                        ReadClipboardHandleWithError(bitmapAliasFormat).Handle);
                     releasedFormats.Clear();
 
                     using var lease = transaction.BeginTemporaryTextAsync(
@@ -411,13 +418,19 @@ public sealed class WindowsClipboardTransactionTests
 
     private static IntPtr ReadClipboardHandle(uint format)
     {
+        var result = ReadClipboardHandleWithError(format);
+        Assert.Equal(0, result.Error);
+        return result.Handle;
+    }
+
+    private static (IntPtr Handle, int Error) ReadClipboardHandleWithError(uint format)
+    {
         Assert.True(NativeMethods.OpenClipboard(IntPtr.Zero));
         try
         {
             Marshal.SetLastPInvokeError(0);
             var handle = NativeMethods.GetClipboardData(format);
-            Assert.Equal(0, Marshal.GetLastPInvokeError());
-            return handle;
+            return (handle, Marshal.GetLastPInvokeError());
         }
         finally
         {


### PR DESCRIPTION
## Summary

- tolerate redundant unavailable standard bitmap formats when another restorable bitmap representation was captured
- preserve OLE `System.Drawing.Bitmap` clipboard images without weakening the failure path for unique unavailable formats
- add regressions for delayed `CF_DIB`, the OLE bitmap alias, and unavailable custom formats

This addresses the `Could not materialize clipboard format 8` follow-up reported in #359. It does not attempt to infer whether a target application consumed the queued paste input.

## Validation

- 6 `WindowsClipboardTransactionTests` passed
- 35 focused clipboard and text-insertion tests passed
- full test suites passed: 431 core tests and 1,852 plugin/UI tests
- `dotnet format TypeWhisper.slnx --no-restore --verify-no-changes` passed for the changed files
- live dev smoke restored the original bitmap and all eight original clipboard formats after temporary text insertion
- focused WPF paste smoke inserted the expected text successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard snapshot and restoration for unavailable or delayed clipboard formats.
  * Preserved text and image content when Windows can recreate missing formats from bitmap data.
  * Improved handling of registered bitmap aliases and delayed DIB representations.
  * Clipboard handles are now reliably released when formats cannot be captured.
  * Improved error reporting when clipboard formats cannot be restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->