### PR TITLE
Add v1.0.8 release notes

### DIFF
--- a/docs/releases/v1.0.8.md
+++ b/docs/releases/v1.0.8.md
@@ -1,0 +1,48 @@
+# TypeWhisper v1.0.8
+
+TypeWhisper 1.0.8 is a stable Windows feature and reliability release focused
+on more flexible workflows, safer authenticated provider integrations, and
+stronger state preservation across recording, updates, and clipboard use.
+
+## Highlights
+
+- Added a first-party integration for authenticated provider CLI sessions used
+  by LLM workflow processing, with executable discovery, authentication status,
+  structured input and output, timeouts, cancellation, and process cleanup.
+- Added configurable `App or website` and `App and website` matching for
+  automatic workflow triggers while preserving the behavior of existing
+  combined workflows.
+- Added `\s` support for inserting literal spaces in dictionary replacements,
+  with updated guidance in every supported app language.
+
+## Reliability Improvements
+
+- Preserved explicitly disabled term packs, vocabulary boosting preferences,
+  and pending industry presets across updates, catalog refreshes, licensing,
+  and user-data migration.
+- Fixed recorder overlays so finalizing is no longer shown as an active
+  recording, with more reliable placement across monitors and DPI scales.
+- Improved bitmap clipboard capture and restoration for delayed, unavailable,
+  and OLE bitmap representations during temporary paste operations.
+- Kept missing or unavailable provider selections visible and actionable
+  instead of silently routing workflow processing to another provider.
+
+## Security and Compatibility
+
+- Restricted provider processes to fixed arguments, a controlled environment
+  and working directory, bounded output, disabled tools and project context,
+  and process-tree termination on cancellation or timeout.
+- Kept unsupported provider paths unavailable until equivalent per-invocation
+  safety controls can be verified.
+- Added stable UI Automation identifiers and clearer recorder overlay status
+  descriptions for accessibility and runtime validation.
+
+## Validation Notes
+
+- Verify stable Velopack channels `win-x64` and `win-arm64`.
+- Confirm x64 and ARM64 installers, portable ZIPs, full nupkg packages,
+  RELEASES files, and JSON manifests are present without `-daily` suffixes.
+- Validate both published portable ZIPs and record the Authenticode status of
+  the published installers.
+- Publish Microsoft Store package `1.0.8.0` and WinGet package `1.0.8`
+  separately from the GitHub release.


### PR DESCRIPTION
## Summary

- add curated release notes for TypeWhisper 1.0.8
- cover the six merged changes since 1.0.7 across workflows, authenticated provider integrations, dictionary behavior, term packs, recorder overlays, and clipboard restoration
- document the separate Microsoft Store 1.0.8.0 and WinGet 1.0.8 publication gates

## Release impact

The tag-driven stable workflow will use this file as the GitHub Release description for v1.0.8.

## Validation

- compared the notes against merged PRs #385, #388, #389, #390, #391, and #393
- `git diff --check`
- documentation-only change, so no runtime tests were required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated provider CLI integration.
  - Added configurable workflow matching.
  - Added support for spaces in dictionary entries.
  - Added provider safety controls.
  - Added accessibility identifiers for improved assistive technology support.

- **Bug Fixes**
  - Improved state preservation.
  - Improved recorder and clipboard reliability.
  - Strengthened packaging validation for more dependable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->