### PR TITLE
Added Filler Words plugin (ported from Mac)

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -50,6 +50,7 @@ jobs:
             'linear'             = 'TypeWhisper.Plugin.Linear'
             'obsidian'           = 'TypeWhisper.Plugin.Obsidian'
             'script'             = 'TypeWhisper.Plugin.Script'
+            'filler-words'       = 'TypeWhisper.Plugin.FillerWords'
             'live-transcript'    = 'TypeWhisper.Plugin.LiveTranscript'
             'granite-speech'     = 'TypeWhisper.Plugin.GraniteSpeech'
             'cohere-transcribe'  = 'TypeWhisper.Plugin.CohereTranscribe'

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordFilter.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordFilter.cs
@@ -1,0 +1,136 @@
+using System.Collections.Concurrent;
+
+namespace TypeWhisper.Plugin.FillerWords;
+
+/// <summary>
+/// Removes configured filler words from transcribed text.
+/// Latin-script and Japanese-script words use separate matching rules because
+/// Japanese text has no whitespace word boundaries.
+/// </summary>
+public static class FillerWordFilter
+{
+    private const int MatcherCacheLimit = 8;
+
+    private static readonly ConcurrentDictionary<string, FillerWordMatcher> MatcherCache = new(StringComparer.Ordinal);
+
+    private static readonly char[] WordSeparators = [',', ';'];
+
+    /// <summary>Filler words applied when the user has not customized the list.</summary>
+    public static IReadOnlyList<string> DefaultFillerWords { get; } =
+    [
+        "ah",
+        "ahh",
+        "eh",
+        "ehm",
+        "hm",
+        "hmm",
+        "uh",
+        "uhh",
+        "um",
+        "umm",
+        "äh",
+        "ähm",
+        "えっと",
+        "えーっと",
+        "ええと",
+        "えーと",
+        "えと",
+        "なんか",
+        "まぁ",
+        "まあ",
+        "あのー",
+        "あのぉ",
+        "そのー",
+        "そのぉ",
+        "うーん",
+        "うーむ"
+    ];
+
+    /// <summary>Removes the default filler words from <paramref name="text"/>.</summary>
+    public static string Remove(string text) => Remove(text, DefaultFillerWords);
+
+    /// <summary>Removes the given filler words from <paramref name="text"/>.</summary>
+    public static string Remove(string text, IReadOnlyList<string> words)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        var normalized = NormalizeWords(words);
+        if (normalized.Count == 0)
+            return text;
+
+        return GetMatcher(normalized).Apply(text);
+    }
+
+    /// <summary>
+    /// Splits user-entered text into filler words. Newlines, commas and semicolons
+    /// all separate entries.
+    /// </summary>
+    public static IReadOnlyList<string> NormalizeWords(string text)
+    {
+        var lines = text.Split('\n');
+        var parts = new List<string>(lines.Length);
+        foreach (var line in lines)
+            parts.AddRange(line.Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries));
+
+        return NormalizeWords(parts);
+    }
+
+    /// <summary>
+    /// Trims, lower-cases and de-duplicates the given words, ordering longest first so
+    /// that longer fillers win over words that are a prefix of them.
+    /// </summary>
+    public static IReadOnlyList<string> NormalizeWords(IReadOnlyList<string> words)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var normalized = new List<string>(words.Count);
+
+        foreach (var word in words)
+        {
+            var cleaned = word.Trim().ToLowerInvariant();
+            if (cleaned.Length == 0 || !seen.Add(cleaned))
+                continue;
+
+            normalized.Add(cleaned);
+        }
+
+        normalized.Sort(static (left, right) =>
+            left.Length != right.Length
+                ? right.Length - left.Length
+                : string.CompareOrdinal(left, right));
+
+        return normalized;
+    }
+
+    /// <summary>Returns whether the word contains kana or CJK ideographs.</summary>
+    internal static bool ContainsJapaneseScript(string word)
+    {
+        foreach (var c in word)
+        {
+            int code = c;
+            var isJapanese = code
+                is (>= 0x3040 and <= 0x309F)  // Hiragana
+                or (>= 0x30A0 and <= 0x30FF)  // Katakana
+                or (>= 0x31F0 and <= 0x31FF)  // Katakana phonetic extensions
+                or (>= 0x3400 and <= 0x4DBF)  // CJK unified ideographs extension A
+                or (>= 0x4E00 and <= 0x9FFF); // CJK unified ideographs
+
+            if (isJapanese)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static FillerWordMatcher GetMatcher(IReadOnlyList<string> normalizedWords)
+    {
+        var key = string.Join(' ', normalizedWords);
+        if (MatcherCache.TryGetValue(key, out var cached))
+            return cached;
+
+        if (MatcherCache.Count >= MatcherCacheLimit)
+            MatcherCache.Clear();
+
+        return MatcherCache.GetOrAdd(key, _ => new FillerWordMatcher(normalizedWords));
+    }
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordFilter.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordFilter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 
 namespace TypeWhisper.Plugin.FillerWords;
 
@@ -124,7 +125,7 @@ public static class FillerWordFilter
 
     private static FillerWordMatcher GetMatcher(IReadOnlyList<string> normalizedWords)
     {
-        var key = string.Join(' ', normalizedWords);
+        var key = BuildCacheKey(normalizedWords);
         if (MatcherCache.TryGetValue(key, out var cached))
             return cached;
 
@@ -132,5 +133,19 @@ public static class FillerWordFilter
             MatcherCache.Clear();
 
         return MatcherCache.GetOrAdd(key, _ => new FillerWordMatcher(normalizedWords));
+    }
+
+    /// <summary>
+    /// Builds a cache key that no other word list can produce. Entries carry their own
+    /// length because a filler word may contain spaces, which would make a plain
+    /// separator ambiguous.
+    /// </summary>
+    private static string BuildCacheKey(IReadOnlyList<string> words)
+    {
+        var key = new StringBuilder();
+        foreach (var word in words)
+            key.Append(word.Length).Append(':').Append(word);
+
+        return key.ToString();
     }
 }

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordMatcher.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordMatcher.cs
@@ -4,14 +4,14 @@ namespace TypeWhisper.Plugin.FillerWords;
 
 /// <summary>
 /// Compiled matching rules for one filler word list.
+/// A match spans the filler word together with the punctuation and horizontal
+/// whitespace attached to it, so each replacement repairs its own spacing and
+/// whitespace elsewhere in the text is left untouched.
 /// </summary>
 internal sealed class FillerWordMatcher
 {
-    private static readonly Regex CollapsedSpacesPattern = new(@"(?<=[^\s]) {2,}(?=[^\s])", RegexOptions.Compiled);
-    private static readonly Regex LeadingSpacesPattern = new(@"^ +", RegexOptions.Compiled | RegexOptions.Multiline);
-    private static readonly Regex TrailingSpacesPattern = new(@" +$", RegexOptions.Compiled);
-
-    private static readonly char[] HorizontalWhitespace = [' ', '\t'];
+    /// <summary>Punctuation that a spoken filler can carry, including the Unicode ellipsis.</summary>
+    private const string AttachedPunctuation = @"[,.!?…]";
 
     private readonly Regex? _latin;
     private readonly Regex? _japanese;
@@ -28,14 +28,24 @@ internal sealed class FillerWordMatcher
     /// <summary>Strips the matcher's filler words from <paramref name="text"/>.</summary>
     internal string Apply(string text)
     {
-        var result = ReplaceAndNormalize(text, _latin, " ");
-        return ReplaceAndNormalize(result, _japanese, "$1");
+        var result = _latin is null ? text : _latin.Replace(text, match => LatinReplacement(match, text));
+
+        return _japanese is null ? result : _japanese.Replace(result, match => JapaneseReplacement(match, result));
     }
 
     private static Regex BuildLatinPattern(IReadOnlyList<string> words)
     {
         var alternation = string.Join('|', words.Select(Regex.Escape));
-        var pattern = @"(?<![\p{L}\p{N}_])[,.!?]?[ \t]*(?:" + alternation + @")(?![\p{L}\p{N}_])[ \t]*[,.!?]?";
+
+        // Leading punctuation is only taken as a whole run that is not itself attached to
+        // surrounding text, so an ellipsis before the filler is never left half-eaten.
+        var pattern =
+            @"(?<lead>[ \t]*)" +
+            @"(?:(?<![\p{L}\p{N}_,.!?…])" + AttachedPunctuation + @"+)?" +
+            @"(?<gap>[ \t]*)" +
+            @"(?<![\p{L}\p{N}_])(?:" + alternation + @")(?![\p{L}\p{N}_])" +
+            AttachedPunctuation + @"*" +
+            @"(?<trail>[ \t]*)";
 
         return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
     }
@@ -57,36 +67,49 @@ internal sealed class FillerWordMatcher
         return new Regex(pattern, RegexOptions.Compiled);
     }
 
-    private static string ReplaceAndNormalize(string text, Regex? pattern, string replacement)
+    /// <summary>
+    /// Rebuilds the separator for one removed Latin filler from the whitespace the match
+    /// consumed, so surrounding indentation and spacing survive untouched.
+    /// </summary>
+    private static string LatinReplacement(Match match, string input)
     {
-        if (pattern is null)
-            return text;
+        var lead = match.Groups["lead"].Value;
 
-        var stripped = pattern.Replace(text, replacement);
-        return string.Equals(stripped, text, StringComparison.Ordinal)
-            ? text
-            : NormalizeWhitespace(stripped, text);
+        // Nothing follows on this line, so the filler's whitespace goes with it.
+        if (!HasTextAfter(match, input))
+            return string.Empty;
+
+        // The filler opened the line: keep only whitespace that was already there.
+        if (!HasTextBefore(match, input))
+            return lead;
+
+        if (lead.Length > 0)
+            return lead;
+
+        var gap = match.Groups["gap"].Value;
+        return gap.Length > 0 ? gap : match.Groups["trail"].Value;
     }
 
-    private static string NormalizeWhitespace(string text, string original)
+    /// <summary>
+    /// Restores the boundary character the Japanese pattern matched before the filler,
+    /// dropping it when it is trailing whitespace with nothing left to separate.
+    /// </summary>
+    private static string JapaneseReplacement(Match match, string input)
     {
-        var result = CollapsedSpacesPattern.Replace(text, " ");
-        result = LeadingSpacesPattern.Replace(result, string.Empty);
-        result = TrailingSpacesPattern.Replace(result, string.Empty);
-        result = result.Trim(HorizontalWhitespace);
+        var boundary = match.Groups[1].Value;
 
-        // Leading spaces in the input separate this text from whatever the host has
-        // already typed, so restore them once the removal artifacts are gone.
-        var prefix = LeadingHorizontalWhitespace(original);
-        return prefix.Length == 0 || result.Length == 0 ? result : prefix + result;
+        return boundary is " " or "\t" && !HasTextAfter(match, input) ? string.Empty : boundary;
     }
 
-    private static string LeadingHorizontalWhitespace(string text)
-    {
-        var length = 0;
-        while (length < text.Length && (text[length] == ' ' || text[length] == '\t'))
-            length++;
+    private static bool HasTextBefore(Match match, string input) =>
+        match.Index > 0 && !IsLineBreak(input[match.Index - 1]);
 
-        return text[..length];
+    private static bool HasTextAfter(Match match, string input)
+    {
+        var end = match.Index + match.Length;
+
+        return end < input.Length && !IsLineBreak(input[end]);
     }
+
+    private static bool IsLineBreak(char c) => c is '\n' or '\r';
 }

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordMatcher.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordMatcher.cs
@@ -1,0 +1,92 @@
+using System.Text.RegularExpressions;
+
+namespace TypeWhisper.Plugin.FillerWords;
+
+/// <summary>
+/// Compiled matching rules for one filler word list.
+/// </summary>
+internal sealed class FillerWordMatcher
+{
+    private static readonly Regex CollapsedSpacesPattern = new(@"(?<=[^\s]) {2,}(?=[^\s])", RegexOptions.Compiled);
+    private static readonly Regex LeadingSpacesPattern = new(@"^ +", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static readonly Regex TrailingSpacesPattern = new(@" +$", RegexOptions.Compiled);
+
+    private static readonly char[] HorizontalWhitespace = [' ', '\t'];
+
+    private readonly Regex? _latin;
+    private readonly Regex? _japanese;
+
+    internal FillerWordMatcher(IReadOnlyList<string> normalizedWords)
+    {
+        var latinWords = normalizedWords.Where(static word => !FillerWordFilter.ContainsJapaneseScript(word)).ToList();
+        var japaneseWords = normalizedWords.Where(FillerWordFilter.ContainsJapaneseScript).ToList();
+
+        _latin = latinWords.Count == 0 ? null : BuildLatinPattern(latinWords);
+        _japanese = japaneseWords.Count == 0 ? null : BuildJapanesePattern(japaneseWords);
+    }
+
+    /// <summary>Strips the matcher's filler words from <paramref name="text"/>.</summary>
+    internal string Apply(string text)
+    {
+        var result = ReplaceAndNormalize(text, _latin, " ");
+        return ReplaceAndNormalize(result, _japanese, "$1");
+    }
+
+    private static Regex BuildLatinPattern(IReadOnlyList<string> words)
+    {
+        var alternation = string.Join('|', words.Select(Regex.Escape));
+        var pattern = @"(?<![\p{L}\p{N}_])[,.!?]?[ \t]*(?:" + alternation + @")(?![\p{L}\p{N}_])[ \t]*[,.!?]?";
+
+        return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    }
+
+    private static Regex BuildJapanesePattern(IReadOnlyList<string> words)
+    {
+        var alternation = string.Join('|', words.Select(static word =>
+        {
+            var escaped = Regex.Escape(word);
+
+            // "まあ"/"まぁ" must not swallow the leading half of a longer drawl such as "まあまあ".
+            return word is "まあ" or "まぁ" ? escaped + @"(?!ま[あぁ])" : escaped;
+        }));
+
+        const string Boundary = @"(^|[\s、。,.!?！？])";
+        const string TrailingSeparator = @"(?:[ \t]*[、,][ \t]*|[ \t]+)?";
+        var pattern = Boundary + @"[ \t]*(?:" + alternation + ")" + TrailingSeparator;
+
+        return new Regex(pattern, RegexOptions.Compiled);
+    }
+
+    private static string ReplaceAndNormalize(string text, Regex? pattern, string replacement)
+    {
+        if (pattern is null)
+            return text;
+
+        var stripped = pattern.Replace(text, replacement);
+        return string.Equals(stripped, text, StringComparison.Ordinal)
+            ? text
+            : NormalizeWhitespace(stripped, text);
+    }
+
+    private static string NormalizeWhitespace(string text, string original)
+    {
+        var result = CollapsedSpacesPattern.Replace(text, " ");
+        result = LeadingSpacesPattern.Replace(result, string.Empty);
+        result = TrailingSpacesPattern.Replace(result, string.Empty);
+        result = result.Trim(HorizontalWhitespace);
+
+        // Leading spaces in the input separate this text from whatever the host has
+        // already typed, so restore them once the removal artifacts are gone.
+        var prefix = LeadingHorizontalWhitespace(original);
+        return prefix.Length == 0 || result.Length == 0 ? result : prefix + result;
+    }
+
+    private static string LeadingHorizontalWhitespace(string text)
+    {
+        var length = 0;
+        while (length < text.Length && (text[length] == ' ' || text[length] == '\t'))
+            length++;
+
+        return text[..length];
+    }
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsPlugin.cs
@@ -1,0 +1,64 @@
+using System.Windows.Controls;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.FillerWords;
+
+/// <summary>
+/// Removes filler words such as "um" and "uh" from transcribed text.
+/// </summary>
+public sealed class FillerWordsPlugin : IPostProcessorPlugin
+{
+    private IPluginHostServices? _host;
+
+    /// <summary>Gets the stable plugin identifier used by the host.</summary>
+    public string PluginId => "com.typewhisper.filler-words";
+
+    /// <summary>Gets the plugin display name shown by the host.</summary>
+    public string PluginName => "Filler Words";
+
+    /// <summary>Gets the plugin version reported to the host.</summary>
+    public string PluginVersion => "1.0.0";
+
+    /// <summary>Gets the processor name shown in the post-processing pipeline.</summary>
+    public string ProcessorName => "Filler Words";
+
+    /// <summary>Gets the post-processing priority. Lower values run first.</summary>
+    public int Priority => 250;
+
+    /// <summary>Gets the settings store, or null when the plugin is not activated.</summary>
+    public FillerWordsSettingsStore? Settings { get; private set; }
+
+    internal IPluginLocalization? Loc => _host?.Localization;
+
+    /// <summary>Activates the plugin and loads the configured filler word list.</summary>
+    public Task ActivateAsync(IPluginHostServices host)
+    {
+        _host = host;
+        Settings = new FillerWordsSettingsStore(host);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Deactivates the plugin.</summary>
+    public Task DeactivateAsync()
+    {
+        Settings = null;
+        _host = null;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Creates the settings view shown by the host.</summary>
+    public UserControl? CreateSettingsView() =>
+        Settings is null ? null : new FillerWordsSettingsView(this, Settings);
+
+    /// <summary>Removes the configured filler words from the transcription.</summary>
+    public Task<string> ProcessAsync(string text, PostProcessingContext context, CancellationToken ct) =>
+        Task.FromResult(FillerWordFilter.Remove(text, Settings?.Words ?? FillerWordFilter.DefaultFillerWords));
+
+    /// <summary>Releases plugin resources.</summary>
+    public void Dispose()
+    {
+        Settings = null;
+        _host = null;
+    }
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsStore.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsStore.cs
@@ -1,0 +1,56 @@
+using TypeWhisper.PluginSDK;
+
+namespace TypeWhisper.Plugin.FillerWords;
+
+/// <summary>
+/// Holds the user-configured filler word list and persists it through the host.
+/// </summary>
+public sealed class FillerWordsSettingsStore
+{
+    private const string WordsKey = "words";
+
+    private readonly IPluginHostServices _host;
+    private string _wordsText;
+
+    internal FillerWordsSettingsStore(IPluginHostServices host)
+    {
+        _host = host;
+
+        var stored = host.GetSetting<string>(WordsKey);
+        if (stored is null)
+        {
+            _wordsText = DefaultWordsText;
+            host.SetSetting(WordsKey, _wordsText);
+        }
+        else
+        {
+            _wordsText = stored;
+        }
+    }
+
+    /// <summary>Gets or sets the raw filler word list as entered by the user.</summary>
+    public string WordsText
+    {
+        get => _wordsText;
+        set
+        {
+            if (string.Equals(_wordsText, value, StringComparison.Ordinal))
+                return;
+
+            _wordsText = value;
+            _host.SetSetting(WordsKey, value);
+        }
+    }
+
+    /// <summary>Gets the normalized filler words parsed from <see cref="WordsText"/>.</summary>
+    public IReadOnlyList<string> Words => FillerWordFilter.NormalizeWords(_wordsText);
+
+    /// <summary>Gets the number of distinct filler words currently configured.</summary>
+    public int WordCount => Words.Count;
+
+    /// <summary>Restores the built-in filler word list.</summary>
+    public void ResetToDefaults() => WordsText = DefaultWordsText;
+
+    /// <summary>Gets the built-in filler word list as newline-separated text.</summary>
+    public static string DefaultWordsText { get; } = string.Join(Environment.NewLine, FillerWordFilter.DefaultFillerWords);
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsView.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="TypeWhisper.Plugin.FillerWords.FillerWordsSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             MinWidth="360">
+    <StackPanel Margin="0,4">
+        <TextBlock x:Name="TitleText" FontWeight="SemiBold" Margin="0,0,0,4" />
+        <TextBlock x:Name="HintText"
+                   FontSize="12"
+                   Opacity="0.7"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,8" />
+
+        <TextBox x:Name="WordsBox"
+                 MinHeight="150"
+                 MaxHeight="260"
+                 AcceptsReturn="True"
+                 AcceptsTab="False"
+                 FontFamily="Consolas"
+                 HorizontalScrollBarVisibility="Auto"
+                 VerticalScrollBarVisibility="Auto"
+                 TextWrapping="NoWrap"
+                 TextChanged="OnWordsChanged" />
+
+        <Grid Margin="0,8,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Name="CountText"
+                       VerticalAlignment="Center"
+                       FontSize="12"
+                       Opacity="0.7" />
+            <Button x:Name="ResetButton"
+                    Grid.Column="1"
+                    Padding="12,4"
+                    Click="OnResetClick" />
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsView.xaml.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace TypeWhisper.Plugin.FillerWords;
+
+/// <summary>
+/// Settings view for the Filler Words plugin. Edits the filler word list.
+/// </summary>
+public partial class FillerWordsSettingsView : UserControl
+{
+    private readonly FillerWordsPlugin _plugin;
+    private readonly FillerWordsSettingsStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the FillerWordsSettingsView class.
+    /// </summary>
+    public FillerWordsSettingsView(FillerWordsPlugin plugin, FillerWordsSettingsStore store)
+    {
+        _plugin = plugin;
+        _store = store;
+        InitializeComponent();
+
+        TitleText.Text = L("Settings.Title");
+        HintText.Text = L("Settings.Hint");
+        ResetButton.Content = L("Settings.ResetDefaults");
+
+        WordsBox.Text = store.WordsText;
+        UpdateCount();
+    }
+
+    private void OnWordsChanged(object sender, TextChangedEventArgs e)
+    {
+        _store.WordsText = WordsBox.Text;
+        UpdateCount();
+    }
+
+    private void OnResetClick(object sender, RoutedEventArgs e)
+    {
+        _store.ResetToDefaults();
+        WordsBox.Text = _store.WordsText;
+    }
+
+    private void UpdateCount() => CountText.Text = L("Settings.WordCount", _store.WordCount);
+
+    private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
+    private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/FillerWordsSettingsView.xaml.cs
@@ -40,7 +40,11 @@ public partial class FillerWordsSettingsView : UserControl
         WordsBox.Text = _store.WordsText;
     }
 
-    private void UpdateCount() => CountText.Text = L("Settings.WordCount", _store.WordCount);
+    private void UpdateCount()
+    {
+        var count = _store.WordCount;
+        CountText.Text = count == 1 ? L("Settings.WordCountOne") : L("Settings.WordCount", count);
+    }
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
     private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;

--- a/plugins/TypeWhisper.Plugin.FillerWords/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Localization/de.json
@@ -1,0 +1,6 @@
+{
+  "Settings.Title": "Füllwörter",
+  "Settings.Hint": "Ein Wort pro Zeile. Kommas und Semikolons sind ebenfalls erlaubt.",
+  "Settings.WordCount": "{0} Wörter",
+  "Settings.ResetDefaults": "Standard wiederherstellen"
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Localization/de.json
@@ -2,5 +2,6 @@
   "Settings.Title": "Füllwörter",
   "Settings.Hint": "Ein Wort pro Zeile. Kommas und Semikolons sind ebenfalls erlaubt.",
   "Settings.WordCount": "{0} Wörter",
+  "Settings.WordCountOne": "1 Wort",
   "Settings.ResetDefaults": "Standard wiederherstellen"
 }

--- a/plugins/TypeWhisper.Plugin.FillerWords/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Localization/en.json
@@ -1,0 +1,6 @@
+{
+  "Settings.Title": "Filler words",
+  "Settings.Hint": "One word per line. Commas and semicolons are also accepted.",
+  "Settings.WordCount": "{0} words",
+  "Settings.ResetDefaults": "Reset Defaults"
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Localization/en.json
@@ -2,5 +2,6 @@
   "Settings.Title": "Filler words",
   "Settings.Hint": "One word per line. Commas and semicolons are also accepted.",
   "Settings.WordCount": "{0} words",
+  "Settings.WordCountOne": "1 word",
   "Settings.ResetDefaults": "Reset Defaults"
 }

--- a/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordFilterTests.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordFilterTests.cs
@@ -1,0 +1,106 @@
+namespace TypeWhisper.Plugin.FillerWords.Tests;
+
+public sealed class FillerWordFilterTests
+{
+    [Theory]
+    [InlineData("So um I think uh this works", "So I think this works")]
+    [InlineData("Well, um, that's it.", "Well, that's it.")]
+    [InlineData("Um, hello", "hello")]
+    [InlineData("hmm let me check", "let me check")]
+    [InlineData("Das ist ähm nicht gut", "Das ist nicht gut")]
+    public void Remove_StripsLatinFillerWords(string input, string expected) =>
+        Assert.Equal(expected, FillerWordFilter.Remove(input));
+
+    [Theory]
+    [InlineData("The umbrella is uhh open", "The umbrella is open")]
+    [InlineData("A hum in the room", "A hum in the room")]
+    [InlineData("Rahm and Graham", "Rahm and Graham")]
+    public void Remove_KeepsWordsThatMerelyContainAFiller(string input, string expected) =>
+        Assert.Equal(expected, FillerWordFilter.Remove(input));
+
+    [Fact]
+    public void Remove_ReturnsInputUnchanged_WhenNothingMatches() =>
+        Assert.Equal("A clean sentence.", FillerWordFilter.Remove("A clean sentence."));
+
+    [Fact]
+    public void Remove_ReturnsInputUnchanged_WhenWordListIsEmpty() =>
+        Assert.Equal("So um I think", FillerWordFilter.Remove("So um I think", []));
+
+    [Fact]
+    public void Remove_ReturnsInputUnchanged_WhenTextIsEmpty() =>
+        Assert.Equal(string.Empty, FillerWordFilter.Remove(string.Empty));
+
+    [Theory]
+    [InlineData(" um hello", " hello")]
+    [InlineData("  um hello", "  hello")]
+    [InlineData("\tum hello", "\thello")]
+    [InlineData(" hello um there", " hello there")]
+    public void Remove_PreservesLeadingWhitespaceFromTheOriginal(string input, string expected) =>
+        Assert.Equal(expected, FillerWordFilter.Remove(input));
+
+    [Fact]
+    public void Remove_DropsLeadingWhitespace_WhenEverythingElseWasFiller() =>
+        Assert.Equal(string.Empty, FillerWordFilter.Remove(" um "));
+
+    [Fact]
+    public void Remove_StripsLeadingWhitespaceIntroducedByRemoval() =>
+        Assert.Equal("hello", FillerWordFilter.Remove("um hello"));
+
+    [Fact]
+    public void Remove_StripsLineLeadingWhitespaceIntroducedByRemoval() =>
+        Assert.Equal("hello\nthere", FillerWordFilter.Remove("hello\num there"));
+
+    [Fact]
+    public void Remove_PreservesLineStructure() =>
+        Assert.Equal("first line\nsecond line", FillerWordFilter.Remove("first um line\nsecond uh line"));
+
+    [Fact]
+    public void Remove_StripsJapaneseFillerWordsWithTheirTrailingComma() =>
+        Assert.Equal("これはテストです。", FillerWordFilter.Remove("えっと、これはテストです。"));
+
+    [Fact]
+    public void Remove_StripsJapaneseFillerWordsMidSentence() =>
+        Assert.Equal("それは、いいですね", FillerWordFilter.Remove("それは、なんかいいですね"));
+
+    [Fact]
+    public void Remove_KeepsRepeatedMaaDrawl() =>
+        Assert.Equal("まあまあいいです", FillerWordFilter.Remove("まあまあいいです"));
+
+    [Fact]
+    public void Remove_HandlesMixedScripts() =>
+        Assert.Equal("So これはテストです。", FillerWordFilter.Remove("So um えっと、これはテストです。"));
+
+    [Fact]
+    public void NormalizeWords_SplitsOnNewlinesCommasAndSemicolons()
+    {
+        var words = FillerWordFilter.NormalizeWords("um, uh;\r\nlike\n");
+
+        Assert.Equal(["like", "uh", "um"], words);
+    }
+
+    [Fact]
+    public void NormalizeWords_LowerCasesTrimsAndDeduplicates()
+    {
+        var words = FillerWordFilter.NormalizeWords("  Um \n um\nUH");
+
+        Assert.Equal(["uh", "um"], words);
+    }
+
+    [Fact]
+    public void NormalizeWords_OrdersLongestFirst()
+    {
+        var words = FillerWordFilter.NormalizeWords("um\nummm\numm");
+
+        Assert.Equal(["ummm", "umm", "um"], words);
+    }
+
+    [Fact]
+    public void Remove_PrefersTheLongestMatchingFiller() =>
+        Assert.Equal("well then", FillerWordFilter.Remove("well umm then", ["um", "umm"]));
+
+    [Fact]
+    public void DefaultFillerWords_AreAllNormalized() =>
+        Assert.Equal(
+            FillerWordFilter.DefaultFillerWords.Count,
+            FillerWordFilter.NormalizeWords(FillerWordFilter.DefaultFillerWords).Count);
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordFilterTests.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordFilterTests.cs
@@ -121,6 +121,17 @@ public sealed class FillerWordFilterTests
     }
 
     [Fact]
+    public void Remove_DoesNotReuseAMatcherBuiltForADifferentWordList()
+    {
+        // Both lists hold the same words separated differently, so a cache key that
+        // simply joins the entries cannot tell them apart.
+        const string Input = "you um actually";
+
+        Assert.Equal("you actually", FillerWordFilter.Remove(Input, ["actually you", "um"]));
+        Assert.Equal(string.Empty, FillerWordFilter.Remove(Input, ["actually", "you um"]));
+    }
+
+    [Fact]
     public void Remove_PrefersTheLongestMatchingFiller() =>
         Assert.Equal("well then", FillerWordFilter.Remove("well umm then", ["um", "umm"]));
 

--- a/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordFilterTests.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordFilterTests.cs
@@ -38,6 +38,32 @@ public sealed class FillerWordFilterTests
     public void Remove_PreservesLeadingWhitespaceFromTheOriginal(string input, string expected) =>
         Assert.Equal(expected, FillerWordFilter.Remove(input));
 
+    [Theory]
+    [InlineData("um Intro\n  code  block", "Intro\n  code  block")]
+    [InlineData("Intro  spaced um text", "Intro  spaced text")]
+    [InlineData("hello\n  um there", "hello\n  there")]
+    [InlineData("hello um\nworld", "hello\nworld")]
+    [InlineData("  indented um line", "  indented line")]
+    public void Remove_LeavesWhitespaceOutsideTheMatchUntouched(string input, string expected) =>
+        Assert.Equal(expected, FillerWordFilter.Remove(input));
+
+    [Theory]
+    [InlineData("Um... hello", "hello")]
+    [InlineData("Um… hello", "hello")]
+    [InlineData("I said um... then", "I said then")]
+    [InlineData("I said um…, then", "I said then")]
+    [InlineData("Right?! um yes", "Right?! yes")]
+    public void Remove_ConsumesPunctuationAttachedToTheFiller(string input, string expected) =>
+        Assert.Equal(expected, FillerWordFilter.Remove(input));
+
+    [Theory]
+    [InlineData("Wait... um, no", "Wait... no")]
+    [InlineData("Wait… um, no", "Wait… no")]
+    [InlineData("Well!!! um okay", "Well!!! okay")]
+    [InlineData("Done. um Next.", "Done. Next.")]
+    public void Remove_KeepsPunctuationBelongingToSurroundingText(string input, string expected) =>
+        Assert.Equal(expected, FillerWordFilter.Remove(input));
+
     [Fact]
     public void Remove_DropsLeadingWhitespace_WhenEverythingElseWasFiller() =>
         Assert.Equal(string.Empty, FillerWordFilter.Remove(" um "));

--- a/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsLocalizationTests.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsLocalizationTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace TypeWhisper.Plugin.FillerWords.Tests;
+
+public sealed class FillerWordsLocalizationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Theory]
+    [InlineData("de")]
+    public void Localization_HasSameKeysAndFormatPlaceholdersAsEnglish(string language)
+    {
+        var english = LoadLocalization("en");
+        var localized = LoadLocalization(language);
+
+        Assert.Equal(english.Keys.OrderBy(key => key, StringComparer.Ordinal),
+            localized.Keys.OrderBy(key => key, StringComparer.Ordinal));
+
+        foreach (var key in english.Keys)
+        {
+            Assert.False(
+                string.IsNullOrWhiteSpace(localized[key]),
+                $"{language} value for {key} must not be empty.");
+            Assert.Equal(FormatPlaceholders(english[key]), FormatPlaceholders(localized[key]));
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("de")]
+    public void Localization_HasASingularWordCountWithoutAPlaceholder(string language)
+    {
+        var localization = LoadLocalization(language);
+
+        Assert.True(localization.ContainsKey("Settings.WordCountOne"));
+        Assert.Empty(FormatPlaceholders(localization["Settings.WordCountOne"]));
+        Assert.Contains("{0}", localization["Settings.WordCount"]);
+    }
+
+    private static Dictionary<string, string> LoadLocalization(string language)
+    {
+        var path = Path.GetFullPath(Path.Join(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.FillerWords", "Localization", $"{language}.json"));
+
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(path), JsonOptions)
+            ?? throw new InvalidOperationException($"Could not load {path}.");
+    }
+
+    private static IEnumerable<string> FormatPlaceholders(string value) =>
+        Regex.Matches(value, @"\{\d+\}").Select(match => match.Value).OrderBy(match => match, StringComparer.Ordinal);
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsPluginTests.cs
@@ -1,0 +1,180 @@
+using System.IO;
+using System.Text.Json;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.FillerWords.Tests;
+
+public sealed class FillerWordsPluginTests
+{
+    private static readonly PostProcessingContext Context = new();
+
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var manifestPath = Path.GetFullPath(Path.Join(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.FillerWords", "manifest.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var sut = new FillerWordsPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
+    public void PluginId_IsExpectedValue() =>
+        Assert.Equal("com.typewhisper.filler-words", new FillerWordsPlugin().PluginId);
+
+    [Fact]
+    public void Priority_IsExpectedValue() =>
+        Assert.Equal(250, new FillerWordsPlugin().Priority);
+
+    [Fact]
+    public async Task ProcessAsync_RemovesDefaultFillerWords()
+    {
+        var sut = new FillerWordsPlugin();
+        await sut.ActivateAsync(new TestPluginHostServices());
+
+        var result = await sut.ProcessAsync("So um I think uh this works", Context, CancellationToken.None);
+
+        Assert.Equal("So I think this works", result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesConfiguredWords()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new FillerWordsPlugin();
+        await sut.ActivateAsync(host);
+        sut.Settings!.WordsText = "basically";
+
+        var result = await sut.ProcessAsync("It is basically fine, um yes", Context, CancellationToken.None);
+
+        Assert.Equal("It is fine, um yes", result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ReturnsTextUnchanged_WhenListIsEmpty()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new FillerWordsPlugin();
+        await sut.ActivateAsync(host);
+        sut.Settings!.WordsText = "   ";
+
+        var result = await sut.ProcessAsync("So um I think", Context, CancellationToken.None);
+
+        Assert.Equal("So um I think", result);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_SeedsDefaultWords()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new FillerWordsPlugin();
+
+        await sut.ActivateAsync(host);
+
+        Assert.Equal(FillerWordsSettingsStore.DefaultWordsText, host.GetSetting<string>("words"));
+    }
+
+    [Fact]
+    public async Task WordsText_PersistsToHostSettings()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new FillerWordsPlugin();
+        await sut.ActivateAsync(host);
+
+        sut.Settings!.WordsText = "meh\nwelp";
+
+        Assert.Equal("meh\nwelp", host.GetSetting<string>("words"));
+        Assert.Equal(2, sut.Settings.WordCount);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_KeepsStoredWords()
+    {
+        var host = new TestPluginHostServices();
+        host.SetSetting("words", "welp");
+        var sut = new FillerWordsPlugin();
+
+        await sut.ActivateAsync(host);
+
+        Assert.Equal("welp", sut.Settings!.WordsText);
+    }
+
+    [Fact]
+    public async Task ResetToDefaults_RestoresBuiltInList()
+    {
+        var host = new TestPluginHostServices();
+        var sut = new FillerWordsPlugin();
+        await sut.ActivateAsync(host);
+        sut.Settings!.WordsText = "welp";
+
+        sut.Settings.ResetToDefaults();
+
+        Assert.Equal(FillerWordsSettingsStore.DefaultWordsText, sut.Settings.WordsText);
+        Assert.Equal(FillerWordFilter.DefaultFillerWords.Count, sut.Settings.WordCount);
+    }
+
+    [Fact]
+    public async Task DeactivateAsync_ClearsSettings()
+    {
+        var sut = new FillerWordsPlugin();
+        await sut.ActivateAsync(new TestPluginHostServices());
+
+        await sut.DeactivateAsync();
+
+        Assert.Null(sut.Settings);
+        Assert.Null(sut.CreateSettingsView());
+    }
+
+    private sealed class TestPluginHostServices : IPluginHostServices
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+        private readonly Dictionary<string, JsonElement> _settings = [];
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value) ? value.Deserialize<T>(JsonOptions) : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new NoOpEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() { }
+        public IPluginLocalization Localization { get; } = new NoOpLocalization();
+
+        public Task StoreSecretAsync(string key, string value) => Task.CompletedTask;
+        public Task<string?> LoadSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+    }
+
+    private sealed class NoOpEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent => new NoOpSubscription();
+
+        private sealed class NoOpSubscription : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+
+    private sealed class NoOpLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+}

--- a/plugins/TypeWhisper.Plugin.FillerWords/TypeWhisper.Plugin.FillerWords.csproj
+++ b/plugins/TypeWhisper.Plugin.FillerWords/TypeWhisper.Plugin.FillerWords.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>TypeWhisper.Plugin.FillerWords</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Tests\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Localization\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Target Name="CopyToAppPlugins" AfterTargets="Build">
+    <PropertyGroup>
+      <AppOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\src\TypeWhisper.Windows\bin\$(Configuration)\$(TargetFramework)'))</AppOutputDir>
+      <PluginOutputDir>$(AppOutputDir)\Plugins\com.typewhisper.filler-words\</PluginOutputDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginOutputDir)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).deps.json" DestinationFolder="$(PluginOutputDir)" Condition="Exists('$(TargetDir)$(TargetName).deps.json')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
+    <ItemGroup>
+      <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+    </ItemGroup>
+    <MakeDir Directories="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
+  </Target>
+</Project>

--- a/plugins/TypeWhisper.Plugin.FillerWords/manifest.json
+++ b/plugins/TypeWhisper.Plugin.FillerWords/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "com.typewhisper.filler-words",
+  "name": "Filler Words",
+  "version": "1.0.0",
+  "minHostVersion": "1.0.0",
+  "author": "TypeWhisper",
+  "description": "Removes filler words like \"um\" and \"uh\" from transcribed text",
+  "descriptions": {
+    "de": "Entfernt Füllwörter wie „ähm“ und „äh“ aus transkribiertem Text."
+  },
+  "category": "post-processor",
+  "isLocal": true,
+  "iconSystemName": "text.badge.minus",
+  "assemblyName": "TypeWhisper.Plugin.FillerWords.dll",
+  "pluginClass": "TypeWhisper.Plugin.FillerWords.FillerWordsPlugin"
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\..\plugins\TypeWhisper.Plugin.OpenRouter\Tests\*.cs" LinkBase="OpenRouter" />
     <Compile Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\Tests\*.cs" LinkBase="LiveTranscript" />
     <Compile Include="..\..\plugins\TypeWhisper.Plugin.SmallestAi\Tests\*.cs" LinkBase="SmallestAi" />
+    <Compile Include="..\..\plugins\TypeWhisper.Plugin.FillerWords\Tests\*.cs" LinkBase="FillerWords" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,6 +43,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.LiveTranscript\TypeWhisper.Plugin.LiveTranscript.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Script\TypeWhisper.Plugin.Script.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.SmallestAi\TypeWhisper.Plugin.SmallestAi.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.FillerWords\TypeWhisper.Plugin.FillerWords.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Cli\TypeWhisper.Cli.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
     <ProjectReference Include="..\..\src\TypeWhisper.Windows\TypeWhisper.Windows.csproj" />


### PR DESCRIPTION
## Summary

Added Filler Words plugin (ported from Mac)

## Test Plan

- [x] `dotnet test`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

## Notes

Works great and is a much needed plugin!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Filler Words plugin that removes configurable filler words from transcribed text.
  - Supports Latin and Japanese filler words, custom word lists, and punctuation-aware matching.
  - Added settings to edit, count, and restore default filler words.
  - Added English and German localization for the settings interface.
  - Added plugin packaging and publishing support.

- **Tests**
  - Added comprehensive coverage for filtering, multilingual text, normalization, settings persistence, localization, and plugin lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->