### PR TITLE
Make plugin registry publishing resilient

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: windows-latest
     concurrency:
-      group: plugin-release-${{ github.ref_name }}
-      cancel-in-progress: true
+      group: plugin-release-gh-pages
+      cancel-in-progress: false
     steps:
       - name: Parse tag
         shell: pwsh
@@ -229,7 +229,9 @@ jobs:
             try {
               Push-Location gh-pages-work
               git fetch origin gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "Fetching gh-pages failed with exit code $LASTEXITCODE" }
               git reset --hard origin/gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "Resetting gh-pages failed with exit code $LASTEXITCODE" }
 
               $registry = @(
                 Get-Content plugins.json | ConvertFrom-Json
@@ -287,7 +289,9 @@ jobs:
                   Set-RegistryProperty $registry[$j] 'downloadUrl' $downloadUrl
                   Set-RegistryProperty $registry[$j] 'sha256' $env:PLUGIN_SHA256
                   Set-RegistryProperty $registry[$j] 'iconSystemName' $manifest.iconSystemName
-                  Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]($manifest.requiresApiKey))
+                  if ($manifest.PSObject.Properties['requiresApiKey']) {
+                    Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]$manifest.requiresApiKey)
+                  }
                   Set-RegistryProperty $registry[$j] 'descriptions' $manifest.descriptions
                   $updated = $true
                   Write-Host "Updated $($registry[$j].id) to v$env:PLUGIN_VERSION"
@@ -332,7 +336,9 @@ jobs:
               $diff = git diff --cached --quiet 2>&1; $hasChanges = $LASTEXITCODE -ne 0
               if ($hasChanges) {
                 git commit -m "Update $env:PROJECT_NAME to v$env:PLUGIN_VERSION"
+                if ($LASTEXITCODE -ne 0) { throw "Committing gh-pages changes failed with exit code $LASTEXITCODE" }
                 git push origin gh-pages
+                if ($LASTEXITCODE -ne 0) { throw "Pushing gh-pages failed with exit code $LASTEXITCODE" }
                 Write-Host "Successfully updated plugins.json (attempt $i)"
               } else {
                 Write-Host "No changes to deploy"

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -14,6 +14,7 @@ jobs:
     concurrency:
       group: plugin-release-gh-pages
       cancel-in-progress: false
+      queue: max
     steps:
       - name: Parse tag
         shell: pwsh
@@ -221,13 +222,19 @@ jobs:
         run: |
           $downloadUrl = "https://typewhisper.github.io/typewhisper-win/plugins/$env:ZIP_NAME"
 
-          git fetch origin gh-pages
-          git worktree add -B gh-pages gh-pages-work origin/gh-pages
-
           $maxRetries = 5
           for ($i = 1; $i -le $maxRetries; $i++) {
+            $locationPushed = $false
             try {
+              if (-not (Test-Path -LiteralPath gh-pages-work)) {
+                git fetch origin gh-pages
+                if ($LASTEXITCODE -ne 0) { throw "Fetching gh-pages for worktree setup failed with exit code $LASTEXITCODE" }
+                git worktree add -B gh-pages gh-pages-work origin/gh-pages
+                if ($LASTEXITCODE -ne 0) { throw "Adding gh-pages worktree failed with exit code $LASTEXITCODE" }
+              }
+
               Push-Location gh-pages-work
+              $locationPushed = $true
               git fetch origin gh-pages
               if ($LASTEXITCODE -ne 0) { throw "Fetching gh-pages failed with exit code $LASTEXITCODE" }
               git reset --hard origin/gh-pages
@@ -330,6 +337,7 @@ jobs:
               Copy-Item (Join-Path .. $env:ZIP_NAME) "plugins/$env:ZIP_NAME" -Force
 
               git add -A
+              if ($LASTEXITCODE -ne 0) { throw "Staging gh-pages changes failed with exit code $LASTEXITCODE" }
               git config user.name "github-actions[bot]"
               git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -344,12 +352,14 @@ jobs:
                 Write-Host "No changes to deploy"
               }
 
-              Pop-Location
               break
             } catch {
-              Pop-Location
               if ($i -eq $maxRetries) { throw }
-              Write-Host "Push failed (attempt $i), retrying in ${i}s..."
+              Write-Host "Publishing failed (attempt $i), retrying in ${i}s..."
               Start-Sleep -Seconds $i
+            } finally {
+              if ($locationPushed) {
+                Pop-Location
+              }
             }
           }

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -138,6 +138,35 @@ public sealed class PluginPackagingWorkflowTests
         Assert.Contains("sha256 = $env:PLUGIN_SHA256", workflow, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void PluginReleaseWorkflow_SerializesRegistryPublishingAndChecksGitFailures()
+    {
+        var workflow = TestFile.ReadProjectFile(".github", "workflows", "publish-plugins.yml");
+
+        Assert.Contains("group: plugin-release-gh-pages", workflow, StringComparison.Ordinal);
+        Assert.Contains("cancel-in-progress: false", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("plugin-release-${{ github.ref_name }}", workflow, StringComparison.Ordinal);
+        Assert.Contains(
+            "if ($LASTEXITCODE -ne 0) { throw \"Pushing gh-pages failed with exit code $LASTEXITCODE\" }",
+            workflow,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PluginReleaseWorkflow_PreservesExistingApiKeyRequirementWhenManifestOmitsIt()
+    {
+        var workflow = TestFile.ReadProjectFile(".github", "workflows", "publish-plugins.yml");
+
+        Assert.Contains(
+            "if ($manifest.PSObject.Properties['requiresApiKey'])",
+            workflow,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]($manifest.requiresApiKey))",
+            workflow,
+            StringComparison.Ordinal);
+    }
+
     private static void CreatePortableArchive(
         string releaseDirectory,
         string fileName,

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -145,21 +145,46 @@ public sealed class PluginPackagingWorkflowTests
 
         Assert.Contains("group: plugin-release-gh-pages", workflow, StringComparison.Ordinal);
         Assert.Contains("cancel-in-progress: false", workflow, StringComparison.Ordinal);
+        Assert.Contains("queue: max", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("plugin-release-${{ github.ref_name }}", workflow, StringComparison.Ordinal);
-        Assert.Contains(
-            "if ($LASTEXITCODE -ne 0) { throw \"Pushing gh-pages failed with exit code $LASTEXITCODE\" }",
-            workflow,
-            StringComparison.Ordinal);
+
+        foreach (var failureMessage in new[]
+                 {
+                     "Fetching gh-pages for worktree setup failed",
+                     "Adding gh-pages worktree failed",
+                     "Fetching gh-pages failed",
+                     "Resetting gh-pages failed",
+                     "Staging gh-pages changes failed",
+                     "Committing gh-pages changes failed",
+                     "Pushing gh-pages failed"
+                 })
+        {
+            Assert.Contains(
+                $"if ($LASTEXITCODE -ne 0) {{ throw \"{failureMessage} with exit code $LASTEXITCODE\" }}",
+                workflow,
+                StringComparison.Ordinal);
+        }
+
+        Assert.Contains("$locationPushed = $false", workflow, StringComparison.Ordinal);
+        Assert.Contains("if ($locationPushed)", workflow, StringComparison.Ordinal);
     }
 
     [Fact]
     public void PluginReleaseWorkflow_PreservesExistingApiKeyRequirementWhenManifestOmitsIt()
     {
-        var workflow = TestFile.ReadProjectFile(".github", "workflows", "publish-plugins.yml");
+        var workflow = TestFile.ReadProjectFile(".github", "workflows", "publish-plugins.yml")
+            .ReplaceLineEndings("\n");
+        var normalizedWorkflow = string.Join(
+            "\n",
+            workflow.Split('\n').Select(line => line.Trim()));
 
         Assert.Contains(
-            "if ($manifest.PSObject.Properties['requiresApiKey'])",
-            workflow,
+            """
+            if ($manifest.PSObject.Properties['requiresApiKey']) {
+            Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]$manifest.requiresApiKey)
+            }
+            """.ReplaceLineEndings("\n"),
+            normalizedWorkflow,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
             "Set-RegistryProperty $registry[$j] 'requiresApiKey' ([bool]($manifest.requiresApiKey))",


### PR DESCRIPTION
## Summary
- serialize plugin release jobs that publish to the shared `gh-pages` registry
- turn native Git failures into PowerShell exceptions so the existing retry loop actually retries
- preserve an existing `requiresApiKey` registry value when a plugin manifest omits that optional field

## Why
Concurrent plugin tags can race while updating `gh-pages`. A failed native `git push` only set `$LASTEXITCODE`, so the workflow printed a success message and exited unsuccessfully instead of retrying.

## Testing
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-restore --filter "FullyQualifiedName~PluginPackagingWorkflowTests" -m:1` (12 passed)
- `dotnet format TypeWhisper.slnx --no-restore --include tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs --verify-no-changes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin publishing reliability by preventing concurrent releases from being canceled unexpectedly.
  - Added stronger failure handling when preparing or publishing release updates.
  - Publishing now clearly reports failures when updating the release branch.
  - Preserved existing API key requirements when a new plugin manifest does not specify a value.
  - Prevented unrelated location data from being published when it is not defined.

- **Tests**
  - Added coverage for concurrency, publishing failures, worktree operations, and API key preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->