### PR TITLE
Refresh Gemini model catalog dynamically

### DIFF
--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -46,6 +46,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     };
 
     private readonly HttpClient _httpClient;
+    private readonly SemaphoreSlim _configurationGate = new(1, 1);
     private IPluginHostServices? _host;
     private string? _apiKey;
     private List<GeminiFetchedModel> _fetchedLlmModels = [];
@@ -155,7 +156,9 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 "API key not configured",
                 PluginRequestFailureKind.Configuration);
 
-        var modelId = string.IsNullOrWhiteSpace(model) ? SupportedModels.First().Id : model;
+        var modelId = string.IsNullOrWhiteSpace(model)
+            ? SupportedModels.First().Id
+            : NormalizeModelId(model);
         return await SendChatCompletionAsync(modelId, systemPrompt, userText, ct);
     }
 
@@ -167,47 +170,146 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
 
     internal async Task SetApiKeyAsync(string apiKey)
     {
-        var normalized = NormalizeApiKey(apiKey);
-        var wasAvailable = IsAvailable;
-        var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
-        var catalogChanged = changed && _fetchedLlmModels.Count > 0;
-
-        _apiKey = normalized;
-        if (catalogChanged)
-            _fetchedLlmModels = [];
-
-        if (_host is not null)
+        await _configurationGate.WaitAsync();
+        try
         {
-            if (normalized is null)
-                await _host.DeleteSecretAsync(ApiKeySecretName);
-            else
-                await _host.StoreSecretAsync(ApiKeySecretName, normalized);
+            var normalized = NormalizeApiKey(apiKey);
+            var previousApiKey = _apiKey;
+            var wasAvailable = IsAvailable;
+            var changed = !string.Equals(previousApiKey, normalized, StringComparison.Ordinal);
+            var catalogChanged = changed && _fetchedLlmModels.Count > 0;
 
+            if (_host is not null)
+            {
+                var secretPersisted = false;
+                var catalogWriteAttempted = false;
+                try
+                {
+                    await PersistApiKeyAsync(_host, normalized);
+                    secretPersisted = true;
+                    if (catalogChanged)
+                    {
+                        catalogWriteAttempted = true;
+                        _host.SetSetting(FetchedLlmModelsSettingName, new List<GeminiFetchedModel>());
+                    }
+                }
+                catch (Exception writeException)
+                {
+                    var rollbackFailures = new List<Exception>();
+                    if (secretPersisted)
+                    {
+                        try
+                        {
+                            await PersistApiKeyAsync(_host, previousApiKey);
+                        }
+                        catch (Exception rollbackException)
+                        {
+                            rollbackFailures.Add(rollbackException);
+                        }
+                    }
+
+                    if (catalogWriteAttempted)
+                    {
+                        try
+                        {
+                            _host.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
+                        }
+                        catch (Exception rollbackException)
+                        {
+                            rollbackFailures.Add(rollbackException);
+                        }
+                    }
+
+                    if (rollbackFailures.Count > 0)
+                    {
+                        throw new InvalidOperationException(
+                            "Failed to persist the API key and restore the previous state.",
+                            new AggregateException([writeException, .. rollbackFailures]));
+                    }
+
+                    throw;
+                }
+            }
+
+            _apiKey = normalized;
             if (catalogChanged)
-                _host.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
+                _fetchedLlmModels = [];
 
-            if ((changed && wasAvailable != IsAvailable) || catalogChanged)
+            if (_host is not null
+                && ((changed && wasAvailable != IsAvailable) || catalogChanged))
+            {
                 _host.NotifyCapabilitiesChanged();
+            }
+        }
+        finally
+        {
+            _configurationGate.Release();
         }
     }
 
-    internal void SetFetchedLlmModels(IEnumerable<GeminiFetchedModel> models)
+    internal async Task<bool> SetFetchedLlmModelsAsync(
+        IEnumerable<GeminiFetchedModel> models,
+        string? expectedApiKey = null)
     {
         var normalized = NormalizeFetchedLlmModels(models);
-        if (ModelCatalogsEqual(_fetchedLlmModels, normalized))
-            return;
+        await _configurationGate.WaitAsync();
+        try
+        {
+            if (expectedApiKey is not null
+                && !string.Equals(_apiKey, expectedApiKey, StringComparison.Ordinal))
+            {
+                _host?.Log(PluginLogLevel.Debug, "Discarded a model catalog fetched for a previous API key.");
+                return false;
+            }
 
-        _fetchedLlmModels = normalized;
-        _host?.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
-        _host?.NotifyCapabilitiesChanged();
+            if (ModelCatalogsEqual(_fetchedLlmModels, normalized))
+                return true;
+
+            if (_host is not null)
+            {
+                try
+                {
+                    _host.SetSetting(FetchedLlmModelsSettingName, normalized);
+                }
+                catch (Exception writeException)
+                {
+                    try
+                    {
+                        _host.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
+                    }
+                    catch (Exception rollbackException)
+                    {
+                        throw new InvalidOperationException(
+                            "Failed to persist the model catalog and restore the previous value.",
+                            new AggregateException(writeException, rollbackException));
+                    }
+
+                    throw;
+                }
+            }
+
+            _fetchedLlmModels = normalized;
+            _host?.NotifyCapabilitiesChanged();
+            return true;
+        }
+        finally
+        {
+            _configurationGate.Release();
+        }
     }
+
+    private static Task PersistApiKeyAsync(IPluginHostServices host, string? apiKey) =>
+        apiKey is null
+            ? host.DeleteSecretAsync(ApiKeySecretName)
+            : host.StoreSecretAsync(ApiKeySecretName, apiKey);
 
     internal async Task<List<GeminiFetchedModel>?> FetchLlmModelsAsync(CancellationToken ct = default)
     {
-        if (!IsAvailable)
+        var apiKey = _apiKey;
+        if (apiKey is null)
             return null;
 
-        using var request = CreateAuthenticatedRequest(HttpMethod.Get, $"{BaseUrl}/models", _apiKey!);
+        using var request = CreateAuthenticatedRequest(HttpMethod.Get, $"{BaseUrl}/models", apiKey);
 
         try
         {
@@ -222,7 +324,19 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
 
             var json = await response.Content.ReadAsStringAsync(ct);
             var catalog = JsonSerializer.Deserialize<GeminiCompatibleModelsResponse>(json, JsonOptions);
-            return NormalizeFetchedLlmModels(catalog?.Data?.OfType<GeminiCompatibleModel>() ?? []);
+            if (catalog?.Data is null)
+            {
+                _host?.Log(PluginLogLevel.Warning, "Model catalog response did not contain a data array.");
+                return null;
+            }
+
+            if (!string.Equals(_apiKey, apiKey, StringComparison.Ordinal))
+            {
+                _host?.Log(PluginLogLevel.Debug, "Discarded a model catalog fetched for a previous API key.");
+                return null;
+            }
+
+            return NormalizeFetchedLlmModels(catalog.Data.OfType<GeminiCompatibleModel>());
         }
         catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -461,6 +575,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     /// </summary>
     public void Dispose()
     {
+        _configurationGate.Dispose();
         _httpClient.Dispose();
     }
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -18,13 +18,13 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     private const string BaseUrl = "https://generativelanguage.googleapis.com/v1beta/openai";
     private const string ApiKeySecretName = "api-key";
     private const string FetchedLlmModelsSettingName = "fetchedLlmModels.v2";
-    internal const string DefaultModel = "gemini-flash-latest";
+    internal const string DefaultModel = "gemini-flash-lite-latest";
 
     private static readonly IReadOnlyList<PluginModelInfo> FallbackLlmModels =
     [
-        new(DefaultModel, "Gemini Flash Latest") { IsRecommended = true },
+        new(DefaultModel, "Gemini Flash Lite Latest") { IsRecommended = true },
+        new("gemini-flash-latest", "Gemini Flash Latest"),
         new("gemini-pro-latest", "Gemini Pro Latest"),
-        new("gemini-flash-lite-latest", "Gemini Flash-Lite Latest"),
     ];
 
     private static readonly string[] ExcludedModelTokens =
@@ -310,6 +310,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 new { role = "system", content = systemPrompt },
                 new { role = "user", content = userText },
             },
+            ["reasoning_effort"] = "low",
             ["max_tokens"] = 2048,
         };
 

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -1,5 +1,8 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Windows.Controls;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
@@ -8,16 +11,56 @@ using TypeWhisper.PluginSDK.Models;
 namespace TypeWhisper.Plugin.Gemini;
 
 /// <summary>
-/// Provides gemini plugin behavior.
+/// Provides Gemini plugin behavior.
 /// </summary>
 public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
 {
     private const string BaseUrl = "https://generativelanguage.googleapis.com/v1beta/openai";
-    private const string DefaultModel = "gemini-2.5-flash";
+    private const string ApiKeySecretName = "api-key";
+    private const string FetchedLlmModelsSettingName = "fetchedLlmModels.v2";
+    internal const string DefaultModel = "gemini-flash-latest";
 
-    private readonly HttpClient _httpClient = new();
+    private static readonly IReadOnlyList<PluginModelInfo> FallbackLlmModels =
+    [
+        new(DefaultModel, "Gemini Flash Latest") { IsRecommended = true },
+        new("gemini-pro-latest", "Gemini Pro Latest"),
+        new("gemini-flash-lite-latest", "Gemini Flash-Lite Latest"),
+    ];
+
+    private static readonly string[] ExcludedModelTokens =
+    [
+        "embedding",
+        "-image",
+        "tts",
+        "live",
+        "audio",
+        "robotics",
+        "computer-use",
+        "deep-research",
+    ];
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly HttpClient _httpClient;
     private IPluginHostServices? _host;
     private string? _apiKey;
+    private List<GeminiFetchedModel> _fetchedLlmModels = [];
+
+    /// <summary>
+    /// Initializes a new instance of the GeminiPlugin class.
+    /// </summary>
+    public GeminiPlugin()
+        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(30) })
+    {
+    }
+
+    internal GeminiPlugin(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
 
     /// <inheritdoc />
     public bool SupportsRequestHedging => true;
@@ -35,7 +78,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.2.0";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.
@@ -43,8 +86,12 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     public async Task ActivateAsync(IPluginHostServices host)
     {
         _host = host;
-        _apiKey = await host.LoadSecretAsync("api-key");
-        host.Log(PluginLogLevel.Info, $"Activated (configured={IsAvailable})");
+        _apiKey = NormalizeApiKey(await host.LoadSecretAsync(ApiKeySecretName));
+        _fetchedLlmModels = NormalizeFetchedLlmModels(
+            host.GetSetting<List<GeminiFetchedModel>>(FetchedLlmModelsSettingName) ?? []);
+        host.Log(
+            PluginLogLevel.Info,
+            $"Activated (configured={IsAvailable}, fetchedModels={_fetchedLlmModels.Count})");
     }
 
     /// <summary>
@@ -75,15 +122,27 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     /// <summary>
     /// Gets the models exposed by this provider.
     /// </summary>
-    public IReadOnlyList<PluginModelInfo> SupportedModels { get; } =
-    [
-        new PluginModelInfo(DefaultModel, "Gemini 2.5 Flash") { IsRecommended = true },
-        new PluginModelInfo("gemini-2.5-pro", "Gemini 2.5 Pro"),
-        new PluginModelInfo("gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite"),
-        new PluginModelInfo("gemma-4-27b-it", "Gemma 4 27B"),
-        new PluginModelInfo("gemma-4-12b-it", "Gemma 4 12B"),
-        new PluginModelInfo("gemma-4-4b-it", "Gemma 4 4B"),
-    ];
+    public IReadOnlyList<PluginModelInfo> SupportedModels
+    {
+        get
+        {
+            if (_fetchedLlmModels.Count == 0)
+                return FallbackLlmModels;
+
+            var defaultModelId = ResolveDefaultModelId(_fetchedLlmModels);
+            return _fetchedLlmModels
+                .OrderByDescending(model => string.Equals(
+                    model.Id,
+                    defaultModelId,
+                    StringComparison.OrdinalIgnoreCase))
+                .ThenBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(model => new PluginModelInfo(model.Id, model.DisplayName ?? model.Id)
+                {
+                    IsRecommended = string.Equals(model.Id, defaultModelId, StringComparison.OrdinalIgnoreCase),
+                })
+                .ToList();
+        }
+    }
 
     /// <summary>
     /// Processes input text with the selected provider configuration.
@@ -95,41 +154,241 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 "API key not configured",
                 PluginRequestFailureKind.Configuration);
 
-        return await OpenAiChatHelper.SendChatCompletionAsync(
-            _httpClient, BaseUrl, _apiKey!, model, systemPrompt, userText, ct);
+        var modelId = string.IsNullOrWhiteSpace(model) ? SupportedModels.First().Id : model;
+        return await SendChatCompletionAsync(modelId, systemPrompt, userText, ct);
     }
 
-    // API key management (for settings view)
+    // API key and model catalog management (for settings view)
 
     internal string? ApiKey => _apiKey;
     internal IPluginLocalization? Loc => _host?.Localization;
+    internal IReadOnlyList<GeminiFetchedModel> FetchedLlmModels => _fetchedLlmModels;
 
     internal async Task SetApiKeyAsync(string apiKey)
     {
-        _apiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
+        var normalized = NormalizeApiKey(apiKey);
+        var wasAvailable = IsAvailable;
+        var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
+
+        _apiKey = normalized;
         if (_host is not null)
         {
-            if (string.IsNullOrWhiteSpace(apiKey))
-                await _host.DeleteSecretAsync("api-key");
+            if (normalized is null)
+                await _host.DeleteSecretAsync(ApiKeySecretName);
             else
-                await _host.StoreSecretAsync("api-key", apiKey);
+                await _host.StoreSecretAsync(ApiKeySecretName, normalized);
+
+            if (changed && wasAvailable != IsAvailable)
+                _host.NotifyCapabilitiesChanged();
+        }
+    }
+
+    internal void SetFetchedLlmModels(IEnumerable<GeminiFetchedModel> models)
+    {
+        _fetchedLlmModels = NormalizeFetchedLlmModels(models);
+        _host?.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
+        _host?.NotifyCapabilitiesChanged();
+    }
+
+    internal async Task<List<GeminiFetchedModel>?> FetchLlmModelsAsync(CancellationToken ct = default)
+    {
+        if (!IsAvailable)
+            return null;
+
+        using var request = CreateAuthenticatedRequest(HttpMethod.Get, $"{BaseUrl}/models", _apiKey!);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var catalog = JsonSerializer.Deserialize<GeminiCompatibleModelsResponse>(json, JsonOptions);
+            return NormalizeFetchedLlmModels(catalog?.Data?.OfType<GeminiCompatibleModel>() ?? []);
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
         }
     }
 
     internal async Task<bool> ValidateApiKeyAsync(string apiKey, CancellationToken ct = default)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/v1/models");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        var normalized = NormalizeApiKey(apiKey);
+        if (normalized is null)
+            return false;
+
+        using var request = CreateAuthenticatedRequest(HttpMethod.Get, $"{BaseUrl}/models", normalized);
         try
         {
-            var response = await _httpClient.SendAsync(request, ct);
+            using var response = await _httpClient.SendAsync(request, ct);
             return response.IsSuccessStatusCode;
         }
-        catch
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
         {
             return false;
         }
     }
+
+    internal static bool IsCompatibleChatModelId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return false;
+
+        var normalized = NormalizeModelId(id);
+        if (!normalized.StartsWith("gemini-", StringComparison.OrdinalIgnoreCase)
+            && !normalized.StartsWith("gemma-", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !ExcludedModelTokens.Any(token => normalized.Contains(token, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<string> SendChatCompletionAsync(
+        string model,
+        string systemPrompt,
+        string userText,
+        CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["model"] = model,
+            ["messages"] = new object[]
+            {
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = userText },
+            },
+            ["temperature"] = 0.1,
+            ["max_tokens"] = 2048,
+        };
+
+        using var request = CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{BaseUrl}/chat/completions",
+            _apiKey!);
+        request.Content = new StringContent(
+            JsonSerializer.Serialize(body),
+            Encoding.UTF8,
+            "application/json");
+
+        using var response = await OpenAiApiHelper.SendWithErrorHandlingAsync(_httpClient, request, ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseChatCompletionResponse(json);
+    }
+
+    private static string ParseChatCompletionResponse(string json)
+    {
+        if (!string.IsNullOrWhiteSpace(json))
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Object
+                && root.TryGetProperty("choices", out var choices)
+                && choices.ValueKind == JsonValueKind.Array
+                && choices.GetArrayLength() > 0
+                && choices[0].TryGetProperty("message", out var message)
+                && message.TryGetProperty("content", out var content)
+                && content.ValueKind == JsonValueKind.String)
+            {
+                var text = content.GetString()?.Trim();
+                if (!string.IsNullOrWhiteSpace(text))
+                    return text;
+            }
+        }
+
+        throw new PluginRequestException(
+            "The provider returned an empty response.",
+            PluginRequestFailureKind.EmptyResponse);
+    }
+
+    private static HttpRequestMessage CreateAuthenticatedRequest(HttpMethod method, string url, string apiKey)
+    {
+        var request = new HttpRequestMessage(method, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        return request;
+    }
+
+    private static List<GeminiFetchedModel> NormalizeFetchedLlmModels(
+        IEnumerable<GeminiCompatibleModel> models) =>
+        NormalizeFetchedLlmModels(models
+            .Where(model => !string.IsNullOrWhiteSpace(model.Id))
+            .Select(model => new GeminiFetchedModel(
+                model.Id!,
+                model.DisplayName)));
+
+    private static List<GeminiFetchedModel> NormalizeFetchedLlmModels(
+        IEnumerable<GeminiFetchedModel> models) =>
+        models
+            .Where(model => model is not null && !string.IsNullOrWhiteSpace(model.Id))
+            .Select(model => new GeminiFetchedModel(
+                NormalizeModelId(model.Id),
+                string.IsNullOrWhiteSpace(model.DisplayName) ? null : model.DisplayName.Trim()))
+            .Where(model => IsCompatibleChatModelId(model.Id))
+            .DistinctBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(model => string.Equals(model.Id, DefaultModel, StringComparison.OrdinalIgnoreCase))
+            .ThenBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static string ResolveDefaultModelId(IReadOnlyList<GeminiFetchedModel> models)
+    {
+        var alias = models.FirstOrDefault(model => string.Equals(
+            model.Id,
+            DefaultModel,
+            StringComparison.OrdinalIgnoreCase));
+        if (alias is not null)
+            return alias.Id;
+
+        return models
+            .Where(model => model.Id.StartsWith("gemini-", StringComparison.OrdinalIgnoreCase)
+                && model.Id.Contains("flash", StringComparison.OrdinalIgnoreCase)
+                && !model.Id.Contains("lite", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(model => model.Id.Contains("preview", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(model => model.Id)
+            .FirstOrDefault()
+            ?? models[0].Id;
+    }
+
+    private static string NormalizeModelId(string id)
+    {
+        var normalized = id.Trim();
+        return normalized.StartsWith("models/", StringComparison.OrdinalIgnoreCase)
+            ? normalized["models/".Length..]
+            : normalized;
+    }
+
+    private static string? NormalizeApiKey(string? apiKey) =>
+        string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
 
     /// <summary>
     /// Releases resources held by the instance.
@@ -139,3 +398,12 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         _httpClient.Dispose();
     }
 }
+
+internal sealed record GeminiFetchedModel(string Id, string? DisplayName);
+
+internal sealed record GeminiCompatibleModelsResponse(
+    [property: JsonPropertyName("data")] List<GeminiCompatibleModel?>? Data);
+
+internal sealed record GeminiCompatibleModel(
+    [property: JsonPropertyName("id")] string? Id,
+    [property: JsonPropertyName("display_name")] string? DisplayName);

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -37,6 +37,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         "robotics",
         "computer-use",
         "deep-research",
+        "omni",
     ];
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -169,8 +170,12 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         var normalized = NormalizeApiKey(apiKey);
         var wasAvailable = IsAvailable;
         var changed = !string.Equals(_apiKey, normalized, StringComparison.Ordinal);
+        var catalogChanged = changed && _fetchedLlmModels.Count > 0;
 
         _apiKey = normalized;
+        if (catalogChanged)
+            _fetchedLlmModels = [];
+
         if (_host is not null)
         {
             if (normalized is null)
@@ -178,14 +183,21 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             else
                 await _host.StoreSecretAsync(ApiKeySecretName, normalized);
 
-            if (changed && wasAvailable != IsAvailable)
+            if (catalogChanged)
+                _host.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
+
+            if ((changed && wasAvailable != IsAvailable) || catalogChanged)
                 _host.NotifyCapabilitiesChanged();
         }
     }
 
     internal void SetFetchedLlmModels(IEnumerable<GeminiFetchedModel> models)
     {
-        _fetchedLlmModels = NormalizeFetchedLlmModels(models);
+        var normalized = NormalizeFetchedLlmModels(models);
+        if (ModelCatalogsEqual(_fetchedLlmModels, normalized))
+            return;
+
+        _fetchedLlmModels = normalized;
         _host?.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
         _host?.NotifyCapabilitiesChanged();
     }
@@ -201,7 +213,12 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         {
             using var response = await _httpClient.SendAsync(request, ct);
             if (!response.IsSuccessStatusCode)
+            {
+                _host?.Log(
+                    PluginLogLevel.Warning,
+                    $"Model catalog request failed with HTTP status {(int)response.StatusCode}.");
                 return null;
+            }
 
             var json = await response.Content.ReadAsStringAsync(ct);
             var catalog = JsonSerializer.Deserialize<GeminiCompatibleModelsResponse>(json, JsonOptions);
@@ -209,22 +226,27 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         }
         catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
+            _host?.Log(PluginLogLevel.Warning, "Model catalog request timed out.");
             return null;
         }
         catch (OperationCanceledException)
         {
+            _host?.Log(PluginLogLevel.Debug, "Model catalog request was canceled by the caller.");
             throw;
         }
-        catch (HttpRequestException)
+        catch (HttpRequestException ex)
         {
+            _host?.Log(PluginLogLevel.Warning, $"Model catalog request failed with {ex.GetType().Name}.");
             return null;
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
+            _host?.Log(PluginLogLevel.Warning, $"Model catalog parsing failed with {ex.GetType().Name}.");
             return null;
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
+            _host?.Log(PluginLogLevel.Warning, $"Model catalog request failed with {ex.GetType().Name}.");
             return null;
         }
     }
@@ -288,7 +310,6 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 new { role = "system", content = systemPrompt },
                 new { role = "user", content = userText },
             },
-            ["temperature"] = 0.1,
             ["max_tokens"] = 2048,
         };
 
@@ -310,19 +331,34 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     {
         if (!string.IsNullOrWhiteSpace(json))
         {
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
-            if (root.ValueKind == JsonValueKind.Object
-                && root.TryGetProperty("choices", out var choices)
-                && choices.ValueKind == JsonValueKind.Array
-                && choices.GetArrayLength() > 0
-                && choices[0].TryGetProperty("message", out var message)
-                && message.TryGetProperty("content", out var content)
-                && content.ValueKind == JsonValueKind.String)
+            JsonDocument doc;
+            try
             {
-                var text = content.GetString()?.Trim();
-                if (!string.IsNullOrWhiteSpace(text))
-                    return text;
+                doc = JsonDocument.Parse(json);
+            }
+            catch (JsonException ex)
+            {
+                throw new PluginRequestException(
+                    "The provider returned a malformed response.",
+                    PluginRequestFailureKind.EmptyResponse,
+                    innerException: ex);
+            }
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind == JsonValueKind.Object
+                    && root.TryGetProperty("choices", out var choices)
+                    && choices.ValueKind == JsonValueKind.Array
+                    && choices.GetArrayLength() > 0
+                    && choices[0].TryGetProperty("message", out var message)
+                    && message.TryGetProperty("content", out var content)
+                    && content.ValueKind == JsonValueKind.String)
+                {
+                    var text = content.GetString()?.Trim();
+                    if (!string.IsNullOrWhiteSpace(text))
+                        return text;
+                }
             }
         }
 
@@ -373,11 +409,39 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 && model.Id.Contains("flash", StringComparison.OrdinalIgnoreCase)
                 && !model.Id.Contains("lite", StringComparison.OrdinalIgnoreCase))
             .OrderBy(model => model.Id.Contains("preview", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(model => GetModelVersion(model.Id))
             .ThenByDescending(model => model.Id, StringComparer.OrdinalIgnoreCase)
             .Select(model => model.Id)
             .FirstOrDefault()
             ?? models[0].Id;
     }
+
+    private static Version GetModelVersion(string id)
+    {
+        const string prefix = "gemini-";
+        if (!id.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return new Version(0, 0);
+
+        var versionEnd = id.IndexOf('-', prefix.Length);
+        if (versionEnd <= prefix.Length)
+            return new Version(0, 0);
+
+        var versionText = id[prefix.Length..versionEnd];
+        if (!versionText.Contains('.'))
+            versionText += ".0";
+
+        return Version.TryParse(versionText, out var version)
+            ? version
+            : new Version(0, 0);
+    }
+
+    private static bool ModelCatalogsEqual(
+        IReadOnlyList<GeminiFetchedModel> first,
+        IReadOnlyList<GeminiFetchedModel> second) =>
+        first.Count == second.Count
+        && first.Zip(second).All(pair =>
+            string.Equals(pair.First.Id, pair.Second.Id, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(pair.First.DisplayName, pair.Second.DisplayName, StringComparison.Ordinal));
 
     private static string NormalizeModelId(string id)
     {

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -54,7 +54,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     /// Initializes a new instance of the GeminiPlugin class.
     /// </summary>
     public GeminiPlugin()
-        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(30) })
+        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(120) })
     {
     }
 

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -310,9 +310,10 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 new { role = "system", content = systemPrompt },
                 new { role = "user", content = userText },
             },
-            ["reasoning_effort"] = "low",
             ["max_tokens"] = 2048,
         };
+        if (model.StartsWith("gemini-", StringComparison.OrdinalIgnoreCase))
+            body["reasoning_effort"] = "low";
 
         using var request = CreateAuthenticatedRequest(
             HttpMethod.Post,

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="TypeWhisper.Plugin.Gemini.GeminiSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Margin="0,4">
+    <StackPanel Margin="0,4" MaxWidth="500">
         <TextBlock Text="API Key" FontWeight="SemiBold" Margin="0,0,0,4" />
         <Grid>
             <Grid.ColumnDefinitions>
@@ -13,5 +13,18 @@
                     Click="OnTestClick" x:Name="TestButton" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />
+
+        <StackPanel x:Name="ModelsSection" Margin="0,16,0,0" Visibility="Collapsed">
+            <Grid Margin="0,0,0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="ModelCatalogLabel" FontWeight="SemiBold" VerticalAlignment="Center" />
+                <Button Grid.Column="1" x:Name="RefreshButton" Padding="12,4"
+                        Click="OnRefreshClick" />
+            </Grid>
+            <TextBlock x:Name="ModelCatalogHintText" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
@@ -10,7 +10,7 @@ namespace TypeWhisper.Plugin.Gemini;
 public partial class GeminiSettingsView : UserControl
 {
     private readonly GeminiPlugin _plugin;
-    private bool _suppressPasswordChanged;
+    private readonly bool _suppressPasswordChanged;
     private bool _autoRefreshStarted;
 
     /// <summary>

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
@@ -10,6 +10,8 @@ namespace TypeWhisper.Plugin.Gemini;
 public partial class GeminiSettingsView : UserControl
 {
     private readonly GeminiPlugin _plugin;
+    private bool _suppressPasswordChanged;
+    private bool _autoRefreshStarted;
 
     /// <summary>
     /// Initializes a new instance of the GeminiSettingsView class.
@@ -19,20 +21,40 @@ public partial class GeminiSettingsView : UserControl
         _plugin = plugin;
         InitializeComponent();
         TestButton.Content = L("Settings.Test");
+        RefreshButton.Content = L("Settings.Refresh");
+        ModelCatalogLabel.Text = L("Settings.ModelCatalog");
 
         // Pre-fill password box if API key is already set
         if (!string.IsNullOrEmpty(plugin.ApiKey))
         {
+            _suppressPasswordChanged = true;
             ApiKeyBox.Password = plugin.ApiKey;
+            _suppressPasswordChanged = false;
         }
+
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        UpdateModelsSection();
+        if (_autoRefreshStarted || !_plugin.IsAvailable || _plugin.FetchedLlmModels.Count > 0)
+            return;
+
+        _autoRefreshStarted = true;
+        await RefreshModelsAsync(showSuccess: false);
     }
 
     private async void OnPasswordChanged(object sender, RoutedEventArgs e)
     {
+        if (_suppressPasswordChanged)
+            return;
+
         var key = ApiKeyBox.Password;
         await _plugin.SetApiKeyAsync(key);
         StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
+        UpdateModelsSection();
     }
 
     private async void OnTestClick(object sender, RoutedEventArgs e)
@@ -54,6 +76,10 @@ public partial class GeminiSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
+                var models = await _plugin.FetchLlmModelsAsync();
+                if (models is { Count: > 0 })
+                    _plugin.SetFetchedLlmModels(models);
+
                 StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
             }
@@ -71,7 +97,78 @@ public partial class GeminiSettingsView : UserControl
         finally
         {
             TestButton.IsEnabled = true;
+            UpdateModelsSection();
         }
+    }
+
+    private async void OnRefreshClick(object sender, RoutedEventArgs e) =>
+        await RefreshModelsAsync(showSuccess: true);
+
+    private async Task RefreshModelsAsync(bool showSuccess)
+    {
+        if (!_plugin.IsAvailable)
+        {
+            StatusText.Text = L("Settings.EnterApiKey");
+            StatusText.Foreground = Brushes.Orange;
+            return;
+        }
+
+        RefreshButton.IsEnabled = false;
+        if (showSuccess)
+        {
+            StatusText.Text = L("Settings.RefreshingModels");
+            StatusText.Foreground = Brushes.Gray;
+        }
+
+        try
+        {
+            var models = await _plugin.FetchLlmModelsAsync();
+            if (models is not { Count: > 0 })
+            {
+                if (showSuccess)
+                {
+                    StatusText.Text = L("Settings.RefreshFailed");
+                    StatusText.Foreground = Brushes.Orange;
+                }
+                return;
+            }
+
+            _plugin.SetFetchedLlmModels(models);
+            if (showSuccess)
+            {
+                StatusText.Text = L("Settings.ModelsFetched", models.Count);
+                StatusText.Foreground = Brushes.Green;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            if (showSuccess)
+            {
+                StatusText.Text = L("Settings.RefreshFailed");
+                StatusText.Foreground = Brushes.Orange;
+            }
+        }
+        catch (Exception ex)
+        {
+            if (showSuccess)
+            {
+                StatusText.Text = L("Settings.Error", ex.Message);
+                StatusText.Foreground = Brushes.Red;
+            }
+        }
+        finally
+        {
+            RefreshButton.IsEnabled = true;
+            UpdateModelsSection();
+        }
+    }
+
+    private void UpdateModelsSection()
+    {
+        ModelsSection.Visibility = _plugin.IsAvailable ? Visibility.Visible : Visibility.Collapsed;
+        ModelCatalogHintText.Text = _plugin.FetchedLlmModels.Count > 0
+            ? L("Settings.ModelsFetchedHint", _plugin.FetchedLlmModels.Count)
+            : L("Settings.DefaultModelsHint");
     }
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
@@ -76,9 +76,10 @@ public partial class GeminiSettingsView : UserControl
             var valid = await _plugin.ValidateApiKeyAsync(key);
             if (valid)
             {
+                var catalogKey = _plugin.ApiKey;
                 var models = await _plugin.FetchLlmModelsAsync();
-                if (models is { Count: > 0 })
-                    _plugin.SetFetchedLlmModels(models);
+                if (models is { Count: > 0 } && catalogKey is not null)
+                    await _plugin.SetFetchedLlmModelsAsync(models, catalogKey);
 
                 StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
@@ -122,8 +123,11 @@ public partial class GeminiSettingsView : UserControl
 
         try
         {
+            var catalogKey = _plugin.ApiKey;
             var models = await _plugin.FetchLlmModelsAsync();
-            if (models is not { Count: > 0 })
+            if (models is not { Count: > 0 }
+                || catalogKey is null
+                || !await _plugin.SetFetchedLlmModelsAsync(models, catalogKey))
             {
                 if (showSuccess)
                 {
@@ -133,7 +137,6 @@ public partial class GeminiSettingsView : UserControl
                 return;
             }
 
-            _plugin.SetFetchedLlmModels(models);
             if (showSuccess)
             {
                 StatusText.Text = L("Settings.ModelsFetched", models.Count);

--- a/plugins/TypeWhisper.Plugin.Gemini/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/Localization/de.json
@@ -1,9 +1,16 @@
 {
   "Settings.Test": "Testen",
+  "Settings.Refresh": "Aktualisieren",
   "Settings.Saved": "Gespeichert",
   "Settings.EnterApiKey": "Bitte zuerst einen API-Key eingeben",
   "Settings.Testing": "Teste...",
+  "Settings.RefreshingModels": "Modelle werden aktualisiert...",
   "Settings.ApiKeyValid": "API-Key gültig!",
   "Settings.ApiKeyInvalid": "Ungültiger API-Key",
+  "Settings.ModelCatalog": "Verfügbare LLM-Modelle",
+  "Settings.DefaultModelsHint": "Die integrierten Gemini-Aliasse werden verwendet. Mit \"Aktualisieren\" werden die für diesen API-Key verfügbaren Gemini- und Gemma-Chatmodelle geladen.",
+  "Settings.ModelsFetched": "Kompatible Gemini- und Gemma-Modelle geladen: {0}.",
+  "Settings.ModelsFetchedHint": "Kompatible Gemini- und Gemma-Modelle aus der API: {0}.",
+  "Settings.RefreshFailed": "Modelle konnten nicht aktualisiert werden. Die gespeicherte oder integrierte Liste bleibt aktiv.",
   "Settings.Error": "Fehler: {0}"
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/Localization/en.json
@@ -1,9 +1,16 @@
 {
   "Settings.Test": "Test",
+  "Settings.Refresh": "Refresh",
   "Settings.Saved": "Saved",
   "Settings.EnterApiKey": "Please enter an API key first",
   "Settings.Testing": "Testing...",
+  "Settings.RefreshingModels": "Refreshing models...",
   "Settings.ApiKeyValid": "API key valid!",
   "Settings.ApiKeyInvalid": "Invalid API key",
+  "Settings.ModelCatalog": "Available LLM models",
+  "Settings.DefaultModelsHint": "Using the built-in Gemini aliases. Refresh to fetch the Gemini and Gemma chat models available to this API key.",
+  "Settings.ModelsFetched": "Compatible Gemini and Gemma models fetched: {0}.",
+  "Settings.ModelsFetchedHint": "Compatible Gemini and Gemma models loaded from the API: {0}.",
+  "Settings.RefreshFailed": "Could not refresh models. Keeping the saved or built-in list.",
   "Settings.Error": "Error: {0}"
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/TypeWhisper.Plugin.Gemini.csproj
+++ b/plugins/TypeWhisper.Plugin.Gemini/TypeWhisper.Plugin.Gemini.csproj
@@ -8,6 +8,9 @@
     <RootNamespace>TypeWhisper.Plugin.Gemini</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/plugins/TypeWhisper.Plugin.Gemini/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/manifest.json
@@ -1,9 +1,15 @@
 {
   "id": "com.typewhisper.gemini",
   "name": "Google Gemini",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "author": "TypeWhisper",
-  "description": "Google Gemini LLM provider for prompt actions and translation",
+  "description": "Google Gemini and Gemma LLM provider with dynamic model discovery for prompt actions and translation",
+  "descriptions": {
+    "de": "Google-Gemini- und Gemma-LLM-Anbieter mit dynamischer Modellerkennung für Prompt-Aktionen und Übersetzungen"
+  },
+  "category": "llm",
+  "categories": ["llm"],
+  "requiresApiKey": true,
   "assemblyName": "TypeWhisper.Plugin.Gemini.dll",
   "pluginClass": "TypeWhisper.Plugin.Gemini.GeminiPlugin"
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
@@ -14,7 +14,7 @@ public sealed class GeminiPluginTests
     [Fact]
     public void PluginVersion_MatchesManifestVersion()
     {
-        var manifestPath = Path.Combine(
+        var manifestPath = Path.Join(
             RepositoryRoot(),
             "plugins",
             "TypeWhisper.Plugin.Gemini",
@@ -486,8 +486,8 @@ public sealed class GeminiPluginTests
             directory is not null;
             directory = directory.Parent)
         {
-            if (File.Exists(Path.Combine(directory.FullName, "TypeWhisper.slnx"))
-                && Directory.Exists(Path.Combine(directory.FullName, "plugins")))
+            if (File.Exists(Path.Join(directory.FullName, "TypeWhisper.slnx"))
+                && Directory.Exists(Path.Join(directory.FullName, "plugins")))
             {
                 return directory.FullName;
             }

--- a/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
@@ -120,6 +120,47 @@ public sealed class GeminiPluginTests
         Assert.Equal("Bearer gemini-key", capturedRequest?.Headers.Authorization?.ToString());
     }
 
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("null")]
+    public async Task FetchLlmModelsAsync_RejectsCatalogWithoutDataArray(string json)
+    {
+        var handler = new CapturingHandler((_, _) => JsonResponse(json));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+        });
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.FetchLlmModelsAsync();
+
+        Assert.Null(result);
+        Assert.Contains(sut.FetchedLlmModels, model => model.Id == "gemini-3.7-flash");
+        Assert.Contains(host.Logs, entry =>
+            entry.Level == PluginLogLevel.Warning
+            && entry.Message.Contains("data array", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task FetchLlmModelsAsync_AcceptsExplicitEmptyCatalog()
+    {
+        var handler = new CapturingHandler((_, _) => JsonResponse("""{"data":[]}"""));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.FetchLlmModelsAsync();
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
     [Fact]
     public async Task SetFetchedLlmModels_KeepsCurrentFetchedFlashModelFirstAndNotifiesHost()
     {
@@ -128,7 +169,7 @@ public sealed class GeminiPluginTests
         using var sut = new GeminiPlugin();
         await sut.ActivateAsync(host);
 
-        sut.SetFetchedLlmModels(
+        await sut.SetFetchedLlmModelsAsync(
         [
             new("gemini-3.7-flash", "Gemini 3.7 Flash"),
             new("gemma-4-26b-a4b-it", "Gemma 4 26B MoE IT"),
@@ -154,8 +195,8 @@ public sealed class GeminiPluginTests
         using var sut = new GeminiPlugin();
         await sut.ActivateAsync(host);
 
-        sut.SetFetchedLlmModels([new("gemini-3.7-flash", "Gemini 3.7 Flash")]);
-        sut.SetFetchedLlmModels([new("models/gemini-3.7-flash", "Gemini 3.7 Flash")]);
+        await sut.SetFetchedLlmModelsAsync([new("gemini-3.7-flash", "Gemini 3.7 Flash")]);
+        await sut.SetFetchedLlmModelsAsync([new("models/gemini-3.7-flash", "Gemini 3.7 Flash")]);
 
         Assert.Equal(1, host.SetSettingCount);
         Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
@@ -183,6 +224,70 @@ public sealed class GeminiPluginTests
         Assert.Empty(host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!);
         Assert.Equal(1, host.SetSettingCount);
         Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_LeavesStateUnchangedWhenSecretWriteFails()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "first-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+        });
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+        host.ResetTracking();
+        host.StoreSecretException = new InvalidOperationException("secret write failed");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SetApiKeyAsync("second-key"));
+
+        Assert.Equal("first-key", sut.ApiKey);
+        Assert.Equal("first-key", host.Secrets["api-key"]);
+        Assert.Contains(sut.FetchedLlmModels, model => model.Id == "gemini-3.7-flash");
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_RestoresSecretWhenCatalogWriteFails()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "first-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+        });
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+        host.ResetTracking();
+        host.SetSettingExceptionAfterWrite = new InvalidOperationException("catalog write failed");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SetApiKeyAsync("second-key"));
+
+        Assert.Equal("first-key", sut.ApiKey);
+        Assert.Equal("first-key", host.Secrets["api-key"]);
+        Assert.Contains(sut.FetchedLlmModels, model => model.Id == "gemini-3.7-flash");
+        Assert.Contains(
+            host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!,
+            model => model.Id == "gemini-3.7-flash");
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetFetchedLlmModelsAsync_LeavesStateUnchangedWhenSettingWriteFails()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+        host.SetSettingExceptionAfterWrite = new InvalidOperationException("catalog write failed");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SetFetchedLlmModelsAsync(
+            [new("gemini-3.7-flash", "Gemini 3.7 Flash")]));
+
+        Assert.Empty(sut.FetchedLlmModels);
+        Assert.Equal(GeminiPlugin.DefaultModel, sut.SupportedModels[0].Id);
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
     }
 
     [Fact]
@@ -244,6 +349,28 @@ public sealed class GeminiPluginTests
         using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
         Assert.Equal("gemma-4-31b-it", body.RootElement.GetProperty("model").GetString());
         Assert.False(body.RootElement.TryGetProperty("reasoning_effort", out _));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NormalizesModelsPrefixBeforeApplyingGeminiOptions()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return JsonResponse("""{"choices":[{"message":{"content":"ok"}}]}""");
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        await sut.ProcessAsync("system", "user", "models/gemini-3.7-flash", CancellationToken.None);
+
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.Equal("gemini-3.7-flash", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal("low", body.RootElement.GetProperty("reasoning_effort").GetString());
     }
 
     [Fact]
@@ -317,11 +444,11 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
-    public void SupportedModels_OrdersFallbackFlashVersionsNumerically()
+    public async Task SupportedModels_OrdersFallbackFlashVersionsNumerically()
     {
         using var sut = new GeminiPlugin();
 
-        sut.SetFetchedLlmModels(
+        await sut.SetFetchedLlmModelsAsync(
         [
             new("gemini-3.7-flash", "Gemini 3.7 Flash"),
             new("gemini-3.10-flash", "Gemini 3.10 Flash"),
@@ -373,20 +500,74 @@ public sealed class GeminiPluginTests
     [Fact]
     public async Task FetchLlmModelsAsync_RethrowsCallerCancellation()
     {
-        var handler = new CapturingHandler((_, _) => JsonResponse("""{"data":[]}"""));
+        var handler = new BlockingHandler(JsonResponse("""{"data":[]}"""));
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "gemini-key";
         using var httpClient = new HttpClient(handler);
         using var sut = new GeminiPlugin(httpClient);
         await sut.ActivateAsync(host);
         using var cts = new CancellationTokenSource();
+
+        var fetchTask = sut.FetchLlmModelsAsync(cts.Token);
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
         cts.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sut.FetchLlmModelsAsync(cts.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetchTask);
 
         Assert.Contains(host.Logs, entry =>
             entry.Level == PluginLogLevel.Debug
             && entry.Message.Contains("canceled", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task FetchLlmModelsAsync_DiscardsCatalogWhenApiKeyChangesInFlight()
+    {
+        var handler = new BlockingHandler(JsonResponse("""
+            {"data":[{"id":"gemini-3.7-flash","display_name":"Gemini 3.7 Flash"}]}
+            """));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "first-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-2.5-flash", "Gemini 2.5 Flash"),
+        });
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var fetchTask = sut.FetchLlmModelsAsync();
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await sut.SetApiKeyAsync("second-key");
+        handler.Release();
+        var result = await fetchTask;
+
+        Assert.Null(result);
+        Assert.Equal("second-key", sut.ApiKey);
+        Assert.Empty(sut.FetchedLlmModels);
+        Assert.Empty(host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!);
+        Assert.Contains(host.Logs, entry =>
+            entry.Level == PluginLogLevel.Debug
+            && entry.Message.Contains("previous API key", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SetFetchedLlmModelsAsync_RejectsCatalogForPreviousApiKey()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "first-key";
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+        await sut.SetApiKeyAsync("second-key");
+
+        var applied = await sut.SetFetchedLlmModelsAsync(
+            [new("gemini-3.7-flash", "Gemini 3.7 Flash")],
+            expectedApiKey: "first-key");
+
+        Assert.False(applied);
+        Assert.Empty(sut.FetchedLlmModels);
+        Assert.Contains(host.Logs, entry =>
+            entry.Level == PluginLogLevel.Debug
+            && entry.Message.Contains("previous API key", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -425,6 +606,26 @@ public sealed class GeminiPluginTests
         }
     }
 
+    private sealed class BlockingHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> Started { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Release() => _release.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Started.TrySetResult(true);
+            await _release.Task.WaitAsync(cancellationToken);
+            return response;
+        }
+    }
+
     private sealed class TestPluginHostServices : IPluginHostServices
     {
         private static readonly JsonSerializerOptions JsonOptions = new()
@@ -437,9 +638,18 @@ public sealed class GeminiPluginTests
         public int NotifyCapabilitiesChangedCount { get; private set; }
         public int SetSettingCount { get; private set; }
         public List<(PluginLogLevel Level, string Message)> Logs { get; } = [];
+        public Exception? StoreSecretException { get; set; }
+        public Exception? SetSettingException { get; set; }
+        public Exception? SetSettingExceptionAfterWrite { get; set; }
 
         public Task StoreSecretAsync(string key, string value)
         {
+            if (StoreSecretException is { } exception)
+            {
+                StoreSecretException = null;
+                throw exception;
+            }
+
             Secrets[key] = value;
             return Task.CompletedTask;
         }
@@ -460,8 +670,19 @@ public sealed class GeminiPluginTests
 
         public void SetSetting<T>(string key, T value)
         {
+            if (SetSettingException is { } exception)
+            {
+                SetSettingException = null;
+                throw exception;
+            }
+
             _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
             SetSettingCount++;
+            if (SetSettingExceptionAfterWrite is { } afterWriteException)
+            {
+                SetSettingExceptionAfterWrite = null;
+                throw afterWriteException;
+            }
         }
 
         public void ResetTracking()

--- a/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
@@ -35,7 +35,7 @@ public sealed class GeminiPluginTests
         using var sut = new GeminiPlugin();
 
         Assert.Equal(
-            ["gemini-flash-latest", "gemini-pro-latest", "gemini-flash-lite-latest"],
+            ["gemini-flash-lite-latest", "gemini-flash-latest", "gemini-pro-latest"],
             sut.SupportedModels.Select(model => model.Id).ToArray());
         Assert.Equal(GeminiPlugin.DefaultModel, Assert.Single(sut.SupportedModels, model => model.IsRecommended).Id);
     }
@@ -178,7 +178,7 @@ public sealed class GeminiPluginTests
 
         Assert.Equal("second-key", host.Secrets["api-key"]);
         Assert.Equal(
-            ["gemini-flash-latest", "gemini-pro-latest", "gemini-flash-lite-latest"],
+            ["gemini-flash-lite-latest", "gemini-flash-latest", "gemini-pro-latest"],
             sut.SupportedModels.Select(model => model.Id).ToArray());
         Assert.Empty(host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!);
         Assert.Equal(1, host.SetSettingCount);
@@ -218,6 +218,7 @@ public sealed class GeminiPluginTests
         using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
         Assert.Equal("gemini-3.7-flash", body.RootElement.GetProperty("model").GetString());
         Assert.Equal(2048, body.RootElement.GetProperty("max_tokens").GetInt32());
+        Assert.Equal("low", body.RootElement.GetProperty("reasoning_effort").GetString());
         Assert.False(body.RootElement.TryGetProperty("temperature", out _));
         Assert.Equal("system", body.RootElement.GetProperty("messages")[0].GetProperty("role").GetString());
         Assert.Equal("user", body.RootElement.GetProperty("messages")[1].GetProperty("role").GetString());

--- a/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
@@ -225,6 +225,28 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
+    public async Task ProcessAsync_OmitsGeminiReasoningEffortForGemmaModels()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return JsonResponse("""{"choices":[{"message":{"content":"ok"}}]}""");
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        await sut.ProcessAsync("system", "user", "gemma-4-31b-it", CancellationToken.None);
+
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.Equal("gemma-4-31b-it", body.RootElement.GetProperty("model").GetString());
+        Assert.False(body.RootElement.TryGetProperty("reasoning_effort", out _));
+    }
+
+    [Fact]
     public async Task ProcessAsync_ClassifiesMalformedSuccessResponse()
     {
         var handler = new CapturingHandler((_, _) => JsonResponse("not-json"));

--- a/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
@@ -14,11 +14,11 @@ public sealed class GeminiPluginTests
     [Fact]
     public void PluginVersion_MatchesManifestVersion()
     {
-        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
-        var relativeManifestPath = Path.Join(
-            "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.Gemini", "manifest.json");
-        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
+        var manifestPath = Path.Combine(
+            RepositoryRoot(),
+            "plugins",
+            "TypeWhisper.Plugin.Gemini",
+            "manifest.json");
         var manifest = JsonSerializer.Deserialize<PluginManifest>(
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
@@ -48,6 +48,8 @@ public sealed class GeminiPluginTests
     [InlineData("gemini-embedding-2", false)]
     [InlineData("gemini-3.1-flash-tts-preview", false)]
     [InlineData("gemini-3.1-flash-live-preview", false)]
+    [InlineData("gemini-omni-flash", false)]
+    [InlineData("gemini-omni-flash-preview", false)]
     [InlineData("gemini-robotics-er-2-preview", false)]
     [InlineData("deep-research-preview", false)]
     [InlineData("veo-3.1-generate-preview", false)]
@@ -145,6 +147,45 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
+    public async Task SetFetchedLlmModels_DoesNotPersistOrNotifyForUnchangedCatalog()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+
+        sut.SetFetchedLlmModels([new("gemini-3.7-flash", "Gemini 3.7 Flash")]);
+        sut.SetFetchedLlmModels([new("models/gemini-3.7-flash", "Gemini 3.7 Flash")]);
+
+        Assert.Equal(1, host.SetSettingCount);
+        Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_ClearsCatalogOwnedByPreviousKey()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "first-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+        });
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+        host.ResetTracking();
+
+        await sut.SetApiKeyAsync("second-key");
+
+        Assert.Equal("second-key", host.Secrets["api-key"]);
+        Assert.Equal(
+            ["gemini-flash-latest", "gemini-pro-latest", "gemini-flash-lite-latest"],
+            sut.SupportedModels.Select(model => model.Id).ToArray());
+        Assert.Empty(host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!);
+        Assert.Equal(1, host.SetSettingCount);
+        Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
     public async Task ProcessAsync_UsesDocumentedGeminiChatEndpoint()
     {
         HttpRequestMessage? capturedRequest = null;
@@ -177,9 +218,29 @@ public sealed class GeminiPluginTests
         using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
         Assert.Equal("gemini-3.7-flash", body.RootElement.GetProperty("model").GetString());
         Assert.Equal(2048, body.RootElement.GetProperty("max_tokens").GetInt32());
-        Assert.Equal(0.1, body.RootElement.GetProperty("temperature").GetDouble(), precision: 3);
+        Assert.False(body.RootElement.TryGetProperty("temperature", out _));
         Assert.Equal("system", body.RootElement.GetProperty("messages")[0].GetProperty("role").GetString());
         Assert.Equal("user", body.RootElement.GetProperty("messages")[1].GetProperty("role").GetString());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ClassifiesMalformedSuccessResponse()
+    {
+        var handler = new CapturingHandler((_, _) => JsonResponse("not-json"));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var error = await Assert.ThrowsAsync<PluginRequestException>(() => sut.ProcessAsync(
+            "system",
+            "user",
+            "gemini-3.7-flash",
+            CancellationToken.None));
+
+        Assert.Equal(PluginRequestFailureKind.EmptyResponse, error.FailureKind);
+        Assert.IsAssignableFrom<JsonException>(error.InnerException);
     }
 
     [Fact]
@@ -233,6 +294,22 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
+    public void SupportedModels_OrdersFallbackFlashVersionsNumerically()
+    {
+        using var sut = new GeminiPlugin();
+
+        sut.SetFetchedLlmModels(
+        [
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+            new("gemini-3.10-flash", "Gemini 3.10 Flash"),
+            new("gemini-3.11-flash-preview", "Gemini 3.11 Flash Preview"),
+        ]);
+
+        Assert.Equal("gemini-3.10-flash", sut.SupportedModels[0].Id);
+        Assert.True(sut.SupportedModels[0].IsRecommended);
+    }
+
+    [Fact]
     public async Task FetchLlmModelsAsync_FailureKeepsCachedCatalog()
     {
         var handler = new CapturingHandler((_, _) =>
@@ -252,6 +329,41 @@ public sealed class GeminiPluginTests
         Assert.Null(result);
         Assert.Contains(sut.SupportedModels, model => model.Id == "gemini-3.7-flash");
         Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+        Assert.Contains(host.Logs, entry =>
+            entry.Level == PluginLogLevel.Warning
+            && entry.Message.Contains("503", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsync_ReturnsFalseForUnauthorizedResponse()
+    {
+        var handler = new CapturingHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+
+        var result = await sut.ValidateApiKeyAsync("invalid-key");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FetchLlmModelsAsync_RethrowsCallerCancellation()
+    {
+        var handler = new CapturingHandler((_, _) => JsonResponse("""{"data":[]}"""));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sut.FetchLlmModelsAsync(cts.Token));
+
+        Assert.Contains(host.Logs, entry =>
+            entry.Level == PluginLogLevel.Debug
+            && entry.Message.Contains("canceled", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -282,6 +394,7 @@ public sealed class GeminiPluginTests
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var body = request.Content is null
                 ? null
                 : await request.Content.ReadAsStringAsync(cancellationToken);
@@ -299,6 +412,8 @@ public sealed class GeminiPluginTests
         private readonly Dictionary<string, JsonElement> _settings = [];
         public Dictionary<string, string?> Secrets { get; } = [];
         public int NotifyCapabilitiesChangedCount { get; private set; }
+        public int SetSettingCount { get; private set; }
+        public List<(PluginLogLevel Level, string Message)> Logs { get; } = [];
 
         public Task StoreSecretAsync(string key, string value)
         {
@@ -320,15 +435,25 @@ public sealed class GeminiPluginTests
                 ? value.Deserialize<T>(JsonOptions)
                 : default;
 
-        public void SetSetting<T>(string key, T value) =>
+        public void SetSetting<T>(string key, T value)
+        {
             _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+            SetSettingCount++;
+        }
+
+        public void ResetTracking()
+        {
+            NotifyCapabilitiesChangedCount = 0;
+            SetSettingCount = 0;
+            Logs.Clear();
+        }
 
         public string PluginDataDirectory => Path.GetTempPath();
         public string? ActiveAppProcessName => null;
         public string? ActiveAppName => null;
         public IPluginEventBus EventBus { get; } = new TestPluginEventBus();
         public IReadOnlyList<string> AvailableProfileNames => [];
-        public void Log(PluginLogLevel level, string message) { }
+        public void Log(PluginLogLevel level, string message) => Logs.Add((level, message));
         public void NotifyCapabilitiesChanged() => NotifyCapabilitiesChangedCount++;
         public IPluginLocalization Localization { get; } = new TestPluginLocalization();
     }
@@ -352,5 +477,21 @@ public sealed class GeminiPluginTests
     private sealed class NoOpDisposable : IDisposable
     {
         public void Dispose() { }
+    }
+
+    private static string RepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            directory is not null;
+            directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "TypeWhisper.slnx"))
+                && Directory.Exists(Path.Combine(directory.FullName, "plugins")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException("TypeWhisper repository root not found.");
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GeminiPluginTests.cs
@@ -1,0 +1,356 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.Plugin.Gemini;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class GeminiPluginTests
+{
+    [Fact]
+    public void PluginVersion_MatchesManifestVersion()
+    {
+        var basePath = Path.GetFullPath(AppContext.BaseDirectory);
+        var relativeManifestPath = Path.Join(
+            "..", "..", "..", "..", "..",
+            "plugins", "TypeWhisper.Plugin.Gemini", "manifest.json");
+        var manifestPath = Path.GetFullPath(relativeManifestPath, basePath);
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        using var sut = new GeminiPlugin();
+
+        Assert.NotNull(manifest);
+        Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
+    public void SupportedModels_UsesCurrentAliasesWithExplicitDefault()
+    {
+        using var sut = new GeminiPlugin();
+
+        Assert.Equal(
+            ["gemini-flash-latest", "gemini-pro-latest", "gemini-flash-lite-latest"],
+            sut.SupportedModels.Select(model => model.Id).ToArray());
+        Assert.Equal(GeminiPlugin.DefaultModel, Assert.Single(sut.SupportedModels, model => model.IsRecommended).Id);
+    }
+
+    [Theory]
+    [InlineData("models/gemini-3.7-flash", true)]
+    [InlineData("gemini-3.1-pro-preview", true)]
+    [InlineData("gemma-4-31b-it", true)]
+    [InlineData("gemini-3.1-flash-image", false)]
+    [InlineData("gemini-embedding-2", false)]
+    [InlineData("gemini-3.1-flash-tts-preview", false)]
+    [InlineData("gemini-3.1-flash-live-preview", false)]
+    [InlineData("gemini-robotics-er-2-preview", false)]
+    [InlineData("deep-research-preview", false)]
+    [InlineData("veo-3.1-generate-preview", false)]
+    public void IsCompatibleChatModelId_FiltersCatalog(string modelId, bool expected)
+    {
+        Assert.Equal(expected, GeminiPlugin.IsCompatibleChatModelId(modelId));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_RestoresNormalizedCachedModels()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = " gemini-key ";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("models/gemma-4-31b-it", " Gemma 4 31B IT "),
+            new("models/gemini-flash-latest", "Gemini Flash Latest"),
+            new("models/gemini-3.1-flash-image", "Nano Banana"),
+        });
+        using var sut = new GeminiPlugin();
+
+        await sut.ActivateAsync(host);
+
+        Assert.True(sut.IsAvailable);
+        Assert.Equal(
+            ["gemini-flash-latest", "gemma-4-31b-it"],
+            sut.SupportedModels.Select(model => model.Id).ToArray());
+        Assert.Equal("Gemma 4 31B IT", sut.SupportedModels.Last().DisplayName);
+    }
+
+    [Fact]
+    public async Task FetchLlmModelsAsync_UsesCompatibleEndpointAndFiltersSparseResults()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new CapturingHandler((request, _) =>
+        {
+            capturedRequest = request;
+            return JsonResponse("""
+                {
+                  "object": "list",
+                  "data": [
+                    null,
+                    { "id": null, "display_name": "Missing ID" },
+                    { "object": "model", "display_name": "No ID" },
+                    { "id": "models/gemini-3.7-flash", "display_name": "Gemini 3.7 Flash" },
+                    { "id": "models/gemma-4-31b-it", "display_name": "Gemma 4 31B IT" },
+                    { "id": "gemini-3.7-flash", "display_name": "Duplicate" },
+                    { "id": "models/gemini-3.1-flash-image", "display_name": "Nano Banana" },
+                    { "id": "models/gemini-embedding-2", "display_name": "Embedding" },
+                    { "id": "models/veo-3.1-generate-preview", "display_name": "Veo" }
+                  ]
+                }
+                """);
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var models = await sut.FetchLlmModelsAsync();
+
+        Assert.NotNull(models);
+        Assert.Equal(
+            ["gemini-3.7-flash", "gemma-4-31b-it"],
+            models!.Select(model => model.Id).ToArray());
+        Assert.Equal("https://generativelanguage.googleapis.com/v1beta/openai/models", capturedRequest?.RequestUri?.ToString());
+        Assert.Equal("Bearer gemini-key", capturedRequest?.Headers.Authorization?.ToString());
+    }
+
+    [Fact]
+    public async Task SetFetchedLlmModels_KeepsCurrentFetchedFlashModelFirstAndNotifiesHost()
+    {
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+
+        sut.SetFetchedLlmModels(
+        [
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+            new("gemma-4-26b-a4b-it", "Gemma 4 26B MoE IT"),
+        ]);
+
+        Assert.Equal(
+            ["gemini-3.7-flash", "gemma-4-26b-a4b-it"],
+            sut.SupportedModels.Select(model => model.Id).ToArray());
+        Assert.True(sut.SupportedModels[0].IsRecommended);
+        Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
+        Assert.Equal(
+            ["gemini-3.7-flash", "gemma-4-26b-a4b-it"],
+            host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!
+                .Select(model => model.Id)
+                .ToArray());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesDocumentedGeminiChatEndpoint()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
+        var handler = new CapturingHandler((request, body) =>
+        {
+            capturedRequest = request;
+            capturedBody = body;
+            return JsonResponse("""{"choices":[{"message":{"content":"  refreshed result  "}}]}""");
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.ProcessAsync(
+            "Clean up technical dictation",
+            "hello world",
+            "gemini-3.7-flash",
+            CancellationToken.None);
+
+        Assert.Equal("refreshed result", result);
+        Assert.Equal(HttpMethod.Post, capturedRequest?.Method);
+        Assert.Equal(
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+            capturedRequest?.RequestUri?.ToString());
+        Assert.Equal("Bearer gemini-key", capturedRequest?.Headers.Authorization?.ToString());
+
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.Equal("gemini-3.7-flash", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal(2048, body.RootElement.GetProperty("max_tokens").GetInt32());
+        Assert.Equal(0.1, body.RootElement.GetProperty("temperature").GetDouble(), precision: 3);
+        Assert.Equal("system", body.RootElement.GetProperty("messages")[0].GetProperty("role").GetString());
+        Assert.Equal("user", body.RootElement.GetProperty("messages")[1].GetProperty("role").GetString());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesCuratedDefaultWhenModelIsBlank()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return JsonResponse("""{"choices":[{"message":{"content":"ok"}}]}""");
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        await sut.ProcessAsync("system", "user", "", CancellationToken.None);
+
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.Equal(GeminiPlugin.DefaultModel, body.RootElement.GetProperty("model").GetString());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesCurrentFetchedFlashModelWhenModelIsBlank()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return JsonResponse("""{"choices":[{"message":{"content":"ok"}}]}""");
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-2.5-flash", "Gemini 2.5 Flash"),
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+            new("gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview"),
+        });
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        await sut.ProcessAsync("system", "user", "", CancellationToken.None);
+
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.Equal("gemini-3.7-flash", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal("gemini-3.7-flash", sut.SupportedModels[0].Id);
+        Assert.True(sut.SupportedModels[0].IsRecommended);
+    }
+
+    [Fact]
+    public async Task FetchLlmModelsAsync_FailureKeepsCachedCatalog()
+    {
+        var handler = new CapturingHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+        });
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.FetchLlmModelsAsync();
+
+        Assert.Null(result);
+        Assert.Contains(sut.SupportedModels, model => model.Id == "gemini-3.7-flash");
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task SetApiKeyAsync_NotifiesOnlyWhenAvailabilityChanges()
+    {
+        var host = new TestPluginHostServices();
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+
+        await sut.SetApiKeyAsync(" first-key ");
+        await sut.SetApiKeyAsync("second-key");
+        await sut.SetApiKeyAsync("");
+
+        Assert.Equal(2, host.NotifyCapabilitiesChangedCount);
+        Assert.DoesNotContain("api-key", host.Secrets.Keys);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class CapturingHandler(
+        Func<HttpRequestMessage, string?, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responder(request, body);
+        }
+    }
+
+    private sealed class TestPluginHostServices : IPluginHostServices
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        private readonly Dictionary<string, JsonElement> _settings = [];
+        public Dictionary<string, string?> Secrets { get; } = [];
+        public int NotifyCapabilitiesChangedCount { get; private set; }
+
+        public Task StoreSecretAsync(string key, string value)
+        {
+            Secrets[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadSecretAsync(string key) =>
+            Task.FromResult(Secrets.TryGetValue(key, out var value) ? value : null);
+
+        public Task DeleteSecretAsync(string key)
+        {
+            Secrets.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public T? GetSetting<T>(string key) =>
+            _settings.TryGetValue(key, out var value)
+                ? value.Deserialize<T>(JsonOptions)
+                : default;
+
+        public void SetSetting<T>(string key, T value) =>
+            _settings[key] = JsonSerializer.SerializeToElement(value, JsonOptions);
+
+        public string PluginDataDirectory => Path.GetTempPath();
+        public string? ActiveAppProcessName => null;
+        public string? ActiveAppName => null;
+        public IPluginEventBus EventBus { get; } = new TestPluginEventBus();
+        public IReadOnlyList<string> AvailableProfileNames => [];
+        public void Log(PluginLogLevel level, string message) { }
+        public void NotifyCapabilitiesChanged() => NotifyCapabilitiesChangedCount++;
+        public IPluginLocalization Localization { get; } = new TestPluginLocalization();
+    }
+
+    private sealed class TestPluginLocalization : IPluginLocalization
+    {
+        public string CurrentLanguage => "en";
+        public IReadOnlyList<string> AvailableLanguages => ["en"];
+        public string GetString(string key) => key;
+        public string GetString(string key, params object[] args) => string.Format(key, args);
+    }
+
+    private sealed class TestPluginEventBus : IPluginEventBus
+    {
+        public void Publish<T>(T pluginEvent) where T : PluginEvent { }
+
+        public IDisposable Subscribe<T>(Func<T, Task> handler) where T : PluginEvent =>
+            new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.AuthenticatedCli\TypeWhisper.Plugin.AuthenticatedCli.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenRouter\TypeWhisper.Plugin.OpenRouter.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Groq\TypeWhisper.Plugin.Groq.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Gemini\TypeWhisper.Plugin.Gemini.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Xai\TypeWhisper.Plugin.Xai.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.ElevenLabs\TypeWhisper.Plugin.ElevenLabs.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Reson8\TypeWhisper.Plugin.Reson8.csproj" />


### PR DESCRIPTION
## Summary
- fetch the Gemini and Gemma chat model catalog dynamically from Google's OpenAI-compatible models endpoint
- normalize models-prefixed IDs and filter non-chat model families
- cache successful catalogs, preserve safe fallback aliases, and add a manual refresh action to plugin settings
- use Google's current OpenAI-compatible chat endpoint and bump the plugin to 1.2.0

This supersedes the model-list update proposed in #135 with an implementation based on the corrected macOS behavior.

## Testing
- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --filter FullyQualifiedName~GeminiPluginTests --no-restore
- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore
- dotnet build plugins/TypeWhisper.Plugin.Gemini/TypeWhisper.Plugin.Gemini.csproj -c Release --no-restore
- F:/typewhisper/typewhisper-dev-tools/build-typewhisper-windows-plugin-dev.ps1 --run gemini C:/Users/marco/.t3/worktrees/typewhisper-win/t3code-ad3db74e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic Gemini and Gemma model discovery, filtering, fallback options, and default-model selection.
  * Added model catalog refresh controls with status and error feedback in settings.
  * Improved API-key storage and management.
  * Updated chat requests and the Gemini plugin to version 1.2.0.

* **Bug Fixes**
  * Improved model restoration, validation, authentication, and handling of unavailable, cancelled, or malformed responses.

* **Localization**
  * Added English and German text for model discovery and refresh features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->