### PR TITLE
Preserve long workflow results and raw transcripts

### DIFF
--- a/plugins/TypeWhisper.Plugin.Claude/ClaudePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Claude/ClaudePlugin.cs
@@ -112,7 +112,7 @@ public sealed class ClaudePlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         var requestBody = new
         {
             model,
-            max_tokens = 2048,
+            max_tokens = LlmOutputTokenBudget.Calculate(systemPrompt, userText),
             system = systemPrompt,
             messages = new[]
             {
@@ -140,6 +140,7 @@ public sealed class ClaudePlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         }
 
         using var doc = JsonDocument.Parse(responseBody);
+        LlmResponseTruncationGuard.ThrowIfAnthropicResponseTruncated(doc.RootElement, "Anthropic");
         if (doc.RootElement.ValueKind == JsonValueKind.Object
             && doc.RootElement.TryGetProperty("content", out var content)
             && content.ValueKind == JsonValueKind.Array)

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -424,7 +424,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 new { role = "system", content = systemPrompt },
                 new { role = "user", content = userText },
             },
-            ["max_tokens"] = 2048,
+            ["max_tokens"] = LlmOutputTokenBudget.Calculate(systemPrompt, userText),
         };
         if (model.StartsWith("gemini-", StringComparison.OrdinalIgnoreCase))
             body["reasoning_effort"] = "low";
@@ -463,6 +463,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             using (doc)
             {
                 var root = doc.RootElement;
+                LlmResponseTruncationGuard.ThrowIfOpenAiChatCompletionTruncated(root, "Gemini");
                 if (root.ValueKind == JsonValueKind.Object
                     && root.TryGetProperty("choices", out var choices)
                     && choices.ValueKind == JsonValueKind.Array

--- a/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
@@ -331,6 +331,42 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
+    public async Task ProcessAsync_ScalesBudgetAndRejectsTokenLimitedPartialResponse()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return JsonResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": { "content": "Partial workflow result" },
+                      "finish_reason": "length"
+                    }
+                  ]
+                }
+                """);
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+        var longTranscript = string.Join(' ', Enumerable.Repeat("dictated workflow input", 1_000));
+
+        var error = await Assert.ThrowsAsync<PluginRequestException>(() => sut.ProcessAsync(
+            "Preserve every detail.",
+            longTranscript,
+            "gemini-3.7-flash",
+            CancellationToken.None));
+
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.True(body.RootElement.GetProperty("max_tokens").GetInt32() > 2048);
+        Assert.Equal(PluginRequestFailureKind.OutputTruncated, error.FailureKind);
+    }
+
+    [Fact]
     public async Task ProcessAsync_OmitsGeminiReasoningEffortForGemmaModels()
     {
         string? capturedBody = null;

--- a/plugins/TypeWhisper.Plugin.GemmaLocal/GemmaLocalPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.GemmaLocal/GemmaLocalPlugin.cs
@@ -132,11 +132,17 @@ public sealed class GemmaLocalPlugin : ILlmProviderPlugin
 
             // Build Gemma chat prompt
             var prompt = FormatGemmaPrompt(systemPrompt, userText);
+            var promptTokenCount = _context.Tokenize(prompt, addBos: true, special: true).Length;
+            var maxOutputTokens = LlmOutputTokenBudget.FitToContext(
+                LlmOutputTokenBudget.Calculate(systemPrompt, userText),
+                promptTokenCount,
+                checked((int)_context.ContextSize),
+                ProviderName);
 
             var executor = new StatelessExecutor(_weights, _context.Params);
             var inferenceParams = new InferenceParams
             {
-                MaxTokens = LlmOutputTokenBudget.Calculate(systemPrompt, userText),
+                MaxTokens = maxOutputTokens,
                 AntiPrompts = ["<end_of_turn>", "<eos>"],
                 SamplingPipeline = new DefaultSamplingPipeline { Temperature = 0.3f },
             };

--- a/plugins/TypeWhisper.Plugin.GemmaLocal/GemmaLocalPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.GemmaLocal/GemmaLocalPlugin.cs
@@ -6,6 +6,7 @@ using LLama;
 using LLama.Common;
 using LLama.Sampling;
 using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Helpers;
 using TypeWhisper.PluginSDK.Models;
 
 namespace TypeWhisper.Plugin.GemmaLocal;
@@ -135,7 +136,7 @@ public sealed class GemmaLocalPlugin : ILlmProviderPlugin
             var executor = new StatelessExecutor(_weights, _context.Params);
             var inferenceParams = new InferenceParams
             {
-                MaxTokens = 2048,
+                MaxTokens = LlmOutputTokenBudget.Calculate(systemPrompt, userText),
                 AntiPrompts = ["<end_of_turn>", "<eos>"],
                 SamplingPipeline = new DefaultSamplingPipeline { Temperature = 0.3f },
             };

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -253,7 +253,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
         var modelId = ResolveLlmModelId(string.IsNullOrWhiteSpace(model) ? null : model);
         return await OpenAiChatHelper.SendChatCompletionAsync(
             _httpClient, BaseUrl, _apiKey!, modelId, systemPrompt, userText, ct,
-            maxOutputTokens: 2048,
+            maxOutputTokens: LlmOutputTokenBudget.Calculate(systemPrompt, userText),
             maxOutputTokenParameter: "max_tokens",
             reasoningEffort: null,
             temperature: 0.1,

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiChatGptClient.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiChatGptClient.cs
@@ -107,6 +107,7 @@ internal sealed class OpenAiChatGptClient
 
             using var doc = JsonDocument.Parse(payload);
             var root = doc.RootElement;
+            LlmResponseTruncationGuard.ThrowIfResponsesApiIncomplete(root, "ChatGPT");
             if (!root.TryGetProperty("type", out var typeEl))
                 continue;
 
@@ -143,6 +144,7 @@ internal sealed class OpenAiChatGptClient
         {
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
+            LlmResponseTruncationGuard.ThrowIfResponsesApiIncomplete(root, "ChatGPT");
 
             if (GetString(root, "output_text") is { Length: > 0 } outputText)
                 return outputText.Trim();

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
@@ -445,7 +445,7 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
             systemPrompt,
             userText,
             ct,
-            maxOutputTokens: 2048,
+            maxOutputTokens: LlmOutputTokenBudget.Calculate(systemPrompt, userText),
             maxOutputTokenParameter: OutputTokenParameter(modelId),
             reasoningEffort: SupportsReasoningEffort(modelId) ? _reasoningEffort : null,
             temperature: ResolvedTemperature(modelId));

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
@@ -445,7 +445,9 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
             systemPrompt,
             userText,
             ct,
-            maxOutputTokens: LlmOutputTokenBudget.Calculate(systemPrompt, userText),
+            maxOutputTokens: SupportsReasoningEffort(modelId)
+                ? LlmOutputTokenBudget.CalculateWithReasoningReserve(systemPrompt, userText)
+                : LlmOutputTokenBudget.Calculate(systemPrompt, userText),
             maxOutputTokenParameter: OutputTokenParameter(modelId),
             reasoningEffort: SupportsReasoningEffort(modelId) ? _reasoningEffort : null,
             temperature: ResolvedTemperature(modelId));

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiResponsesClient.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiResponsesClient.cs
@@ -68,6 +68,8 @@ internal sealed class OpenAiResponsesClient
                 }
             }),
             ["store"] = OpenAiJson.Element(false),
+            ["max_output_tokens"] = OpenAiJson.Element(
+                LlmOutputTokenBudget.Calculate(systemPrompt, userText)),
         };
 
         if (!string.IsNullOrWhiteSpace(reasoningEffort))
@@ -87,6 +89,7 @@ internal sealed class OpenAiResponsesClient
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
+        LlmResponseTruncationGuard.ThrowIfResponsesApiIncomplete(root, "OpenAI");
 
         if (root.TryGetProperty("output_text", out var outputText)
             && outputText.ValueKind == JsonValueKind.String)

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiResponsesClient.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiResponsesClient.cs
@@ -69,7 +69,9 @@ internal sealed class OpenAiResponsesClient
             }),
             ["store"] = OpenAiJson.Element(false),
             ["max_output_tokens"] = OpenAiJson.Element(
-                LlmOutputTokenBudget.Calculate(systemPrompt, userText)),
+                string.IsNullOrWhiteSpace(reasoningEffort)
+                    ? LlmOutputTokenBudget.Calculate(systemPrompt, userText)
+                    : LlmOutputTokenBudget.CalculateWithReasoningReserve(systemPrompt, userText)),
         };
 
         if (!string.IsNullOrWhiteSpace(reasoningEffort))

--- a/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using TypeWhisper.Plugin.OpenAi;
 using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Helpers;
 using TypeWhisper.PluginSDK.Models;
 
 namespace TypeWhisper.PluginSystem.Tests;
@@ -191,6 +192,9 @@ public class OpenAiPluginTests
         Assert.Equal("Fix grammar", body["instructions"].GetString());
         Assert.Equal("medium", body["reasoning"].GetProperty("effort").GetString());
         Assert.Equal("user", body["input"][0].GetProperty("role").GetString());
+        Assert.Equal(
+            LlmOutputTokenBudget.CalculateWithReasoningReserve("Fix grammar", "hello world"),
+            body["max_output_tokens"].GetInt32());
     }
 
     [Fact]
@@ -228,6 +232,23 @@ public class OpenAiPluginTests
         var error = Assert.Throws<PluginRequestException>(() => OpenAiResponsesClient.ParseResponse(json));
 
         Assert.Equal(PluginRequestFailureKind.OutputTruncated, error.FailureKind);
+    }
+
+    [Fact]
+    public void ResponsesParser_ClassifiesNonTokenIncompleteOutputSeparately()
+    {
+        var json = """
+        {
+          "id": "resp_123",
+          "status": "incomplete",
+          "incomplete_details": { "reason": "content_filter" },
+          "output_text": "Partial workflow result"
+        }
+        """;
+
+        var error = Assert.Throws<PluginRequestException>(() => OpenAiResponsesClient.ParseResponse(json));
+
+        Assert.Equal(PluginRequestFailureKind.OutputIncomplete, error.FailureKind);
     }
 
     [Fact]
@@ -812,7 +833,9 @@ public class OpenAiPluginTests
 
         using var doc = JsonDocument.Parse(capturedBody!);
         Assert.Equal("o4-mini", doc.RootElement.GetProperty("model").GetString());
-        Assert.Equal(2048, doc.RootElement.GetProperty("max_completion_tokens").GetInt32());
+        Assert.Equal(
+            LlmOutputTokenBudget.CalculateWithReasoningReserve("Fix grammar", "hello world"),
+            doc.RootElement.GetProperty("max_completion_tokens").GetInt32());
         Assert.Equal("medium", doc.RootElement.GetProperty("reasoning_effort").GetString());
         Assert.False(doc.RootElement.TryGetProperty("max_tokens", out _));
         Assert.False(doc.RootElement.TryGetProperty("temperature", out _));

--- a/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
@@ -214,6 +214,23 @@ public class OpenAiPluginTests
     }
 
     [Fact]
+    public void ResponsesParser_RejectsIncompleteTokenLimitedOutput()
+    {
+        var json = """
+        {
+          "id": "resp_123",
+          "status": "incomplete",
+          "incomplete_details": { "reason": "max_output_tokens" },
+          "output_text": "Partial workflow result"
+        }
+        """;
+
+        var error = Assert.Throws<PluginRequestException>(() => OpenAiResponsesClient.ParseResponse(json));
+
+        Assert.Equal(PluginRequestFailureKind.OutputTruncated, error.FailureKind);
+    }
+
+    [Fact]
     public void RealtimeUri_UsesGAEndpointWithoutBetaHeader()
     {
         var headers = OpenAiRealtimeStreamingSession.CreateRealtimeHeaders("sk-test");
@@ -954,6 +971,23 @@ public class OpenAiPluginTests
         """;
 
         Assert.Equal("Hello world", OpenAiChatGptClient.ParseResponseText(stream));
+    }
+
+    [Fact]
+    public void ChatGptResponseParser_RejectsIncompleteEventAfterPartialText()
+    {
+        var stream = """
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","delta":"Partial workflow result"}
+        event: response.incomplete
+        data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}}
+
+        """;
+
+        var error = Assert.Throws<PluginRequestException>(() =>
+            OpenAiChatGptClient.ParseResponseText(stream));
+
+        Assert.Equal(PluginRequestFailureKind.OutputTruncated, error.FailureKind);
     }
 
     [Fact]

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/OpenAiCompatiblePlugin.cs
@@ -542,7 +542,7 @@ public sealed class OpenAiCompatiblePlugin :
                 new { role = "user", content = userText }
             },
             ["temperature"] = 0.1,
-            ["max_tokens"] = 2048
+            ["max_tokens"] = LlmOutputTokenBudget.Calculate(systemPrompt, userText)
         };
         AddThinkingConfiguration(body, profile.BaseUrl, profile.ThinkingEnabled);
 
@@ -588,6 +588,9 @@ public sealed class OpenAiCompatiblePlugin :
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
+        LlmResponseTruncationGuard.ThrowIfOpenAiChatCompletionTruncated(
+            root,
+            "The OpenAI-compatible provider");
 
         if (root.ValueKind == JsonValueKind.Object
             && root.TryGetProperty("choices", out var choices)

--- a/plugins/TypeWhisper.Plugin.OpenRouter/OpenRouterPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenRouter/OpenRouterPlugin.cs
@@ -511,7 +511,7 @@ public sealed class OpenRouterPlugin : ITranscriptionEnginePlugin, ILlmProviderP
                 new { role = "system", content = systemPrompt },
                 new { role = "user", content = userText }
             },
-            ["max_tokens"] = 2048
+            ["max_tokens"] = LlmOutputTokenBudget.Calculate(systemPrompt, userText)
         };
 
         if (_temperatureMode == TemperatureModeCustom)
@@ -565,6 +565,7 @@ public sealed class OpenRouterPlugin : ITranscriptionEnginePlugin, ILlmProviderP
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
+        LlmResponseTruncationGuard.ThrowIfOpenAiChatCompletionTruncated(root, "OpenRouter");
 
         if (root.ValueKind == JsonValueKind.Object
             && root.TryGetProperty("choices", out var choices)

--- a/plugins/TypeWhisper.Plugin.Xai/XaiResponsesClient.cs
+++ b/plugins/TypeWhisper.Plugin.Xai/XaiResponsesClient.cs
@@ -37,6 +37,8 @@ internal sealed class XaiResponsesClient
         {
             ["model"] = XaiJson.Element(model),
             ["store"] = XaiJson.Element(false),
+            ["max_output_tokens"] = XaiJson.Element(
+                LlmOutputTokenBudget.Calculate(systemPrompt, userText)),
             ["input"] = XaiJson.Element(new object[]
             {
                 new { role = "system", content = systemPrompt },
@@ -67,6 +69,7 @@ internal sealed class XaiResponsesClient
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
+        LlmResponseTruncationGuard.ThrowIfResponsesApiIncomplete(root, "xAI");
 
         if (TryGetNonEmptyString(root, "output_text") is { } outputText)
             return outputText;

--- a/src/TypeWhisper.Core/Services/DevelopmentDataSeed.cs
+++ b/src/TypeWhisper.Core/Services/DevelopmentDataSeed.cs
@@ -226,6 +226,7 @@ public static class DevelopmentDataSeedFactory
                 var provider = providers[(dayOffset * 2 + recordIndex) % providers.Length];
                 var sample = samples[(dayOffset * 3 + recordIndex) % samples.Length];
                 var timestamp = now.Date.AddDays(-dayOffset).AddHours(hours[recordIndex]);
+                var isWorkflowSample = dayOffset == 29 && recordIndex == recordsForDay - 1;
 
                 records.Add(HistoryRecord(
                     $"dev-history-{sequence + 1:000}",
@@ -236,7 +237,9 @@ public static class DevelopmentDataSeedFactory
                     app.ProcessName,
                     8.5 + (dayOffset * 3 + recordIndex * 5) % 16,
                     provider.Engine,
-                    provider.Model));
+                    provider.Model,
+                    isWorkflowSample ? "Dev Meeting Notes" : null,
+                    isWorkflowSample ? "dev-workflow-meeting-notes" : null));
             }
         }
 
@@ -277,7 +280,9 @@ public static class DevelopmentDataSeedFactory
         string appProcessName,
         double durationSeconds,
         string engine,
-        string model) =>
+        string model,
+        string? profileName = null,
+        string? workflowId = null) =>
         new()
         {
             Id = id,
@@ -288,6 +293,8 @@ public static class DevelopmentDataSeedFactory
             AppProcessName = appProcessName,
             DurationSeconds = durationSeconds,
             Language = "en",
+            ProfileName = profileName,
+            WorkflowId = workflowId,
             EngineUsed = engine,
             ModelUsed = model,
             CreatedAt = timestamp

--- a/src/TypeWhisper.PluginSDK/Helpers/LlmOutputTokenBudget.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/LlmOutputTokenBudget.cs
@@ -9,6 +9,8 @@ public static class LlmOutputTokenBudget
     public const int MinimumTokens = 2048;
     /// <summary>The maximum response budget requested from providers.</summary>
     public const int MaximumTokens = 8192;
+    /// <summary>Additional output capacity reserved for reasoning tokens.</summary>
+    public const int ReasoningReserveTokens = 25_000;
 
     private const int CharactersPerEstimatedToken = 4;
     private const int LongInputThresholdTokens = 1024;
@@ -29,5 +31,37 @@ public static class LlmOutputTokenBudget
         var desired = estimatedInputTokens + CompletionReserveTokens;
         var rounded = ((desired + BudgetStepTokens - 1) / BudgetStepTokens) * BudgetStepTokens;
         return (int)Math.Clamp(rounded, MinimumTokens, MaximumTokens);
+    }
+
+    /// <summary>
+    /// Returns the visible-output budget plus capacity for hidden reasoning tokens.
+    /// </summary>
+    public static int CalculateWithReasoningReserve(string? systemPrompt, string? userText) =>
+        checked(Calculate(systemPrompt, userText) + ReasoningReserveTokens);
+
+    /// <summary>
+    /// Caps an output budget to a local model's remaining context capacity.
+    /// </summary>
+    public static int FitToContext(
+        int requestedOutputTokens,
+        int promptTokenCount,
+        int contextSize,
+        string providerName)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(requestedOutputTokens, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(promptTokenCount);
+        ArgumentOutOfRangeException.ThrowIfLessThan(contextSize, 1);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+
+        var remainingTokens = contextSize - promptTokenCount;
+        if (remainingTokens <= 0)
+        {
+            throw new PluginRequestException(
+                $"{providerName} cannot process this workflow because its formatted prompt exceeds the model context window.",
+                PluginRequestFailureKind.RequestTooLarge,
+                isTransient: false);
+        }
+
+        return Math.Min(requestedOutputTokens, remainingTokens);
     }
 }

--- a/src/TypeWhisper.PluginSDK/Helpers/LlmOutputTokenBudget.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/LlmOutputTokenBudget.cs
@@ -1,0 +1,33 @@
+namespace TypeWhisper.PluginSDK.Helpers;
+
+/// <summary>
+/// Calculates a bounded workflow response budget from the supplied prompt text.
+/// </summary>
+public static class LlmOutputTokenBudget
+{
+    /// <summary>The legacy minimum response budget.</summary>
+    public const int MinimumTokens = 2048;
+    /// <summary>The maximum response budget requested from providers.</summary>
+    public const int MaximumTokens = 8192;
+
+    private const int CharactersPerEstimatedToken = 4;
+    private const int LongInputThresholdTokens = 1024;
+    private const int CompletionReserveTokens = 2048;
+    private const int BudgetStepTokens = 256;
+
+    /// <summary>
+    /// Returns an output budget that preserves the legacy cap for short input and scales for long workflows.
+    /// </summary>
+    public static int Calculate(string? systemPrompt, string? userText)
+    {
+        var totalCharacters = (long)(systemPrompt?.Length ?? 0) + (userText?.Length ?? 0);
+        var estimatedInputTokens = (totalCharacters + CharactersPerEstimatedToken - 1)
+            / CharactersPerEstimatedToken;
+        if (estimatedInputTokens <= LongInputThresholdTokens)
+            return MinimumTokens;
+
+        var desired = estimatedInputTokens + CompletionReserveTokens;
+        var rounded = ((desired + BudgetStepTokens - 1) / BudgetStepTokens) * BudgetStepTokens;
+        return (int)Math.Clamp(rounded, MinimumTokens, MaximumTokens);
+    }
+}

--- a/src/TypeWhisper.PluginSDK/Helpers/LlmResponseTruncationGuard.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/LlmResponseTruncationGuard.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace TypeWhisper.PluginSDK.Helpers;
+
+/// <summary>
+/// Rejects provider responses that explicitly report an incomplete token-limited result.
+/// </summary>
+public static class LlmResponseTruncationGuard
+{
+    private static readonly string[] TokenLimitReasons =
+    [
+        "length",
+        "max_tokens",
+        "max_output_tokens",
+        "model_context_window_exceeded"
+    ];
+
+    /// <summary>Rejects a token-limited OpenAI-compatible chat completion.</summary>
+    public static void ThrowIfOpenAiChatCompletionTruncated(
+        JsonElement root,
+        string providerName)
+    {
+        if (!root.TryGetProperty("choices", out var choices)
+            || choices.ValueKind != JsonValueKind.Array
+            || choices.GetArrayLength() == 0)
+        {
+            return;
+        }
+
+        var firstChoice = choices[0];
+        if (IsTokenLimitReason(GetString(firstChoice, "finish_reason"))
+            || IsTokenLimitReason(GetString(firstChoice, "native_finish_reason")))
+        {
+            Throw(providerName);
+        }
+    }
+
+    /// <summary>Rejects a token-limited Anthropic message response.</summary>
+    public static void ThrowIfAnthropicResponseTruncated(
+        JsonElement root,
+        string providerName)
+    {
+        if (IsTokenLimitReason(GetString(root, "stop_reason")))
+            Throw(providerName);
+    }
+
+    /// <summary>Rejects an incomplete Responses API result or completion event.</summary>
+    public static void ThrowIfResponsesApiIncomplete(
+        JsonElement root,
+        string providerName)
+    {
+        if (root.TryGetProperty("response", out var response)
+            && response.ValueKind == JsonValueKind.Object)
+        {
+            ThrowIfResponsesApiIncomplete(response, providerName);
+        }
+
+        var status = GetString(root, "status");
+        if (string.Equals(status, "incomplete", StringComparison.OrdinalIgnoreCase))
+            Throw(providerName);
+
+        if (root.TryGetProperty("incomplete_details", out var details)
+            && details.ValueKind == JsonValueKind.Object
+            && IsTokenLimitReason(GetString(details, "reason")))
+        {
+            Throw(providerName);
+        }
+    }
+
+    private static bool IsTokenLimitReason(string? reason) =>
+        !string.IsNullOrWhiteSpace(reason)
+        && TokenLimitReasons.Contains(reason, StringComparer.OrdinalIgnoreCase);
+
+    private static string? GetString(JsonElement element, string propertyName) =>
+        element.ValueKind == JsonValueKind.Object
+        && element.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static void Throw(string providerName) =>
+        throw new PluginRequestException(
+            $"{providerName} stopped the workflow response at its token limit.",
+            PluginRequestFailureKind.OutputTruncated,
+            isTransient: false);
+}

--- a/src/TypeWhisper.PluginSDK/Helpers/LlmResponseTruncationGuard.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/LlmResponseTruncationGuard.cs
@@ -55,16 +55,20 @@ public static class LlmResponseTruncationGuard
             ThrowIfResponsesApiIncomplete(response, providerName);
         }
 
+        var reason = root.TryGetProperty("incomplete_details", out var details)
+                     && details.ValueKind == JsonValueKind.Object
+            ? GetString(details, "reason")
+            : null;
         var status = GetString(root, "status");
         if (string.Equals(status, "incomplete", StringComparison.OrdinalIgnoreCase))
-            Throw(providerName);
-
-        if (root.TryGetProperty("incomplete_details", out var details)
-            && details.ValueKind == JsonValueKind.Object
-            && IsTokenLimitReason(GetString(details, "reason")))
         {
-            Throw(providerName);
+            if (IsTokenLimitReason(reason))
+                Throw(providerName);
+            ThrowIncomplete(providerName);
         }
+
+        if (IsTokenLimitReason(reason))
+            Throw(providerName);
     }
 
     private static bool IsTokenLimitReason(string? reason) =>
@@ -82,5 +86,11 @@ public static class LlmResponseTruncationGuard
         throw new PluginRequestException(
             $"{providerName} stopped the workflow response at its token limit.",
             PluginRequestFailureKind.OutputTruncated,
+            isTransient: false);
+
+    private static void ThrowIncomplete(string providerName) =>
+        throw new PluginRequestException(
+            $"{providerName} returned an incomplete workflow response.",
+            PluginRequestFailureKind.OutputIncomplete,
             isTransient: false);
 }

--- a/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
+++ b/src/TypeWhisper.PluginSDK/Helpers/OpenAiChatHelper.cs
@@ -33,7 +33,7 @@ public static class OpenAiChatHelper
             systemPrompt,
             userText,
             ct,
-            maxOutputTokens: 2048,
+            maxOutputTokens: LlmOutputTokenBudget.Calculate(systemPrompt, userText),
             maxOutputTokenParameter: "max_tokens",
             reasoningEffort: null,
             temperature: 0.1);
@@ -136,6 +136,7 @@ public static class OpenAiChatHelper
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
+        LlmResponseTruncationGuard.ThrowIfOpenAiChatCompletionTruncated(root, "The provider");
 
         if (root.ValueKind == JsonValueKind.Object
             && root.TryGetProperty("choices", out var choices)

--- a/src/TypeWhisper.PluginSDK/PluginRequestException.cs
+++ b/src/TypeWhisper.PluginSDK/PluginRequestException.cs
@@ -30,7 +30,9 @@ public enum PluginRequestFailureKind
     /// <summary>The request was cancelled.</summary>
     Cancellation,
     /// <summary>The provider stopped before completing the response because of an output limit.</summary>
-    OutputTruncated
+    OutputTruncated,
+    /// <summary>The provider returned an incomplete response for a reason other than an output limit.</summary>
+    OutputIncomplete
 }
 
 /// <summary>

--- a/src/TypeWhisper.PluginSDK/PluginRequestException.cs
+++ b/src/TypeWhisper.PluginSDK/PluginRequestException.cs
@@ -28,7 +28,9 @@ public enum PluginRequestFailureKind
     /// <summary>The provider rejected an invalid or unsupported request.</summary>
     InvalidRequest,
     /// <summary>The request was cancelled.</summary>
-    Cancellation
+    Cancellation,
+    /// <summary>The provider stopped before completing the response because of an output limit.</summary>
+    OutputTruncated
 }
 
 /// <summary>

--- a/src/TypeWhisper.Windows/Services/HistoryWorkflowRetryService.cs
+++ b/src/TypeWhisper.Windows/Services/HistoryWorkflowRetryService.cs
@@ -183,6 +183,7 @@ public sealed class HistoryWorkflowRetryService
                 PluginRequestFailureKind.RateLimit => "The workflow provider rate limit was reached.",
                 PluginRequestFailureKind.ServerError => "The workflow provider returned a server error.",
                 PluginRequestFailureKind.EmptyResponse => "The workflow provider returned an empty response.",
+                PluginRequestFailureKind.OutputTruncated => "The workflow provider stopped at its output token limit.",
                 PluginRequestFailureKind.Authentication => "Workflow provider authentication failed.",
                 PluginRequestFailureKind.Permission => "The workflow provider denied this request.",
                 PluginRequestFailureKind.Configuration => "The workflow provider is not configured correctly.",

--- a/src/TypeWhisper.Windows/Services/HistoryWorkflowRetryService.cs
+++ b/src/TypeWhisper.Windows/Services/HistoryWorkflowRetryService.cs
@@ -184,6 +184,7 @@ public sealed class HistoryWorkflowRetryService
                 PluginRequestFailureKind.ServerError => "The workflow provider returned a server error.",
                 PluginRequestFailureKind.EmptyResponse => "The workflow provider returned an empty response.",
                 PluginRequestFailureKind.OutputTruncated => "The workflow provider stopped at its output token limit.",
+                PluginRequestFailureKind.OutputIncomplete => "The workflow provider returned an incomplete response.",
                 PluginRequestFailureKind.Authentication => "Workflow provider authentication failed.",
                 PluginRequestFailureKind.Permission => "The workflow provider denied this request.",
                 PluginRequestFailureKind.Configuration => "The workflow provider is not configured correctly.",

--- a/src/TypeWhisper.Windows/Services/PromptProcessingService.cs
+++ b/src/TypeWhisper.Windows/Services/PromptProcessingService.cs
@@ -395,6 +395,7 @@ public sealed class PromptProcessingService : IWorkflowTextProcessor
             PluginRequestFailureKind.RateLimit => "rate limit",
             PluginRequestFailureKind.ServerError => "provider server error",
             PluginRequestFailureKind.EmptyResponse => "empty response",
+            PluginRequestFailureKind.OutputTruncated => "output token limit",
             PluginRequestFailureKind.Authentication => "authentication error",
             PluginRequestFailureKind.Permission => "permission error",
             PluginRequestFailureKind.Configuration => "configuration error",

--- a/src/TypeWhisper.Windows/Services/PromptProcessingService.cs
+++ b/src/TypeWhisper.Windows/Services/PromptProcessingService.cs
@@ -396,6 +396,7 @@ public sealed class PromptProcessingService : IWorkflowTextProcessor
             PluginRequestFailureKind.ServerError => "provider server error",
             PluginRequestFailureKind.EmptyResponse => "empty response",
             PluginRequestFailureKind.OutputTruncated => "output token limit",
+            PluginRequestFailureKind.OutputIncomplete => "incomplete provider response",
             PluginRequestFailureKind.Authentication => "authentication error",
             PluginRequestFailureKind.Permission => "permission error",
             PluginRequestFailureKind.Configuration => "configuration error",

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -3067,6 +3067,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 PluginRequestFailureKind.RateLimit => "The workflow provider rate limit was reached.",
                 PluginRequestFailureKind.ServerError => "The workflow provider returned a server error.",
                 PluginRequestFailureKind.EmptyResponse => "The workflow provider returned an empty response.",
+                PluginRequestFailureKind.OutputTruncated => "The workflow provider stopped at its output token limit.",
                 PluginRequestFailureKind.Authentication => "Workflow provider authentication failed.",
                 PluginRequestFailureKind.Permission => "The workflow provider denied this request.",
                 PluginRequestFailureKind.Configuration => "The workflow provider is not configured correctly.",

--- a/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/DictationViewModel.cs
@@ -3068,6 +3068,7 @@ public partial class DictationViewModel : ObservableObject, IDisposable, IDictat
                 PluginRequestFailureKind.ServerError => "The workflow provider returned a server error.",
                 PluginRequestFailureKind.EmptyResponse => "The workflow provider returned an empty response.",
                 PluginRequestFailureKind.OutputTruncated => "The workflow provider stopped at its output token limit.",
+                PluginRequestFailureKind.OutputIncomplete => "The workflow provider returned an incomplete response.",
                 PluginRequestFailureKind.Authentication => "Workflow provider authentication failed.",
                 PluginRequestFailureKind.Permission => "The workflow provider denied this request.",
                 PluginRequestFailureKind.Configuration => "The workflow provider is not configured correctly.",

--- a/src/TypeWhisper.Windows/ViewModels/HistoryViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/HistoryViewModel.cs
@@ -425,10 +425,8 @@ public partial class HistoryEntryViewModel : ObservableObject
     private void SaveEdit()
     {
         _parent.SaveEdit(this, EditText);
-        Record = Record with { FinalText = EditText };
+        ReplaceRecord(Record with { FinalText = EditText });
         IsEditing = false;
-        OnPropertyChanged(nameof(Record));
-        OnPropertyChanged(nameof(HasDistinctWorkflowRawText));
     }
 
     [RelayCommand]
@@ -485,10 +483,8 @@ public partial class HistoryEntryViewModel : ObservableObject
                 status => Application.Current?.Dispatcher.InvokeAsync(() => RetryStatusText = status).Task
                           ?? Task.CompletedTask,
                 _retryCts.Token);
-            Record = updated;
+            ReplaceRecord(updated);
             RetryStatusText = Loc.Instance["History.RetrySucceeded"];
-            OnPropertyChanged(nameof(Record));
-            OnPropertyChanged(nameof(IsWorkflowFailed));
         }
         catch (OperationCanceledException)
         {
@@ -496,11 +492,9 @@ public partial class HistoryEntryViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Record = _parent.GetCurrentRecord(Record.Id) ?? Record;
+            ReplaceRecord(_parent.GetCurrentRecord(Record.Id) ?? Record);
             RetryErrorText = HistoryWorkflowRetryService.SanitizeFailure(ex);
             RetryStatusText = "";
-            OnPropertyChanged(nameof(Record));
-            OnPropertyChanged(nameof(IsWorkflowFailed));
         }
         finally
         {
@@ -509,6 +503,17 @@ public partial class HistoryEntryViewModel : ObservableObject
             _retryCts = null;
             RetryWorkflowCommand.NotifyCanExecuteChanged();
         }
+    }
+
+    /// <summary>
+    /// Replaces the backing history record and refreshes all derived UI predicates.
+    /// </summary>
+    internal void ReplaceRecord(TranscriptionRecord record)
+    {
+        Record = record;
+        OnPropertyChanged(nameof(Record));
+        OnPropertyChanged(nameof(IsWorkflowFailed));
+        OnPropertyChanged(nameof(HasDistinctWorkflowRawText));
     }
 
     [RelayCommand]

--- a/src/TypeWhisper.Windows/ViewModels/HistoryViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/HistoryViewModel.cs
@@ -377,6 +377,15 @@ public partial class HistoryEntryViewModel : ObservableObject
     /// Gets whether post-processing failed for this entry.
     /// </summary>
     public bool IsWorkflowFailed => Record.Status == TranscriptionRecordStatus.WorkflowPostProcessingFailed;
+    /// <summary>
+    /// Gets whether a successful workflow entry has a distinct raw transcription to recover.
+    /// </summary>
+    public bool HasDistinctWorkflowRawText =>
+        !IsWorkflowFailed
+        && (!string.IsNullOrWhiteSpace(Record.WorkflowId)
+            || !string.IsNullOrWhiteSpace(Record.ProfileName))
+        && !string.IsNullOrWhiteSpace(Record.RawText)
+        && !string.Equals(Record.RawText.Trim(), Record.FinalText.Trim(), StringComparison.Ordinal);
 
     /// <summary>
     /// Initializes a new instance of the HistoryEntryViewModel class.
@@ -419,6 +428,7 @@ public partial class HistoryEntryViewModel : ObservableObject
         Record = Record with { FinalText = EditText };
         IsEditing = false;
         OnPropertyChanged(nameof(Record));
+        OnPropertyChanged(nameof(HasDistinctWorkflowRawText));
     }
 
     [RelayCommand]

--- a/src/TypeWhisper.Windows/Views/Sections/HistorySection.xaml
+++ b/src/TypeWhisper.Windows/Views/Sections/HistorySection.xaml
@@ -115,6 +115,8 @@
             <ListBox.ItemContainerStyle>
                 <Style TargetType="ListBoxItem">
                     <Setter Property="Focusable" Value="False"/>
+                    <Setter Property="AutomationProperties.AutomationId"
+                            Value="{Binding Record.Id, StringFormat=HistoryEntry.{0}}"/>
                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                     <Setter Property="Padding" Value="0"/>
                     <Setter Property="Margin" Value="0"/>
@@ -177,54 +179,60 @@
                         <!-- Right: card -->
                         <Border Grid.Column="1" Style="{StaticResource TimelineCardStyle}"
                                 Margin="0,4,8,4">
-                            <Border.InputBindings>
-                                <MouseBinding MouseAction="LeftClick"
-                                              Command="{Binding ToggleExpandCommand}"/>
-                            </Border.InputBindings>
-
                             <StackPanel>
                                 <!-- Collapsed: time + preview + badges -->
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
+                                <Button Command="{Binding ToggleExpandCommand}"
+                                        AutomationProperties.AutomationId="{Binding Record.Id, StringFormat=HistoryToggle.{0}}"
+                                        AutomationProperties.Name="{Binding Record.Preview}"
+                                        Background="Transparent" BorderThickness="0" Padding="0"
+                                        HorizontalContentAlignment="Stretch" Cursor="Hand">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
 
-                                    <TextBlock Grid.Column="0" Text="{Binding TimeLabel}"
-                                               Foreground="{StaticResource HintBrush}" FontSize="12"
-                                               VerticalAlignment="Top" Margin="0,0,10,0"/>
+                                        <TextBlock Grid.Column="0" Text="{Binding TimeLabel}"
+                                                   Foreground="{StaticResource HintBrush}" FontSize="12"
+                                                   VerticalAlignment="Top" Margin="0,0,10,0"/>
 
-                                    <TextBlock Grid.Column="1" Text="{Binding Record.Preview}"
-                                               Foreground="{StaticResource TextBrush}" FontSize="13"
-                                               TextTrimming="CharacterEllipsis"
-                                               VerticalAlignment="Top"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Record.Preview}"
+                                                   Foreground="{StaticResource TextBrush}" FontSize="13"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   VerticalAlignment="Top"/>
 
-                                    <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="8,0,0,0">
-                                        <Border Style="{StaticResource BadgeStyle}"
-                                                Background="#4A1F24"
-                                                AutomationProperties.AutomationId="{Binding Record.Id, StringFormat=HistoryWorkflowFailedBadge.{0}}"
-                                                Visibility="{Binding IsWorkflowFailed, Converter={StaticResource BoolToVis}}">
-                                            <TextBlock Text="{loc:Str History.WorkflowFailedBadge}"
-                                                       Foreground="{StaticResource DangerBrush}" FontSize="11"/>
-                                        </Border>
-                                        <Border Style="{StaticResource BadgeStyle}"
-                                                Background="#2A3A5A"
-                                                Visibility="{Binding Record.ProfileName, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
-                                            <TextBlock Text="{Binding Record.ProfileName}"
-                                                       Foreground="{StaticResource AccentBrush}" FontSize="11"/>
-                                        </Border>
-                                        <Border Style="{StaticResource BadgeStyle}"
-                                                Visibility="{Binding Record.AppProcessName, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
-                                            <TextBlock Text="{Binding Record.AppProcessName}"
-                                                       Foreground="{StaticResource HintBrush}" FontSize="11"/>
-                                        </Border>
-                                        <Border Style="{StaticResource BadgeStyle}">
-                                            <TextBlock Text="{Binding DurationLabel}"
-                                                       Foreground="{StaticResource HintBrush}" FontSize="11"/>
-                                        </Border>
-                                    </StackPanel>
-                                </Grid>
+                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="8,0,0,0">
+                                            <Border Style="{StaticResource BadgeStyle}"
+                                                    Background="#4A1F24"
+                                                    AutomationProperties.AutomationId="{Binding Record.Id, StringFormat=HistoryWorkflowFailedBadge.{0}}"
+                                                    Visibility="{Binding IsWorkflowFailed, Converter={StaticResource BoolToVis}}">
+                                                <TextBlock Text="{loc:Str History.WorkflowFailedBadge}"
+                                                           Foreground="{StaticResource DangerBrush}" FontSize="11"/>
+                                            </Border>
+                                            <Border Style="{StaticResource BadgeStyle}"
+                                                    Background="#2A3A5A"
+                                                    Visibility="{Binding Record.ProfileName, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
+                                                <TextBlock Text="{Binding Record.ProfileName}"
+                                                           Foreground="{StaticResource AccentBrush}" FontSize="11"/>
+                                            </Border>
+                                            <Border Style="{StaticResource BadgeStyle}"
+                                                    Visibility="{Binding Record.AppProcessName, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
+                                                <TextBlock Text="{Binding Record.AppProcessName}"
+                                                           Foreground="{StaticResource HintBrush}" FontSize="11"/>
+                                            </Border>
+                                            <Border Style="{StaticResource BadgeStyle}">
+                                                <TextBlock Text="{Binding DurationLabel}"
+                                                           Foreground="{StaticResource HintBrush}" FontSize="11"/>
+                                            </Border>
+                                        </StackPanel>
+                                    </Grid>
+                                </Button>
 
                                 <!-- Expanded -->
                                 <StackPanel Visibility="{Binding IsExpanded, Converter={StaticResource BoolToVis}}">
@@ -301,6 +309,27 @@
                                             </Style>
                                         </TextBlock.Style>
                                     </TextBlock>
+
+                                    <!-- Raw transcription for successful workflow output -->
+                                    <Border CornerRadius="6" Padding="10" Margin="0,0,0,10"
+                                            Background="{StaticResource CardBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Visibility="{Binding HasDistinctWorkflowRawText, Converter={StaticResource BoolToVis}}">
+                                        <StackPanel>
+                                            <TextBlock Text="{loc:Str History.RawTextLabel}"
+                                                       Foreground="{StaticResource HintBrush}" FontSize="11"/>
+                                            <TextBlock Text="{Binding Record.RawText}" TextWrapping="Wrap"
+                                                       AutomationProperties.AutomationId="{Binding Record.Id, StringFormat=HistorySuccessfulRawText.{0}}"
+                                                       Foreground="{StaticResource TextBrush}" FontSize="13"
+                                                       Margin="0,3,0,6"/>
+                                            <Button Content="{loc:Str History.CopyRawText}"
+                                                    Command="{Binding CopyRawTextCommand}"
+                                                    AutomationProperties.AutomationId="{Binding Record.Id, StringFormat=HistoryCopySuccessfulRawText.{0}}"
+                                                    Style="{StaticResource LinkButtonStyle}"
+                                                    HorizontalAlignment="Left"/>
+                                        </StackPanel>
+                                    </Border>
 
                                     <!-- Edit mode -->
                                     <StackPanel Visibility="{Binding IsEditing, Converter={StaticResource BoolToVis}}">

--- a/tests/TypeWhisper.Core.Tests/Services/DevelopmentDataSeedTests.cs
+++ b/tests/TypeWhisper.Core.Tests/Services/DevelopmentDataSeedTests.cs
@@ -66,6 +66,9 @@ public sealed class DevelopmentDataSeedTests : IDisposable
         Assert.True(seed.HistoryRecords.Sum(record => record.WordCount) > 1_200);
         Assert.Contains(seed.HistoryRecords, record => record.AppProcessName == "outlook");
         Assert.Contains(seed.HistoryRecords, record => record.AppProcessName == "obsidian");
+        Assert.Contains(seed.HistoryRecords, record =>
+            record.WorkflowId == "dev-workflow-meeting-notes"
+            && record.RawText != record.FinalText);
         Assert.Equal(
             seed.HistoryRecords.Select(record => new
             {

--- a/tests/TypeWhisper.PluginSystem.Tests/HistoryWorkflowRawTextTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HistoryWorkflowRawTextTests.cs
@@ -1,0 +1,43 @@
+using TypeWhisper.Core.Models;
+using TypeWhisper.Windows.ViewModels;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class HistoryWorkflowRawTextTests
+{
+    [Fact]
+    public void SuccessfulWorkflowEntry_ExposesDistinctRawTranscription()
+    {
+        var record = new TranscriptionRecord
+        {
+            Id = "successful-workflow",
+            Timestamp = DateTime.UtcNow,
+            RawText = "The complete raw transcription remains available.",
+            FinalText = "The transformed workflow result.",
+            ProfileName = "Coding Prompt Assistant"
+        };
+
+        var entry = new HistoryEntryViewModel(record, null!);
+
+        Assert.True(entry.HasDistinctWorkflowRawText);
+    }
+
+    [Fact]
+    public void History_ExposesDistinctRawTextForSuccessfulWorkflowEntries()
+    {
+        var xaml = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Views",
+            "Sections",
+            "HistorySection.xaml");
+
+        Assert.Contains(
+            "Visibility=\"{Binding HasDistinctWorkflowRawText, Converter={StaticResource BoolToVis}}\"",
+            xaml);
+        Assert.Contains("StringFormat=HistoryEntry.{0}", xaml);
+        Assert.Contains("StringFormat=HistoryToggle.{0}", xaml);
+        Assert.Contains("StringFormat=HistorySuccessfulRawText.{0}", xaml);
+        Assert.Contains("StringFormat=HistoryCopySuccessfulRawText.{0}", xaml);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/HistoryWorkflowRawTextTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HistoryWorkflowRawTextTests.cs
@@ -23,6 +23,27 @@ public sealed class HistoryWorkflowRawTextTests
     }
 
     [Fact]
+    public void ReplacingRecord_NotifiesDistinctRawTranscriptionPredicate()
+    {
+        var original = new TranscriptionRecord
+        {
+            Id = "successful-workflow",
+            Timestamp = DateTime.UtcNow,
+            RawText = "The original transcription.",
+            FinalText = "The original transcription.",
+            ProfileName = "Coding Prompt Assistant"
+        };
+        var entry = new HistoryEntryViewModel(original, null!);
+        var changedProperties = new List<string?>();
+        entry.PropertyChanged += (_, args) => changedProperties.Add(args.PropertyName);
+
+        entry.ReplaceRecord(original with { FinalText = "The transformed workflow result." });
+
+        Assert.True(entry.HasDistinctWorkflowRawText);
+        Assert.Contains(nameof(HistoryEntryViewModel.HasDistinctWorkflowRawText), changedProperties);
+    }
+
+    [Fact]
     public void History_ExposesDistinctRawTextForSuccessfulWorkflowEntries()
     {
         var xaml = TestFile.ReadProjectFile(

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
@@ -84,6 +84,41 @@ public sealed class OpenAiChatHelperTests
     }
 
     [Fact]
+    public void OutputTokenBudget_AddsReasoningCapacityWithoutReducingVisibleBudget()
+    {
+        var visibleBudget = LlmOutputTokenBudget.Calculate("", "short input");
+
+        var totalBudget = LlmOutputTokenBudget.CalculateWithReasoningReserve("", "short input");
+
+        Assert.Equal(visibleBudget + LlmOutputTokenBudget.ReasoningReserveTokens, totalBudget);
+    }
+
+    [Fact]
+    public void OutputTokenBudget_CapsLocalGenerationToRemainingContext()
+    {
+        var budget = LlmOutputTokenBudget.FitToContext(
+            requestedOutputTokens: 2048,
+            promptTokenCount: 3500,
+            contextSize: 4096,
+            providerName: "Local model");
+
+        Assert.Equal(596, budget);
+    }
+
+    [Fact]
+    public void OutputTokenBudget_RejectsPromptWithoutOutputCapacity()
+    {
+        var error = Assert.Throws<PluginRequestException>(() =>
+            LlmOutputTokenBudget.FitToContext(
+                requestedOutputTokens: 2048,
+                promptTokenCount: 4097,
+                contextSize: 4096,
+                providerName: "Local model"));
+
+        Assert.Equal(PluginRequestFailureKind.RequestTooLarge, error.FailureKind);
+    }
+
+    [Fact]
     public void SendChatCompletionAsync_PreservesLegacySevenParameterOverload()
     {
         var parameterTypes = new[]

--- a/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/OpenAiChatHelperTests.cs
@@ -1,11 +1,88 @@
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
 
 namespace TypeWhisper.PluginSystem.Tests;
 
 public sealed class OpenAiChatHelperTests
 {
+    [Fact]
+    public async Task SendChatCompletionAsync_ScalesOutputBudgetForLongWorkflowInput()
+    {
+        string? capturedBody = null;
+        using var httpClient = new HttpClient(new StubHandler(async request =>
+        {
+            capturedBody = await request.Content!.ReadAsStringAsync();
+            return JsonResponse("""
+                {
+                  "choices": [
+                    { "message": { "content": "Complete result" }, "finish_reason": "stop" }
+                  ]
+                }
+                """);
+        }));
+        var longTranscript = string.Join(' ', Enumerable.Repeat("dictated workflow input", 1_000));
+
+        var result = await OpenAiChatHelper.SendChatCompletionAsync(
+            httpClient,
+            "https://provider.example",
+            "test-key",
+            "test-model",
+            "Preserve every detail.",
+            longTranscript,
+            CancellationToken.None);
+
+        Assert.Equal("Complete result", result);
+        using var body = JsonDocument.Parse(Assert.IsType<string>(capturedBody));
+        Assert.True(
+            body.RootElement.GetProperty("max_tokens").GetInt32() > 2048,
+            "Long workflow input must receive more than the fixed legacy output budget.");
+    }
+
+    [Fact]
+    public async Task SendChatCompletionAsync_RejectsTokenLimitedPartialResponse()
+    {
+        using var httpClient = new HttpClient(new StubHandler(_ => Task.FromResult(JsonResponse("""
+            {
+              "choices": [
+                {
+                  "message": { "content": "This result ends in the middle" },
+                  "finish_reason": "length"
+                }
+              ]
+            }
+            """))));
+
+        var error = await Assert.ThrowsAsync<PluginRequestException>(() =>
+            OpenAiChatHelper.SendChatCompletionAsync(
+                httpClient,
+                "https://provider.example",
+                "test-key",
+                "test-model",
+                "Preserve every detail.",
+                "Long dictated input",
+                CancellationToken.None));
+
+        Assert.Contains("token", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(PluginRequestFailureKind.OutputTruncated, error.FailureKind);
+        Assert.False(error.IsTransient);
+    }
+
+    [Theory]
+    [InlineData(100, 2048)]
+    [InlineData(8_000, 4096)]
+    [InlineData(100_000, 8192)]
+    public void OutputTokenBudget_ScalesAndRemainsBounded(int inputLength, int expectedTokens)
+    {
+        var budget = LlmOutputTokenBudget.Calculate("", new string('a', inputLength));
+
+        Assert.Equal(expectedTokens, budget);
+    }
+
     [Fact]
     public void SendChatCompletionAsync_PreservesLegacySevenParameterOverload()
     {
@@ -58,5 +135,19 @@ public sealed class OpenAiChatHelperTests
 
         Assert.NotNull(method);
         Assert.Equal(typeof(Task<string>), method!.ReturnType);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => responder(request);
     }
 }

--- a/tools/TypeWhisper.UiAutomation/Flows/HistoryWorkflowRawText.json
+++ b/tools/TypeWhisper.UiAutomation/Flows/HistoryWorkflowRawText.json
@@ -1,0 +1,25 @@
+{
+  "steps": [
+    {
+      "action": "invoke",
+      "automationId": "History"
+    },
+    {
+      "action": "wait",
+      "automationId": "SettingsSection.History"
+    },
+    {
+      "action": "invoke",
+      "automationId": "HistoryToggle.dev-history-092"
+    },
+    {
+      "action": "wait",
+      "automationId": "HistorySuccessfulRawText.dev-history-092"
+    },
+    {
+      "action": "capture",
+      "automationId": "SettingsWindow",
+      "file": "history-workflow-raw-text.png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Scale workflow output budgets for long prompts across supported LLM provider paths.
- Reject provider responses that explicitly report token-limited or incomplete output instead of treating partial text as successful.
- Expose distinct raw transcriptions for successful workflow entries in History, including a copy action and an automation-friendly entry toggle.
- Add provider, parser, History, seed, and native UI automation regression coverage.
- Cap local Gemma generation to its remaining model context and reserve reasoning capacity on OpenAI requests.

## Reproduction

Before the fix, focused regression tests confirmed all three parts of the reported failure path:

- long workflow requests retained the fixed 2048-token output budget;
- a response ending with `finish_reason: length` was returned as successful partial text;
- successful workflow entries did not expose their separately stored raw transcription in History.

## Validation

- `dotnet test TypeWhisper.slnx --no-restore` (2506 passed)
- `HistoryWorkflowRawTextTests` (3 passed)
- `HistoryWorkflowRawText.json` native UI automation flow
- Windows development build and responsive app launch
- no new crash-log entry

Closes #392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * AI requests now allocate output capacity based on input length, improving results for longer transcripts.
  * Responses that are truncated or incomplete are detected and reported clearly.
  * Local generation respects available model context limits.
  * Workflow failures now explain when output reaches a token limit or is incomplete.

* **History**
  * Successful workflow entries can display and copy the original transcription when it differs from the final text.
  * Development history samples now include workflow-linked records.

* **Tests**
  * Added coverage for long-input handling, incomplete responses, and workflow raw-text display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->