### PR TITLE
Fix low-level hook thread initialization

### DIFF
--- a/src/TypeWhisper.Windows/Native/KeyboardHook.cs
+++ b/src/TypeWhisper.Windows/Native/KeyboardHook.cs
@@ -10,7 +10,8 @@ namespace TypeWhisper.Windows.Native;
 /// </summary>
 public sealed class KeyboardHook : IDisposable
 {
-    private static readonly Lazy<LowLevelHookThread> SharedHookThread = new();
+    private static readonly Lazy<LowLevelHookThread> SharedHookThread =
+        new(() => new LowLevelHookThread());
 
     private IntPtr _keyboardHookId = IntPtr.Zero;
     private IntPtr _mouseHookId = IntPtr.Zero;

--- a/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HotkeyInputTests.cs
@@ -692,6 +692,21 @@ public class HotkeyInputTests
     }
 
     [Fact]
+    public void KeyboardHook_StartsAndStopsWithoutLazyConstructionFailure()
+    {
+        using var sut = new KeyboardHook();
+        sut.SetHotkey("Ctrl+Shift");
+
+        var exception = Record.Exception(() =>
+        {
+            sut.Start();
+            sut.Stop();
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void KeyedHotkey_RequiresExactModifiers()
     {
         var unmodified = CreateStateMachine(0, NativeMethods.VK_INSERT);


### PR DESCRIPTION
## Summary

- construct the shared low-level hook thread through an explicit factory
- add a regression test that starts and stops `KeyboardHook`

## Root cause

The parameterless `Lazy<LowLevelHookThread>` constructor uses reflection and requires a public parameterless constructor. `LowLevelHookThread` has a constructor with an optional argument, which is not a parameterless constructor at runtime. This caused a `MissingMemberException` during application startup after #400.

## Validation

- targeted startup regression test: 1 passed
- complete hotkey test set: 270 passed
- Debug dev build started successfully from the hotfix branch
- running process remained responsive, API discovery was refreshed, and no new crash entry was written

Follow-up to #400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting and stopping keyboard hooks configured with modifier-only hotkeys such as Ctrl+Shift.
  * Prevented an exception caused by delayed keyboard hook initialization.

* **Tests**
  * Added regression coverage for starting and stopping modifier-only keyboard hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->