### PR TITLE
Keep dictation hotkeys responsive

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -434,12 +434,17 @@ public sealed class KeyboardHook : IDisposable
 
 internal sealed class LowLevelHookThread : IDisposable
 {
+    private static readonly TimeSpan DefaultInvokeTimeout = TimeSpan.FromSeconds(5);
+
     private readonly Thread _thread;
     private readonly Dispatcher _dispatcher;
+    private readonly TimeSpan _invokeTimeout;
+    private Exception? _loopFailure;
     private int _disposed;
 
-    public LowLevelHookThread()
+    public LowLevelHookThread(TimeSpan? invokeTimeout = null)
     {
+        _invokeTimeout = invokeTimeout ?? DefaultInvokeTimeout;
         var ready = new TaskCompletionSource<Dispatcher>(TaskCreationOptions.RunContinuationsAsynchronously);
         _thread = new Thread(() =>
         {
@@ -448,9 +453,18 @@ internal sealed class LowLevelHookThread : IDisposable
                 var dispatcher = Dispatcher.CurrentDispatcher;
                 ready.TrySetResult(dispatcher);
                 Dispatcher.Run();
+
+                if (Volatile.Read(ref _disposed) == 0)
+                {
+                    MarkUnusable(new InvalidOperationException(
+                        "The low-level hook dispatcher stopped unexpectedly."));
+                }
             }
             catch (Exception ex)
             {
+                // This is the thread boundary. Recording every recoverable loop failure prevents
+                // an unhandled background-thread exception or a dead dispatcher reference.
+                MarkUnusable(ex);
                 ready.TrySetException(ex);
             }
         })
@@ -463,26 +477,59 @@ internal sealed class LowLevelHookThread : IDisposable
         _dispatcher = ready.Task.GetAwaiter().GetResult();
     }
 
-    public bool IsAlive => Volatile.Read(ref _disposed) == 0 && _thread.IsAlive;
+    public bool IsAlive =>
+        Volatile.Read(ref _disposed) == 0
+        && Volatile.Read(ref _loopFailure) is null
+        && _thread.IsAlive
+        && !_dispatcher.HasShutdownStarted
+        && !_dispatcher.HasShutdownFinished;
 
     public void Invoke(Action action)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        if (_dispatcher.CheckAccess())
+        ArgumentNullException.ThrowIfNull(action);
+        Invoke<object?>(() =>
         {
             action();
-            return;
-        }
-
-        _dispatcher.Invoke(action, DispatcherPriority.Send);
+            return null;
+        });
     }
 
     public T Invoke<T>(Func<T> action)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        return _dispatcher.CheckAccess()
-            ? action()
-            : _dispatcher.Invoke(action, DispatcherPriority.Send);
+        ArgumentNullException.ThrowIfNull(action);
+        ThrowIfDisposedOrFaulted();
+        if (_dispatcher.CheckAccess())
+            return action();
+
+        ThrowIfCannotSchedule();
+        var operationStarted = 0;
+
+        try
+        {
+            return _dispatcher.Invoke(
+                () =>
+                {
+                    Interlocked.Exchange(ref operationStarted, 1);
+                    return action();
+                },
+                DispatcherPriority.Send,
+                CancellationToken.None,
+                _invokeTimeout);
+        }
+        catch (TimeoutException ex) when (Volatile.Read(ref operationStarted) == 0)
+        {
+            throw MarkUnusableAndCreateException(ex);
+        }
+        catch (OperationCanceledException ex) when (Volatile.Read(ref operationStarted) == 0)
+        {
+            throw MarkUnusableAndCreateException(ex);
+        }
+        catch (InvalidOperationException ex) when (
+            Volatile.Read(ref operationStarted) == 0
+            && (_dispatcher.HasShutdownStarted || _dispatcher.HasShutdownFinished || !_thread.IsAlive))
+        {
+            throw MarkUnusableAndCreateException(ex);
+        }
     }
 
     public void Dispose()
@@ -490,14 +537,47 @@ internal sealed class LowLevelHookThread : IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        if (_dispatcher.CheckAccess())
-            _dispatcher.InvokeShutdown();
-        else
-            _dispatcher.BeginInvokeShutdown(DispatcherPriority.Send);
+        if (!_dispatcher.HasShutdownStarted && !_dispatcher.HasShutdownFinished)
+        {
+            if (_dispatcher.CheckAccess())
+                _dispatcher.InvokeShutdown();
+            else
+                _dispatcher.BeginInvokeShutdown(DispatcherPriority.Send);
+        }
 
         if (Thread.CurrentThread != _thread)
             _thread.Join(TimeSpan.FromSeconds(5));
     }
+
+    private void ThrowIfDisposedOrFaulted()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        var failure = Volatile.Read(ref _loopFailure);
+        if (failure is not null)
+            throw CreateUnavailableException(failure);
+    }
+
+    private void ThrowIfCannotSchedule()
+    {
+        if (_thread.IsAlive && !_dispatcher.HasShutdownStarted && !_dispatcher.HasShutdownFinished)
+            return;
+
+        var failure = new InvalidOperationException("The low-level hook dispatcher is not running.");
+        MarkUnusable(failure);
+        throw CreateUnavailableException(Volatile.Read(ref _loopFailure) ?? failure);
+    }
+
+    private InvalidOperationException MarkUnusableAndCreateException(Exception failure)
+    {
+        MarkUnusable(failure);
+        return CreateUnavailableException(Volatile.Read(ref _loopFailure) ?? failure);
+    }
+
+    private void MarkUnusable(Exception failure) =>
+        Interlocked.CompareExchange(ref _loopFailure, failure, null);
+
+    private static InvalidOperationException CreateUnavailableException(Exception failure) =>
+        new("The low-level hook dispatcher is unavailable.", failure);
 }
 
 internal sealed class LowLevelHookEventArgs(long timestamp) : EventArgs

--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Threading;
 
 namespace TypeWhisper.Windows.Native;
 
@@ -8,11 +10,20 @@ namespace TypeWhisper.Windows.Native;
 /// </summary>
 public sealed class KeyboardHook : IDisposable
 {
+    private static readonly Lazy<LowLevelHookThread> SharedHookThread = new();
+
     private IntPtr _keyboardHookId = IntPtr.Zero;
     private IntPtr _mouseHookId = IntPtr.Zero;
     private readonly NativeMethods.LowLevelKeyboardProc _keyboardProc;
     private readonly NativeMethods.LowLevelMouseProc _mouseProc;
-    private bool _disposed;
+    private readonly object _lifecycleGate = new();
+    private readonly ConcurrentQueue<Action> _pendingEvents = new();
+    private volatile SynchronizationContext? _eventContext;
+    private int _eventDrainScheduled;
+    private int _eventGeneration;
+    private bool _started;
+    private volatile bool _disposed;
+    private volatile bool _isEnabled = true;
     private readonly HotkeyMatchStateMachine _stateMachine = new();
     private readonly MouseHotkeyMatchStateMachine _mouseStateMachine = new();
     private HotkeyTargetKind _targetKind;
@@ -28,7 +39,11 @@ public sealed class KeyboardHook : IDisposable
     /// <summary>
     /// Gets or sets the is enabled value.
     /// </summary>
-    public bool IsEnabled { get; set; } = true;
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set => _isEnabled = value;
+    }
 
     internal bool HasConfiguredHotkey => _stateMachine.HasHotkey || _mouseStateMachine.HasHotkey;
 
@@ -67,7 +82,23 @@ public sealed class KeyboardHook : IDisposable
     /// </summary>
     public void Start()
     {
-        if (_keyboardHookId != IntPtr.Zero || _mouseHookId != IntPtr.Zero) return;
+        lock (_lifecycleGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_started)
+                return;
+
+            _eventContext = SynchronizationContext.Current;
+            Interlocked.Increment(ref _eventGeneration);
+            SharedHookThread.Value.Invoke(StartCore);
+            _started = _keyboardHookId != IntPtr.Zero || _mouseHookId != IntPtr.Zero;
+        }
+    }
+
+    private void StartCore()
+    {
+        if (_keyboardHookId != IntPtr.Zero || _mouseHookId != IntPtr.Zero)
+            return;
 
         using var process = Process.GetCurrentProcess();
         using var module = process.MainModule;
@@ -99,6 +130,21 @@ public sealed class KeyboardHook : IDisposable
     /// </summary>
     public void Stop()
     {
+        lock (_lifecycleGate)
+        {
+            Interlocked.Increment(ref _eventGeneration);
+            if (_started || _keyboardHookId != IntPtr.Zero || _mouseHookId != IntPtr.Zero)
+                SharedHookThread.Value.Invoke(StopCore);
+            else
+                ResetStateMachines();
+
+            _started = false;
+            _eventContext = null;
+        }
+    }
+
+    private void StopCore()
+    {
         if (_keyboardHookId != IntPtr.Zero)
         {
             NativeMethods.UnhookWindowsHookEx(_keyboardHookId);
@@ -109,14 +155,32 @@ public sealed class KeyboardHook : IDisposable
             NativeMethods.UnhookWindowsHookEx(_mouseHookId);
             _mouseHookId = IntPtr.Zero;
         }
+        ResetStateMachines();
+    }
+
+    private void ResetStateMachines()
+    {
         _stateMachine.Reset();
         _mouseStateMachine.Reset();
     }
 
     internal void ResetRuntimeState()
     {
-        _stateMachine.ResetRuntimeState();
-        _mouseStateMachine.ResetRuntimeState();
+        lock (_lifecycleGate)
+        {
+            if (_started)
+            {
+                SharedHookThread.Value.Invoke(() =>
+                {
+                    _stateMachine.ResetRuntimeState();
+                    _mouseStateMachine.ResetRuntimeState();
+                });
+                return;
+            }
+
+            _stateMachine.ResetRuntimeState();
+            _mouseStateMachine.ResetRuntimeState();
+        }
     }
 
     private IntPtr KeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
@@ -135,6 +199,7 @@ public sealed class KeyboardHook : IDisposable
             var result = _stateMachine.ProcessKeyEvent(vkCode, isKeyDown, isKeyUp);
             if (IsEnabled)
             {
+                var timestamp = Stopwatch.GetTimestamp();
                 if (result.SyntheticKeyDownVk != 0)
                     SendSyntheticKeyDown((ushort)result.SyntheticKeyDownVk);
                 if (result.SyntheticKeyTapVk != 0)
@@ -142,9 +207,9 @@ public sealed class KeyboardHook : IDisposable
                 if (result.SyntheticKeyUpVk != 0)
                     SendSyntheticKeyUp((ushort)result.SyntheticKeyUpVk);
                 if (result.RaiseKeyDown)
-                    KeyDown?.Invoke(this, EventArgs.Empty);
+                    QueueHookEvent(KeyDown, timestamp);
                 if (result.RaiseKeyUp)
-                    KeyUp?.Invoke(this, EventArgs.Empty);
+                    QueueHookEvent(KeyUp, timestamp);
                 if (result.Swallow)
                     return (IntPtr)1;
             }
@@ -168,10 +233,11 @@ public sealed class KeyboardHook : IDisposable
                     GetCurrentModifiers());
                 if (IsEnabled)
                 {
+                    var timestamp = Stopwatch.GetTimestamp();
                     if (result.RaiseKeyDown)
-                        KeyDown?.Invoke(this, EventArgs.Empty);
+                        QueueHookEvent(KeyDown, timestamp);
                     if (result.RaiseKeyUp)
-                        KeyUp?.Invoke(this, EventArgs.Empty);
+                        QueueHookEvent(KeyUp, timestamp);
                     if (result.Swallow)
                         return (IntPtr)1;
                 }
@@ -179,6 +245,55 @@ public sealed class KeyboardHook : IDisposable
         }
 
         return NativeMethods.CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
+    }
+
+    private void QueueHookEvent(EventHandler? handler, long timestamp)
+    {
+        if (handler is null)
+            return;
+
+        var generation = Volatile.Read(ref _eventGeneration);
+        _pendingEvents.Enqueue(() =>
+        {
+            if (!_disposed
+                && IsEnabled
+                && generation == Volatile.Read(ref _eventGeneration))
+            {
+                handler(this, new LowLevelHookEventArgs(timestamp));
+            }
+        });
+
+        ScheduleEventDrain();
+    }
+
+    private void ScheduleEventDrain()
+    {
+        if (Interlocked.CompareExchange(ref _eventDrainScheduled, 1, 0) != 0)
+            return;
+
+        var context = _eventContext;
+        if (context is not null)
+        {
+            context.Post(static state => ((KeyboardHook)state!).DrainPendingEvents(), this);
+            return;
+        }
+
+        ThreadPool.QueueUserWorkItem(static state => ((KeyboardHook)state!).DrainPendingEvents(), this);
+    }
+
+    private void DrainPendingEvents()
+    {
+        try
+        {
+            while (_pendingEvents.TryDequeue(out var pendingEvent))
+                pendingEvent();
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _eventDrainScheduled, 0);
+            if (!_pendingEvents.IsEmpty)
+                ScheduleEventDrain();
+        }
     }
 
     internal static bool ShouldIgnoreInjectedInput(in NativeMethods.KBDLLHOOKSTRUCT hookStruct) =>
@@ -315,6 +430,79 @@ public sealed class KeyboardHook : IDisposable
         }
         GC.SuppressFinalize(this);
     }
+}
+
+internal sealed class LowLevelHookThread : IDisposable
+{
+    private readonly Thread _thread;
+    private readonly Dispatcher _dispatcher;
+    private int _disposed;
+
+    public LowLevelHookThread()
+    {
+        var ready = new TaskCompletionSource<Dispatcher>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _thread = new Thread(() =>
+        {
+            try
+            {
+                var dispatcher = Dispatcher.CurrentDispatcher;
+                ready.TrySetResult(dispatcher);
+                Dispatcher.Run();
+            }
+            catch (Exception ex)
+            {
+                ready.TrySetException(ex);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "TypeWhisper low-level input hooks"
+        };
+        _thread.SetApartmentState(ApartmentState.MTA);
+        _thread.Start();
+        _dispatcher = ready.Task.GetAwaiter().GetResult();
+    }
+
+    public bool IsAlive => Volatile.Read(ref _disposed) == 0 && _thread.IsAlive;
+
+    public void Invoke(Action action)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        if (_dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        _dispatcher.Invoke(action, DispatcherPriority.Send);
+    }
+
+    public T Invoke<T>(Func<T> action)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        return _dispatcher.CheckAccess()
+            ? action()
+            : _dispatcher.Invoke(action, DispatcherPriority.Send);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        if (_dispatcher.CheckAccess())
+            _dispatcher.InvokeShutdown();
+        else
+            _dispatcher.BeginInvokeShutdown(DispatcherPriority.Send);
+
+        if (Thread.CurrentThread != _thread)
+            _thread.Join(TimeSpan.FromSeconds(5));
+    }
+}
+
+internal sealed class LowLevelHookEventArgs(long timestamp) : EventArgs
+{
+    public long Timestamp { get; } = timestamp;
 }
 
 internal readonly record struct HotkeyProcessResult(

--- a/src/TypeWhisper.Windows/Services/HotkeyService.cs
+++ b/src/TypeWhisper.Windows/Services/HotkeyService.cs
@@ -24,7 +24,7 @@ public sealed class HotkeyService : IDisposable
     private readonly List<(KeyboardHook Hook, string WorkflowId)> _workflowHooks = [];
 
     private bool _disposed;
-    private DateTime _keyDownTime;
+    private long _keyDownTimestamp;
     private bool _isActive;
 
     /// <summary>
@@ -280,8 +280,8 @@ public sealed class HotkeyService : IDisposable
 
     // --- Hybrid: short press = toggle, long hold = PTT ---
 
-    private DateTime _lastActionTime;
-    private DateTime _lastRecorderToggleActionTime;
+    private long _lastActionTimestamp;
+    private long _lastRecorderToggleActionTimestamp;
     private static readonly TimeSpan DebounceInterval = TimeSpan.FromMilliseconds(300);
 
     private void OnHybridKeyDown(object? sender, EventArgs e)
@@ -289,9 +289,9 @@ public sealed class HotkeyService : IDisposable
         if (!IsEnabled) return;
 
         // Debounce rapid key presses
-        var now = DateTime.UtcNow;
-        if (now - _lastActionTime < DebounceInterval) return;
-        _lastActionTime = now;
+        var now = GetEventTimestamp(e);
+        if (IsWithinDebounceInterval(_lastActionTimestamp, now)) return;
+        _lastActionTimestamp = now;
 
         if (_isActive)
         {
@@ -301,7 +301,7 @@ public sealed class HotkeyService : IDisposable
             return;
         }
 
-        _keyDownTime = DateTime.UtcNow;
+        _keyDownTimestamp = now;
         _isActive = true;
         CurrentMode = HotkeyMode.PushToTalk;
         DictationStartRequested?.Invoke(this, EventArgs.Empty);
@@ -311,7 +311,7 @@ public sealed class HotkeyService : IDisposable
     {
         if (!_isActive) return;
 
-        var holdMs = (DateTime.UtcNow - _keyDownTime).TotalMilliseconds;
+        var holdMs = Stopwatch.GetElapsedTime(_keyDownTimestamp, GetEventTimestamp(e)).TotalMilliseconds;
         if (holdMs < PushToTalkThresholdMs)
         {
             CurrentMode = HotkeyMode.Toggle;
@@ -329,9 +329,9 @@ public sealed class HotkeyService : IDisposable
     {
         if (!IsEnabled) return;
 
-        var now = DateTime.UtcNow;
-        if (now - _lastActionTime < DebounceInterval) return;
-        _lastActionTime = now;
+        var now = GetEventTimestamp(e);
+        if (IsWithinDebounceInterval(_lastActionTimestamp, now)) return;
+        _lastActionTimestamp = now;
 
         if (_isActive)
         {
@@ -395,11 +395,18 @@ public sealed class HotkeyService : IDisposable
     private void OnRecorderToggleKeyDown(object? sender, EventArgs e)
     {
         if (!IsEnabled) return;
-        var now = DateTime.UtcNow;
-        if (now - _lastRecorderToggleActionTime < DebounceInterval) return;
-        _lastRecorderToggleActionTime = now;
+        var now = GetEventTimestamp(e);
+        if (IsWithinDebounceInterval(_lastRecorderToggleActionTimestamp, now)) return;
+        _lastRecorderToggleActionTimestamp = now;
         RecorderToggleRequested?.Invoke(this, EventArgs.Empty);
     }
+
+    private static long GetEventTimestamp(EventArgs e) =>
+        e is LowLevelHookEventArgs hookEvent ? hookEvent.Timestamp : Stopwatch.GetTimestamp();
+
+    private static bool IsWithinDebounceInterval(long previousTimestamp, long currentTimestamp) =>
+        previousTimestamp != 0
+        && Stopwatch.GetElapsedTime(previousTimestamp, currentTimestamp) < DebounceInterval;
 
     // --- Common ---
 

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -429,6 +429,57 @@ public class HotkeyInputTests
         Assert.True(sut.IsAlive);
     }
 
+    [Fact]
+    public void LowLevelHookThread_StopsThreadOnDispose()
+    {
+        var sut = new LowLevelHookThread();
+        _ = sut.Invoke(() => Environment.CurrentManagedThreadId);
+
+        sut.Dispose();
+
+        Assert.False(sut.IsAlive);
+    }
+
+    [Fact]
+    public async Task LowLevelHookThread_FailsFastWhenDispatcherCannotAcceptWork()
+    {
+        using var sut = new LowLevelHookThread(TimeSpan.FromMilliseconds(200));
+        using var dispatcherBlocked = new ManualResetEventSlim();
+        using var releaseDispatcher = new ManualResetEventSlim();
+        var blockingInvoke = Task.Run(() => sut.Invoke(() =>
+        {
+            dispatcherBlocked.Set();
+            releaseDispatcher.Wait();
+        }));
+        Assert.True(dispatcherBlocked.Wait(TimeSpan.FromSeconds(2)));
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => sut.Invoke(() => { }));
+
+            Assert.True(exception.InnerException is TimeoutException or OperationCanceledException);
+            Assert.False(sut.IsAlive);
+        }
+        finally
+        {
+            releaseDispatcher.Set();
+            await blockingInvoke;
+        }
+    }
+
+    [Fact]
+    public void LowLevelHookThread_FailsFastAfterUnexpectedDispatcherShutdown()
+    {
+        using var sut = new LowLevelHookThread();
+
+        sut.Invoke(() =>
+            System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvokeShutdown(
+                System.Windows.Threading.DispatcherPriority.Send));
+
+        Assert.True(SpinWait.SpinUntil(() => !sut.IsAlive, TimeSpan.FromSeconds(2)));
+        Assert.Throws<InvalidOperationException>(() => sut.Invoke(() => { }));
+    }
+
     [Theory]
     [InlineData(NativeMethods.VK_RETURN)]
     [InlineData(NativeMethods.VK_TAB)]

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -415,6 +415,20 @@ public class HotkeyInputTests
         Assert.False(KeyboardHook.ShouldIgnoreInjectedInput(hardwareInput));
     }
 
+    [Fact]
+    public void LowLevelHookThread_InvokesOnDedicatedReusableThread()
+    {
+        using var sut = new LowLevelHookThread();
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        var firstHookThreadId = sut.Invoke(() => Environment.CurrentManagedThreadId);
+        var secondHookThreadId = sut.Invoke(() => Environment.CurrentManagedThreadId);
+
+        Assert.NotEqual(callerThreadId, firstHookThreadId);
+        Assert.Equal(firstHookThreadId, secondHookThreadId);
+        Assert.True(sut.IsAlive);
+    }
+
     [Theory]
     [InlineData(NativeMethods.VK_RETURN)]
     [InlineData(NativeMethods.VK_TAB)]

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -451,10 +451,11 @@ public class HotkeyInputTests
             dispatcherBlocked.Set();
             releaseDispatcher.Wait();
         }));
-        Assert.True(dispatcherBlocked.Wait(TimeSpan.FromSeconds(2)));
 
         try
         {
+            Assert.True(dispatcherBlocked.Wait(TimeSpan.FromSeconds(2)));
+
             var exception = Assert.Throws<InvalidOperationException>(() => sut.Invoke(() => { }));
 
             Assert.True(exception.InnerException is TimeoutException or OperationCanceledException);

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyServiceTests.cs
@@ -182,6 +182,27 @@ public sealed class HotkeyServiceTests
     }
 
     [Fact]
+    public void HybridShortPress_StaysInToggleModeWhenUiDeliveryIsDelayed()
+    {
+        var sut = new HotkeyService(
+            new FakeSettingsService(AppSettings.Default),
+            new FakeWorkflowService());
+        var starts = 0;
+        var stops = 0;
+        sut.DictationStartRequested += (_, _) => starts++;
+        sut.DictationStopRequested += (_, _) => stops++;
+        var keyDownTimestamp = Stopwatch.GetTimestamp();
+        var keyUpTimestamp = keyDownTimestamp + (long)(Stopwatch.Frequency * 0.1);
+
+        InvokePrivate(sut, "OnHybridKeyDown", new LowLevelHookEventArgs(keyDownTimestamp));
+        InvokePrivate(sut, "OnHybridKeyUp", new LowLevelHookEventArgs(keyUpTimestamp));
+
+        Assert.Equal(1, starts);
+        Assert.Equal(0, stops);
+        Assert.Equal(HotkeyMode.Toggle, sut.CurrentMode);
+    }
+
+    [Fact]
     public void WorkflowPaletteRequested_EventIsRaised()
     {
         var sut = new HotkeyService(

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyServiceTests.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using System.Reflection;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.Native;
 using TypeWhisper.Windows.Services;
 
 namespace TypeWhisper.PluginSystem.Tests;
@@ -159,6 +161,27 @@ public sealed class HotkeyServiceTests
     }
 
     [Fact]
+    public void HybridHold_UsesInputTimestampsWhenUiDeliveryIsDelayed()
+    {
+        var sut = new HotkeyService(
+            new FakeSettingsService(AppSettings.Default),
+            new FakeWorkflowService());
+        var starts = 0;
+        var stops = 0;
+        sut.DictationStartRequested += (_, _) => starts++;
+        sut.DictationStopRequested += (_, _) => stops++;
+        var keyDownTimestamp = Stopwatch.GetTimestamp();
+        var keyUpTimestamp = keyDownTimestamp + (long)(Stopwatch.Frequency * 0.7);
+
+        InvokePrivate(sut, "OnHybridKeyDown", new LowLevelHookEventArgs(keyDownTimestamp));
+        InvokePrivate(sut, "OnHybridKeyUp", new LowLevelHookEventArgs(keyUpTimestamp));
+
+        Assert.Equal(1, starts);
+        Assert.Equal(1, stops);
+        Assert.Null(sut.CurrentMode);
+    }
+
+    [Fact]
     public void WorkflowPaletteRequested_EventIsRaised()
     {
         var sut = new HotkeyService(
@@ -177,11 +200,11 @@ public sealed class HotkeyServiceTests
         Assert.True(raised);
     }
 
-    private static void InvokePrivate(HotkeyService sut, string methodName)
+    private static void InvokePrivate(HotkeyService sut, string methodName, EventArgs? eventArgs = null)
     {
         var method = typeof(HotkeyService).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
-        method!.Invoke(sut, [null, EventArgs.Empty]);
+        method!.Invoke(sut, [null, eventArgs ?? EventArgs.Empty]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- run low-level keyboard and mouse hooks on a dedicated message-loop thread
- marshal hotkey actions back to the original synchronization context without losing input timing
- cover dedicated hook threading and delayed hybrid hold delivery

## Root cause
Windows low-level hooks were installed on the WPF UI thread. If that thread stayed blocked long enough during dictation work, Windows could silently remove the hook, leaving the app responsive while configured shortcuts stopped firing.

## Validation
- reproduced on `v1.0.9-daily.20260819`: Ctrl+Space stopped responding after three recording cycles while API dictation still worked
- 225 focused hotkey tests
- 442 Core tests
- 1,922 PluginSystem tests excluding the global clipboard suite, plus 7/7 clipboard tests in isolation
- Release build
- 15/15 repeated Ctrl+Space cycles after the fix
- hotkey accepted while the WPF UI thread was blocked for 1.8 seconds
- final 5/5 runtime cycles from the stable dev build

Addresses #317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard and mouse input handling for more reliable hotkey activation.
  * Improved debounce and timing behavior, including when input processing is delayed.
  * Prevented outdated, disabled, or inactive input events from triggering actions.
  * Improved hotkey behavior across hybrid, toggle, and recorder controls.
  * Improved reliability when input processing is interrupted, unavailable, or unexpectedly stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->