### PR TITLE
Handle unavailable clipboard file formats

### DIFF
--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -285,7 +285,7 @@ internal sealed class WindowsClipboardTransaction : IDisposable
 
             foreach (var unavailableFormat in unavailableFormats)
             {
-                if (CanSkipUnavailableBitmapFormat(unavailableFormat.Format))
+                if (CanSkipUnavailableFormat(unavailableFormat.Format))
                     continue;
 
                 throw ClipboardError(
@@ -351,7 +351,7 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         return length > 0 ? $"{format} ('{name}')" : format.ToString();
     }
 
-    private static bool CanSkipUnavailableBitmapFormat(uint unavailableFormat)
+    private static bool CanSkipUnavailableFormat(uint unavailableFormat)
     {
         // Some clipboard owners advertise delayed bitmap formats but fail to render them.
         // Drop those unusable representations instead of blocking dictated text insertion.
@@ -369,12 +369,15 @@ internal sealed class WindowsClipboardTransaction : IDisposable
             name,
             name.Capacity);
 
-        // OLE image providers can advertise this managed bitmap alias without exposing a
-        // native handle.
-        return length > 0 && string.Equals(
-            name.ToString(),
-            "System.Drawing.Bitmap",
-            StringComparison.Ordinal);
+        if (length <= 0)
+            return false;
+
+        // OLE providers can advertise managed bitmap or virtual-file representations
+        // without exposing a materializable Win32 clipboard handle.
+        return name.ToString() is
+            "System.Drawing.Bitmap" or
+            "FileContents" or
+            "FileName";
     }
 
     private static IntPtr DuplicateClipboardHandle(uint format, IntPtr sourceHandle)

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -349,6 +349,49 @@ public sealed class WindowsClipboardTransactionTests
         }
     }
 
+    [Theory]
+    [InlineData("FileContents")]
+    [InlineData("FileName")]
+    public void UnavailableShellTransferFormat_DoesNotBlockTemporaryTextAndRestoresRemainingFormats(
+        string formatName)
+    {
+        lock (ClipboardTestLock)
+        {
+            RunOnStaThread(() =>
+            {
+                using var transaction = new WindowsClipboardTransaction(Dispatcher.CurrentDispatcher);
+                var originalClipboard = BackupClipboard(transaction);
+                try
+                {
+                    using var owner = SeedTextWithUnavailableRegisteredFormat(
+                        formatName,
+                        out var unavailableFormat);
+                    Assert.Contains(unavailableFormat, EnumerateClipboardFormats());
+                    Assert.Equal(IntPtr.Zero, ReadClipboardHandle(unavailableFormat));
+
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                    Assert.Equal("dictated", Clipboard.GetText());
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    Assert.Equal("previous", Clipboard.GetText());
+                    Assert.DoesNotContain(unavailableFormat, EnumerateClipboardFormats());
+                }
+                finally
+                {
+                    RestoreClipboardBackup(transaction, originalClipboard);
+                }
+            });
+        }
+    }
+
     [Fact]
     public void UnavailableUniqueFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
     {
@@ -536,6 +579,40 @@ public sealed class WindowsClipboardTransactionTests
             Assert.Equal(
                 IntPtr.Zero,
                 NativeMethods.SetClipboardData(NativeMethods.CF_DIB, IntPtr.Zero));
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+
+        return owner;
+    }
+
+    private static HwndSource SeedTextWithUnavailableRegisteredFormat(
+        string formatName,
+        out uint unavailableFormat)
+    {
+        unavailableFormat = NativeMethods.RegisterClipboardFormat(formatName);
+        Assert.NotEqual(0u, unavailableFormat);
+        var owner = new HwndSource(new HwndSourceParameters(
+            $"TypeWhisper unavailable {formatName} owner")
+        {
+            ParentWindow = new IntPtr(-3),
+            WindowStyle = 0
+        });
+
+        Assert.True(NativeMethods.OpenClipboard(owner.Handle));
+        try
+        {
+            Assert.True(NativeMethods.EmptyClipboard());
+            SetGlobalData(
+                NativeMethods.CF_UNICODETEXT,
+                Encoding.Unicode.GetBytes("previous\0"));
+            Marshal.SetLastPInvokeError(0);
+            Assert.Equal(
+                IntPtr.Zero,
+                NativeMethods.SetClipboardData(unavailableFormat, IntPtr.Zero));
             Assert.Equal(0, Marshal.GetLastPInvokeError());
         }
         finally


### PR DESCRIPTION
## Summary

- allow temporary clipboard snapshots to skip unavailable OLE `FileContents` and `FileName` representations
- preserve fail-closed behavior for unknown unavailable clipboard formats
- add native Windows clipboard regressions for both reported format names

## Validation

- 9 Windows clipboard transaction tests passed
- 29 text insertion tests passed
- full suites passed: 460 core tests and 2,127 plugin/UI tests
- `dotnet format TypeWhisper.slnx --no-restore --verify-no-changes` passed for the changed files
- `git diff --check` passed

Closes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved clipboard handling when shell-transfer formats such as file contents or file names are unavailable.
  - Temporary text operations can now proceed without being blocked by unsupported clipboard formats.
  - Unknown unavailable formats continue to be reported as errors.

- **Tests**
  - Added coverage for preserving remaining clipboard formats during these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->