### PR TITLE
Fix long online live transcription previews

### DIFF
--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -713,10 +713,7 @@ public sealed class StreamingHandler : IDisposable
                     {
                         bestOverlapLength = overlapLength;
                         bestConfirmedTrailingTokensToReplace = confirmedTrailingTokensToReplace;
-                        var nextWindowWord = windowStart + overlapLength;
-                        bestWindowTailStart = nextWindowWord < windowWords.Count
-                            ? windowWords[nextWindowWord].Start
-                            : windowText.Length;
+                        bestWindowTailStart = windowWords[windowStart + overlapLength - 1].End;
                     }
 
                     break;
@@ -727,21 +724,61 @@ public sealed class StreamingHandler : IDisposable
         if (bestOverlapLength == 0)
             return confirmed;
 
-        var tail = windowText[bestWindowTailStart..].TrimStart();
+        var tail = windowText[bestWindowTailStart..];
         if (string.IsNullOrEmpty(tail))
             return confirmed;
 
         var stablePrefix = bestConfirmedTrailingTokensToReplace == 0
             ? confirmed
             : confirmed[..confirmedWords[^bestConfirmedTrailingTokensToReplace].Start].TrimEnd();
-        return string.IsNullOrEmpty(stablePrefix) ? tail : stablePrefix + " " + tail;
+        return AppendRollingTail(stablePrefix, tail);
     }
+
+    private static string AppendRollingTail(string prefix, string tail)
+    {
+        prefix = prefix.TrimEnd();
+        tail = tail.TrimStart();
+        if (string.IsNullOrEmpty(prefix))
+            return tail;
+        if (string.IsNullOrEmpty(tail))
+            return prefix;
+
+        var firstWordCharacter = 0;
+        while (firstWordCharacter < tail.Length
+               && !char.IsLetterOrDigit(tail[firstWordCharacter]))
+        {
+            firstWordCharacter++;
+        }
+
+        var boundary = tail[..firstWordCharacter];
+        var remainingTail = tail[firstWordCharacter..].TrimStart();
+        var punctuationLength = boundary.Length;
+        while (punctuationLength > 0 && char.IsWhiteSpace(boundary[punctuationLength - 1]))
+            punctuationLength--;
+
+        var punctuation = boundary[..punctuationLength];
+        var boundaryToAppend = !string.IsNullOrEmpty(punctuation)
+            && (prefix.EndsWith(punctuation, StringComparison.Ordinal)
+                || HasRollingBoundaryPunctuation(prefix[^1]))
+                ? boundary[punctuationLength..]
+                : boundary;
+        if (string.IsNullOrEmpty(boundaryToAppend) && string.IsNullOrEmpty(boundary))
+        {
+            boundaryToAppend = " ";
+        }
+
+        return prefix + boundaryToAppend + remainingTail;
+    }
+
+    private static bool HasRollingBoundaryPunctuation(char value) =>
+        ".,!?;:…。！？、，；：".Contains(value);
 
     private static List<RollingWindowWord> TokenizeRollingWindowWords(string text) =>
         RollingWindowWordRegex.Matches(text)
             .Select(match => new RollingWindowWord(
                 match.Value.Replace('’', '\'').ToUpperInvariant(),
-                match.Index))
+                match.Index,
+                match.Index + match.Length))
             .ToList();
 
     private static bool RollingWindowWordsEqual(
@@ -765,7 +802,7 @@ public sealed class StreamingHandler : IDisposable
         return true;
     }
 
-    private sealed record RollingWindowWord(string Normalized, int Start);
+    private sealed record RollingWindowWord(string Normalized, int Start, int End);
 
     /// <summary>
     /// Releases resources held by the instance.

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Net.WebSockets;
+using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using TypeWhisper.Core.Interfaces;
 using TypeWhisper.PluginSDK;
@@ -38,6 +39,16 @@ public sealed class StreamingHandler : IDisposable
 
     private const int MaxPendingStreamingAudioBytes = 1024 * 1024;
     private const int StreamingAudioChannelCapacity = 128;
+    private const int SampleRate = 16000;
+    private const int OnlineBatchPollingWindowSeconds = 30;
+    private const int MaximumRollingWindowLeadingTokensToSkip = 12;
+    private const int MaximumRollingWindowTrailingTokensToReplace = 12;
+    private const int MinimumRollingWindowOverlapWords = 3;
+    private static readonly TimeSpan LocalPollingInterval = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan OnlineBatchPollingInterval = TimeSpan.FromSeconds(5);
+    private static readonly Regex RollingWindowWordRegex = new(
+        @"[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
     /// Gets or sets the on partial text update value.
@@ -96,7 +107,13 @@ public sealed class StreamingHandler : IDisposable
         }
         else
         {
-            _streamingTask = RunPollingFallbackAsync(languageHints, task, isStillRecording, sessionVersion, ct);
+            _streamingTask = RunPollingFallbackAsync(
+                languageHints,
+                task,
+                isStillRecording,
+                sessionVersion,
+                ct,
+                useOnlineBatchWindow: plugin is { SupportsModelDownload: false });
         }
     }
 
@@ -224,7 +241,8 @@ public sealed class StreamingHandler : IDisposable
                     isStillRecording,
                     sessionVersion,
                     ct,
-                    preparation.Engine);
+                    preparation.Engine,
+                    useOnlineBatchWindow: !plugin.SupportsModelDownload);
             }
         }
         catch (OperationCanceledException)
@@ -476,14 +494,16 @@ public sealed class StreamingHandler : IDisposable
     private async Task RunPollingFallbackAsync(
         IReadOnlyList<string> languageHints, TranscriptionTask task,
         Func<bool> isStillRecording, int sessionVersion, CancellationToken ct,
-        ITranscriptionEngine? preparedEngine = null)
+        ITranscriptionEngine? preparedEngine = null,
+        bool useOnlineBatchWindow = false)
     {
         var engine = preparedEngine ?? _modelManager.Engine;
-        var pollInterval = TimeSpan.FromSeconds(3.0);
+        var pollInterval = GetPollingInterval(useOnlineBatchWindow);
 
         try
         {
-            await Task.Delay(pollInterval, ct);
+            // Keep the first preview responsive, then use the provider-safe repeat cadence.
+            await Task.Delay(LocalPollingInterval, ct);
 
             while (!ct.IsCancellationRequested && isStillRecording())
             {
@@ -495,7 +515,13 @@ public sealed class StreamingHandler : IDisposable
                 {
                     try
                     {
-                        var result = await engine.TranscribeWithLanguageHintsAsync(buffer, languageHints, task, ct);
+                        var pollingBuffer = SelectPollingBuffer(buffer, useOnlineBatchWindow);
+                        var isRollingSnapshot = pollingBuffer.Length < buffer.Length;
+                        var result = await engine.TranscribeWithLanguageHintsAsync(
+                            pollingBuffer,
+                            languageHints,
+                            task,
+                            ct);
 
                         if (result.NoSpeechProbability is > 0.8f)
                             continue;
@@ -504,11 +530,32 @@ public sealed class StreamingHandler : IDisposable
 
                         if (!string.IsNullOrEmpty(text))
                         {
-                            if (_transcriptState.TryApplyPolling(
-                                sessionVersion,
-                                text,
-                                _dictionary.ApplyCorrections,
-                                out var stable))
+                            bool applied;
+                            string stable;
+                            if (useOnlineBatchWindow)
+                            {
+                                applied = isRollingSnapshot
+                                    ? _transcriptState.TryApplyRollingPolling(
+                                        sessionVersion,
+                                        text,
+                                        _dictionary.ApplyCorrections,
+                                        out stable)
+                                    : _transcriptState.TryApplySnapshotPolling(
+                                        sessionVersion,
+                                        text,
+                                        _dictionary.ApplyCorrections,
+                                        out stable);
+                            }
+                            else
+                            {
+                                applied = _transcriptState.TryApplyPolling(
+                                    sessionVersion,
+                                    text,
+                                    _dictionary.ApplyCorrections,
+                                    out stable);
+                            }
+
+                            if (applied)
                             {
                                 OnPartialTextUpdate?.Invoke(stable);
                             }
@@ -525,6 +572,20 @@ public sealed class StreamingHandler : IDisposable
             }
         }
         catch (OperationCanceledException) { }
+    }
+
+    internal static TimeSpan GetPollingInterval(bool useOnlineBatchWindow) =>
+        useOnlineBatchWindow ? OnlineBatchPollingInterval : LocalPollingInterval;
+
+    internal static float[] SelectPollingBuffer(float[] buffer, bool useOnlineBatchWindow)
+    {
+        if (!useOnlineBatchWindow)
+            return buffer;
+
+        var maximumSamples = OnlineBatchPollingWindowSeconds * SampleRate;
+        return buffer.Length <= maximumSamples
+            ? buffer
+            : buffer[^maximumSamples..];
     }
 
     // ── Helpers ──
@@ -591,6 +652,121 @@ public sealed class StreamingHandler : IDisposable
 
         return newText;
     }
+
+    /// <summary>
+    /// Appends the new tail from an overlapping rolling transcription window.
+    /// </summary>
+    internal static string MergeRollingText(string confirmed, string windowText)
+    {
+        confirmed = confirmed.Trim();
+        windowText = windowText.Trim();
+        if (string.IsNullOrEmpty(confirmed))
+            return windowText;
+        if (string.IsNullOrEmpty(windowText))
+            return confirmed;
+        if (windowText.StartsWith(confirmed, StringComparison.Ordinal))
+            return windowText;
+        if (confirmed.EndsWith(windowText, StringComparison.Ordinal))
+            return confirmed;
+
+        var confirmedWords = TokenizeRollingWindowWords(confirmed);
+        var windowWords = TokenizeRollingWindowWords(windowText);
+        if (confirmedWords.Count < MinimumRollingWindowOverlapWords
+            || windowWords.Count < MinimumRollingWindowOverlapWords)
+        {
+            return confirmed;
+        }
+
+        var bestOverlapLength = 0;
+        var bestConfirmedTrailingTokensToReplace = 0;
+        var bestWindowTailStart = windowText.Length;
+        var maximumWindowStart = Math.Min(
+            MaximumRollingWindowLeadingTokensToSkip,
+            windowWords.Count - MinimumRollingWindowOverlapWords);
+        var maximumConfirmedTrailingTokensToReplace = Math.Min(
+            MaximumRollingWindowTrailingTokensToReplace,
+            confirmedWords.Count - MinimumRollingWindowOverlapWords);
+
+        for (var confirmedTrailingTokensToReplace = 0;
+             confirmedTrailingTokensToReplace <= maximumConfirmedTrailingTokensToReplace;
+             confirmedTrailingTokensToReplace++)
+        {
+            var confirmedEnd = confirmedWords.Count - confirmedTrailingTokensToReplace;
+            for (var windowStart = 0; windowStart <= maximumWindowStart; windowStart++)
+            {
+                var maximumOverlap = Math.Min(confirmedEnd, windowWords.Count - windowStart);
+                for (var overlapLength = maximumOverlap;
+                     overlapLength >= MinimumRollingWindowOverlapWords;
+                     overlapLength--)
+                {
+                    var confirmedStart = confirmedEnd - overlapLength;
+                    if (!RollingWindowWordsEqual(
+                            confirmedWords,
+                            confirmedStart,
+                            windowWords,
+                            windowStart,
+                            overlapLength))
+                    {
+                        continue;
+                    }
+
+                    if (overlapLength > bestOverlapLength)
+                    {
+                        bestOverlapLength = overlapLength;
+                        bestConfirmedTrailingTokensToReplace = confirmedTrailingTokensToReplace;
+                        var nextWindowWord = windowStart + overlapLength;
+                        bestWindowTailStart = nextWindowWord < windowWords.Count
+                            ? windowWords[nextWindowWord].Start
+                            : windowText.Length;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        if (bestOverlapLength == 0)
+            return confirmed;
+
+        var tail = windowText[bestWindowTailStart..].TrimStart();
+        if (string.IsNullOrEmpty(tail))
+            return confirmed;
+
+        var stablePrefix = bestConfirmedTrailingTokensToReplace == 0
+            ? confirmed
+            : confirmed[..confirmedWords[^bestConfirmedTrailingTokensToReplace].Start].TrimEnd();
+        return string.IsNullOrEmpty(stablePrefix) ? tail : stablePrefix + " " + tail;
+    }
+
+    private static List<RollingWindowWord> TokenizeRollingWindowWords(string text) =>
+        RollingWindowWordRegex.Matches(text)
+            .Select(match => new RollingWindowWord(
+                match.Value.Replace('’', '\'').ToUpperInvariant(),
+                match.Index))
+            .ToList();
+
+    private static bool RollingWindowWordsEqual(
+        IReadOnlyList<RollingWindowWord> first,
+        int firstStart,
+        IReadOnlyList<RollingWindowWord> second,
+        int secondStart,
+        int length)
+    {
+        for (var i = 0; i < length; i++)
+        {
+            if (!string.Equals(
+                    first[firstStart + i].Normalized,
+                    second[secondStart + i].Normalized,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed record RollingWindowWord(string Normalized, int Start);
 
     /// <summary>
     /// Releases resources held by the instance.

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -46,8 +46,14 @@ public sealed class StreamingHandler : IDisposable
     private const int MinimumRollingWindowOverlapWords = 3;
     private static readonly TimeSpan LocalPollingInterval = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan OnlineBatchPollingInterval = TimeSpan.FromSeconds(5);
+    private const string RollingWindowCjkCharacterClass =
+        @"\u1100-\u11FF\u2E80-\u2FFF\u3040-\u30FF\u3100-\u318F\u31A0-\u31BF" +
+        @"\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFF\uA960-\uA97F\uAC00-\uD7AF" +
+        @"\uD7B0-\uD7FF\uF900-\uFAFF\uFF66-\uFF9D";
     private static readonly Regex RollingWindowWordRegex = new(
-        @"[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*",
+        $@"[{RollingWindowCjkCharacterClass}]|" +
+        $@"[\p{{L}}\p{{N}}-[{RollingWindowCjkCharacterClass}]]+" +
+        $@"(?:['’][\p{{L}}\p{{N}}-[{RollingWindowCjkCharacterClass}]]+)*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>

--- a/src/TypeWhisper.Windows/Services/StreamingHandler.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingHandler.cs
@@ -523,10 +523,9 @@ public sealed class StreamingHandler : IDisposable
                             task,
                             ct);
 
-                        if (result.NoSpeechProbability is > 0.8f)
-                            continue;
-
-                        var text = result.Text?.Trim() ?? "";
+                        var text = result.NoSpeechProbability is > 0.8f
+                            ? ""
+                            : result.Text?.Trim() ?? "";
 
                         if (!string.IsNullOrEmpty(text))
                         {

--- a/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
@@ -116,6 +116,67 @@ internal sealed class StreamingTranscriptState
         return true;
     }
 
+    /// <summary>
+    /// Applies a complete, growing transcript snapshot from an online batch provider.
+    /// </summary>
+    public bool TryApplySnapshotPolling(
+        int sessionVersion,
+        string rawText,
+        Func<string, string> corrector,
+        out string displayText)
+    {
+        displayText = "";
+        if (!IsCurrentSession(sessionVersion))
+            return false;
+
+        var text = rawText.Trim();
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        text = corrector(text);
+        if (string.IsNullOrEmpty(text)
+            || string.Equals(text, _confirmedText, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        _confirmedText = text;
+        _lastDisplayedText = text;
+        displayText = text;
+        return true;
+    }
+
+    /// <summary>
+    /// Applies an overlapping rolling-window transcript without regressing prior preview text.
+    /// </summary>
+    public bool TryApplyRollingPolling(
+        int sessionVersion,
+        string rawText,
+        Func<string, string> corrector,
+        out string displayText)
+    {
+        displayText = "";
+        if (!IsCurrentSession(sessionVersion))
+            return false;
+
+        var text = rawText.Trim();
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        text = corrector(text);
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        var merged = StreamingHandler.MergeRollingText(_confirmedText, text);
+        if (string.Equals(merged, _confirmedText, StringComparison.Ordinal))
+            return false;
+
+        _confirmedText = merged;
+        _lastDisplayedText = merged;
+        displayText = merged;
+        return true;
+    }
+
     private static string MergeFinalSegment(string confirmedText, string lastFinalSegment, string newText)
     {
         if (string.IsNullOrEmpty(confirmedText))

--- a/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
+++ b/src/TypeWhisper.Windows/Services/StreamingTranscriptState.cs
@@ -5,10 +5,14 @@ namespace TypeWhisper.Windows.Services;
 
 internal sealed class StreamingTranscriptState
 {
+    private const int RollingMergeFailuresBeforeRecovery = 2;
+
     private int _sessionVersion;
     private string _confirmedText = "";
     private string _lastDisplayedText = "";
     private string _lastFinalSegment = "";
+    private string _lastRollingPollingText = "";
+    private int _rollingMergeFailureCount;
 
     /// <summary>
     /// Starts a new streaming transcript session and returns its version token.
@@ -18,6 +22,8 @@ internal sealed class StreamingTranscriptState
         _confirmedText = "";
         _lastDisplayedText = "";
         _lastFinalSegment = "";
+        _lastRollingPollingText = "";
+        _rollingMergeFailureCount = 0;
         return Interlocked.Increment(ref _sessionVersion);
     }
 
@@ -33,6 +39,8 @@ internal sealed class StreamingTranscriptState
         _confirmedText = "";
         _lastDisplayedText = "";
         _lastFinalSegment = "";
+        _lastRollingPollingText = "";
+        _rollingMergeFailureCount = 0;
         return finalText;
     }
 
@@ -112,6 +120,8 @@ internal sealed class StreamingTranscriptState
         var stable = StreamingHandler.StabilizeText(_confirmedText, text);
         _confirmedText = stable;
         _lastDisplayedText = stable;
+        _lastRollingPollingText = "";
+        _rollingMergeFailureCount = 0;
         displayText = stable;
         return true;
     }
@@ -142,6 +152,8 @@ internal sealed class StreamingTranscriptState
 
         _confirmedText = text;
         _lastDisplayedText = text;
+        _lastRollingPollingText = "";
+        _rollingMergeFailureCount = 0;
         displayText = text;
         return true;
     }
@@ -169,10 +181,22 @@ internal sealed class StreamingTranscriptState
 
         var merged = StreamingHandler.MergeRollingText(_confirmedText, text);
         if (string.Equals(merged, _confirmedText, StringComparison.Ordinal))
-            return false;
+        {
+            if (string.Equals(text, _lastRollingPollingText, StringComparison.Ordinal))
+                return false;
+
+            _lastRollingPollingText = text;
+            _rollingMergeFailureCount++;
+            if (_rollingMergeFailureCount < RollingMergeFailuresBeforeRecovery)
+                return false;
+
+            merged = _confirmedText.TrimEnd() + " " + text;
+        }
 
         _confirmedText = merged;
         _lastDisplayedText = merged;
+        _lastRollingPollingText = text;
+        _rollingMergeFailureCount = 0;
         displayText = merged;
         return true;
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Reflection;
 using Moq;
 using NAudio.Wave;
@@ -427,14 +428,71 @@ public class StreamingTranscriptionTests
         Assert.Equal(0, (int)GetPrivateField(handler, "_pendingStreamingAudioBytes")!);
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition)
+    [Fact]
+    public async Task StreamingHandler_OnlineBatchPollingBoundsGrowingAudioRequests()
     {
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new CapturingPollingPlugin();
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var fullModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "batch");
+        await modelManager.LoadModelAsync(fullModelId);
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+
+        handler.StartWhenReadyWithLanguageHints(
+            ["en"],
+            TranscriptionTask.Transcribe,
+            () => audio.IsRecording,
+            Task.FromResult(CreateReadyPreparation(modelManager, fullModelId)),
+            allowOnlineBatchPolling: true);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+        capture.RaiseData(BuildPcm16Chunk(TimeSpan.FromSeconds(45)), 45 * 16000 * 2);
+
+        await WaitUntilAsync(() => plugin.RequestDurations.Count == 1, TimeSpan.FromSeconds(8));
+
+        Assert.InRange(plugin.RequestDurations.Single().TotalSeconds, 29.9, 30.1);
+    }
+
+    [Fact]
+    public void StreamingHandler_OnlineBatchPollingLeavesCapacityForFinalRequest()
+    {
+        var interval = StreamingHandler.GetPollingInterval(useOnlineBatchWindow: true);
+        var previewRequestsPerMinute = TimeSpan.FromMinutes(1).TotalSeconds / interval.TotalSeconds;
+
+        Assert.Equal(TimeSpan.FromSeconds(5), interval);
+        Assert.True(previewRequestsPerMinute + 1 <= 20);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? waitTimeout = null)
+    {
+        using var timeout = new CancellationTokenSource(waitTimeout ?? TimeSpan.FromSeconds(3));
         while (!condition())
         {
             timeout.Token.ThrowIfCancellationRequested();
             await Task.Delay(20, timeout.Token);
         }
+    }
+
+    private static byte[] BuildPcm16Chunk(TimeSpan duration)
+    {
+        var bytes = new byte[(int)(duration.TotalSeconds * 16000 * 2)];
+        for (var i = 0; i < bytes.Length; i += 2)
+        {
+            bytes[i] = 0x00;
+            bytes[i + 1] = 0x20;
+        }
+
+        return bytes;
     }
 
     private static async Task<bool> CompletesWithinAsync(Task task, TimeSpan timeout)
@@ -611,6 +669,54 @@ public class StreamingTranscriptionTests
         public Task FinalizeAsync(CancellationToken ct) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public void RaiseTranscript(StreamingTranscriptEvent evt) => TranscriptReceived?.Invoke(evt);
+    }
+
+    private sealed class CapturingPollingPlugin : ITranscriptionEnginePlugin
+    {
+        private readonly List<TimeSpan> _requestDurations = [];
+
+        public string PluginId => "com.test.polling";
+        public string PluginName => "Polling";
+        public string PluginVersion => "1.0.0";
+        public string ProviderId => "polling";
+        public string ProviderDisplayName => "Polling";
+        public bool IsConfigured => true;
+        public IReadOnlyList<PluginModelInfo> TranscriptionModels { get; } =
+            [new PluginModelInfo("batch", "Batch")];
+        public string? SelectedModelId { get; private set; }
+        public bool SupportsTranslation => false;
+        public IReadOnlyList<TimeSpan> RequestDurations
+        {
+            get
+            {
+                lock (_requestDurations)
+                    return [.. _requestDurations];
+            }
+        }
+
+        public Task ActivateAsync(IPluginHostServices host) => Task.CompletedTask;
+        public Task DeactivateAsync() => Task.CompletedTask;
+        public System.Windows.Controls.UserControl? CreateSettingsView() => null;
+        public void Dispose() { }
+        public void SelectModel(string modelId) => SelectedModelId = modelId;
+
+        public Task<PluginTranscriptionResult> TranscribeAsync(
+            byte[] wavAudio,
+            string? language,
+            bool translate,
+            string? prompt,
+            CancellationToken ct)
+        {
+            using var stream = new MemoryStream(wavAudio, writable: false);
+            using var reader = new WaveFileReader(stream);
+            lock (_requestDurations)
+                _requestDurations.Add(reader.TotalTime);
+
+            return Task.FromResult(new PluginTranscriptionResult(
+                "preview",
+                language ?? "en",
+                reader.TotalTime.TotalSeconds));
+        }
     }
 
     private sealed class PassthroughDictionaryService : IDictionaryService
@@ -852,10 +958,102 @@ public class StabilizeTextTests
         var result = StreamingHandler.StabilizeText("", "  Hello  ");
         Assert.Equal("Hello", result);
     }
+
+    [Fact]
+    public void RollingWindow_AppendsOnlyWordsAfterOverlap()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo charlie delta echo foxtrot golf hotel",
+            "echo foxtrot golf hotel india juliet");
+
+        Assert.Equal(
+            "Alpha bravo charlie delta echo foxtrot golf hotel india juliet",
+            result);
+    }
+
+    [Fact]
+    public void RollingWindow_ToleratesChangedLeadingWordsAndPunctuation()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo Charlie, delta echo foxtrot golf hotel.",
+            "uncertain boundary CHARLIE delta echo foxtrot golf hotel, india juliet");
+
+        Assert.Equal(
+            "Alpha bravo Charlie, delta echo foxtrot golf hotel. india juliet",
+            result);
+    }
+
+    [Fact]
+    public void RollingWindow_ReplacesUnstableTrailingBoundaryWords()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo charlie delta echo foxtrot mistaken ending",
+            "uncertain boundary charlie delta echo foxtrot corrected ending and tail");
+
+        Assert.Equal(
+            "Alpha bravo charlie delta echo foxtrot corrected ending and tail",
+            result);
+    }
+
+    [Fact]
+    public void RollingWindow_WithoutSafeOverlapKeepsConfirmedText()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo charlie delta",
+            "Completely unrelated words appear here");
+
+        Assert.Equal("Alpha bravo charlie delta", result);
+    }
 }
 
 public class StreamingTranscriptStateTests
 {
+    [Fact]
+    public void SnapshotPolling_ReplacesRewrittenGrowingHypothesis()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        Assert.True(sut.TryApplySnapshotPolling(
+            sessionVersion,
+            "At the beginning we are checking a long-term",
+            text => text,
+            out _));
+        Assert.True(sut.TryApplySnapshotPolling(
+            sessionVersion,
+            "At the beginning we are checking whether a long transcription remains complete",
+            text => text,
+            out var display));
+
+        Assert.Equal(
+            "At the beginning we are checking whether a long transcription remains complete",
+            display);
+        Assert.Equal(display, sut.StopSession());
+    }
+
+    [Fact]
+    public void RollingPolling_PreservesFullPreviewAcrossOverlappingWindows()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        Assert.True(sut.TryApplyPolling(
+            sessionVersion,
+            "Alpha bravo charlie delta echo foxtrot golf hotel",
+            text => text,
+            out _));
+        Assert.True(sut.TryApplyRollingPolling(
+            sessionVersion,
+            "echo foxtrot golf hotel india juliet",
+            text => text,
+            out var mergedDisplay));
+
+        Assert.Equal(
+            "Alpha bravo charlie delta echo foxtrot golf hotel india juliet",
+            mergedDisplay);
+        Assert.Equal(mergedDisplay, sut.StopSession());
+    }
+
     [Fact]
     public void StopSession_FallsBackToOnlyInterimRealtimeText()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -1065,6 +1065,29 @@ public class StabilizeTextTests
         Assert.Equal("Alpha bravo charlie delta.", result);
     }
 
+    [Theory]
+    [InlineData(
+        "今天我们测试长时间语音转写是否稳定。",
+        "语音转写是否稳定。然后继续说话。",
+        "今天我们测试长时间语音转写是否稳定。然后继续说话。")]
+    [InlineData(
+        "これは長い音声入力のテストです。",
+        "音声入力のテストです。そして続けます。",
+        "これは長い音声入力のテストです。そして続けます。")]
+    [InlineData(
+        "이것은긴음성입력테스트입니다.",
+        "음성입력테스트입니다.계속말합니다.",
+        "이것은긴음성입력테스트입니다.계속말합니다.")]
+    public void RollingWindow_MergesTruncatedUnspacedCjkWindows(
+        string confirmed,
+        string windowText,
+        string expected)
+    {
+        var result = StreamingHandler.MergeRollingText(confirmed, windowText);
+
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public void RollingWindow_WithoutSafeOverlapKeepsConfirmedText()
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -504,9 +504,11 @@ public class StreamingTranscriptionTests
         capture.RaiseData(BuildPcm16Chunk(TimeSpan.FromSeconds(45)), 45 * 16000 * 2);
 
         await WaitUntilAsync(() => plugin.RequestDurations.Count == 1, TimeSpan.FromSeconds(8));
-        await Task.Delay(500);
+        await Task.Delay(TimeSpan.FromSeconds(4));
 
         Assert.Single(plugin.RequestDurations);
+        await WaitUntilAsync(() => plugin.RequestDurations.Count == 2, TimeSpan.FromSeconds(2));
+        Assert.Equal(2, plugin.RequestDurations.Count);
     }
 
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? waitTimeout = null)
@@ -1031,6 +1033,36 @@ public class StabilizeTextTests
         Assert.Equal(
             "Alpha bravo charlie delta echo foxtrot corrected ending and tail",
             result);
+    }
+
+    [Fact]
+    public void RollingWindow_PreservesPunctuationAfterOverlap()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo charlie delta",
+            "bravo charlie delta. Echo foxtrot");
+
+        Assert.Equal("Alpha bravo charlie delta. Echo foxtrot", result);
+    }
+
+    [Fact]
+    public void RollingWindow_DoesNotDuplicateExistingBoundaryPunctuation()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo charlie delta.",
+            "BRAVO CHARLIE DELTA. Echo foxtrot");
+
+        Assert.Equal("Alpha bravo charlie delta. Echo foxtrot", result);
+    }
+
+    [Fact]
+    public void RollingWindow_PreservesTrailingPunctuationAfterNormalizedOverlap()
+    {
+        var result = StreamingHandler.MergeRollingText(
+            "Alpha bravo charlie delta",
+            "BRAVO CHARLIE DELTA.");
+
+        Assert.Equal("Alpha bravo charlie delta.", result);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/StreamingTranscriptionTests.cs
@@ -473,6 +473,42 @@ public class StreamingTranscriptionTests
         Assert.True(previewRequestsPerMinute + 1 <= 20);
     }
 
+    [Fact]
+    public async Task StreamingHandler_OnlineBatchNoSpeechStillWaitsBetweenRequests()
+    {
+        var settings = new FakeSettingsService(AppSettings.Default);
+        using var pluginManager = TestPluginManagerFactory.Create(settings);
+        var plugin = new CapturingPollingPlugin { NoSpeechProbability = 1f };
+        TestPluginManagerFactory.SetPrivateField(
+            pluginManager,
+            "_transcriptionEngines",
+            new List<ITranscriptionEnginePlugin> { plugin });
+
+        var modelManager = new ModelManagerService(pluginManager, settings);
+        var fullModelId = ModelManagerService.GetPluginModelId(plugin.PluginId, "batch");
+        await modelManager.LoadModelAsync(fullModelId);
+
+        var devices = new FakeAudioInputDeviceProvider("Test Microphone");
+        var captures = new FakeAudioInputCaptureFactory();
+        using var audio = new AudioRecordingService(devices, captures, Timeout.InfiniteTimeSpan);
+        using var handler = new StreamingHandler(modelManager, audio, new PassthroughDictionaryService());
+
+        handler.StartWhenReadyWithLanguageHints(
+            ["en"],
+            TranscriptionTask.Transcribe,
+            () => audio.IsRecording,
+            Task.FromResult(CreateReadyPreparation(modelManager, fullModelId)),
+            allowOnlineBatchPolling: true);
+        audio.StartRecording();
+        var capture = Assert.Single(captures.Created);
+        capture.RaiseData(BuildPcm16Chunk(TimeSpan.FromSeconds(45)), 45 * 16000 * 2);
+
+        await WaitUntilAsync(() => plugin.RequestDurations.Count == 1, TimeSpan.FromSeconds(8));
+        await Task.Delay(500);
+
+        Assert.Single(plugin.RequestDurations);
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? waitTimeout = null)
     {
         using var timeout = new CancellationTokenSource(waitTimeout ?? TimeSpan.FromSeconds(3));
@@ -685,6 +721,7 @@ public class StreamingTranscriptionTests
             [new PluginModelInfo("batch", "Batch")];
         public string? SelectedModelId { get; private set; }
         public bool SupportsTranslation => false;
+        public float? NoSpeechProbability { get; init; }
         public IReadOnlyList<TimeSpan> RequestDurations
         {
             get
@@ -715,7 +752,8 @@ public class StreamingTranscriptionTests
             return Task.FromResult(new PluginTranscriptionResult(
                 "preview",
                 language ?? "en",
-                reader.TotalTime.TotalSeconds));
+                reader.TotalTime.TotalSeconds,
+                NoSpeechProbability));
         }
     }
 
@@ -1052,6 +1090,39 @@ public class StreamingTranscriptStateTests
             "Alpha bravo charlie delta echo foxtrot golf hotel india juliet",
             mergedDisplay);
         Assert.Equal(mergedDisplay, sut.StopSession());
+    }
+
+    [Fact]
+    public void RollingPolling_RecoversAfterConsecutiveUnmatchedWindows()
+    {
+        var sut = new StreamingTranscriptState();
+        var sessionVersion = sut.StartSession();
+
+        Assert.True(sut.TryApplySnapshotPolling(
+            sessionVersion,
+            "Confirmed text before a long pause",
+            text => text,
+            out _));
+        Assert.False(sut.TryApplyRollingPolling(
+            sessionVersion,
+            "A new topic starts after the pause",
+            text => text,
+            out _));
+        Assert.False(sut.TryApplyRollingPolling(
+            sessionVersion,
+            "A new topic starts after the pause",
+            text => text,
+            out _));
+        Assert.True(sut.TryApplyRollingPolling(
+            sessionVersion,
+            "A new topic starts after the pause and continues",
+            text => text,
+            out var recoveredDisplay));
+
+        Assert.Equal(
+            "Confirmed text before a long pause A new topic starts after the pause and continues",
+            recoveredDisplay);
+        Assert.Equal(recoveredDisplay, sut.StopSession());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- limit online batch live-preview requests to the trailing 30 seconds of audio
- use a provider-safe five-second polling cadence after the initial preview
- merge overlapping transcripts while replacing unstable words at window boundaries
- keep final transcription on the complete recording

## Reproduction and verification

- reproduced the defect before the change with a 45-second recording that sent the complete 45 seconds in one preview request
- verified the Groq key and `whisper-large-v3-turbo` through the live API with a 91.12-second, 274-word sample
- exercised rolling 30-second Groq windows through 63 seconds; the preview grew from 88 to 200 words and retained the final control phrase

## Tests

- focused streaming tests: 50 passed
- Release solution: 460 Core tests and 2,025 PluginSystem tests passed
- development app launched successfully with no new crash-log entry

Fixes #404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved live transcription by continuously processing recent audio while preserving confirmed text.
  * Added support for smoother CJK character handling, overlapping results, corrected wording, punctuation changes, and unstable trailing text.
  * Improved polling reliability with configurable timing, safer audio windows, and recovery after unmatched results.
  * Prevented empty, stale, or unchanged results from replacing useful transcript content.

* **Tests**
  * Expanded coverage for CJK merging, polling limits, rolling transcripts, rewritten hypotheses, recovery, and preview preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->