### PR TITLE
Filter phantom thank-you tails from Groq transcripts

### DIFF
--- a/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Groq/GroqPlugin.cs
@@ -18,6 +18,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
 {
     private const string BaseUrl = "https://api.groq.com/openai";
     private const int TranscriptionUploadBitRate = 48_000;
+    private const float TerminalHallucinationNoSpeechThreshold = 0.8f;
     private static readonly TimeSpan DefaultHttpTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan DefaultTranscriptionHttpTimeout = TimeSpan.FromMinutes(10);
     private readonly HttpClient _httpClient;
@@ -84,7 +85,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.5";
+    public string PluginVersion => "1.0.6";
 
     /// <summary>
     /// Activates the plugin and loads any persisted configuration.
@@ -476,8 +477,7 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
         var language = root.TryGetProperty("language", out var langEl) ? langEl.GetString() : null;
         var duration = root.TryGetProperty("duration", out var durEl) ? durEl.GetDouble() : 0;
 
-        var segments = new List<PluginTranscriptionSegment>();
-        float? minNoSpeechProb = null;
+        var parsedSegments = new List<ParsedTranscriptionSegment>();
         if (root.TryGetProperty("segments", out var segmentsEl)
             && segmentsEl.ValueKind == JsonValueKind.Array)
         {
@@ -492,22 +492,87 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
                 var end = seg.TryGetProperty("end", out var endEl)
                     ? endEl.GetDouble()
                     : 0;
-                segments.Add(new PluginTranscriptionSegment(segmentText, start, end));
-
-                if (seg.TryGetProperty("no_speech_prob", out var nspEl))
-                {
-                    var prob = (float)nspEl.GetDouble();
-                    minNoSpeechProb = minNoSpeechProb is null
-                        ? prob
-                        : Math.Min(minNoSpeechProb.Value, prob);
-                }
+                var noSpeechProbability = seg.TryGetProperty("no_speech_prob", out var nspEl)
+                    && nspEl.ValueKind == JsonValueKind.Number
+                    ? (float?)nspEl.GetDouble()
+                    : null;
+                parsedSegments.Add(new ParsedTranscriptionSegment(
+                    new PluginTranscriptionSegment(segmentText, start, end),
+                    noSpeechProbability));
             }
         }
 
-        return new PluginTranscriptionResult(text.Trim(), language, duration, minNoSpeechProb)
+        text = RemoveTerminalThankYouHallucination(text, parsedSegments);
+        float? minNoSpeechProb = null;
+        foreach (var segment in parsedSegments)
         {
-            Segments = segments
+            if (segment.NoSpeechProbability is not { } probability)
+                continue;
+
+            minNoSpeechProb = minNoSpeechProb is null
+                ? probability
+                : Math.Min(minNoSpeechProb.Value, probability);
+        }
+
+        return new PluginTranscriptionResult(
+            text.Trim(),
+            language,
+            duration,
+            minNoSpeechProb)
+        {
+            Segments = parsedSegments.Select(segment => segment.Segment).ToList()
         };
+    }
+
+    private static string RemoveTerminalThankYouHallucination(
+        string text,
+        List<ParsedTranscriptionSegment> segments)
+    {
+        if (segments.Count == 0)
+            return text;
+
+        var terminalSegment = segments[^1];
+        if (terminalSegment.NoSpeechProbability is not > TerminalHallucinationNoSpeechThreshold
+            || !IsThankYouOnly(terminalSegment.Segment.Text))
+        {
+            return text;
+        }
+
+        var trimmedText = text.Trim();
+        var segmentText = terminalSegment.Segment.Text.Trim();
+        if (segmentText.Length == 0
+            || !trimmedText.EndsWith(segmentText, StringComparison.Ordinal))
+        {
+            return text;
+        }
+
+        var textWithoutSegment = trimmedText[..^segmentText.Length].TrimEnd();
+        if (textWithoutSegment.Length == 0)
+            return text;
+
+        segments.RemoveAt(segments.Count - 1);
+        return textWithoutSegment;
+    }
+
+    private static bool IsThankYouOnly(string text)
+    {
+        const string expected = "thankyou";
+        var index = 0;
+        foreach (var ch in text)
+        {
+            if (!char.IsLetterOrDigit(ch))
+                continue;
+
+            if (index >= expected.Length
+                || char.ToLowerInvariant(ch) != expected[index])
+            {
+                return false;
+            }
+
+            index++;
+        }
+
+        return index == expected.Length;
     }
 
     /// <summary>
@@ -522,6 +587,10 @@ public sealed class GroqPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugin,
 
     private sealed record TranscriptionModelEntry(
         string Id, string DisplayName, string ApiModelName, bool SupportsTranslation);
+
+    private sealed record ParsedTranscriptionSegment(
+        PluginTranscriptionSegment Segment,
+        float? NoSpeechProbability);
 }
 
 internal sealed record GroqTranscriptionUpload(byte[] Data, string FileName, string ContentType);

--- a/plugins/TypeWhisper.Plugin.Groq/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Groq/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.groq",
   "name": "Groq",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "Groq Whisper transcription and Llama translation",

--- a/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/GroqPluginTests.cs
@@ -182,6 +182,120 @@ public class GroqPluginTests
         Assert.Equal("ok", result.Text);
     }
 
+    [Fact]
+    public async Task TranscribeAsync_RemovesHighNoSpeechTerminalThankYouSegment()
+    {
+        var result = await TranscribeResponseAsync("""
+            {
+              "text": "Please send the updated draft. Thank you.",
+              "language": "en",
+              "duration": 8.0,
+              "segments": [
+                {
+                  "text": " Please send the updated draft.",
+                  "start": 0.0,
+                  "end": 5.0,
+                  "no_speech_prob": 0.02
+                },
+                {
+                  "text": " Thank you.",
+                  "start": 5.0,
+                  "end": 8.0,
+                  "no_speech_prob": 0.95
+                }
+              ]
+            }
+            """);
+
+        Assert.Equal("Please send the updated draft.", result.Text);
+        var segment = Assert.Single(result.Segments);
+        Assert.Equal(" Please send the updated draft.", segment.Text);
+        Assert.Equal(0.02f, result.NoSpeechProbability);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_PreservesConfidentTerminalThankYouSegment()
+    {
+        var result = await TranscribeResponseAsync("""
+            {
+              "text": "Please send the updated draft. Thank you.",
+              "language": "en",
+              "duration": 8.0,
+              "segments": [
+                {
+                  "text": " Please send the updated draft.",
+                  "start": 0.0,
+                  "end": 5.0,
+                  "no_speech_prob": 0.02
+                },
+                {
+                  "text": " Thank you.",
+                  "start": 5.0,
+                  "end": 8.0,
+                  "no_speech_prob": 0.05
+                }
+              ]
+            }
+            """);
+
+        Assert.Equal("Please send the updated draft. Thank you.", result.Text);
+        Assert.Equal(2, result.Segments.Count);
+        Assert.Equal(0.02f, result.NoSpeechProbability);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_PreservesHighNoSpeechTerminalContentThatIsNotKnownHallucination()
+    {
+        var result = await TranscribeResponseAsync("""
+            {
+              "text": "Please send the updated draft. Tomorrow morning.",
+              "language": "en",
+              "duration": 8.0,
+              "segments": [
+                {
+                  "text": " Please send the updated draft.",
+                  "start": 0.0,
+                  "end": 5.0,
+                  "no_speech_prob": 0.02
+                },
+                {
+                  "text": " Tomorrow morning.",
+                  "start": 5.0,
+                  "end": 8.0,
+                  "no_speech_prob": 0.95
+                }
+              ]
+            }
+            """);
+
+        Assert.Equal("Please send the updated draft. Tomorrow morning.", result.Text);
+        Assert.Equal(2, result.Segments.Count);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_PreservesStandaloneThankYouForNoSpeechPolicy()
+    {
+        var result = await TranscribeResponseAsync("""
+            {
+              "text": "Thank you.",
+              "language": "en",
+              "duration": 3.0,
+              "segments": [
+                {
+                  "text": " Thank you.",
+                  "start": 0.0,
+                  "end": 3.0,
+                  "no_speech_prob": 0.95
+                }
+              ]
+            }
+            """);
+
+        Assert.Equal("Thank you.", result.Text);
+        Assert.Single(result.Segments);
+        Assert.Equal(0.95f, result.NoSpeechProbability);
+    }
+
     [Theory]
     [InlineData(typeof(IOException))]
     [InlineData(typeof(InvalidOperationException))]
@@ -387,6 +501,25 @@ public class GroqPluginTests
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
+
+    private static async Task<PluginTranscriptionResult> TranscribeResponseAsync(string responseJson)
+    {
+        var normalHandler = new CapturingHandler((_, _) =>
+            throw new InvalidOperationException("Normal HTTP client should not be used for transcription."));
+        var transcriptionHandler = new CapturingHandler((_, _) => JsonResponse(responseJson));
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "groq-key";
+
+        using var normalHttpClient = new HttpClient(normalHandler) { Timeout = TimeSpan.FromSeconds(5) };
+        using var transcriptionHttpClient = GroqPlugin.CreateTranscriptionHttpClient(transcriptionHandler);
+        using var sut = new GroqPlugin(
+            normalHttpClient,
+            transcriptionHttpClient,
+            _ => new GroqTranscriptionUpload([1, 2, 3], "audio.m4a", "audio/mp4"));
+        await sut.ActivateAsync(host);
+
+        return await sut.TranscribeAsync([4, 5, 6], "en", false, null, CancellationToken.None);
+    }
 
     private static Exception CreateCompressionFailure(Type exceptionType)
     {

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
@@ -20,7 +20,7 @@ public sealed class WorkflowProviderReleaseMetadataTests
         { "TypeWhisper.Plugin.Claude", "1.0.1" },
         { "TypeWhisper.Plugin.Gemini", "1.2.1" },
         { "TypeWhisper.Plugin.GemmaLocal", "1.0.1" },
-        { "TypeWhisper.Plugin.Groq", "1.0.5" },
+        { "TypeWhisper.Plugin.Groq", "1.0.6" },
         { "TypeWhisper.Plugin.OpenAi", "1.1.2" },
         { "TypeWhisper.Plugin.OpenAiCompatible", "1.0.6" },
         { "TypeWhisper.Plugin.OpenRouter", "1.1.1" },


### PR DESCRIPTION
## Summary

- remove an isolated terminal "Thank you" segment when Groq marks it above the existing 0.8 no-speech threshold and earlier transcript text remains
- preserve confident or standalone "Thank you" dictations and unrelated terminal content
- bump the Groq plugin release metadata to 1.0.6

## Related Issue

Closes #416

## Test Plan

- [x] `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~GroqPluginTests|FullyQualifiedName~DictationFinalTextPolicyTests|FullyQualifiedName~WorkflowProviderReleaseMetadataTests" --no-restore`
- [ ] Tested the changed functionality manually with live Groq audio

## Notes

Groq verbose transcription responses expose per-segment no-speech probabilities. The existing minimum aggregation protects real speech at the recording level, but it also masks a suspicious trailing segment after earlier confident speech. This keeps that conservative recording-level behavior while filtering only the reported stock phrase at the terminal segment boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Groq transcription cleanup by removing certain low-confidence, terminal “Thank you.” hallucinations.
  * Preserved legitimate “Thank you.” responses and other valid terminal content.
  * Improved handling of speech confidence and no-speech indicators.

* **Tests**
  * Added coverage for hallucination removal and preservation scenarios.

* **Chores**
  * Updated the Groq plugin to version 1.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->