### PR TITLE
Allow dictation with unavailable clipboard bitmaps

### DIFF
--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -220,7 +220,6 @@ internal sealed class WindowsClipboardTransaction : IDisposable
     private WindowsClipboardSnapshot CaptureSnapshotCore(uint enterpriseFormat)
     {
         var entries = new List<ClipboardFormatHandle>();
-        var capturedFormats = new HashSet<uint>();
         var unavailableFormats = new List<UnavailableClipboardFormat>();
         string? enterpriseId = null;
         try
@@ -281,15 +280,12 @@ internal sealed class WindowsClipboardTransaction : IDisposable
                     nextFormat,
                     duplicateHandle,
                     _handleReleaseObserver));
-                capturedFormats.Add(nextFormat);
                 currentFormat = nextFormat;
             }
 
             foreach (var unavailableFormat in unavailableFormats)
             {
-                if (CanRestoreFromCapturedBitmapRepresentation(
-                        unavailableFormat.Format,
-                        capturedFormats))
+                if (CanSkipUnavailableBitmapFormat(unavailableFormat.Format))
                     continue;
 
                 throw ClipboardError(
@@ -355,19 +351,10 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         return length > 0 ? $"{format} ('{name}')" : format.ToString();
     }
 
-    private static bool CanRestoreFromCapturedBitmapRepresentation(
-        uint unavailableFormat,
-        IReadOnlySet<uint> capturedFormats)
+    private static bool CanSkipUnavailableBitmapFormat(uint unavailableFormat)
     {
-        var hasBitmapRepresentation =
-            capturedFormats.Contains(NativeMethods.CF_BITMAP) ||
-            capturedFormats.Contains(NativeMethods.CF_DIB) ||
-            capturedFormats.Contains(NativeMethods.CF_DIBV5);
-        if (!hasBitmapRepresentation)
-            return false;
-
-        // EnumClipboardFormats includes bitmap formats synthesized from another available
-        // bitmap representation. Windows recreates those alternatives after restoration.
+        // Some clipboard owners advertise delayed bitmap formats but fail to render them.
+        // Drop those unusable representations instead of blocking dictated text insertion.
         if (unavailableFormat is NativeMethods.CF_BITMAP
             or NativeMethods.CF_DIB
             or NativeMethods.CF_DIBV5)
@@ -383,7 +370,7 @@ internal sealed class WindowsClipboardTransaction : IDisposable
             name.Capacity);
 
         // OLE image providers can advertise this managed bitmap alias without exposing a
-        // native handle. The captured standard bitmap formats preserve the same image.
+        // native handle.
         return length > 0 && string.Equals(
             name.ToString(),
             "System.Drawing.Bitmap",

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -312,6 +312,44 @@ public sealed class WindowsClipboardTransactionTests
     }
 
     [Fact]
+    public void UnavailableDib_DoesNotBlockTemporaryTextAndRestoresRemainingFormats()
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                using var transaction = new WindowsClipboardTransaction(Dispatcher.CurrentDispatcher);
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    using var bitmapOwner = SeedTextWithUnavailableDib();
+                    Assert.Contains(NativeMethods.CF_DIB, EnumerateClipboardFormats());
+                    Assert.Equal(IntPtr.Zero, ReadClipboardHandle(NativeMethods.CF_DIB));
+
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    Assert.Equal("dictated", Clipboard.GetText());
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    Assert.Equal("previous", Clipboard.GetText());
+                    Assert.DoesNotContain(NativeMethods.CF_DIB, EnumerateClipboardFormats());
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
+    [Fact]
     public void UnavailableUniqueFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
     {
         lock (ClipboardTestLock)
@@ -465,6 +503,35 @@ public sealed class WindowsClipboardTransactionTests
                     Marshal.GetLastPInvokeError());
             }
 
+            Marshal.SetLastPInvokeError(0);
+            Assert.Equal(
+                IntPtr.Zero,
+                NativeMethods.SetClipboardData(NativeMethods.CF_DIB, IntPtr.Zero));
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        return owner;
+    }
+
+    private static HwndSource SeedTextWithUnavailableDib()
+    {
+        var owner = new HwndSource(new HwndSourceParameters("TypeWhisper unavailable bitmap owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+            SetGlobalData(
+                NativeMethods.CF_UNICODETEXT,
+                Encoding.Unicode.GetBytes("previous\0"));
             Marshal.SetLastPInvokeError(0);
             Assert.Equal(
                 IntPtr.Zero,


### PR DESCRIPTION
## Summary

- allow dictated text insertion when a clipboard owner advertises bitmap data it cannot materialize
- discard only the unusable bitmap representation while restoring all remaining clipboard formats
- retain fail-closed behavior for unavailable non-bitmap formats

## Validation

- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --no-build --no-restore --filter "FullyQualifiedName~WindowsClipboardTransactionTests|FullyQualifiedName~TextInsertionServiceTests"` (36 passed)
- `dotnet test TypeWhisper.slnx --no-restore` (2,369 passed)
- dev build and launch from the stable TypeWhisper-Dev output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard handling when unavailable bitmap formats are present.
  * Temporary text operations now complete successfully and restore available clipboard content without retaining unsupported bitmap data.

* **Tests**
  * Added coverage for clipboard restoration with text and unavailable bitmap content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->