### PR TITLE
Release updated workflow provider plugins

### DIFF
--- a/plugins/TypeWhisper.Plugin.Claude/ClaudePlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Claude/ClaudePlugin.cs
@@ -37,7 +37,7 @@ public sealed class ClaudePlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.1";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.

--- a/plugins/TypeWhisper.Plugin.Claude/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Claude/manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "com.typewhisper.claude",
   "name": "Claude",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Anthropic Claude LLM for prompt processing",
   "assemblyName": "TypeWhisper.Plugin.Claude.dll",

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -80,7 +80,7 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.2.0";
+    public string PluginVersion => "1.2.1";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.

--- a/plugins/TypeWhisper.Plugin.Gemini/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "com.typewhisper.gemini",
   "name": "Google Gemini",
-  "version": "1.2.0",
+  "version": "1.2.1",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Google Gemini and Gemma LLM provider with dynamic model discovery for prompt actions and translation",
   "descriptions": {

--- a/plugins/TypeWhisper.Plugin.GemmaLocal/GemmaLocalPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.GemmaLocal/GemmaLocalPlugin.cs
@@ -50,7 +50,7 @@ public sealed class GemmaLocalPlugin : ILlmProviderPlugin
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.1";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.

--- a/plugins/TypeWhisper.Plugin.GemmaLocal/manifest.json
+++ b/plugins/TypeWhisper.Plugin.GemmaLocal/manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "com.typewhisper.gemma-local",
   "name": "Gemma 4 (Local)",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Run Google Gemma 4 locally via Ollama or any OpenAI-compatible server",
   "assemblyName": "TypeWhisper.Plugin.GemmaLocal.dll",

--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -84,7 +84,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.4";
+    public string PluginVersion => "1.0.5";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.

--- a/plugins/TypeWhisper.Plugin.Groq/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Groq/manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "com.typewhisper.groq",
   "name": "Groq",
-  "version": "1.0.4",
+  "version": "1.0.5",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Groq Whisper transcription and Llama translation",
   "category": "transcription",

--- a/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
@@ -29,7 +29,7 @@ public class OpenAiPluginTests
 
         Assert.NotNull(manifest);
         Assert.Equal(manifest.Version, sut.PluginVersion);
-        Assert.Equal("1.0.0", manifest.MinHostVersion);
+        Assert.Equal("1.0.9", manifest.MinHostVersion);
         Assert.Contains("text-to-speech", manifest.Description, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("API key", manifest.Description, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(["transcription", "llm", "tts"], manifest.Categories);

--- a/plugins/TypeWhisper.Plugin.OpenAi/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAi/manifest.json
@@ -2,7 +2,7 @@
   "id": "com.typewhisper.openai",
   "name": "OpenAI / ChatGPT",
   "version": "1.1.2",
-  "minHostVersion": "1.0.0",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "OpenAI transcription, prompt processing, and text-to-speech with dynamic API and ChatGPT model catalogs. STT/TTS require an API key; prompts can use ChatGPT login.",
   "descriptions": {

--- a/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAiCompatible/manifest.json
@@ -2,6 +2,7 @@
   "id": "com.typewhisper.openai-compatible",
   "name": "OpenAI Compatible",
   "version": "1.0.6",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Connect to any OpenAI-compatible server (Ollama, LM Studio, vLLM, etc.)",
   "category": "transcription",

--- a/plugins/TypeWhisper.Plugin.OpenRouter/OpenRouterPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenRouter/OpenRouterPlugin.cs
@@ -97,7 +97,7 @@ public sealed class OpenRouterPlugin : ITranscriptionEnginePlugin, ILlmProviderP
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.1.0";
+    public string PluginVersion => "1.1.1";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.

--- a/plugins/TypeWhisper.Plugin.OpenRouter/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenRouter/manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "com.typewhisper.openrouter",
   "name": "OpenRouter",
-  "version": "1.1.0",
+  "version": "1.1.1",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Access LLMs and speech-to-text models from OpenAI, Anthropic, Meta, Google and more via OpenRouter. Shows model pricing and account balance. Requires API key.",
   "descriptions": {

--- a/plugins/TypeWhisper.Plugin.Xai/XaiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Xai/XaiPlugin.cs
@@ -88,7 +88,7 @@ public sealed class XaiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin, 
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.0";
+    public string PluginVersion => "1.0.1";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.

--- a/plugins/TypeWhisper.Plugin.Xai/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Xai/manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "com.typewhisper.xai",
   "name": "xAI / Grok",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Cloud LLM, speech-to-text, and text-to-speech via xAI Grok APIs. Requires an xAI API key.",
   "descriptions": {

--- a/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
+++ b/tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj
@@ -27,6 +27,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenAi\TypeWhisper.Plugin.OpenAi.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.Claude\TypeWhisper.Plugin.Claude.csproj" />
+    <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.GemmaLocal\TypeWhisper.Plugin.GemmaLocal.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenAiCompatible\TypeWhisper.Plugin.OpenAiCompatible.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.AuthenticatedCli\TypeWhisper.Plugin.AuthenticatedCli.csproj" />
     <ProjectReference Include="..\..\plugins\TypeWhisper.Plugin.OpenRouter\TypeWhisper.Plugin.OpenRouter.csproj" />

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using System.Text.Json;
+using TypeWhisper.Plugin.Claude;
+using TypeWhisper.Plugin.Gemini;
+using TypeWhisper.Plugin.GemmaLocal;
+using TypeWhisper.Plugin.Groq;
+using TypeWhisper.Plugin.OpenAi;
+using TypeWhisper.Plugin.OpenAiCompatible;
+using TypeWhisper.Plugin.OpenRouter;
+using TypeWhisper.Plugin.Xai;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class WorkflowProviderReleaseMetadataTests
+{
+    public static TheoryData<string, string> Providers => new()
+    {
+        { "TypeWhisper.Plugin.Claude", "1.0.1" },
+        { "TypeWhisper.Plugin.Gemini", "1.2.1" },
+        { "TypeWhisper.Plugin.GemmaLocal", "1.0.1" },
+        { "TypeWhisper.Plugin.Groq", "1.0.5" },
+        { "TypeWhisper.Plugin.OpenAi", "1.1.2" },
+        { "TypeWhisper.Plugin.OpenAiCompatible", "1.0.6" },
+        { "TypeWhisper.Plugin.OpenRouter", "1.1.1" },
+        { "TypeWhisper.Plugin.Xai", "1.0.1" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void ReleaseMetadata_MatchesRuntimeAndRequiresCompatibleHost(
+        string projectName,
+        string expectedVersion)
+    {
+        var manifestPath = Path.Join(RepositoryRoot(), "plugins", projectName, "manifest.json");
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var plugin = CreatePlugin(projectName);
+
+        try
+        {
+            Assert.NotNull(manifest);
+            Assert.Equal(expectedVersion, manifest.Version);
+            Assert.Equal(expectedVersion, plugin.PluginVersion);
+            Assert.Equal("1.0.9", manifest.MinHostVersion);
+        }
+        finally
+        {
+            (plugin as IDisposable)?.Dispose();
+        }
+    }
+
+    private static ITypeWhisperPlugin CreatePlugin(string projectName) => projectName switch
+    {
+        "TypeWhisper.Plugin.Claude" => new ClaudePlugin(),
+        "TypeWhisper.Plugin.Gemini" => new GeminiPlugin(),
+        "TypeWhisper.Plugin.GemmaLocal" => new GemmaLocalPlugin(),
+        "TypeWhisper.Plugin.Groq" => new GroqPlugin(),
+        "TypeWhisper.Plugin.OpenAi" => new OpenAiPlugin(),
+        "TypeWhisper.Plugin.OpenAiCompatible" => new OpenAiCompatiblePlugin(),
+        "TypeWhisper.Plugin.OpenRouter" => new OpenRouterPlugin(),
+        "TypeWhisper.Plugin.Xai" => new XaiPlugin(),
+        _ => throw new ArgumentOutOfRangeException(nameof(projectName), projectName, null),
+    };
+
+    private static string RepositoryRoot() => Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory,
+        "..", "..", "..", "..", ".."));
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
@@ -38,18 +38,12 @@ public sealed class WorkflowProviderReleaseMetadataTests
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         var plugin = CreatePlugin(projectName);
+        using var disposablePlugin = plugin as IDisposable;
 
-        try
-        {
-            Assert.NotNull(manifest);
-            Assert.Equal(expectedVersion, manifest.Version);
-            Assert.Equal(expectedVersion, plugin.PluginVersion);
-            Assert.Equal("1.0.9", manifest.MinHostVersion);
-        }
-        finally
-        {
-            (plugin as IDisposable)?.Dispose();
-        }
+        Assert.NotNull(manifest);
+        Assert.Equal(expectedVersion, manifest.Version);
+        Assert.Equal(expectedVersion, plugin.PluginVersion);
+        Assert.Equal("1.0.9", manifest.MinHostVersion);
     }
 
     private static ITypeWhisperPlugin CreatePlugin(string projectName) => projectName switch
@@ -65,7 +59,7 @@ public sealed class WorkflowProviderReleaseMetadataTests
         _ => throw new ArgumentOutOfRangeException(nameof(projectName), projectName, null),
     };
 
-    private static string RepositoryRoot() => Path.GetFullPath(Path.Combine(
+    private static string RepositoryRoot() => Path.GetFullPath(Path.Join(
         AppContext.BaseDirectory,
         "..", "..", "..", "..", ".."));
 }


### PR DESCRIPTION
## Summary

- bump the marketplace versions for the eight workflow providers changed by #409
- require TypeWhisper 1.0.9 because the updated plugins use the new workflow output SDK helpers
- add shared release metadata coverage for manifest, runtime, and host-version parity

## Validation

- targeted release metadata and version tests: 14 passed
- Release configuration metadata tests: 8 passed
- `dotnet test TypeWhisper.slnx --no-restore`: 2,514 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Claude, Gemini, Gemma Local, Groq, OpenRouter, and xAI integrations to their latest patch releases.
  * Updated OpenAI integration compatibility requirements to host version 1.0.9 or later.
  * Added the same minimum host requirement for OpenAI-compatible integrations.
  * Added compatibility requirements across supported integrations for host version 1.0.9 or later.

* **Bug Fixes**
  * Improved release metadata validation to ensure integration versions and host requirements remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->