### PR TITLE
Release TypeWhisper 1.0.9

### DIFF
--- a/docs/releases/v1.0.9.md
+++ b/docs/releases/v1.0.9.md
@@ -1,0 +1,53 @@
+# TypeWhisper v1.0.9
+
+TypeWhisper 1.0.9 makes the latest workflow-provider plugins available to the
+host and fixes several issues affecting dictation, long-running workflows, and
+plugin management.
+
+## Highlights
+
+- Added a configurable Filler Words plugin for removing filler words from
+  transcribed text while preserving surrounding whitespace and punctuation.
+- Added configurable US, UK, Canadian, and Australian English spelling for
+  automatic language detection.
+- Added dynamic Gemini model discovery with model-specific reasoning options
+  and a more responsive default model.
+- Made the workflow-provider plugins that require TypeWhisper 1.0.9 available
+  in Discover, including Groq 1.0.6.
+
+## Reliability improvements
+
+- Kept dictation hotkeys responsive and fixed low-level hook initialization on
+  their dedicated message-loop thread.
+- Unloaded local transcription models when switching providers, so inactive
+  models no longer retain their resources.
+- Brought the existing TypeWhisper window to the foreground when the app is
+  launched a second time.
+- Handled unavailable clipboard bitmap and file-drop formats without blocking
+  dictation.
+- Prevented long online transcription previews from stalling while preserving
+  rolling preview cadence, punctuation, and unspaced CJK text.
+- Increased output budgets for long workflow prompts and rejected explicitly
+  truncated provider responses instead of returning incomplete text.
+- Filtered high-confidence terminal “Thank you” hallucinations from Groq
+  transcripts while preserving genuine dictated content.
+
+## Plugins and packaging
+
+- Fixed the manual plugin folder shown by Microsoft Store builds so the path is
+  visible to Explorer and the Open folder button reaches the real MSIX data
+  directory.
+- Made plugin registry publishing resilient to overlapping releases and kept
+  Filler Words versioning independent from app releases.
+- Added automated Windows UI screenshot capture and expanded release metadata
+  validation for workflow-provider plugins.
+
+## Validation notes
+
+- Verify stable Velopack channels `win-x64` and `win-arm64`.
+- Confirm x64 and ARM64 installers, portable ZIPs, full nupkg packages,
+  RELEASES files, and JSON manifests are present without `-daily` suffixes.
+- Validate both published portable ZIPs and record the Authenticode status of
+  the published installers.
+- Publish Microsoft Store package `1.0.9.0` and WinGet package `1.0.9`
+  separately from the GitHub release.

--- a/src/TypeWhisper.Windows/Services/AppDistribution.cs
+++ b/src/TypeWhisper.Windows/Services/AppDistribution.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace TypeWhisper.Windows.Services;
 
 /// <summary>
@@ -41,6 +43,47 @@ public static class AppDistribution
         "TypeWhisper.TypeWhisper_51tqb5623pxja",
         "9PF42ZCR0JR0",
         "ms-windows-store://pdp/?productid=9PF42ZCR0JR0");
+
+    internal static string ResolveShellVisiblePath(string path) =>
+        ResolveShellVisiblePath(
+            path,
+            Current,
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            StoreIdentity.PackageFamilyName);
+
+    internal static string ResolveShellVisiblePath(
+        string path,
+        AppDistributionKind distributionKind,
+        string localAppDataPath,
+        string packageFamilyName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(localAppDataPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageFamilyName);
+
+        var fullPath = Path.GetFullPath(path);
+        if (distributionKind != AppDistributionKind.Store)
+            return fullPath;
+
+        var localAppDataRoot = Path.GetFullPath(localAppDataPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!fullPath.Equals(localAppDataRoot, StringComparison.OrdinalIgnoreCase)
+            && !fullPath.StartsWith(
+                localAppDataRoot + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return fullPath;
+        }
+
+        var relativePath = Path.GetRelativePath(localAppDataRoot, fullPath);
+        return Path.GetFullPath(Path.Join(
+            localAppDataRoot,
+            "Packages",
+            packageFamilyName,
+            "LocalCache",
+            "Local",
+            relativePath));
+    }
 }
 
 /// <summary>

--- a/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
+++ b/src/TypeWhisper.Windows/ViewModels/PluginsViewModel.cs
@@ -111,7 +111,8 @@ public partial class PluginsViewModel : ObservableObject
     /// <summary>
     /// Gets the folder where manually installed plugins are discovered.
     /// </summary>
-    public string ManualPluginFolderPath => _registryService.PluginsPath;
+    public string ManualPluginFolderPath =>
+        AppDistribution.ResolveShellVisiblePath(_registryService.PluginsPath);
 
     [ObservableProperty] private bool _isLoadingRegistry;
     [ObservableProperty] private bool _isMarketplaceSelected;

--- a/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Runtime.InteropServices;
 using TypeWhisper.Windows.Services;
 
@@ -16,6 +17,59 @@ public class UpdateServiceTests
         Assert.Equal("TypeWhisper.TypeWhisper_51tqb5623pxja", identity.PackageFamilyName);
         Assert.Equal("9PF42ZCR0JR0", identity.StoreProductId);
         Assert.Equal("ms-windows-store://pdp/?productid=9PF42ZCR0JR0", identity.StoreProtocolLink);
+    }
+
+    [Fact]
+    public void ResolveShellVisiblePath_DirectDistributionKeepsLocalAppDataPath()
+    {
+        var localAppDataPath = Path.Combine(@"C:\", "Users", "test", "AppData", "Local");
+        var pluginPath = Path.Combine(localAppDataPath, "TypeWhisper-UserData", "Plugins");
+
+        var resolved = AppDistribution.ResolveShellVisiblePath(
+            pluginPath,
+            AppDistributionKind.Direct,
+            localAppDataPath,
+            AppDistribution.StoreIdentity.PackageFamilyName);
+
+        Assert.Equal(Path.GetFullPath(pluginPath), resolved);
+    }
+
+    [Fact]
+    public void ResolveShellVisiblePath_StoreDistributionUsesPhysicalPackageCache()
+    {
+        var localAppDataPath = Path.Combine(@"C:\", "Users", "test", "AppData", "Local");
+        var pluginPath = Path.Combine(localAppDataPath, "TypeWhisper-UserData", "Plugins");
+        var expected = Path.Combine(
+            localAppDataPath,
+            "Packages",
+            AppDistribution.StoreIdentity.PackageFamilyName,
+            "LocalCache",
+            "Local",
+            "TypeWhisper-UserData",
+            "Plugins");
+
+        var resolved = AppDistribution.ResolveShellVisiblePath(
+            pluginPath,
+            AppDistributionKind.Store,
+            localAppDataPath,
+            AppDistribution.StoreIdentity.PackageFamilyName);
+
+        Assert.Equal(Path.GetFullPath(expected), resolved);
+    }
+
+    [Fact]
+    public void ResolveShellVisiblePath_StoreDistributionKeepsPathsOutsideLocalAppData()
+    {
+        var localAppDataPath = Path.Combine(@"C:\", "Users", "test", "AppData", "Local");
+        var pluginPath = Path.Combine(@"D:\", "TypeWhisper", "Plugins");
+
+        var resolved = AppDistribution.ResolveShellVisiblePath(
+            pluginPath,
+            AppDistributionKind.Store,
+            localAppDataPath,
+            AppDistribution.StoreIdentity.PackageFamilyName);
+
+        Assert.Equal(Path.GetFullPath(pluginPath), resolved);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/UpdateServiceTests.cs
@@ -22,8 +22,8 @@ public class UpdateServiceTests
     [Fact]
     public void ResolveShellVisiblePath_DirectDistributionKeepsLocalAppDataPath()
     {
-        var localAppDataPath = Path.Combine(@"C:\", "Users", "test", "AppData", "Local");
-        var pluginPath = Path.Combine(localAppDataPath, "TypeWhisper-UserData", "Plugins");
+        var localAppDataPath = Path.Join(@"C:\", "Users", "test", "AppData", "Local");
+        var pluginPath = Path.Join(localAppDataPath, "TypeWhisper-UserData", "Plugins");
 
         var resolved = AppDistribution.ResolveShellVisiblePath(
             pluginPath,
@@ -37,9 +37,9 @@ public class UpdateServiceTests
     [Fact]
     public void ResolveShellVisiblePath_StoreDistributionUsesPhysicalPackageCache()
     {
-        var localAppDataPath = Path.Combine(@"C:\", "Users", "test", "AppData", "Local");
-        var pluginPath = Path.Combine(localAppDataPath, "TypeWhisper-UserData", "Plugins");
-        var expected = Path.Combine(
+        var localAppDataPath = Path.Join(@"C:\", "Users", "test", "AppData", "Local");
+        var pluginPath = Path.Join(localAppDataPath, "TypeWhisper-UserData", "Plugins");
+        var expected = Path.Join(
             localAppDataPath,
             "Packages",
             AppDistribution.StoreIdentity.PackageFamilyName,
@@ -60,8 +60,8 @@ public class UpdateServiceTests
     [Fact]
     public void ResolveShellVisiblePath_StoreDistributionKeepsPathsOutsideLocalAppData()
     {
-        var localAppDataPath = Path.Combine(@"C:\", "Users", "test", "AppData", "Local");
-        var pluginPath = Path.Combine(@"D:\", "TypeWhisper", "Plugins");
+        var localAppDataPath = Path.Join(@"C:\", "Users", "test", "AppData", "Local");
+        var pluginPath = Path.Join(@"D:\", "TypeWhisper", "Plugins");
 
         var resolved = AppDistribution.ResolveShellVisiblePath(
             pluginPath,


### PR DESCRIPTION
## Summary

- prepare curated release notes for TypeWhisper 1.0.9
- resolve the Microsoft Store plugin directory to its Explorer-visible MSIX location
- use the resolved path consistently for display, directory creation, and the Open folder action
- make marketplace plugins requiring host version 1.0.9, including Groq 1.0.6, available when the release is installed

## Validation

- dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Debug --no-restore --filter 'FullyQualifiedName~UpdateServiceTests' (37 passed)
- targeted marketplace, integrations layout, release metadata, Groq, and distribution tests (92 passed)
- dotnet build src/TypeWhisper.Windows/TypeWhisper.Windows.csproj -c Debug --no-restore -p:TypeWhisperStoreBuild=true -p:Version=1.0.9
- git diff --check

## Local environment notes

- PowerShell 7 (pwsh), Bash, and the ARM64 VC++ redistributable files are not installed on the freshly provisioned workstation; the corresponding full release and packaging coverage is delegated to CI.