### PR TITLE
Keep Filler Words version independent of app releases

### DIFF
--- a/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsPluginTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Models;
+using TypeWhisper.PluginSystem.Tests;
 
 namespace TypeWhisper.Plugin.FillerWords.Tests;
 
@@ -12,10 +13,8 @@ public sealed class FillerWordsPluginTests
     [Fact]
     public void PluginVersion_MatchesManifestVersion()
     {
-        var manifestPath = Path.GetFullPath(Path.Join(
-            AppContext.BaseDirectory,
-            "..", "..", "..", "..", "..",
-            "plugins", "TypeWhisper.Plugin.FillerWords", "manifest.json"));
+        var manifestPath = TestFile.ProjectFile(
+            "plugins", "TypeWhisper.Plugin.FillerWords", "manifest.json");
         var manifest = JsonSerializer.Deserialize<PluginManifest>(
             File.ReadAllText(manifestPath),
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/plugins/TypeWhisper.Plugin.FillerWords/TypeWhisper.Plugin.FillerWords.csproj
+++ b/plugins/TypeWhisper.Plugin.FillerWords/TypeWhisper.Plugin.FillerWords.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>TypeWhisper.Plugin.FillerWords</RootNamespace>
     <PluginVersion Condition="'$(PluginVersion)' == ''">1.0.0</PluginVersion>
     <Version>$(PluginVersion)</Version>
+    <InformationalVersion>$(PluginVersion)</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs
@@ -139,6 +139,20 @@ public sealed class PluginPackagingWorkflowTests
     }
 
     [Fact]
+    public void FillerWordsProject_PreservesPluginVersionWhenAppVersionIsOverridden()
+    {
+        var project = TestFile.ReadProjectFile(
+            "plugins",
+            "TypeWhisper.Plugin.FillerWords",
+            "TypeWhisper.Plugin.FillerWords.csproj");
+
+        Assert.Contains(
+            "<InformationalVersion>$(PluginVersion)</InformationalVersion>",
+            project,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PluginReleaseWorkflow_SerializesRegistryPublishingAndChecksGitFailures()
     {
         var workflow = TestFile.ReadProjectFile(".github", "workflows", "publish-plugins.yml");


### PR DESCRIPTION
## Summary
- keep the Filler Words informational version tied to the plugin release version when the app build overrides `Version`
- add regression coverage for the app-release version collision
- resolve the manifest through the repository helper so the version test supports centralized artifact output

## Validation
- `dotnet test tests/TypeWhisper.Core.Tests/TypeWhisper.Core.Tests.csproj -c Release -p:Version=1.0.9-daily.20260825` (460 passed)
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Release -p:Version=1.0.9-daily.20260825` (2,122 passed)
- `dotnet format tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --verify-no-changes --no-restore --include plugins/TypeWhisper.Plugin.FillerWords/Tests/FillerWordsPluginTests.cs tests/TypeWhisper.PluginSystem.Tests/PluginPackagingWorkflowTests.cs`
- `git diff --check`

## Context
Fixes the deterministic Filler Words version mismatch in scheduled Release run https://github.com/TypeWhisper/typewhisper-win/actions/runs/32809510496/job/97686081067.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FillerWords plugin version information now remains consistent when the application version is overridden.

* **Tests**
  * Added coverage to verify plugin version preservation during packaging.
  * Improved test file path handling for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->