### PR TITLE
Bring the running app to the foreground on relaunch

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Windows;
+using System.Windows.Interop;
 using System.Windows.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Win32;
@@ -9,6 +10,7 @@ using TypeWhisper.Core.Models;
 using TypeWhisper.Core.Services;
 using TypeWhisper.Core.Services.SpokenFormatting;
 using TypeWhisper.Core.Services.Sync;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
@@ -31,6 +33,9 @@ public partial class App : Application
     private FileTranscriptionWindow? _fileTranscriptionWindow;
     private WelcomeWindow? _welcomeWindow;
     private DispatcherTimer? _protocolCallbackTimer;
+    private RegisteredWaitHandle? _singleInstanceActivationRegistration;
+    private bool _startupPresentationReady;
+    private bool _pendingSingleInstanceActivation;
     private static readonly string ProtocolCallbackInboxPath = Path.Combine(TypeWhisperEnvironment.DataPath, "protocol-callback.txt");
 
     /// <summary>
@@ -149,6 +154,7 @@ public partial class App : Application
 
         var mainWindow = _serviceProvider.GetRequiredService<MainWindow>();
         mainWindow.Show();
+        StartSingleInstanceActivationListener();
         await Dispatcher.Yield(DispatcherPriority.ContextIdle);
 
         // Apply staged plugin updates before plugin assemblies are loaded.
@@ -252,6 +258,13 @@ public partial class App : Application
                     ShowSettingsWindow(route, focusPluginId: completionRequest.PluginIdToConfigure);
             };
             _welcomeWindow.Show();
+        }
+
+        _startupPresentationReady = true;
+        if (_pendingSingleInstanceActivation)
+        {
+            _pendingSingleInstanceActivation = false;
+            ActivatePrimaryInstance();
         }
 
         // Migrate old local model IDs to plugin-prefixed format
@@ -409,6 +422,43 @@ public partial class App : Application
         ShowSettingsWindow(SettingsRoute.License);
     }
 
+    private void StartSingleInstanceActivationListener()
+    {
+        _singleInstanceActivationRegistration = Program.ListenForActivationRequests(() =>
+        {
+            if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+                return;
+
+            _ = Dispatcher.BeginInvoke(() =>
+            {
+                if (!_startupPresentationReady)
+                {
+                    _pendingSingleInstanceActivation = true;
+                    return;
+                }
+
+                ActivatePrimaryInstance();
+            });
+        });
+    }
+
+    private void ActivatePrimaryInstance()
+    {
+        if (_welcomeWindow is { IsLoaded: true })
+        {
+            RestoreAndActivateWindow(_welcomeWindow);
+            return;
+        }
+
+        if (_settingsWindow is { IsLoaded: true })
+        {
+            RestoreAndActivateWindow(_settingsWindow);
+            return;
+        }
+
+        ShowSettingsWindow(SettingsRoute.Dashboard);
+    }
+
     internal void ShowSettingsWindow(
         SettingsRoute? route = null,
         bool presentFileImporter = false,
@@ -424,7 +474,7 @@ public partial class App : Application
         {
             if (_settingsWindow.DataContext is SettingsWindowViewModel existingViewModel)
                 ApplySettingsWindowRequest(existingViewModel, route, presentFileImporter, focusPluginId);
-            _settingsWindow.Activate();
+            RestoreAndActivateWindow(_settingsWindow);
             return;
         }
 
@@ -434,6 +484,22 @@ public partial class App : Application
 
         if (_settingsWindow.DataContext is SettingsWindowViewModel viewModel)
             ApplySettingsWindowRequest(viewModel, route, presentFileImporter, focusPluginId);
+
+        RestoreAndActivateWindow(_settingsWindow);
+    }
+
+    private static void RestoreAndActivateWindow(Window window)
+    {
+        if (window.WindowState == WindowState.Minimized)
+            window.WindowState = WindowState.Normal;
+
+        if (!window.IsVisible)
+            window.Show();
+
+        window.Activate();
+        var handle = new WindowInteropHelper(window).Handle;
+        if (handle != IntPtr.Zero)
+            NativeMethods.SetForegroundWindow(handle);
     }
 
     private static void ApplySettingsWindowRequest(
@@ -647,6 +713,8 @@ public partial class App : Application
     protected override void OnExit(ExitEventArgs e)
     {
         _startupCancellation.Cancel();
+        _singleInstanceActivationRegistration?.Unregister(null);
+        _singleInstanceActivationRegistration = null;
         _protocolCallbackTimer?.Stop();
         _historyRetentionCoordinator?.HandleShutdown();
         _trayIcon?.Dispose();

--- a/src/TypeWhisper.Windows/Native/NativeMethods.cs
+++ b/src/TypeWhisper.Windows/Native/NativeMethods.cs
@@ -318,6 +318,13 @@ internal static partial class NativeMethods
     public static partial bool SetForegroundWindow(IntPtr hWnd);
 
     /// <summary>
+    /// Allows the supplied process to set the foreground window.
+    /// </summary>
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool AllowSetForegroundWindow(uint processId);
+
+    /// <summary>
     /// Returns an ancestor window for the supplied window handle.
     /// </summary>
     [LibraryImport("user32.dll")]

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using TypeWhisper.Windows.Services;
 using TypeWhisper.Windows.Services.Localization;
 using TypeWhisper.Windows.Services.Plugins;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Core;
 #if TYPEWHISPER_STORE
 using Windows.ApplicationModel;
@@ -19,6 +20,7 @@ namespace TypeWhisper.Windows;
 public static class Program
 {
     private static Mutex? _singleInstanceMutex;
+    private static SingleInstanceActivationSignal? _singleInstanceActivationSignal;
     private static IReadOnlyList<string>? _restartArgs;
     private static readonly string CallbackInboxPath = Path.Combine(TypeWhisperEnvironment.DataPath, "protocol-callback.txt");
 
@@ -78,6 +80,7 @@ public static class Program
         var callbackArg = args.FirstOrDefault(SupporterDiscordService.CanHandleCallbackUri);
 
         // Single instance check
+        using var activationSignal = SingleInstanceActivationSignal.OpenOrCreate();
         _singleInstanceMutex = new Mutex(true, "TypeWhisper-SingleInstance", out var createdNew);
         if (!createdNew)
         {
@@ -87,6 +90,12 @@ public static class Program
                 {
                     Directory.CreateDirectory(TypeWhisperEnvironment.DataPath);
                     File.WriteAllText(CallbackInboxPath, callbackArg);
+                }
+
+                if (ShouldNotifyRunningInstance(StartMinimized, callbackArg))
+                {
+                    AllowRunningInstanceToSetForegroundWindow();
+                    activationSignal.Notify();
                 }
             }
             finally
@@ -98,6 +107,8 @@ public static class Program
             // Another instance is already running
             return;
         }
+
+        _singleInstanceActivationSignal = activationSignal;
 
         try
         {
@@ -128,9 +139,43 @@ public static class Program
             _singleInstanceMutex.ReleaseMutex();
             _singleInstanceMutex.Dispose();
             _singleInstanceMutex = null;
+            _singleInstanceActivationSignal = null;
 
             if (restartArgs is not null)
                 StartRestartProcess(restartArgs);
+        }
+    }
+
+    internal static RegisteredWaitHandle ListenForActivationRequests(Action callback)
+    {
+        var signal = _singleInstanceActivationSignal
+            ?? throw new InvalidOperationException("The single-instance activation signal is not initialized.");
+        return signal.Listen(callback);
+    }
+
+    internal static bool ShouldNotifyRunningInstance(bool startMinimized, string? callbackArg) =>
+        !startMinimized && string.IsNullOrWhiteSpace(callbackArg);
+
+    private static void AllowRunningInstanceToSetForegroundWindow()
+    {
+        using var current = Process.GetCurrentProcess();
+        foreach (var candidate in Process.GetProcessesByName(current.ProcessName))
+        {
+            using (candidate)
+            {
+                try
+                {
+                    if (candidate.Id == current.Id || candidate.SessionId != current.SessionId)
+                        continue;
+
+                    NativeMethods.AllowSetForegroundWindow((uint)candidate.Id);
+                    return;
+                }
+                catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+                {
+                    Debug.WriteLine($"Could not grant foreground access to TypeWhisper process {candidate.Id}: {ex.Message}");
+                }
+            }
         }
     }
 

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -169,7 +169,6 @@ public static class Program
                         continue;
 
                     NativeMethods.AllowSetForegroundWindow((uint)candidate.Id);
-                    return;
                 }
                 catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
                 {

--- a/src/TypeWhisper.Windows/Services/SingleInstanceActivationSignal.cs
+++ b/src/TypeWhisper.Windows/Services/SingleInstanceActivationSignal.cs
@@ -1,0 +1,65 @@
+namespace TypeWhisper.Windows.Services;
+
+/// <summary>
+/// Signals an interactive launch to the already running TypeWhisper instance.
+/// </summary>
+internal sealed class SingleInstanceActivationSignal : IDisposable
+{
+    private const string DefaultEventName = "TypeWhisper-SingleInstance-Activation";
+    private readonly EventWaitHandle _event;
+    private bool _disposed;
+
+    private SingleInstanceActivationSignal(EventWaitHandle activationEvent)
+    {
+        _event = activationEvent;
+    }
+
+    /// <summary>
+    /// Opens the shared activation signal, creating it when necessary.
+    /// </summary>
+    public static SingleInstanceActivationSignal OpenOrCreate(string eventName = DefaultEventName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
+        return new SingleInstanceActivationSignal(
+            new EventWaitHandle(false, EventResetMode.AutoReset, eventName));
+    }
+
+    /// <summary>
+    /// Notifies the running instance that the user launched TypeWhisper again.
+    /// </summary>
+    public bool Notify()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _event.Set();
+    }
+
+    /// <summary>
+    /// Registers a callback that runs whenever another instance requests activation.
+    /// </summary>
+    public RegisteredWaitHandle Listen(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        return ThreadPool.RegisterWaitForSingleObject(
+            _event,
+            static (state, timedOut) =>
+            {
+                if (!timedOut)
+                    ((Action)state!).Invoke();
+            },
+            callback,
+            Timeout.InfiniteTimeSpan,
+            executeOnlyOnce: false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _event.Dispose();
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/SingleInstanceActivationSignalTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SingleInstanceActivationSignalTests.cs
@@ -1,0 +1,74 @@
+using TypeWhisper.Windows;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class SingleInstanceActivationSignalTests
+{
+    [Fact]
+    public void NotifyBeforeListen_IsDeliveredWhenListenerStarts()
+    {
+        var eventName = $"TypeWhisper-SingleInstance-Activation-{Guid.NewGuid():N}";
+        using var primary = SingleInstanceActivationSignal.OpenOrCreate(eventName);
+        using var secondary = SingleInstanceActivationSignal.OpenOrCreate(eventName);
+        using var delivered = new ManualResetEventSlim();
+
+        Assert.True(secondary.Notify());
+
+        var registration = primary.Listen(delivered.Set);
+        try
+        {
+            Assert.True(delivered.Wait(TimeSpan.FromSeconds(5)));
+        }
+        finally
+        {
+            registration.Unregister(null);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, "", true)]
+    [InlineData(true, null, false)]
+    [InlineData(false, "typewhisper://supporter/discord", false)]
+    public void Program_NotifiesTheRunningInstanceOnlyForInteractiveLaunches(
+        bool startMinimized,
+        string? callbackArg,
+        bool expected)
+    {
+        Assert.Equal(expected, Program.ShouldNotifyRunningInstance(startMinimized, callbackArg));
+    }
+
+    [Fact]
+    public void Program_UsesTheActivationSignalForAnExistingInstance()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Program.cs");
+
+        Assert.Contains("SingleInstanceActivationSignal.OpenOrCreate()", source);
+        Assert.Contains("if (ShouldNotifyRunningInstance(StartMinimized, callbackArg))", source);
+        Assert.Contains("activationSignal.Notify();", source);
+
+        var foregroundPermissionIndex = source.IndexOf(
+            "AllowRunningInstanceToSetForegroundWindow();",
+            StringComparison.Ordinal);
+        var notifyIndex = source.IndexOf("activationSignal.Notify();", StringComparison.Ordinal);
+        Assert.True(foregroundPermissionIndex >= 0);
+        Assert.True(notifyIndex > foregroundPermissionIndex);
+    }
+
+    [Fact]
+    public void App_ActivatesOnboardingOrDashboardWhenAnotherInstanceStarts()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "App.xaml.cs");
+
+        Assert.Contains("StartSingleInstanceActivationListener();", source);
+        Assert.Contains("ActivatePrimaryInstance();", source);
+        Assert.Contains("ShowSettingsWindow(SettingsRoute.Dashboard);", source);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/SingleInstanceActivationSignalTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SingleInstanceActivationSignalTests.cs
@@ -60,6 +60,31 @@ public sealed class SingleInstanceActivationSignalTests
     }
 
     [Fact]
+    public void Program_GrantsForegroundAccessToEverySameSessionCandidate()
+    {
+        var source = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Program.cs");
+        var methodStart = source.IndexOf(
+            "private static void AllowRunningInstanceToSetForegroundWindow()",
+            StringComparison.Ordinal);
+        Assert.True(methodStart >= 0);
+
+        var methodEnd = source.IndexOf(
+            "internal static bool IsPortableLayout",
+            methodStart,
+            StringComparison.Ordinal);
+
+        Assert.True(methodEnd > methodStart);
+
+        var methodSource = source[methodStart..methodEnd];
+        Assert.Contains("candidate.SessionId != current.SessionId", methodSource);
+        Assert.Contains("NativeMethods.AllowSetForegroundWindow((uint)candidate.Id);", methodSource);
+        Assert.DoesNotContain("return;", methodSource);
+    }
+
+    [Fact]
     public void App_ActivatesOnboardingOrDashboardWhenAnotherInstanceStarts()
     {
         var source = TestFile.ReadProjectFile(


### PR DESCRIPTION
## Summary
- signal the existing TypeWhisper process when the app is launched again
- restore and activate onboarding, the current settings window, or the dashboard
- preserve tray-only startup and protocol callback behavior
- add regression coverage for activation signaling and launch routing

## Testing
- dotnet test TypeWhisper.slnx --no-restore --verbosity minimal
- dotnet build src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Release -p:TypeWhisperStoreBuild=true --no-restore --verbosity minimal
- manual tray relaunch smoke test with one process and foreground-window verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added single-instance app behavior to prevent duplicate interactive windows.
  - Launching the app again now reactivates the existing window instead of opening another instance.
  - Existing welcome, settings, and dashboard windows are restored when activated, including minimized or hidden windows.
  - The app now reliably brings the appropriate window to the foreground during activation.
- **Bug Fixes**
  - Improved handling of activation requests received while the app is still starting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->