### PR TITLE
Add Gemini 3.5 transcription support

### DIFF
--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -433,12 +433,20 @@ public sealed class GeminiPlugin :
                                 previousLlmModels,
                                 previousTranscriptionModels,
                                 previousFetchedAt);
-                            if (selectionChanged)
-                            {
-                                _host.SetSetting(
-                                    SelectedTranscriptionModelSettingName,
-                                    previousSelectedModelId);
-                            }
+                        }
+                        catch (Exception rollbackException)
+                        {
+                            rollbackFailures.Add(rollbackException);
+                        }
+                    }
+
+                    if (selectionChanged)
+                    {
+                        try
+                        {
+                            _host.SetSetting(
+                                SelectedTranscriptionModelSettingName,
+                                previousSelectedModelId);
                         }
                         catch (Exception rollbackException)
                         {
@@ -490,9 +498,13 @@ public sealed class GeminiPlugin :
         try
         {
             var nativeModels = new List<GeminiNativeModel>();
+            var seenPageTokens = new HashSet<string>(StringComparer.Ordinal);
             string? pageToken = null;
+            const int maxPageCount = 100;
+            var pageCount = 0;
             do
             {
+                pageCount++;
                 var url = $"{NativeBaseUrl}/models?pageSize=1000";
                 if (!string.IsNullOrWhiteSpace(pageToken))
                     url += $"&pageToken={Uri.EscapeDataString(pageToken)}";
@@ -518,11 +530,28 @@ public sealed class GeminiPlugin :
                 }
 
                 nativeModels.AddRange(page.Models.OfType<GeminiNativeModel>());
-                pageToken = string.IsNullOrWhiteSpace(page.NextPageToken)
+                var nextPageToken = string.IsNullOrWhiteSpace(page.NextPageToken)
                     ? null
                     : page.NextPageToken;
+
+                if (nextPageToken is not null && !seenPageTokens.Add(nextPageToken))
+                {
+                    _host?.Log(
+                        PluginLogLevel.Warning,
+                        "Model catalog pagination returned a repeated page token.");
+                    nextPageToken = null;
+                }
+
+                pageToken = nextPageToken;
             }
-            while (pageToken is not null);
+            while (pageToken is not null && pageCount < maxPageCount);
+
+            if (pageToken is not null)
+            {
+                _host?.Log(
+                    PluginLogLevel.Warning,
+                    $"Model catalog pagination exceeded {maxPageCount} pages.");
+            }
 
             if (!string.Equals(_apiKey, apiKey, StringComparison.Ordinal))
             {
@@ -909,7 +938,7 @@ public sealed class GeminiPlugin :
     {
         var available = models
             .Select(model => new GeminiFetchedModel(
-                ResolveNativeModelId(model),
+                NormalizeModelId(ResolveNativeModelId(model)),
                 model.DisplayName))
             .Where(model => !string.IsNullOrWhiteSpace(model.Id))
             .DistinctBy(model => model.Id, StringComparer.OrdinalIgnoreCase)

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiPlugin.cs
@@ -11,14 +11,29 @@ using TypeWhisper.PluginSDK.Models;
 namespace TypeWhisper.Plugin.Gemini;
 
 /// <summary>
-/// Provides Gemini plugin behavior.
+/// Provides Gemini language-model and transcription capabilities.
 /// </summary>
-public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
+public sealed class GeminiPlugin :
+    ITranscriptionEnginePlugin,
+    ILlmProviderPlugin,
+    ILlmRequestHedgingSupport
 {
-    private const string BaseUrl = "https://generativelanguage.googleapis.com/v1beta/openai";
+    private const string NativeBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
+    private const string OpenAiBaseUrl = "https://generativelanguage.googleapis.com/v1beta/openai";
     private const string ApiKeySecretName = "api-key";
     private const string FetchedLlmModelsSettingName = "fetchedLlmModels.v2";
+    private const string FetchedTranscriptionModelsSettingName = "fetchedTranscriptionModels.v1";
+    private const string ModelCatalogFetchedAtSettingName = "modelCatalogFetchedAtUtc";
+    private const string SelectedTranscriptionModelSettingName = "selectedTranscriptionModel";
+    private const string TranscriptionModeSettingName = "transcriptionMode";
+    private const string PluginVersionValue = "1.3.0";
+    private const string SmartModeSettingValue = "smart";
+    private const string VerbatimModeSettingValue = "verbatim";
+
     internal const string DefaultModel = "gemini-flash-lite-latest";
+    internal const string DefaultTranscriptionModel = "gemini-3.5-transcribe";
+    internal const string DefaultLiveTranscriptionModel = "gemini-3.5-transcribe-live";
+    internal static readonly TimeSpan ModelCatalogRefreshInterval = TimeSpan.FromHours(24);
 
     private static readonly IReadOnlyList<PluginModelInfo> FallbackLlmModels =
     [
@@ -27,18 +42,31 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         new("gemini-pro-latest", "Gemini Pro Latest"),
     ];
 
-    private static readonly string[] ExcludedModelTokens =
+    private static readonly IReadOnlyList<GeminiFetchedTranscriptionModel> FallbackTranscriptionModels =
+    [
+        new(
+            DefaultTranscriptionModel,
+            "Gemini 3.5 Transcribe",
+            DefaultLiveTranscriptionModel),
+    ];
+
+    private static readonly string[] ExcludedLlmModelTokens =
     [
         "embedding",
         "-image",
         "tts",
         "live",
         "audio",
+        "transcribe",
         "robotics",
         "computer-use",
         "deep-research",
         "omni",
     ];
+
+    private static readonly DictionaryTermsBudget DictionaryBudget = new(
+        MaxTerms: 100,
+        MaxTotalChars: 4_000);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -50,12 +78,16 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     private IPluginHostServices? _host;
     private string? _apiKey;
     private List<GeminiFetchedModel> _fetchedLlmModels = [];
+    private List<GeminiFetchedTranscriptionModel> _fetchedTranscriptionModels = [];
+    private DateTimeOffset? _modelCatalogFetchedAt;
+    private string _selectedTranscriptionModelId = DefaultTranscriptionModel;
+    private GeminiTranscriptionMode _transcriptionMode = GeminiTranscriptionMode.Smart;
 
     /// <summary>
-    /// Initializes a new instance of the GeminiPlugin class.
+    /// Initializes a new instance of the Gemini plugin.
     /// </summary>
     public GeminiPlugin()
-        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(120) })
+        : this(new HttpClient { Timeout = TimeSpan.FromMinutes(5) })
     {
     }
 
@@ -69,61 +101,209 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
 
     // ITypeWhisperPlugin
 
-    /// <summary>
-    /// Gets the stable plugin identifier used by the host.
-    /// </summary>
+    /// <inheritdoc />
     public string PluginId => "com.typewhisper.gemini";
-    /// <summary>
-    /// Gets the plugin display name shown by the host.
-    /// </summary>
-    public string PluginName => "Google Gemini";
-    /// <summary>
-    /// Gets the plugin version reported to the host.
-    /// </summary>
-    public string PluginVersion => "1.2.1";
 
-    /// <summary>
-    /// Activates the plugin and loads any persisted configuration.
-    /// </summary>
+    /// <inheritdoc />
+    public string PluginName => "Google Gemini";
+
+    /// <inheritdoc />
+    public string PluginVersion => PluginVersionValue;
+
+    /// <inheritdoc />
     public async Task ActivateAsync(IPluginHostServices host)
     {
         _host = host;
         _apiKey = NormalizeApiKey(await host.LoadSecretAsync(ApiKeySecretName));
         _fetchedLlmModels = NormalizeFetchedLlmModels(
             host.GetSetting<List<GeminiFetchedModel>>(FetchedLlmModelsSettingName) ?? []);
+        _fetchedTranscriptionModels = NormalizeFetchedTranscriptionModels(
+            host.GetSetting<List<GeminiFetchedTranscriptionModel>>(FetchedTranscriptionModelsSettingName) ?? []);
+        _modelCatalogFetchedAt = LoadCatalogFetchedAt(host);
+        _transcriptionMode = ParseTranscriptionMode(
+            host.GetSetting<string>(TranscriptionModeSettingName));
+        _selectedTranscriptionModelId = NormalizeSelectedTranscriptionModelId(
+            host.GetSetting<string>(SelectedTranscriptionModelSettingName));
+
         host.Log(
             PluginLogLevel.Info,
-            $"Activated (configured={IsAvailable}, fetchedModels={_fetchedLlmModels.Count})");
+            $"Activated (configured={IsAvailable}, llmModels={_fetchedLlmModels.Count}, " +
+            $"transcriptionModels={_fetchedTranscriptionModels.Count})");
     }
 
-    /// <summary>
-    /// Deactivates the plugin and releases provider resources.
-    /// </summary>
+    /// <inheritdoc />
     public Task DeactivateAsync()
     {
         _host = null;
         return Task.CompletedTask;
     }
 
-    /// <summary>
-    /// Creates the settings view shown by the host, or null when no UI is required.
-    /// </summary>
+    /// <inheritdoc />
     public UserControl? CreateSettingsView() => new GeminiSettingsView(this);
+
+    // ITranscriptionEnginePlugin
+
+    /// <inheritdoc />
+    public string ProviderId => "gemini";
+
+    /// <inheritdoc />
+    public string ProviderDisplayName => "Google Gemini";
+
+    /// <inheritdoc />
+    public bool IsConfigured => IsAvailable;
+
+    /// <inheritdoc />
+    public IReadOnlyList<PluginModelInfo> TranscriptionModels
+    {
+        get
+        {
+            var models = AvailableTranscriptionModels;
+            var defaultId = ResolveDefaultTranscriptionModelId(models);
+            return models
+                .OrderByDescending(model => string.Equals(
+                    model.Id,
+                    defaultId,
+                    StringComparison.OrdinalIgnoreCase))
+                .ThenBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(model => new PluginModelInfo(
+                    model.Id,
+                    model.DisplayName ?? FormatModelDisplayName(model.Id))
+                {
+                    IsRecommended = string.Equals(
+                        model.Id,
+                        defaultId,
+                        StringComparison.OrdinalIgnoreCase),
+                    LanguageCount = 85,
+                })
+                .ToList();
+        }
+    }
+
+    /// <inheritdoc />
+    public string? SelectedModelId => _selectedTranscriptionModelId;
+
+    /// <inheritdoc />
+    public bool SupportsTranslation => false;
+
+    /// <inheritdoc />
+    public bool SupportsStreaming => SelectedTranscriptionModel?.LiveModelId is not null;
+
+    /// <inheritdoc />
+    public bool SupportsDictionaryTerms => true;
+
+    /// <inheritdoc />
+    public DictionaryTermsBudget DictionaryTermsBudget => DictionaryBudget;
+
+    /// <inheritdoc />
+    public bool SupportsStreamingForPrompt(string? prompt) =>
+        SupportsStreaming && string.IsNullOrWhiteSpace(prompt);
+
+    /// <inheritdoc />
+    public void SelectModel(string modelId)
+    {
+        var normalized = NormalizeModelId(modelId);
+        if (AvailableTranscriptionModels.All(model =>
+            !string.Equals(model.Id, normalized, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException($"Unknown transcription model: {modelId}", nameof(modelId));
+        }
+
+        if (string.Equals(
+            _selectedTranscriptionModelId,
+            normalized,
+            StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _selectedTranscriptionModelId = normalized;
+        _host?.SetSetting(SelectedTranscriptionModelSettingName, normalized);
+        _host?.NotifyCapabilitiesChanged();
+    }
+
+    /// <inheritdoc />
+    public Task<PluginTranscriptionResult> TranscribeAsync(
+        byte[] wavAudio,
+        string? language,
+        bool translate,
+        string? prompt,
+        CancellationToken ct) =>
+        TranscribeWithLanguageHintsAsync(
+            wavAudio,
+            NormalizeLanguage(language) is { } normalizedLanguage ? [normalizedLanguage] : [],
+            translate,
+            prompt,
+            ct);
+
+    /// <inheritdoc />
+    public async Task<PluginTranscriptionResult> TranscribeWithLanguageHintsAsync(
+        byte[] wavAudio,
+        IReadOnlyList<string> languageHints,
+        bool translate,
+        string? prompt,
+        CancellationToken ct)
+    {
+        if (translate)
+            throw new InvalidOperationException("Gemini Transcribe does not support translation.");
+        if (!IsConfigured || SelectedTranscriptionModel is not { } model)
+        {
+            throw new PluginRequestException(
+                "API key and transcription model required",
+                PluginRequestFailureKind.Configuration);
+        }
+
+        return await GeminiTranscriptionClient.TranscribeAsync(
+            _httpClient,
+            NativeBaseUrl,
+            _apiKey!,
+            model.Id,
+            wavAudio,
+            NormalizeLanguageHints(languageHints),
+            ExtractVocabulary(prompt),
+            _transcriptionMode,
+            (level, message) => _host?.Log(level, message),
+            ct);
+    }
+
+    /// <inheritdoc />
+    public Task<IStreamingSession> StartStreamingAsync(string? language, CancellationToken ct) =>
+        StartStreamingWithLanguageHintsAsync(
+            NormalizeLanguage(language) is { } normalizedLanguage ? [normalizedLanguage] : [],
+            ct);
+
+    /// <inheritdoc />
+    public async Task<IStreamingSession> StartStreamingWithLanguageHintsAsync(
+        IReadOnlyList<string> languageHints,
+        CancellationToken ct)
+    {
+        if (!IsConfigured)
+        {
+            throw new PluginRequestException(
+                "API key not configured",
+                PluginRequestFailureKind.Configuration);
+        }
+
+        if (SelectedTranscriptionModel?.LiveModelId is not { } liveModelId)
+            throw new NotSupportedException("The selected Gemini transcription model does not support live streaming.");
+
+        return await GeminiStreamingSession.ConnectAsync(
+            _apiKey!,
+            liveModelId,
+            NormalizeLanguageHints(languageHints),
+            customVocabulary: [],
+            _transcriptionMode,
+            ct);
+    }
 
     // ILlmProviderPlugin
 
-    /// <summary>
-    /// Gets the provider name displayed in the UI.
-    /// </summary>
+    /// <inheritdoc />
     public string ProviderName => "Google Gemini";
-    /// <summary>
-    /// Gets whether the provider can currently accept requests.
-    /// </summary>
+
+    /// <inheritdoc />
     public bool IsAvailable => !string.IsNullOrEmpty(_apiKey);
 
-    /// <summary>
-    /// Gets the models exposed by this provider.
-    /// </summary>
+    /// <inheritdoc />
     public IReadOnlyList<PluginModelInfo> SupportedModels
     {
         get
@@ -131,30 +311,37 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             if (_fetchedLlmModels.Count == 0)
                 return FallbackLlmModels;
 
-            var defaultModelId = ResolveDefaultModelId(_fetchedLlmModels);
+            var defaultModelId = ResolveDefaultLlmModelId(_fetchedLlmModels);
             return _fetchedLlmModels
                 .OrderByDescending(model => string.Equals(
                     model.Id,
                     defaultModelId,
                     StringComparison.OrdinalIgnoreCase))
                 .ThenBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
-                .Select(model => new PluginModelInfo(model.Id, model.DisplayName ?? model.Id)
+                .Select(model => new PluginModelInfo(model.Id, model.DisplayName ?? FormatModelDisplayName(model.Id))
                 {
-                    IsRecommended = string.Equals(model.Id, defaultModelId, StringComparison.OrdinalIgnoreCase),
+                    IsRecommended = string.Equals(
+                        model.Id,
+                        defaultModelId,
+                        StringComparison.OrdinalIgnoreCase),
                 })
                 .ToList();
         }
     }
 
-    /// <summary>
-    /// Processes input text with the selected provider configuration.
-    /// </summary>
-    public async Task<string> ProcessAsync(string systemPrompt, string userText, string model, CancellationToken ct)
+    /// <inheritdoc />
+    public async Task<string> ProcessAsync(
+        string systemPrompt,
+        string userText,
+        string model,
+        CancellationToken ct)
     {
         if (!IsAvailable)
+        {
             throw new PluginRequestException(
                 "API key not configured",
                 PluginRequestFailureKind.Configuration);
+        }
 
         var modelId = string.IsNullOrWhiteSpace(model)
             ? SupportedModels.First().Id
@@ -162,11 +349,22 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         return await SendChatCompletionAsync(modelId, systemPrompt, userText, ct);
     }
 
-    // API key and model catalog management (for settings view)
+    // Settings and model catalog management
 
     internal string? ApiKey => _apiKey;
     internal IPluginLocalization? Loc => _host?.Localization;
     internal IReadOnlyList<GeminiFetchedModel> FetchedLlmModels => _fetchedLlmModels;
+    internal IReadOnlyList<GeminiFetchedTranscriptionModel> FetchedTranscriptionModels =>
+        _fetchedTranscriptionModels;
+    internal DateTimeOffset? ModelCatalogFetchedAt => _modelCatalogFetchedAt;
+    internal GeminiTranscriptionMode TranscriptionMode => _transcriptionMode;
+
+    internal bool ShouldRefreshModelCatalog(DateTimeOffset now) =>
+        IsAvailable
+        && (_modelCatalogFetchedAt is not { } fetchedAt
+            || now - fetchedAt >= ModelCatalogRefreshInterval
+            || _fetchedLlmModels.Count == 0
+            || _fetchedTranscriptionModels.Count == 0);
 
     internal async Task SetApiKeyAsync(string apiKey)
     {
@@ -177,20 +375,44 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             var previousApiKey = _apiKey;
             var wasAvailable = IsAvailable;
             var changed = !string.Equals(previousApiKey, normalized, StringComparison.Ordinal);
-            var catalogChanged = changed && _fetchedLlmModels.Count > 0;
+            if (!changed)
+                return;
+
+            var previousLlmModels = _fetchedLlmModels;
+            var previousTranscriptionModels = _fetchedTranscriptionModels;
+            var previousFetchedAt = _modelCatalogFetchedAt;
+            var previousSelectedModelId = _selectedTranscriptionModelId;
+            var nextSelectedModelId = NormalizeSelectedTranscriptionModelId(
+                previousSelectedModelId,
+                FallbackTranscriptionModels);
+            var selectionChanged = !string.Equals(
+                previousSelectedModelId,
+                nextSelectedModelId,
+                StringComparison.OrdinalIgnoreCase);
+            var catalogChanged = previousLlmModels.Count > 0
+                || previousTranscriptionModels.Count > 0
+                || previousFetchedAt is not null;
 
             if (_host is not null)
             {
                 var secretPersisted = false;
-                var catalogWriteAttempted = false;
                 try
                 {
                     await PersistApiKeyAsync(_host, normalized);
                     secretPersisted = true;
                     if (catalogChanged)
                     {
-                        catalogWriteAttempted = true;
-                        _host.SetSetting(FetchedLlmModelsSettingName, new List<GeminiFetchedModel>());
+                        PersistCatalogSettings(
+                            _host,
+                            llmModels: [],
+                            transcriptionModels: [],
+                            fetchedAt: null);
+                    }
+                    if (selectionChanged)
+                    {
+                        _host.SetSetting(
+                            SelectedTranscriptionModelSettingName,
+                            nextSelectedModelId);
                     }
                 }
                 catch (Exception writeException)
@@ -198,21 +420,25 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                     var rollbackFailures = new List<Exception>();
                     if (secretPersisted)
                     {
-                        try
-                        {
-                            await PersistApiKeyAsync(_host, previousApiKey);
-                        }
-                        catch (Exception rollbackException)
-                        {
-                            rollbackFailures.Add(rollbackException);
-                        }
+                        try { await PersistApiKeyAsync(_host, previousApiKey); }
+                        catch (Exception rollbackException) { rollbackFailures.Add(rollbackException); }
                     }
 
-                    if (catalogWriteAttempted)
+                    if (catalogChanged)
                     {
                         try
                         {
-                            _host.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
+                            PersistCatalogSettings(
+                                _host,
+                                previousLlmModels,
+                                previousTranscriptionModels,
+                                previousFetchedAt);
+                            if (selectionChanged)
+                            {
+                                _host.SetSetting(
+                                    SelectedTranscriptionModelSettingName,
+                                    previousSelectedModelId);
+                            }
                         }
                         catch (Exception rollbackException)
                         {
@@ -232,14 +458,13 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             }
 
             _apiKey = normalized;
-            if (catalogChanged)
-                _fetchedLlmModels = [];
+            _fetchedLlmModels = [];
+            _fetchedTranscriptionModels = [];
+            _modelCatalogFetchedAt = null;
+            _selectedTranscriptionModelId = nextSelectedModelId;
 
-            if (_host is not null
-                && ((changed && wasAvailable != IsAvailable) || catalogChanged))
-            {
+            if (_host is not null && (wasAvailable != IsAvailable || catalogChanged))
                 _host.NotifyCapabilitiesChanged();
-            }
         }
         finally
         {
@@ -247,96 +472,70 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         }
     }
 
-    internal async Task<bool> SetFetchedLlmModelsAsync(
-        IEnumerable<GeminiFetchedModel> models,
-        string? expectedApiKey = null)
+    internal void SetTranscriptionMode(GeminiTranscriptionMode mode)
     {
-        var normalized = NormalizeFetchedLlmModels(models);
-        await _configurationGate.WaitAsync();
-        try
-        {
-            if (expectedApiKey is not null
-                && !string.Equals(_apiKey, expectedApiKey, StringComparison.Ordinal))
-            {
-                _host?.Log(PluginLogLevel.Debug, "Discarded a model catalog fetched for a previous API key.");
-                return false;
-            }
+        if (_transcriptionMode == mode)
+            return;
 
-            if (ModelCatalogsEqual(_fetchedLlmModels, normalized))
-                return true;
-
-            if (_host is not null)
-            {
-                try
-                {
-                    _host.SetSetting(FetchedLlmModelsSettingName, normalized);
-                }
-                catch (Exception writeException)
-                {
-                    try
-                    {
-                        _host.SetSetting(FetchedLlmModelsSettingName, _fetchedLlmModels);
-                    }
-                    catch (Exception rollbackException)
-                    {
-                        throw new InvalidOperationException(
-                            "Failed to persist the model catalog and restore the previous value.",
-                            new AggregateException(writeException, rollbackException));
-                    }
-
-                    throw;
-                }
-            }
-
-            _fetchedLlmModels = normalized;
-            _host?.NotifyCapabilitiesChanged();
-            return true;
-        }
-        finally
-        {
-            _configurationGate.Release();
-        }
+        _transcriptionMode = mode;
+        _host?.SetSetting(TranscriptionModeSettingName, FormatTranscriptionMode(mode));
     }
 
-    private static Task PersistApiKeyAsync(IPluginHostServices host, string? apiKey) =>
-        apiKey is null
-            ? host.DeleteSecretAsync(ApiKeySecretName)
-            : host.StoreSecretAsync(ApiKeySecretName, apiKey);
-
-    internal async Task<List<GeminiFetchedModel>?> FetchLlmModelsAsync(CancellationToken ct = default)
+    internal async Task<GeminiModelCatalog?> FetchModelCatalogAsync(CancellationToken ct = default)
     {
         var apiKey = _apiKey;
         if (apiKey is null)
             return null;
 
-        using var request = CreateAuthenticatedRequest(HttpMethod.Get, $"{BaseUrl}/models", apiKey);
-
         try
         {
-            using var response = await _httpClient.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
+            var nativeModels = new List<GeminiNativeModel>();
+            string? pageToken = null;
+            do
             {
-                _host?.Log(
-                    PluginLogLevel.Warning,
-                    $"Model catalog request failed with HTTP status {(int)response.StatusCode}.");
-                return null;
-            }
+                var url = $"{NativeBaseUrl}/models?pageSize=1000";
+                if (!string.IsNullOrWhiteSpace(pageToken))
+                    url += $"&pageToken={Uri.EscapeDataString(pageToken)}";
 
-            var json = await response.Content.ReadAsStringAsync(ct);
-            var catalog = JsonSerializer.Deserialize<GeminiCompatibleModelsResponse>(json, JsonOptions);
-            if (catalog?.Data is null)
-            {
-                _host?.Log(PluginLogLevel.Warning, "Model catalog response did not contain a data array.");
-                return null;
+                using var request = CreateNativeRequest(HttpMethod.Get, url, apiKey);
+                using var response = await _httpClient.SendAsync(request, ct);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _host?.Log(
+                        PluginLogLevel.Warning,
+                        $"Model catalog request failed with HTTP status {(int)response.StatusCode}.");
+                    return null;
+                }
+
+                var json = await response.Content.ReadAsStringAsync(ct);
+                var page = JsonSerializer.Deserialize<GeminiNativeModelsResponse>(json, JsonOptions);
+                if (page?.Models is null)
+                {
+                    _host?.Log(
+                        PluginLogLevel.Warning,
+                        "Model catalog response did not contain a models array.");
+                    return null;
+                }
+
+                nativeModels.AddRange(page.Models.OfType<GeminiNativeModel>());
+                pageToken = string.IsNullOrWhiteSpace(page.NextPageToken)
+                    ? null
+                    : page.NextPageToken;
             }
+            while (pageToken is not null);
 
             if (!string.Equals(_apiKey, apiKey, StringComparison.Ordinal))
             {
-                _host?.Log(PluginLogLevel.Debug, "Discarded a model catalog fetched for a previous API key.");
+                _host?.Log(
+                    PluginLogLevel.Debug,
+                    "Discarded a model catalog fetched for a previous API key.");
                 return null;
             }
 
-            return NormalizeFetchedLlmModels(catalog.Data.OfType<GeminiCompatibleModel>());
+            return new GeminiModelCatalog(
+                NormalizeFetchedLlmModels(nativeModels),
+                NormalizeFetchedTranscriptionModels(nativeModels),
+                DateTimeOffset.UtcNow);
         }
         catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -365,13 +564,128 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         }
     }
 
+    internal async Task<List<GeminiFetchedModel>?> FetchLlmModelsAsync(CancellationToken ct = default) =>
+        (await FetchModelCatalogAsync(ct))?.LlmModels.ToList();
+
+    internal async Task<bool> SetFetchedModelCatalogAsync(
+        GeminiModelCatalog catalog,
+        string? expectedApiKey = null)
+    {
+        var normalizedLlmModels = NormalizeFetchedLlmModels(catalog.LlmModels);
+        var normalizedTranscriptionModels = NormalizeFetchedTranscriptionModels(
+            catalog.TranscriptionModels);
+        var normalizedFetchedAt = catalog.FetchedAtUtc.ToUniversalTime();
+        var availableTranscriptionModels = normalizedTranscriptionModels.Count > 0
+            ? normalizedTranscriptionModels
+            : FallbackTranscriptionModels;
+        var nextSelectedModelId = NormalizeSelectedTranscriptionModelId(
+            _selectedTranscriptionModelId,
+            availableTranscriptionModels);
+        var selectionChanged = !string.Equals(
+            _selectedTranscriptionModelId,
+            nextSelectedModelId,
+            StringComparison.OrdinalIgnoreCase);
+
+        await _configurationGate.WaitAsync();
+        try
+        {
+            if (expectedApiKey is not null
+                && !string.Equals(_apiKey, expectedApiKey, StringComparison.Ordinal))
+            {
+                _host?.Log(
+                    PluginLogLevel.Debug,
+                    "Discarded a model catalog fetched for a previous API key.");
+                return false;
+            }
+
+            var catalogsChanged = !ModelCatalogsEqual(_fetchedLlmModels, normalizedLlmModels)
+                || !TranscriptionModelCatalogsEqual(
+                    _fetchedTranscriptionModels,
+                    normalizedTranscriptionModels);
+
+            if (_host is not null)
+            {
+                var previousLlmModels = _fetchedLlmModels;
+                var previousTranscriptionModels = _fetchedTranscriptionModels;
+                var previousFetchedAt = _modelCatalogFetchedAt;
+                try
+                {
+                    PersistCatalogSettings(
+                        _host,
+                        normalizedLlmModels,
+                        normalizedTranscriptionModels,
+                        normalizedFetchedAt);
+                    if (selectionChanged)
+                    {
+                        _host.SetSetting(
+                            SelectedTranscriptionModelSettingName,
+                            nextSelectedModelId);
+                    }
+                }
+                catch (Exception writeException)
+                {
+                    try
+                    {
+                        PersistCatalogSettings(
+                            _host,
+                            previousLlmModels,
+                            previousTranscriptionModels,
+                            previousFetchedAt);
+                        if (selectionChanged)
+                        {
+                            _host.SetSetting(
+                                SelectedTranscriptionModelSettingName,
+                                _selectedTranscriptionModelId);
+                        }
+                    }
+                    catch (Exception rollbackException)
+                    {
+                        throw new InvalidOperationException(
+                            "Failed to persist the model catalog and restore the previous value.",
+                            new AggregateException(writeException, rollbackException));
+                    }
+
+                    throw;
+                }
+            }
+
+            _fetchedLlmModels = normalizedLlmModels;
+            _fetchedTranscriptionModels = normalizedTranscriptionModels;
+            _modelCatalogFetchedAt = normalizedFetchedAt;
+
+            _selectedTranscriptionModelId = nextSelectedModelId;
+
+            if (catalogsChanged || selectionChanged)
+                _host?.NotifyCapabilitiesChanged();
+            return true;
+        }
+        finally
+        {
+            _configurationGate.Release();
+        }
+    }
+
+    internal async Task<bool> SetFetchedLlmModelsAsync(
+        IEnumerable<GeminiFetchedModel> models,
+        string? expectedApiKey = null)
+    {
+        var catalog = new GeminiModelCatalog(
+            models.ToList(),
+            _fetchedTranscriptionModels,
+            DateTimeOffset.UtcNow);
+        return await SetFetchedModelCatalogAsync(catalog, expectedApiKey);
+    }
+
     internal async Task<bool> ValidateApiKeyAsync(string apiKey, CancellationToken ct = default)
     {
         var normalized = NormalizeApiKey(apiKey);
         if (normalized is null)
             return false;
 
-        using var request = CreateAuthenticatedRequest(HttpMethod.Get, $"{BaseUrl}/models", normalized);
+        using var request = CreateNativeRequest(
+            HttpMethod.Get,
+            $"{NativeBaseUrl}/models?pageSize=1",
+            normalized);
         try
         {
             using var response = await _httpClient.SendAsync(request, ct);
@@ -407,8 +721,27 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             return false;
         }
 
-        return !ExcludedModelTokens.Any(token => normalized.Contains(token, StringComparison.OrdinalIgnoreCase));
+        return !ExcludedLlmModelTokens.Any(token =>
+            normalized.Contains(token, StringComparison.OrdinalIgnoreCase));
     }
+
+    internal static bool IsCompatibleTranscriptionModelId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return false;
+
+        var normalized = NormalizeModelId(id);
+        return normalized.StartsWith("gemini-", StringComparison.OrdinalIgnoreCase)
+            && normalized.Contains("-transcribe", StringComparison.OrdinalIgnoreCase)
+            && !IsLiveTranscriptionModelId(normalized);
+    }
+
+    internal static IReadOnlyList<string> ExtractVocabulary(string? prompt) =>
+        PluginDictionaryTerms.Clip(
+            string.IsNullOrWhiteSpace(prompt)
+                ? []
+                : prompt.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+            DictionaryBudget);
 
     private async Task<string> SendChatCompletionAsync(
         string model,
@@ -429,9 +762,9 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
         if (model.StartsWith("gemini-", StringComparison.OrdinalIgnoreCase))
             body["reasoning_effort"] = "low";
 
-        using var request = CreateAuthenticatedRequest(
+        using var request = CreateOpenAiCompatibleRequest(
             HttpMethod.Post,
-            $"{BaseUrl}/chat/completions",
+            $"{OpenAiBaseUrl}/chat/completions",
             _apiKey!);
         request.Content = new StringContent(
             JsonSerializer.Serialize(body),
@@ -484,19 +817,75 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             PluginRequestFailureKind.EmptyResponse);
     }
 
-    private static HttpRequestMessage CreateAuthenticatedRequest(HttpMethod method, string url, string apiKey)
+    private IReadOnlyList<GeminiFetchedTranscriptionModel> AvailableTranscriptionModels =>
+        _fetchedTranscriptionModels.Count > 0
+            ? _fetchedTranscriptionModels
+            : FallbackTranscriptionModels;
+
+    private GeminiFetchedTranscriptionModel? SelectedTranscriptionModel =>
+        AvailableTranscriptionModels.FirstOrDefault(model => string.Equals(
+            model.Id,
+            _selectedTranscriptionModelId,
+            StringComparison.OrdinalIgnoreCase));
+
+    private string NormalizeSelectedTranscriptionModelId(string? modelId)
+        => NormalizeSelectedTranscriptionModelId(modelId, AvailableTranscriptionModels);
+
+    private static string NormalizeSelectedTranscriptionModelId(
+        string? modelId,
+        IReadOnlyList<GeminiFetchedTranscriptionModel> available)
+    {
+        var normalized = string.IsNullOrWhiteSpace(modelId)
+            ? null
+            : NormalizeModelId(modelId);
+        return available.FirstOrDefault(model => string.Equals(
+                model.Id,
+                normalized,
+                StringComparison.OrdinalIgnoreCase))?.Id
+            ?? ResolveDefaultTranscriptionModelId(available);
+    }
+
+    private static Task PersistApiKeyAsync(IPluginHostServices host, string? apiKey) =>
+        apiKey is null
+            ? host.DeleteSecretAsync(ApiKeySecretName)
+            : host.StoreSecretAsync(ApiKeySecretName, apiKey);
+
+    private static void PersistCatalogSettings(
+        IPluginHostServices host,
+        IReadOnlyList<GeminiFetchedModel> llmModels,
+        IReadOnlyList<GeminiFetchedTranscriptionModel> transcriptionModels,
+        DateTimeOffset? fetchedAt)
+    {
+        host.SetSetting(FetchedLlmModelsSettingName, llmModels.ToList());
+        host.SetSetting(FetchedTranscriptionModelsSettingName, transcriptionModels.ToList());
+        host.SetSetting(ModelCatalogFetchedAtSettingName, fetchedAt);
+    }
+
+    private static HttpRequestMessage CreateOpenAiCompatibleRequest(
+        HttpMethod method,
+        string url,
+        string apiKey)
     {
         var request = new HttpRequestMessage(method, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         return request;
     }
 
+    internal static HttpRequestMessage CreateNativeRequest(
+        HttpMethod method,
+        string url,
+        string apiKey)
+    {
+        var request = new HttpRequestMessage(method, url);
+        request.Headers.TryAddWithoutValidation("x-goog-api-key", apiKey);
+        return request;
+    }
+
     private static List<GeminiFetchedModel> NormalizeFetchedLlmModels(
-        IEnumerable<GeminiCompatibleModel> models) =>
+        IEnumerable<GeminiNativeModel> models) =>
         NormalizeFetchedLlmModels(models
-            .Where(model => !string.IsNullOrWhiteSpace(model.Id))
             .Select(model => new GeminiFetchedModel(
-                model.Id!,
+                ResolveNativeModelId(model),
                 model.DisplayName)));
 
     private static List<GeminiFetchedModel> NormalizeFetchedLlmModels(
@@ -508,11 +897,63 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
                 string.IsNullOrWhiteSpace(model.DisplayName) ? null : model.DisplayName.Trim()))
             .Where(model => IsCompatibleChatModelId(model.Id))
             .DistinctBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
-            .OrderByDescending(model => string.Equals(model.Id, DefaultModel, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(model => string.Equals(
+                model.Id,
+                DefaultModel,
+                StringComparison.OrdinalIgnoreCase))
             .ThenBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-    private static string ResolveDefaultModelId(IReadOnlyList<GeminiFetchedModel> models)
+    private static List<GeminiFetchedTranscriptionModel> NormalizeFetchedTranscriptionModels(
+        IEnumerable<GeminiNativeModel> models)
+    {
+        var available = models
+            .Select(model => new GeminiFetchedModel(
+                ResolveNativeModelId(model),
+                model.DisplayName))
+            .Where(model => !string.IsNullOrWhiteSpace(model.Id))
+            .DistinctBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var liveModelIds = available
+            .Where(model => IsLiveTranscriptionModelId(model.Id))
+            .Select(model => model.Id)
+            .ToList();
+
+        return NormalizeFetchedTranscriptionModels(available
+            .Where(model => IsCompatibleTranscriptionModelId(model.Id))
+            .Select(model => new GeminiFetchedTranscriptionModel(
+                model.Id,
+                model.DisplayName,
+                ResolveLiveSibling(model.Id, liveModelIds))));
+    }
+
+    private static List<GeminiFetchedTranscriptionModel> NormalizeFetchedTranscriptionModels(
+        IEnumerable<GeminiFetchedTranscriptionModel> models) =>
+        models
+            .Where(model => model is not null && !string.IsNullOrWhiteSpace(model.Id))
+            .Select(model => new GeminiFetchedTranscriptionModel(
+                NormalizeModelId(model.Id),
+                string.IsNullOrWhiteSpace(model.DisplayName) ? null : model.DisplayName.Trim(),
+                string.IsNullOrWhiteSpace(model.LiveModelId)
+                    ? null
+                    : NormalizeModelId(model.LiveModelId)))
+            .Where(model => IsCompatibleTranscriptionModelId(model.Id))
+            .DistinctBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(model => model.Id.Contains("preview", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(model => GetModelVersion(model.Id))
+            .ThenByDescending(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static string? ResolveLiveSibling(
+        string unaryModelId,
+        IReadOnlyList<string> liveModelIds) =>
+        liveModelIds.FirstOrDefault(liveModelId => string.Equals(
+                liveModelId,
+                unaryModelId + "-live",
+                StringComparison.OrdinalIgnoreCase));
+
+    private static string ResolveDefaultLlmModelId(IReadOnlyList<GeminiFetchedModel> models)
     {
         var alias = models.FirstOrDefault(model => string.Equals(
             model.Id,
@@ -532,6 +973,15 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             .FirstOrDefault()
             ?? models[0].Id;
     }
+
+    private static string ResolveDefaultTranscriptionModelId(
+        IReadOnlyList<GeminiFetchedTranscriptionModel> models) =>
+        models
+            .OrderBy(model => model.Id.Contains("preview", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(model => GetModelVersion(model.Id))
+            .ThenByDescending(model => model.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(model => model.Id)
+            .First();
 
     private static Version GetModelVersion(string id)
     {
@@ -560,6 +1010,20 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             string.Equals(pair.First.Id, pair.Second.Id, StringComparison.OrdinalIgnoreCase)
             && string.Equals(pair.First.DisplayName, pair.Second.DisplayName, StringComparison.Ordinal));
 
+    private static bool TranscriptionModelCatalogsEqual(
+        IReadOnlyList<GeminiFetchedTranscriptionModel> first,
+        IReadOnlyList<GeminiFetchedTranscriptionModel> second) =>
+        first.Count == second.Count
+        && first.Zip(second).All(pair =>
+            string.Equals(pair.First.Id, pair.Second.Id, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(pair.First.DisplayName, pair.Second.DisplayName, StringComparison.Ordinal)
+            && string.Equals(pair.First.LiveModelId, pair.Second.LiveModelId, StringComparison.OrdinalIgnoreCase));
+
+    private static string ResolveNativeModelId(GeminiNativeModel model) =>
+        !string.IsNullOrWhiteSpace(model.BaseModelId)
+            ? model.BaseModelId!
+            : model.Name ?? "";
+
     private static string NormalizeModelId(string id)
     {
         var normalized = id.Trim();
@@ -568,12 +1032,77 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
             : normalized;
     }
 
+    private static bool IsLiveTranscriptionModelId(string id)
+    {
+        var normalized = NormalizeModelId(id);
+        return normalized.Contains("-transcribe-live", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? NormalizeLanguage(string? language)
+    {
+        var normalized = language?.Trim();
+        return string.IsNullOrWhiteSpace(normalized)
+            || normalized.Equals("auto", StringComparison.OrdinalIgnoreCase)
+                ? null
+                : normalized;
+    }
+
+    private static IReadOnlyList<string> NormalizeLanguageHints(
+        IReadOnlyList<string> languageHints)
+    {
+        var normalized = new List<string>();
+        foreach (var languageHint in languageHints)
+        {
+            if (NormalizeLanguage(languageHint) is not { } value
+                || normalized.Contains(value, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            normalized.Add(value);
+        }
+
+        return normalized;
+    }
+
+    private static string FormatModelDisplayName(string modelId) =>
+        string.Join(' ', NormalizeModelId(modelId)
+            .Split('-', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Length == 0
+                ? part
+                : char.ToUpperInvariant(part[0]) + part[1..]));
+
     private static string? NormalizeApiKey(string? apiKey) =>
         string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
 
-    /// <summary>
-    /// Releases resources held by the instance.
-    /// </summary>
+    private static GeminiTranscriptionMode ParseTranscriptionMode(string? mode) =>
+        string.Equals(mode, VerbatimModeSettingValue, StringComparison.OrdinalIgnoreCase)
+            ? GeminiTranscriptionMode.Verbatim
+            : GeminiTranscriptionMode.Smart;
+
+    private static string FormatTranscriptionMode(GeminiTranscriptionMode mode) =>
+        mode == GeminiTranscriptionMode.Verbatim
+            ? VerbatimModeSettingValue
+            : SmartModeSettingValue;
+
+    private static DateTimeOffset? LoadCatalogFetchedAt(IPluginHostServices host)
+    {
+        try
+        {
+            var value = host.GetSetting<DateTimeOffset?>(ModelCatalogFetchedAtSettingName);
+            return value == default ? null : value?.ToUniversalTime();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         _configurationGate.Dispose();
@@ -581,11 +1110,31 @@ public sealed class GeminiPlugin : ILlmProviderPlugin, ILlmRequestHedgingSupport
     }
 }
 
+internal enum GeminiTranscriptionMode
+{
+    Smart,
+    Verbatim,
+}
+
 internal sealed record GeminiFetchedModel(string Id, string? DisplayName);
 
-internal sealed record GeminiCompatibleModelsResponse(
-    [property: JsonPropertyName("data")] List<GeminiCompatibleModel?>? Data);
+internal sealed record GeminiFetchedTranscriptionModel(
+    string Id,
+    string? DisplayName,
+    string? LiveModelId);
 
-internal sealed record GeminiCompatibleModel(
-    [property: JsonPropertyName("id")] string? Id,
-    [property: JsonPropertyName("display_name")] string? DisplayName);
+internal sealed record GeminiModelCatalog(
+    IReadOnlyList<GeminiFetchedModel> LlmModels,
+    IReadOnlyList<GeminiFetchedTranscriptionModel> TranscriptionModels,
+    DateTimeOffset FetchedAtUtc);
+
+internal sealed record GeminiNativeModelsResponse(
+    [property: JsonPropertyName("models")] List<GeminiNativeModel?>? Models,
+    [property: JsonPropertyName("nextPageToken")] string? NextPageToken);
+
+internal sealed record GeminiNativeModel(
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("baseModelId")] string? BaseModelId,
+    [property: JsonPropertyName("displayName")] string? DisplayName,
+    [property: JsonPropertyName("supportedGenerationMethods")]
+    IReadOnlyList<string>? SupportedGenerationMethods);

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml
@@ -2,15 +2,19 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StackPanel Margin="0,4" MaxWidth="500">
-        <TextBlock Text="API Key" FontWeight="SemiBold" Margin="0,0,0,4" />
+        <TextBlock x:Name="ApiKeyLabel" Text="API Key" FontWeight="SemiBold" Margin="0,0,0,4" />
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <PasswordBox x:Name="ApiKeyBox" PasswordChanged="OnPasswordChanged" />
+            <PasswordBox x:Name="ApiKeyBox"
+                         PasswordChanged="OnPasswordChanged"
+                         AutomationProperties.AutomationId="GeminiApiKey"
+                         AutomationProperties.LabeledBy="{Binding ElementName=ApiKeyLabel}" />
             <Button Grid.Column="1" Margin="8,0,0,0" Padding="12,4"
-                    Click="OnTestClick" x:Name="TestButton" />
+                    Click="OnTestClick" x:Name="TestButton"
+                    AutomationProperties.AutomationId="GeminiTestApiKey" />
         </Grid>
         <TextBlock x:Name="StatusText" Margin="0,4,0,0" FontSize="12" />
 
@@ -22,9 +26,24 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Name="ModelCatalogLabel" FontWeight="SemiBold" VerticalAlignment="Center" />
                 <Button Grid.Column="1" x:Name="RefreshButton" Padding="12,4"
-                        Click="OnRefreshClick" />
+                        Click="OnRefreshClick"
+                        AutomationProperties.AutomationId="GeminiRefreshModels" />
             </Grid>
             <TextBlock x:Name="ModelCatalogHintText" FontSize="11" Foreground="Gray" TextWrapping="Wrap" />
+
+            <TextBlock x:Name="TranscriptionModeLabel"
+                       FontWeight="SemiBold"
+                       Margin="0,16,0,4" />
+            <ComboBox x:Name="TranscriptionModePicker"
+                      DisplayMemberPath="DisplayName"
+                      SelectionChanged="OnTranscriptionModeChanged"
+                      AutomationProperties.AutomationId="GeminiTranscriptionMode"
+                      AutomationProperties.LabeledBy="{Binding ElementName=TranscriptionModeLabel}" />
+            <TextBlock x:Name="TranscriptionModeHintText"
+                       Margin="0,4,0,0"
+                       FontSize="11"
+                       Foreground="Gray"
+                       TextWrapping="Wrap" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
@@ -10,7 +10,7 @@ namespace TypeWhisper.Plugin.Gemini;
 public partial class GeminiSettingsView : UserControl
 {
     private readonly GeminiPlugin _plugin;
-    private bool _suppressPasswordChanged;
+    private readonly bool _suppressPasswordChanged;
     private bool _suppressControlChanged;
     private bool _autoRefreshStarted;
     private CancellationTokenSource? _apiKeyRefreshDebounce;
@@ -80,26 +80,29 @@ public partial class GeminiSettingsView : UserControl
 
     private async Task RefreshCatalogAfterDelayAsync(CancellationTokenSource debounce)
     {
-        try
+        using (debounce)
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(750), debounce.Token);
-            if (!ReferenceEquals(_apiKeyRefreshDebounce, debounce)
-                || !_plugin.ShouldRefreshModelCatalog(DateTimeOffset.UtcNow))
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(750), debounce.Token);
+                if (!ReferenceEquals(_apiKeyRefreshDebounce, debounce)
+                    || !_plugin.ShouldRefreshModelCatalog(DateTimeOffset.UtcNow))
+                {
+                    return;
+                }
+
+                _autoRefreshStarted = true;
+                await RefreshModelsAsync(showSuccess: false);
+            }
+            catch (OperationCanceledException) when (debounce.IsCancellationRequested)
             {
                 return;
             }
-
-            _autoRefreshStarted = true;
-            await RefreshModelsAsync(showSuccess: false);
-        }
-        catch (OperationCanceledException) when (debounce.IsCancellationRequested)
-        {
-        }
-        finally
-        {
-            if (ReferenceEquals(_apiKeyRefreshDebounce, debounce))
-                _apiKeyRefreshDebounce = null;
-            debounce.Dispose();
+            finally
+            {
+                if (ReferenceEquals(_apiKeyRefreshDebounce, debounce))
+                    _apiKeyRefreshDebounce = null;
+            }
         }
     }
 

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiSettingsView.xaml.cs
@@ -10,8 +10,10 @@ namespace TypeWhisper.Plugin.Gemini;
 public partial class GeminiSettingsView : UserControl
 {
     private readonly GeminiPlugin _plugin;
-    private readonly bool _suppressPasswordChanged;
+    private bool _suppressPasswordChanged;
+    private bool _suppressControlChanged;
     private bool _autoRefreshStarted;
+    private CancellationTokenSource? _apiKeyRefreshDebounce;
 
     /// <summary>
     /// Initializes a new instance of the GeminiSettingsView class.
@@ -23,6 +25,8 @@ public partial class GeminiSettingsView : UserControl
         TestButton.Content = L("Settings.Test");
         RefreshButton.Content = L("Settings.Refresh");
         ModelCatalogLabel.Text = L("Settings.ModelCatalog");
+        TranscriptionModeLabel.Text = L("Settings.TranscriptionMode");
+        TranscriptionModeHintText.Text = L("Settings.TranscriptionModeHint");
 
         // Pre-fill password box if API key is already set
         if (!string.IsNullOrEmpty(plugin.ApiKey))
@@ -33,12 +37,14 @@ public partial class GeminiSettingsView : UserControl
         }
 
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
+        PopulateTranscriptionModePicker();
         UpdateModelsSection();
-        if (_autoRefreshStarted || !_plugin.IsAvailable || _plugin.FetchedLlmModels.Count > 0)
+        if (_autoRefreshStarted || !_plugin.ShouldRefreshModelCatalog(DateTimeOffset.UtcNow))
             return;
 
         _autoRefreshStarted = true;
@@ -55,6 +61,52 @@ public partial class GeminiSettingsView : UserControl
         StatusText.Text = string.IsNullOrWhiteSpace(key) ? "" : L("Settings.Saved");
         StatusText.Foreground = Brushes.Gray;
         UpdateModelsSection();
+        ScheduleCatalogRefreshAfterApiKeyChange();
+    }
+
+    private void ScheduleCatalogRefreshAfterApiKeyChange()
+    {
+        _apiKeyRefreshDebounce?.Cancel();
+        if (!_plugin.IsAvailable)
+        {
+            _apiKeyRefreshDebounce = null;
+            return;
+        }
+
+        var debounce = new CancellationTokenSource();
+        _apiKeyRefreshDebounce = debounce;
+        _ = RefreshCatalogAfterDelayAsync(debounce);
+    }
+
+    private async Task RefreshCatalogAfterDelayAsync(CancellationTokenSource debounce)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(750), debounce.Token);
+            if (!ReferenceEquals(_apiKeyRefreshDebounce, debounce)
+                || !_plugin.ShouldRefreshModelCatalog(DateTimeOffset.UtcNow))
+            {
+                return;
+            }
+
+            _autoRefreshStarted = true;
+            await RefreshModelsAsync(showSuccess: false);
+        }
+        catch (OperationCanceledException) when (debounce.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (ReferenceEquals(_apiKeyRefreshDebounce, debounce))
+                _apiKeyRefreshDebounce = null;
+            debounce.Dispose();
+        }
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _apiKeyRefreshDebounce?.Cancel();
+        _apiKeyRefreshDebounce = null;
     }
 
     private async void OnTestClick(object sender, RoutedEventArgs e)
@@ -77,9 +129,9 @@ public partial class GeminiSettingsView : UserControl
             if (valid)
             {
                 var catalogKey = _plugin.ApiKey;
-                var models = await _plugin.FetchLlmModelsAsync();
-                if (models is { Count: > 0 } && catalogKey is not null)
-                    await _plugin.SetFetchedLlmModelsAsync(models, catalogKey);
+                var catalog = await _plugin.FetchModelCatalogAsync();
+                if (catalog is not null && catalogKey is not null)
+                    await _plugin.SetFetchedModelCatalogAsync(catalog, catalogKey);
 
                 StatusText.Text = L("Settings.ApiKeyValid");
                 StatusText.Foreground = Brushes.Green;
@@ -124,10 +176,10 @@ public partial class GeminiSettingsView : UserControl
         try
         {
             var catalogKey = _plugin.ApiKey;
-            var models = await _plugin.FetchLlmModelsAsync();
-            if (models is not { Count: > 0 }
+            var catalog = await _plugin.FetchModelCatalogAsync();
+            if (catalog is null
                 || catalogKey is null
-                || !await _plugin.SetFetchedLlmModelsAsync(models, catalogKey))
+                || !await _plugin.SetFetchedModelCatalogAsync(catalog, catalogKey))
             {
                 if (showSuccess)
                 {
@@ -139,7 +191,10 @@ public partial class GeminiSettingsView : UserControl
 
             if (showSuccess)
             {
-                StatusText.Text = L("Settings.ModelsFetched", models.Count);
+                StatusText.Text = L(
+                    "Settings.ModelsFetched",
+                    catalog.LlmModels.Count,
+                    catalog.TranscriptionModels.Count);
                 StatusText.Foreground = Brushes.Green;
             }
         }
@@ -170,10 +225,41 @@ public partial class GeminiSettingsView : UserControl
     {
         ModelsSection.Visibility = _plugin.IsAvailable ? Visibility.Visible : Visibility.Collapsed;
         ModelCatalogHintText.Text = _plugin.FetchedLlmModels.Count > 0
-            ? L("Settings.ModelsFetchedHint", _plugin.FetchedLlmModels.Count)
+            || _plugin.FetchedTranscriptionModels.Count > 0
+            ? L(
+                "Settings.ModelsFetchedHint",
+                _plugin.FetchedLlmModels.Count,
+                _plugin.FetchedTranscriptionModels.Count)
             : L("Settings.DefaultModelsHint");
+    }
+
+    private void OnTranscriptionModeChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!_suppressControlChanged
+            && TranscriptionModePicker.SelectedItem is TranscriptionModeOption option)
+        {
+            _plugin.SetTranscriptionMode(option.Mode);
+        }
+    }
+
+    private void PopulateTranscriptionModePicker()
+    {
+        _suppressControlChanged = true;
+        var options = new List<TranscriptionModeOption>
+        {
+            new(GeminiTranscriptionMode.Smart, L("Settings.ModeSmart")),
+            new(GeminiTranscriptionMode.Verbatim, L("Settings.ModeVerbatim")),
+        };
+        TranscriptionModePicker.ItemsSource = options;
+        TranscriptionModePicker.SelectedItem = options.First(option =>
+            option.Mode == _plugin.TranscriptionMode);
+        _suppressControlChanged = false;
     }
 
     private string L(string key) => _plugin.Loc?.GetString(key) ?? key;
     private string L(string key, params object[] args) => _plugin.Loc?.GetString(key, args) ?? key;
+
+    private sealed record TranscriptionModeOption(
+        GeminiTranscriptionMode Mode,
+        string DisplayName);
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
@@ -1,0 +1,336 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.PluginSDK;
+
+namespace TypeWhisper.Plugin.Gemini;
+
+internal sealed class GeminiStreamingSession : IStreamingSession
+{
+    private const string LiveWebSocketUrl =
+        "wss://generativelanguage.googleapis.com/ws/" +
+        "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
+
+    private readonly ClientWebSocket _webSocket;
+    private readonly GeminiStreamingTranscriptCollector _collector;
+    private readonly CancellationTokenSource _receiveCts = new();
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly TaskCompletionSource<bool> _setupCompleted = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private Task? _receiveTask;
+    private bool _disposed;
+
+    private GeminiStreamingSession(
+        ClientWebSocket webSocket,
+        GeminiStreamingTranscriptCollector collector)
+    {
+        _webSocket = webSocket;
+        _collector = collector;
+    }
+
+    /// <inheritdoc />
+    public event Action<StreamingTranscriptEvent>? TranscriptReceived;
+
+    /// <summary>
+    /// Opens and configures a Gemini Live transcription session.
+    /// </summary>
+    public static async Task<GeminiStreamingSession> ConnectAsync(
+        string apiKey,
+        string modelId,
+        IReadOnlyList<string> languageHints,
+        IReadOnlyList<string> customVocabulary,
+        GeminiTranscriptionMode mode,
+        CancellationToken ct)
+    {
+        var webSocket = new ClientWebSocket();
+        await webSocket.ConnectAsync(BuildWebSocketUri(apiKey), ct);
+
+        var session = new GeminiStreamingSession(
+            webSocket,
+            new GeminiStreamingTranscriptCollector());
+        session._receiveTask = session.ReceiveLoopAsync(session._receiveCts.Token);
+        await session.SendTextAsync(
+            CreateSetupPayload(modelId, languageHints, customVocabulary, mode),
+            ct);
+
+        try
+        {
+            await session._setupCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
+            return session;
+        }
+        catch
+        {
+            await session.DisposeAsync();
+            throw;
+        }
+    }
+
+    internal static Uri BuildWebSocketUri(string apiKey) =>
+        new($"{LiveWebSocketUrl}?key={Uri.EscapeDataString(apiKey)}");
+
+    internal static string CreateSetupPayload(
+        string modelId,
+        IReadOnlyList<string> languageHints,
+        IReadOnlyList<string> customVocabulary,
+        GeminiTranscriptionMode mode)
+    {
+        var transcription = new Dictionary<string, object?>
+        {
+            ["languageCodes"] = languageHints,
+            ["mode"] = mode == GeminiTranscriptionMode.Smart ? "SMART" : "VERBATIM",
+        };
+        if (customVocabulary.Count > 0)
+            transcription["customVocabulary"] = customVocabulary;
+
+        return JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["setup"] = new Dictionary<string, object?>
+            {
+                ["model"] = $"models/{NormalizeModelId(modelId)}",
+                ["generationConfig"] = new Dictionary<string, object?>
+                {
+                    ["responseModalities"] = new[] { "TEXT" },
+                },
+                ["inputAudioTranscription"] = transcription,
+            }
+        });
+    }
+
+    internal static string CreateAudioPayload(ReadOnlySpan<byte> pcm16Audio) =>
+        JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["realtimeInput"] = new Dictionary<string, object?>
+            {
+                ["audio"] = new Dictionary<string, object?>
+                {
+                    ["data"] = Convert.ToBase64String(pcm16Audio),
+                    ["mimeType"] = "audio/pcm;rate=16000",
+                }
+            }
+        });
+
+    /// <inheritdoc />
+    public async Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
+    {
+        if (_disposed || _webSocket.State != WebSocketState.Open || pcm16Audio.Length == 0)
+            return;
+
+        await _sendLock.WaitAsync(ct);
+        try
+        {
+            if (!_disposed && _webSocket.State == WebSocketState.Open)
+                await SendTextAsync(CreateAudioPayload(pcm16Audio.Span), ct);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task FinalizeAsync(CancellationToken ct)
+    {
+        if (_disposed || _webSocket.State != WebSocketState.Open)
+            return;
+
+        await _sendLock.WaitAsync(ct);
+        try
+        {
+            if (!_disposed && _webSocket.State == WebSocketState.Open)
+            {
+                await SendTextAsync(
+                    """{"realtimeInput":{"audioStreamEnd":true}}""",
+                    ct);
+            }
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    private async Task SendTextAsync(string json, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        await _webSocket.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken ct)
+    {
+        var buffer = new byte[16_384];
+        using var messageBuffer = new MemoryStream();
+
+        try
+        {
+            while (!ct.IsCancellationRequested && _webSocket.State == WebSocketState.Open)
+            {
+                messageBuffer.SetLength(0);
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await _webSocket.ReceiveAsync(buffer, ct);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        return;
+                    messageBuffer.Write(buffer, 0, result.Count);
+                }
+                while (!result.EndOfMessage);
+
+                if (!IsJsonMessageType(result.MessageType))
+                    continue;
+
+                var json = Encoding.UTF8.GetString(
+                    messageBuffer.GetBuffer(),
+                    0,
+                    (int)messageBuffer.Length);
+                var update = _collector.ApplyEvent(json);
+                if (update.SetupCompleted)
+                    _setupCompleted.TrySetResult(true);
+                if (update.ErrorMessage is { } errorMessage)
+                {
+                    _setupCompleted.TrySetException(new InvalidOperationException(errorMessage));
+                    Debug.WriteLine($"Gemini Live transcription error: {errorMessage}");
+                }
+                if (update.Transcript is not null)
+                    TranscriptReceived?.Invoke(update.Transcript);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex) when (ex is WebSocketException or JsonException or InvalidOperationException)
+        {
+            _setupCompleted.TrySetException(ex);
+            Debug.WriteLine($"Gemini Live receive error: {ex.Message}");
+        }
+    }
+
+    internal static bool IsJsonMessageType(WebSocketMessageType messageType) =>
+        messageType is WebSocketMessageType.Text or WebSocketMessageType.Binary;
+
+    private static string NormalizeModelId(string modelId) =>
+        modelId.StartsWith("models/", StringComparison.OrdinalIgnoreCase)
+            ? modelId["models/".Length..]
+            : modelId;
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _receiveCts.Cancel();
+
+        await _sendLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            if (_webSocket.State == WebSocketState.Open)
+            {
+                try
+                {
+                    await _webSocket.CloseAsync(
+                        WebSocketCloseStatus.NormalClosure,
+                        null,
+                        CancellationToken.None);
+                }
+                catch (Exception ex) when (ex is WebSocketException or InvalidOperationException)
+                {
+                    Debug.WriteLine($"Gemini Live close error: {ex.Message}");
+                }
+            }
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+
+        if (_receiveTask is not null)
+        {
+            try { await _receiveTask; }
+            catch (OperationCanceledException) { }
+        }
+
+        _sendLock.Dispose();
+        _receiveCts.Dispose();
+        _webSocket.Dispose();
+    }
+}
+
+internal sealed class GeminiStreamingTranscriptCollector
+{
+    /// <summary>
+    /// Parses one Gemini Live server event.
+    /// </summary>
+    public GeminiStreamingUpdate ApplyEvent(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (TryGetProperty(root, "setupComplete", "setup_complete", out _))
+            return new GeminiStreamingUpdate(SetupCompleted: true, null, null);
+
+        if (root.TryGetProperty("error", out var error))
+        {
+            var message = TryGetString(error, "message")
+                ?? (error.ValueKind == JsonValueKind.String ? error.GetString() : null)
+                ?? "Unknown Gemini Live error";
+            return new GeminiStreamingUpdate(false, null, message);
+        }
+
+        if (!TryGetProperty(root, "serverContent", "server_content", out var serverContent))
+            return GeminiStreamingUpdate.Empty;
+
+        if (TryGetProperty(
+                serverContent,
+                "inputTranscription",
+                "input_transcription",
+                out var final)
+            && TryGetString(final, "text") is { } finalText
+            && !string.IsNullOrWhiteSpace(finalText))
+        {
+            return new GeminiStreamingUpdate(
+                false,
+                new StreamingTranscriptEvent(finalText.Trim(), IsFinal: true),
+                null);
+        }
+
+        if (TryGetProperty(
+                serverContent,
+                "interimInputTranscription",
+                "interim_input_transcription",
+                out var interim)
+            && TryGetString(interim, "text") is { } interimText
+            && !string.IsNullOrWhiteSpace(interimText))
+        {
+            return new GeminiStreamingUpdate(
+                false,
+                new StreamingTranscriptEvent(interimText.Trim(), IsFinal: false),
+                null);
+        }
+
+        return GeminiStreamingUpdate.Empty;
+    }
+
+    private static bool TryGetProperty(
+        JsonElement element,
+        string camelCaseName,
+        string snakeCaseName,
+        out JsonElement value) =>
+        element.TryGetProperty(camelCaseName, out value)
+        || element.TryGetProperty(snakeCaseName, out value);
+
+    private static string? TryGetString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+}
+
+internal sealed record GeminiStreamingUpdate(
+    bool SetupCompleted,
+    StreamingTranscriptEvent? Transcript,
+    string? ErrorMessage)
+{
+    public static GeminiStreamingUpdate Empty { get; } = new(false, null, null);
+}

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
@@ -185,7 +185,9 @@ internal sealed class GeminiStreamingSession : IStreamingSession
                     messageBuffer.GetBuffer(),
                     0,
                     (int)messageBuffer.Length);
-                var update = _collector.ApplyEvent(json);
+                if (!TryApplyEvent(_collector, json, out var update))
+                    continue;
+
                 if (update.SetupCompleted)
                     _setupCompleted.TrySetResult(true);
                 if (update.ErrorMessage is { } errorMessage)
@@ -194,17 +196,55 @@ internal sealed class GeminiStreamingSession : IStreamingSession
                     Debug.WriteLine($"Gemini Live transcription error: {errorMessage}");
                 }
                 if (update.Transcript is not null)
-                    TranscriptReceived?.Invoke(update.Transcript);
+                    NotifyTranscriptHandlers(TranscriptReceived, update.Transcript);
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             Debug.WriteLine("Gemini Live receive loop canceled.");
         }
-        catch (Exception ex) when (ex is WebSocketException or JsonException or InvalidOperationException)
+        catch (Exception ex)
         {
             _setupCompleted.TrySetException(ex);
             Debug.WriteLine($"Gemini Live receive error: {ex.Message}");
+        }
+    }
+
+    internal static bool TryApplyEvent(
+        GeminiStreamingTranscriptCollector collector,
+        string json,
+        out GeminiStreamingUpdate update)
+    {
+        try
+        {
+            update = collector.ApplyEvent(json);
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            Debug.WriteLine($"Gemini Live event parse error: {ex.Message}");
+            update = GeminiStreamingUpdate.Empty;
+            return false;
+        }
+    }
+
+    internal static void NotifyTranscriptHandlers(
+        Action<StreamingTranscriptEvent>? handlers,
+        StreamingTranscriptEvent transcript)
+    {
+        if (handlers is null)
+            return;
+
+        foreach (Action<StreamingTranscriptEvent> handler in handlers.GetInvocationList())
+        {
+            try
+            {
+                handler(transcript);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Gemini Live transcript handler error: {ex.Message}");
+            }
         }
     }
 

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
@@ -20,7 +20,7 @@ internal sealed class GeminiStreamingSession : IStreamingSession
     private readonly TaskCompletionSource<bool> _setupCompleted = new(
         TaskCreationOptions.RunContinuationsAsynchronously);
     private Task? _receiveTask;
-    private bool _disposed;
+    private int _disposeStarted;
 
     private GeminiStreamingSession(
         ClientWebSocket webSocket,
@@ -114,14 +114,17 @@ internal sealed class GeminiStreamingSession : IStreamingSession
     /// <inheritdoc />
     public async Task SendAudioAsync(ReadOnlyMemory<byte> pcm16Audio, CancellationToken ct)
     {
-        if (_disposed || _webSocket.State != WebSocketState.Open || pcm16Audio.Length == 0)
+        if (pcm16Audio.Length == 0)
             return;
 
         await _sendLock.WaitAsync(ct);
         try
         {
-            if (!_disposed && _webSocket.State == WebSocketState.Open)
+            if (Volatile.Read(ref _disposeStarted) == 0
+                && _webSocket.State == WebSocketState.Open)
+            {
                 await SendTextAsync(CreateAudioPayload(pcm16Audio.Span), ct);
+            }
         }
         finally
         {
@@ -132,13 +135,11 @@ internal sealed class GeminiStreamingSession : IStreamingSession
     /// <inheritdoc />
     public async Task FinalizeAsync(CancellationToken ct)
     {
-        if (_disposed || _webSocket.State != WebSocketState.Open)
-            return;
-
         await _sendLock.WaitAsync(ct);
         try
         {
-            if (!_disposed && _webSocket.State == WebSocketState.Open)
+            if (Volatile.Read(ref _disposeStarted) == 0
+                && _webSocket.State == WebSocketState.Open)
             {
                 await SendTextAsync(
                     """{"realtimeInput":{"audioStreamEnd":true}}""",
@@ -196,8 +197,9 @@ internal sealed class GeminiStreamingSession : IStreamingSession
                     TranscriptReceived?.Invoke(update.Transcript);
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+            Debug.WriteLine("Gemini Live receive loop canceled.");
         }
         catch (Exception ex) when (ex is WebSocketException or JsonException or InvalidOperationException)
         {
@@ -217,10 +219,9 @@ internal sealed class GeminiStreamingSession : IStreamingSession
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
             return;
 
-        _disposed = true;
         _receiveCts.Cancel();
 
         await _sendLock.WaitAsync(CancellationToken.None);
@@ -247,12 +248,8 @@ internal sealed class GeminiStreamingSession : IStreamingSession
         }
 
         if (_receiveTask is not null)
-        {
-            try { await _receiveTask; }
-            catch (OperationCanceledException) { }
-        }
+            await _receiveTask;
 
-        _sendLock.Dispose();
         _receiveCts.Dispose();
         _webSocket.Dispose();
     }

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiStreamingSession.cs
@@ -45,24 +45,27 @@ internal sealed class GeminiStreamingSession : IStreamingSession
         CancellationToken ct)
     {
         var webSocket = new ClientWebSocket();
-        await webSocket.ConnectAsync(BuildWebSocketUri(apiKey), ct);
-
-        var session = new GeminiStreamingSession(
-            webSocket,
-            new GeminiStreamingTranscriptCollector());
-        session._receiveTask = session.ReceiveLoopAsync(session._receiveCts.Token);
-        await session.SendTextAsync(
-            CreateSetupPayload(modelId, languageHints, customVocabulary, mode),
-            ct);
-
+        GeminiStreamingSession? session = null;
         try
         {
+            await webSocket.ConnectAsync(BuildWebSocketUri(apiKey), ct);
+
+            session = new GeminiStreamingSession(
+                webSocket,
+                new GeminiStreamingTranscriptCollector());
+            session._receiveTask = session.ReceiveLoopAsync(session._receiveCts.Token);
+            await session.SendTextAsync(
+                CreateSetupPayload(modelId, languageHints, customVocabulary, mode),
+                ct);
             await session._setupCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
             return session;
         }
         catch
         {
-            await session.DisposeAsync();
+            if (session is null)
+                webSocket.Dispose();
+            else
+                await session.DisposeAsync();
             throw;
         }
     }
@@ -220,7 +223,7 @@ internal sealed class GeminiStreamingSession : IStreamingSession
             update = collector.ApplyEvent(json);
             return true;
         }
-        catch (JsonException ex)
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             Debug.WriteLine($"Gemini Live event parse error: {ex.Message}");
             update = GeminiStreamingUpdate.Empty;

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
@@ -197,10 +197,10 @@ internal static class GeminiTranscriptionClient
             else if (chunkId == "data")
                 dataSize = Math.Min(chunkSize, Math.Max(0, wavAudio.Length - dataStart));
 
-            var paddedChunkSize = chunkSize + (chunkSize & 1);
-            if (paddedChunkSize > wavAudio.Length - dataStart)
+            var paddedChunkSize = (long)chunkSize + (chunkSize & 1);
+            if (paddedChunkSize > wavAudio.Length - (long)dataStart)
                 break;
-            offset = dataStart + paddedChunkSize;
+            offset = dataStart + (int)paddedChunkSize;
         }
 
         return byteRate > 0 && dataSize > 0

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
@@ -184,7 +184,7 @@ internal static class GeminiTranscriptionClient
 
         var byteRate = 0;
         var dataSize = 0;
-        for (var offset = 12; offset + 8 <= wavAudio.Length;)
+        for (var offset = 12; offset <= wavAudio.Length - 8;)
         {
             var chunkId = Encoding.ASCII.GetString(wavAudio, offset, 4);
             var chunkSize = BinaryPrimitives.ReadInt32LittleEndian(wavAudio.AsSpan(offset + 4, 4));
@@ -192,7 +192,7 @@ internal static class GeminiTranscriptionClient
                 break;
 
             var dataStart = offset + 8;
-            if (chunkId == "fmt " && chunkSize >= 12 && dataStart + 12 <= wavAudio.Length)
+            if (chunkId == "fmt " && chunkSize >= 12 && dataStart <= wavAudio.Length - 12)
                 byteRate = BinaryPrimitives.ReadInt32LittleEndian(wavAudio.AsSpan(dataStart + 8, 4));
             else if (chunkId == "data")
                 dataSize = Math.Min(chunkSize, Math.Max(0, wavAudio.Length - dataStart));

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
@@ -347,39 +347,34 @@ internal static class GeminiTranscriptionClient
         if (response.IsSuccessStatusCode)
             return response;
 
-        var statusCode = (int)response.StatusCode;
-        var retryAfter = response.Headers.RetryAfter?.Delta;
-        if (retryAfter is null && response.Headers.RetryAfter?.Date is { } retryAt)
-            retryAfter = retryAt - DateTimeOffset.UtcNow;
+        using (response)
+        {
+            var statusCode = (int)response.StatusCode;
+            var retryAfter = response.Headers.RetryAfter?.Delta;
+            if (retryAfter is null && response.Headers.RetryAfter?.Date is { } retryAt)
+                retryAfter = retryAt - DateTimeOffset.UtcNow;
 
-        string errorBody;
-        try
-        {
-            errorBody = await response.Content.ReadAsStringAsync(ct);
-        }
-        finally
-        {
-            response.Dispose();
-        }
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
 
-        var failureKind = statusCode switch
-        {
-            401 => PluginRequestFailureKind.Authentication,
-            403 => PluginRequestFailureKind.Permission,
-            408 => PluginRequestFailureKind.Timeout,
-            413 => PluginRequestFailureKind.RequestTooLarge,
-            429 => PluginRequestFailureKind.RateLimit,
-            >= 500 and <= 599 => PluginRequestFailureKind.ServerError,
-            >= 400 and <= 499 => PluginRequestFailureKind.InvalidRequest,
-            _ => PluginRequestFailureKind.Unknown,
-        };
-        var message = statusCode switch
-        {
-            401 => "Invalid Gemini API key",
-            429 => "Gemini rate limit reached, please wait",
-            _ => $"Gemini API error {statusCode}: {OpenAiApiHelper.ExtractErrorMessage(errorBody)}",
-        };
-        throw new PluginRequestException(message, failureKind, statusCode, retryAfter);
+            var failureKind = statusCode switch
+            {
+                401 => PluginRequestFailureKind.Authentication,
+                403 => PluginRequestFailureKind.Permission,
+                408 => PluginRequestFailureKind.Timeout,
+                413 => PluginRequestFailureKind.RequestTooLarge,
+                429 => PluginRequestFailureKind.RateLimit,
+                >= 500 and <= 599 => PluginRequestFailureKind.ServerError,
+                >= 400 and <= 499 => PluginRequestFailureKind.InvalidRequest,
+                _ => PluginRequestFailureKind.Unknown,
+            };
+            var message = statusCode switch
+            {
+                401 => "Invalid Gemini API key",
+                429 => "Gemini rate limit reached, please wait",
+                _ => $"Gemini API error {statusCode}: {OpenAiApiHelper.ExtractErrorMessage(errorBody)}",
+            };
+            throw new PluginRequestException(message, failureKind, statusCode, retryAfter);
+        }
     }
 
     private static bool TryGetString(JsonElement element, string propertyName, out string value)

--- a/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/GeminiTranscriptionClient.cs
@@ -1,0 +1,399 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TypeWhisper.PluginSDK;
+using TypeWhisper.PluginSDK.Helpers;
+using TypeWhisper.PluginSDK.Models;
+
+namespace TypeWhisper.Plugin.Gemini;
+
+internal static class GeminiTranscriptionClient
+{
+    private const string AudioMimeType = "audio/wav";
+
+    /// <summary>
+    /// Uploads WAV audio, creates a stateless transcription interaction, and removes the upload.
+    /// </summary>
+    public static async Task<PluginTranscriptionResult> TranscribeAsync(
+        HttpClient httpClient,
+        string baseUrl,
+        string apiKey,
+        string modelId,
+        byte[] wavAudio,
+        IReadOnlyList<string> languageHints,
+        IReadOnlyList<string> customVocabulary,
+        GeminiTranscriptionMode mode,
+        Action<PluginLogLevel, string>? log,
+        CancellationToken ct)
+    {
+        if (wavAudio.Length == 0)
+        {
+            throw new PluginRequestException(
+                "Audio is empty.",
+                PluginRequestFailureKind.InvalidRequest);
+        }
+
+        GeminiUploadedFile? uploadedFile = null;
+        try
+        {
+            uploadedFile = await UploadAudioAsync(httpClient, baseUrl, apiKey, wavAudio, ct);
+            using var request = GeminiPlugin.CreateNativeRequest(
+                HttpMethod.Post,
+                $"{baseUrl}/interactions",
+                apiKey);
+            request.Content = new StringContent(
+                CreateInteractionPayload(
+                    modelId,
+                    uploadedFile.Uri,
+                    languageHints,
+                    customVocabulary,
+                    mode),
+                Encoding.UTF8,
+                "application/json");
+
+            using var response = await SendAsync(httpClient, request, ct);
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var text = ParseInteractionText(json);
+            return new PluginTranscriptionResult(
+                text,
+                languageHints.FirstOrDefault(),
+                CalculateWavDurationSeconds(wavAudio),
+                NoSpeechProbability: null);
+        }
+        finally
+        {
+            if (uploadedFile is not null)
+                await DeleteUploadBestEffortAsync(httpClient, baseUrl, apiKey, uploadedFile.Name, log);
+        }
+    }
+
+    internal static string CreateInteractionPayload(
+        string modelId,
+        string fileUri,
+        IReadOnlyList<string> languageHints,
+        IReadOnlyList<string> customVocabulary,
+        GeminiTranscriptionMode mode)
+    {
+        var transcriptionConfig = new Dictionary<string, object?>
+        {
+            ["language_codes"] = languageHints,
+            ["mode"] = mode == GeminiTranscriptionMode.Smart
+                ? "smart"
+                : new Dictionary<string, object?> { ["type"] = "verbatim" },
+        };
+        if (customVocabulary.Count > 0)
+            transcriptionConfig["custom_vocabulary"] = customVocabulary;
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = modelId,
+            ["input"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["type"] = "audio",
+                    ["uri"] = fileUri,
+                    ["mime_type"] = AudioMimeType,
+                }
+            },
+            ["generation_config"] = new Dictionary<string, object?>
+            {
+                ["transcription_config"] = transcriptionConfig,
+            },
+            ["store"] = false,
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    internal static string ParseInteractionText(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+            if (root.TryGetProperty("status", out var statusElement)
+                && statusElement.ValueKind == JsonValueKind.String
+                && statusElement.GetString() is { } status
+                && !status.Equals("completed", StringComparison.OrdinalIgnoreCase))
+            {
+                var failureKind = status.Equals("incomplete", StringComparison.OrdinalIgnoreCase)
+                    ? PluginRequestFailureKind.OutputIncomplete
+                    : PluginRequestFailureKind.ServerError;
+                throw new PluginRequestException(
+                    $"Gemini transcription interaction ended with status '{status}'.",
+                    failureKind);
+            }
+
+            if (!root.TryGetProperty("steps", out var steps)
+                || steps.ValueKind != JsonValueKind.Array)
+            {
+                throw new PluginRequestException(
+                    "Gemini returned a transcription response without output steps.",
+                    PluginRequestFailureKind.EmptyResponse);
+            }
+
+            foreach (var step in steps.EnumerateArray().Reverse())
+            {
+                if (!TryGetString(step, "type", out var type)
+                    || !type.Equals("model_output", StringComparison.OrdinalIgnoreCase)
+                    || !step.TryGetProperty("content", out var content)
+                    || content.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                var parts = content
+                    .EnumerateArray()
+                    .Where(part => TryGetString(part, "type", out var contentType)
+                        && contentType.Equals("text", StringComparison.OrdinalIgnoreCase))
+                    .Select(part => TryGetString(part, "text", out var text) ? text : null)
+                    .Where(text => !string.IsNullOrWhiteSpace(text))
+                    .ToList();
+                if (parts.Count > 0)
+                    return string.Concat(parts).Trim();
+            }
+        }
+        catch (PluginRequestException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw new PluginRequestException(
+                "Gemini returned a malformed transcription response.",
+                PluginRequestFailureKind.EmptyResponse,
+                innerException: ex);
+        }
+
+        throw new PluginRequestException(
+            "Gemini returned an empty transcription.",
+            PluginRequestFailureKind.EmptyResponse);
+    }
+
+    internal static double CalculateWavDurationSeconds(byte[] wavAudio)
+    {
+        if (wavAudio.Length < 12
+            || Encoding.ASCII.GetString(wavAudio, 0, 4) != "RIFF"
+            || Encoding.ASCII.GetString(wavAudio, 8, 4) != "WAVE")
+        {
+            return 0;
+        }
+
+        var byteRate = 0;
+        var dataSize = 0;
+        for (var offset = 12; offset + 8 <= wavAudio.Length;)
+        {
+            var chunkId = Encoding.ASCII.GetString(wavAudio, offset, 4);
+            var chunkSize = BinaryPrimitives.ReadInt32LittleEndian(wavAudio.AsSpan(offset + 4, 4));
+            if (chunkSize < 0)
+                break;
+
+            var dataStart = offset + 8;
+            if (chunkId == "fmt " && chunkSize >= 12 && dataStart + 12 <= wavAudio.Length)
+                byteRate = BinaryPrimitives.ReadInt32LittleEndian(wavAudio.AsSpan(dataStart + 8, 4));
+            else if (chunkId == "data")
+                dataSize = Math.Min(chunkSize, Math.Max(0, wavAudio.Length - dataStart));
+
+            var paddedChunkSize = chunkSize + (chunkSize & 1);
+            if (paddedChunkSize > wavAudio.Length - dataStart)
+                break;
+            offset = dataStart + paddedChunkSize;
+        }
+
+        return byteRate > 0 && dataSize > 0
+            ? dataSize / (double)byteRate
+            : 0;
+    }
+
+    private static async Task<GeminiUploadedFile> UploadAudioAsync(
+        HttpClient httpClient,
+        string baseUrl,
+        string apiKey,
+        byte[] wavAudio,
+        CancellationToken ct)
+    {
+        var uploadBaseUrl = baseUrl.Replace(
+            "/v1beta",
+            "/upload/v1beta",
+            StringComparison.OrdinalIgnoreCase);
+        using var startRequest = GeminiPlugin.CreateNativeRequest(
+            HttpMethod.Post,
+            $"{uploadBaseUrl}/files",
+            apiKey);
+        startRequest.Headers.TryAddWithoutValidation("X-Goog-Upload-Protocol", "resumable");
+        startRequest.Headers.TryAddWithoutValidation("X-Goog-Upload-Command", "start");
+        startRequest.Headers.TryAddWithoutValidation(
+            "X-Goog-Upload-Header-Content-Length",
+            wavAudio.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        startRequest.Headers.TryAddWithoutValidation(
+            "X-Goog-Upload-Header-Content-Type",
+            AudioMimeType);
+        startRequest.Content = new StringContent(
+            """{"file":{"display_name":"typewhisper-audio.wav"}}""",
+            Encoding.UTF8,
+            "application/json");
+
+        using var startResponse = await SendAsync(httpClient, startRequest, ct);
+        if (!startResponse.Headers.TryGetValues("X-Goog-Upload-URL", out var uploadUrls)
+            || uploadUrls.FirstOrDefault() is not { } uploadUrl
+            || string.IsNullOrWhiteSpace(uploadUrl))
+        {
+            throw new PluginRequestException(
+                "Gemini did not return an upload URL.",
+                PluginRequestFailureKind.EmptyResponse);
+        }
+
+        using var uploadRequest = new HttpRequestMessage(HttpMethod.Post, uploadUrl);
+        uploadRequest.Headers.TryAddWithoutValidation("X-Goog-Upload-Offset", "0");
+        uploadRequest.Headers.TryAddWithoutValidation("X-Goog-Upload-Command", "upload, finalize");
+        uploadRequest.Content = new ByteArrayContent(wavAudio);
+        uploadRequest.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(AudioMimeType);
+
+        using var uploadResponse = await SendAsync(httpClient, uploadRequest, ct);
+        var json = await uploadResponse.Content.ReadAsStringAsync(ct);
+        return ParseUploadedFile(json);
+    }
+
+    private static GeminiUploadedFile ParseUploadedFile(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (!document.RootElement.TryGetProperty("file", out var file)
+                || !TryGetString(file, "name", out var name)
+                || !TryGetString(file, "uri", out var uri)
+                || string.IsNullOrWhiteSpace(name)
+                || string.IsNullOrWhiteSpace(uri))
+            {
+                throw new PluginRequestException(
+                    "Gemini returned incomplete uploaded-file metadata.",
+                    PluginRequestFailureKind.EmptyResponse);
+            }
+
+            return new GeminiUploadedFile(name, uri);
+        }
+        catch (PluginRequestException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw new PluginRequestException(
+                "Gemini returned malformed uploaded-file metadata.",
+                PluginRequestFailureKind.EmptyResponse,
+                innerException: ex);
+        }
+    }
+
+    private static async Task DeleteUploadBestEffortAsync(
+        HttpClient httpClient,
+        string baseUrl,
+        string apiKey,
+        string fileName,
+        Action<PluginLogLevel, string>? log)
+    {
+        using var cleanupCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        try
+        {
+            using var request = GeminiPlugin.CreateNativeRequest(
+                HttpMethod.Delete,
+                $"{baseUrl}/{fileName.TrimStart('/')}",
+                apiKey);
+            using var response = await httpClient.SendAsync(request, cleanupCts.Token);
+            if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
+            {
+                log?.Invoke(
+                    PluginLogLevel.Warning,
+                    $"Could not delete Gemini audio upload (HTTP {(int)response.StatusCode}).");
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or InvalidOperationException)
+        {
+            log?.Invoke(
+                PluginLogLevel.Warning,
+                $"Could not delete Gemini audio upload ({ex.GetType().Name}).");
+        }
+    }
+
+    private static async Task<HttpResponseMessage> SendAsync(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        CancellationToken ct)
+    {
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient.SendAsync(request, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            ct.ThrowIfCancellationRequested();
+            throw new PluginRequestException(
+                $"Network error: {ex.Message}",
+                PluginRequestFailureKind.Network,
+                innerException: ex);
+        }
+        catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new PluginRequestException(
+                "Gemini API request timed out.",
+                PluginRequestFailureKind.Timeout,
+                innerException: ex);
+        }
+
+        if (response.IsSuccessStatusCode)
+            return response;
+
+        var statusCode = (int)response.StatusCode;
+        var retryAfter = response.Headers.RetryAfter?.Delta;
+        if (retryAfter is null && response.Headers.RetryAfter?.Date is { } retryAt)
+            retryAfter = retryAt - DateTimeOffset.UtcNow;
+
+        string errorBody;
+        try
+        {
+            errorBody = await response.Content.ReadAsStringAsync(ct);
+        }
+        finally
+        {
+            response.Dispose();
+        }
+
+        var failureKind = statusCode switch
+        {
+            401 => PluginRequestFailureKind.Authentication,
+            403 => PluginRequestFailureKind.Permission,
+            408 => PluginRequestFailureKind.Timeout,
+            413 => PluginRequestFailureKind.RequestTooLarge,
+            429 => PluginRequestFailureKind.RateLimit,
+            >= 500 and <= 599 => PluginRequestFailureKind.ServerError,
+            >= 400 and <= 499 => PluginRequestFailureKind.InvalidRequest,
+            _ => PluginRequestFailureKind.Unknown,
+        };
+        var message = statusCode switch
+        {
+            401 => "Invalid Gemini API key",
+            429 => "Gemini rate limit reached, please wait",
+            _ => $"Gemini API error {statusCode}: {OpenAiApiHelper.ExtractErrorMessage(errorBody)}",
+        };
+        throw new PluginRequestException(message, failureKind, statusCode, retryAfter);
+    }
+
+    private static bool TryGetString(JsonElement element, string propertyName, out string value)
+    {
+        value = "";
+        if (!element.TryGetProperty(propertyName, out var property)
+            || property.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = property.GetString() ?? "";
+        return true;
+    }
+
+    private sealed record GeminiUploadedFile(string Name, string Uri);
+}

--- a/plugins/TypeWhisper.Plugin.Gemini/Localization/de.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/Localization/de.json
@@ -7,10 +7,14 @@
   "Settings.RefreshingModels": "Modelle werden aktualisiert...",
   "Settings.ApiKeyValid": "API-Key gültig!",
   "Settings.ApiKeyInvalid": "Ungültiger API-Key",
-  "Settings.ModelCatalog": "Verfügbare LLM-Modelle",
-  "Settings.DefaultModelsHint": "Die integrierten Gemini-Aliasse werden verwendet. Mit \"Aktualisieren\" werden die für diesen API-Key verfügbaren Gemini- und Gemma-Chatmodelle geladen.",
-  "Settings.ModelsFetched": "Kompatible Gemini- und Gemma-Modelle geladen: {0}.",
-  "Settings.ModelsFetchedHint": "Kompatible Gemini- und Gemma-Modelle aus der API: {0}.",
+  "Settings.ModelCatalog": "Verfügbare Modelle",
+  "Settings.DefaultModelsHint": "Die integrierten Gemini-Modelle für Chat und Transkription werden verwendet. Mit \"Aktualisieren\" werden die für diesen API-Key verfügbaren Modelle geladen.",
+  "Settings.ModelsFetched": "Modelle geladen: {0} Chat, {1} Transkription.",
+  "Settings.ModelsFetchedHint": "Modelle aus der Gemini API: {0} Chat, {1} Transkription. Der Katalog wird nach 24 Stunden automatisch aktualisiert.",
   "Settings.RefreshFailed": "Modelle konnten nicht aktualisiert werden. Die gespeicherte oder integrierte Liste bleibt aktiv.",
+  "Settings.TranscriptionMode": "Transkriptionsstil",
+  "Settings.TranscriptionModeHint": "Smart entfernt Füllwörter, übernimmt gesprochene Korrekturen und formatiert diktierten Text. Wortgetreu erhält die gesprochenen Wörter.",
+  "Settings.ModeSmart": "Smart",
+  "Settings.ModeVerbatim": "Wortgetreu",
   "Settings.Error": "Fehler: {0}"
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/Localization/en.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/Localization/en.json
@@ -7,10 +7,14 @@
   "Settings.RefreshingModels": "Refreshing models...",
   "Settings.ApiKeyValid": "API key valid!",
   "Settings.ApiKeyInvalid": "Invalid API key",
-  "Settings.ModelCatalog": "Available LLM models",
-  "Settings.DefaultModelsHint": "Using the built-in Gemini aliases. Refresh to fetch the Gemini and Gemma chat models available to this API key.",
-  "Settings.ModelsFetched": "Compatible Gemini and Gemma models fetched: {0}.",
-  "Settings.ModelsFetchedHint": "Compatible Gemini and Gemma models loaded from the API: {0}.",
+  "Settings.ModelCatalog": "Available models",
+  "Settings.DefaultModelsHint": "Using the built-in Gemini chat and transcription models. Refresh to fetch the models available to this API key.",
+  "Settings.ModelsFetched": "Models fetched: {0} chat, {1} transcription.",
+  "Settings.ModelsFetchedHint": "Models loaded from the Gemini API: {0} chat, {1} transcription. The catalog refreshes automatically after 24 hours.",
   "Settings.RefreshFailed": "Could not refresh models. Keeping the saved or built-in list.",
+  "Settings.TranscriptionMode": "Transcription style",
+  "Settings.TranscriptionModeHint": "Smart removes filler words, applies spoken corrections, and formats dictated text. Verbatim preserves the words as spoken.",
+  "Settings.ModeSmart": "Smart",
+  "Settings.ModeVerbatim": "Verbatim",
   "Settings.Error": "Error: {0}"
 }

--- a/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
@@ -144,7 +144,7 @@ public sealed class GeminiPluginTests
                     { "name": "models/gemma-4-31b-it", "displayName": "Gemma 4 31B IT" },
                     { "name": "models/gemini-3.7-flash", "displayName": "Duplicate" },
                     { "name": "models/gemini-3.5-transcribe", "baseModelId": "gemini-3.5-transcribe", "displayName": "Gemini 3.5 Transcribe" },
-                    { "name": "models/gemini-3.5-transcribe-live", "baseModelId": "gemini-3.5-transcribe-live", "displayName": "Gemini 3.5 Transcribe Live" },
+                    { "name": "models/gemini-3.5-transcribe-live", "displayName": "Gemini 3.5 Transcribe Live" },
                     { "name": "models/gemini-3.1-flash-image", "displayName": "Nano Banana" },
                     { "name": "models/gemini-embedding-2", "displayName": "Embedding" },
                     { "name": "models/veo-3.1-generate-preview", "displayName": "Veo" }
@@ -213,6 +213,35 @@ public sealed class GeminiPluginTests
         Assert.Equal(
             "gemini-3.5-transcribe-live",
             Assert.Single(catalog.TranscriptionModels).LiveModelId);
+    }
+
+    [Fact]
+    public async Task FetchModelCatalogAsync_StopsWhenPageTokenRepeats()
+    {
+        var requestCount = 0;
+        var handler = new CapturingHandler((_, _) =>
+        {
+            requestCount++;
+            return JsonResponse("""
+                {
+                  "models":[{"name":"models/gemini-3.7-flash"}],
+                  "nextPageToken":"repeated-page"
+                }
+                """);
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var catalog = await sut.FetchModelCatalogAsync();
+
+        Assert.NotNull(catalog);
+        Assert.Equal(2, requestCount);
+        Assert.Contains(host.Logs, entry =>
+            entry.Level == PluginLogLevel.Warning
+            && entry.Message.Contains("repeated page token", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -548,6 +577,39 @@ public sealed class GeminiPluginTests
             collector.ApplyEvent("""
                 {"serverContent":{"inputTranscription":{"text":" Hallo Welt "}}}
                 """).Transcript);
+
+        Assert.False(GeminiStreamingSession.TryApplyEvent(collector, "not json", out _));
+        Assert.True(GeminiStreamingSession.TryApplyEvent(
+            collector,
+            """{"serverContent":{"inputTranscription":{"text":"Still running"}}}""",
+            out var recoveredUpdate));
+        Assert.Equal("Still running", recoveredUpdate.Transcript?.Text);
+    }
+
+    [Fact]
+    public void StreamingSession_IsolatesTranscriptHandlerFailures()
+    {
+        var delivered = 0;
+        Action<StreamingTranscriptEvent> handlers = _ => throw new InvalidOperationException("boom");
+        handlers += _ => delivered++;
+
+        GeminiStreamingSession.NotifyTranscriptHandlers(
+            handlers,
+            new StreamingTranscriptEvent("Hello", false));
+
+        Assert.Equal(1, delivered);
+    }
+
+    [Fact]
+    public void CalculateWavDurationSeconds_RejectsOverflowingChunkSize()
+    {
+        var wav = new byte[20];
+        Encoding.ASCII.GetBytes("RIFF").CopyTo(wav, 0);
+        Encoding.ASCII.GetBytes("WAVE").CopyTo(wav, 8);
+        Encoding.ASCII.GetBytes("JUNK").CopyTo(wav, 12);
+        BitConverter.GetBytes(int.MaxValue).CopyTo(wav, 16);
+
+        Assert.Equal(0, GeminiTranscriptionClient.CalculateWavDurationSeconds(wav));
     }
 
     [Theory]

--- a/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
@@ -579,6 +579,7 @@ public sealed class GeminiPluginTests
                 """).Transcript);
 
         Assert.False(GeminiStreamingSession.TryApplyEvent(collector, "not json", out _));
+        Assert.False(GeminiStreamingSession.TryApplyEvent(collector, "[]", out _));
         Assert.True(GeminiStreamingSession.TryApplyEvent(
             collector,
             """{"serverContent":{"inputTranscription":{"text":"Still running"}}}""",

--- a/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.Gemini/Tests/GeminiPluginTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using TypeWhisper.Plugin.Gemini;
@@ -41,6 +42,40 @@ public sealed class GeminiPluginTests
         Assert.Equal(GeminiPlugin.DefaultModel, Assert.Single(sut.SupportedModels, model => model.IsRecommended).Id);
     }
 
+    [Fact]
+    public void TranscriptionCapability_UsesGeminiTranscribeWithLiveAndDictionarySupport()
+    {
+        using var sut = new GeminiPlugin();
+
+        Assert.IsAssignableFrom<ITranscriptionEnginePlugin>(sut);
+        Assert.Equal(
+            [GeminiPlugin.DefaultTranscriptionModel],
+            sut.TranscriptionModels.Select(model => model.Id).ToArray());
+        Assert.Equal(GeminiPlugin.DefaultTranscriptionModel, sut.SelectedModelId);
+        Assert.True(sut.TranscriptionModels[0].IsRecommended);
+        Assert.True(sut.SupportsStreaming);
+        Assert.True(sut.SupportsDictionaryTerms);
+        Assert.False(sut.SupportsTranslation);
+        Assert.Equal(100, sut.DictionaryTermsBudget.MaxTerms);
+        Assert.Equal(4_000, sut.DictionaryTermsBudget.MaxTotalChars);
+        Assert.True(sut.SupportsStreamingForPrompt(null));
+        Assert.False(sut.SupportsStreamingForPrompt("TypeWhisper"));
+    }
+
+    [Fact]
+    public async Task FetchedTranscriptionCatalog_DoesNotInventUnavailableLiveSibling()
+    {
+        using var sut = new GeminiPlugin();
+
+        await sut.SetFetchedModelCatalogAsync(new GeminiModelCatalog(
+            [],
+            [new("gemini-3.5-transcribe", "Gemini 3.5 Transcribe", LiveModelId: null)],
+            DateTimeOffset.UtcNow));
+
+        Assert.False(sut.SupportsStreaming);
+        Assert.False(sut.SupportsStreamingForPrompt(null));
+    }
+
     [Theory]
     [InlineData("models/gemini-3.7-flash", true)]
     [InlineData("gemini-3.1-pro-preview", true)]
@@ -49,6 +84,8 @@ public sealed class GeminiPluginTests
     [InlineData("gemini-embedding-2", false)]
     [InlineData("gemini-3.1-flash-tts-preview", false)]
     [InlineData("gemini-3.1-flash-live-preview", false)]
+    [InlineData("gemini-3.5-transcribe", false)]
+    [InlineData("gemini-3.5-transcribe-live", false)]
     [InlineData("gemini-omni-flash", false)]
     [InlineData("gemini-omni-flash-preview", false)]
     [InlineData("gemini-robotics-er-2-preview", false)]
@@ -57,6 +94,16 @@ public sealed class GeminiPluginTests
     public void IsCompatibleChatModelId_FiltersCatalog(string modelId, bool expected)
     {
         Assert.Equal(expected, GeminiPlugin.IsCompatibleChatModelId(modelId));
+    }
+
+    [Theory]
+    [InlineData("models/gemini-3.5-transcribe", true)]
+    [InlineData("gemini-3.5-transcribe-preview", true)]
+    [InlineData("gemini-3.5-transcribe-live", false)]
+    [InlineData("gemini-3.7-flash", false)]
+    public void IsCompatibleTranscriptionModelId_FiltersCatalog(string modelId, bool expected)
+    {
+        Assert.Equal(expected, GeminiPlugin.IsCompatibleTranscriptionModelId(modelId));
     }
 
     [Fact]
@@ -82,7 +129,7 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
-    public async Task FetchLlmModelsAsync_UsesCompatibleEndpointAndFiltersSparseResults()
+    public async Task FetchModelCatalogAsync_UsesNativeEndpointAndSeparatesCapabilities()
     {
         HttpRequestMessage? capturedRequest = null;
         var handler = new CapturingHandler((request, _) =>
@@ -90,17 +137,17 @@ public sealed class GeminiPluginTests
             capturedRequest = request;
             return JsonResponse("""
                 {
-                  "object": "list",
-                  "data": [
+                  "models": [
                     null,
-                    { "id": null, "display_name": "Missing ID" },
-                    { "object": "model", "display_name": "No ID" },
-                    { "id": "models/gemini-3.7-flash", "display_name": "Gemini 3.7 Flash" },
-                    { "id": "models/gemma-4-31b-it", "display_name": "Gemma 4 31B IT" },
-                    { "id": "gemini-3.7-flash", "display_name": "Duplicate" },
-                    { "id": "models/gemini-3.1-flash-image", "display_name": "Nano Banana" },
-                    { "id": "models/gemini-embedding-2", "display_name": "Embedding" },
-                    { "id": "models/veo-3.1-generate-preview", "display_name": "Veo" }
+                    { "name": null, "displayName": "Missing ID" },
+                    { "name": "models/gemini-3.7-flash", "baseModelId": "gemini-3.7-flash", "displayName": "Gemini 3.7 Flash" },
+                    { "name": "models/gemma-4-31b-it", "displayName": "Gemma 4 31B IT" },
+                    { "name": "models/gemini-3.7-flash", "displayName": "Duplicate" },
+                    { "name": "models/gemini-3.5-transcribe", "baseModelId": "gemini-3.5-transcribe", "displayName": "Gemini 3.5 Transcribe" },
+                    { "name": "models/gemini-3.5-transcribe-live", "baseModelId": "gemini-3.5-transcribe-live", "displayName": "Gemini 3.5 Transcribe Live" },
+                    { "name": "models/gemini-3.1-flash-image", "displayName": "Nano Banana" },
+                    { "name": "models/gemini-embedding-2", "displayName": "Embedding" },
+                    { "name": "models/veo-3.1-generate-preview", "displayName": "Veo" }
                   ]
                 }
                 """);
@@ -111,20 +158,94 @@ public sealed class GeminiPluginTests
         using var sut = new GeminiPlugin(httpClient);
         await sut.ActivateAsync(host);
 
-        var models = await sut.FetchLlmModelsAsync();
+        var catalog = await sut.FetchModelCatalogAsync();
 
-        Assert.NotNull(models);
+        Assert.NotNull(catalog);
         Assert.Equal(
             ["gemini-3.7-flash", "gemma-4-31b-it"],
-            models!.Select(model => model.Id).ToArray());
-        Assert.Equal("https://generativelanguage.googleapis.com/v1beta/openai/models", capturedRequest?.RequestUri?.ToString());
-        Assert.Equal("Bearer gemini-key", capturedRequest?.Headers.Authorization?.ToString());
+            catalog!.LlmModels.Select(model => model.Id).ToArray());
+        var transcriptionModel = Assert.Single(catalog.TranscriptionModels);
+        Assert.Equal("gemini-3.5-transcribe", transcriptionModel.Id);
+        Assert.Equal("gemini-3.5-transcribe-live", transcriptionModel.LiveModelId);
+        Assert.Equal(
+            "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000",
+            capturedRequest?.RequestUri?.ToString());
+        Assert.Null(capturedRequest?.Headers.Authorization);
+        Assert.Equal(
+            "gemini-key",
+            Assert.Single(capturedRequest!.Headers.GetValues("x-goog-api-key")));
+    }
+
+    [Fact]
+    public async Task FetchModelCatalogAsync_FollowsNativePagination()
+    {
+        var requestedUris = new List<string>();
+        var handler = new CapturingHandler((request, _) =>
+        {
+            var uri = request.RequestUri!.ToString();
+            requestedUris.Add(uri);
+            return uri.Contains("pageToken=second%2Bpage", StringComparison.Ordinal)
+                ? JsonResponse("""
+                    {"models":[{"name":"models/gemini-3.5-transcribe-live"}]}
+                    """)
+                : JsonResponse("""
+                    {
+                      "models":[
+                        {"name":"models/gemini-3.7-flash"},
+                        {"name":"models/gemini-3.5-transcribe"}
+                      ],
+                      "nextPageToken":"second+page"
+                    }
+                    """);
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var catalog = await sut.FetchModelCatalogAsync();
+
+        Assert.NotNull(catalog);
+        Assert.Equal(2, requestedUris.Count);
+        Assert.Contains("pageToken=second%2Bpage", requestedUris[1], StringComparison.Ordinal);
+        Assert.Equal("gemini-3.7-flash", Assert.Single(catalog!.LlmModels).Id);
+        Assert.Equal(
+            "gemini-3.5-transcribe-live",
+            Assert.Single(catalog.TranscriptionModels).LiveModelId);
+    }
+
+    [Fact]
+    public async Task ShouldRefreshModelCatalog_UsesTwentyFourHourTtlAndRequiresBothCapabilities()
+    {
+        var fetchedAt = new DateTimeOffset(2026, 8, 28, 10, 0, 0, TimeSpan.Zero);
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        host.SetSetting("fetchedLlmModels.v2", new List<GeminiFetchedModel>
+        {
+            new("gemini-3.7-flash", "Gemini 3.7 Flash"),
+        });
+        host.SetSetting("fetchedTranscriptionModels.v1", new List<GeminiFetchedTranscriptionModel>
+        {
+            new("gemini-3.5-transcribe", "Gemini 3.5 Transcribe", "gemini-3.5-transcribe-live"),
+        });
+        host.SetSetting("modelCatalogFetchedAtUtc", fetchedAt);
+        using var sut = new GeminiPlugin();
+        await sut.ActivateAsync(host);
+
+        Assert.False(sut.ShouldRefreshModelCatalog(fetchedAt.AddHours(23)));
+        Assert.True(sut.ShouldRefreshModelCatalog(fetchedAt.AddHours(24)));
+
+        host.SetSetting("fetchedTranscriptionModels.v1", new List<GeminiFetchedTranscriptionModel>());
+        using var incompleteCatalog = new GeminiPlugin();
+        await incompleteCatalog.ActivateAsync(host);
+        Assert.True(incompleteCatalog.ShouldRefreshModelCatalog(fetchedAt.AddMinutes(1)));
     }
 
     [Theory]
     [InlineData("{}")]
     [InlineData("null")]
-    public async Task FetchLlmModelsAsync_RejectsCatalogWithoutDataArray(string json)
+    public async Task FetchLlmModelsAsync_RejectsCatalogWithoutModelsArray(string json)
     {
         var handler = new CapturingHandler((_, _) => JsonResponse(json));
         var host = new TestPluginHostServices();
@@ -143,13 +264,13 @@ public sealed class GeminiPluginTests
         Assert.Contains(sut.FetchedLlmModels, model => model.Id == "gemini-3.7-flash");
         Assert.Contains(host.Logs, entry =>
             entry.Level == PluginLogLevel.Warning
-            && entry.Message.Contains("data array", StringComparison.OrdinalIgnoreCase));
+            && entry.Message.Contains("models array", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
     public async Task FetchLlmModelsAsync_AcceptsExplicitEmptyCatalog()
     {
-        var handler = new CapturingHandler((_, _) => JsonResponse("""{"data":[]}"""));
+        var handler = new CapturingHandler((_, _) => JsonResponse("""{"models":[]}"""));
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "gemini-key";
         using var httpClient = new HttpClient(handler);
@@ -189,7 +310,7 @@ public sealed class GeminiPluginTests
     }
 
     [Fact]
-    public async Task SetFetchedLlmModels_DoesNotPersistOrNotifyForUnchangedCatalog()
+    public async Task SetFetchedLlmModels_RefreshesTimestampWithoutNotifyingForUnchangedCatalog()
     {
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "gemini-key";
@@ -197,10 +318,13 @@ public sealed class GeminiPluginTests
         await sut.ActivateAsync(host);
 
         await sut.SetFetchedLlmModelsAsync([new("gemini-3.7-flash", "Gemini 3.7 Flash")]);
+        var firstFetchedAt = sut.ModelCatalogFetchedAt;
+        host.ResetTracking();
         await sut.SetFetchedLlmModelsAsync([new("models/gemini-3.7-flash", "Gemini 3.7 Flash")]);
 
-        Assert.Equal(1, host.SetSettingCount);
-        Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
+        Assert.Equal(3, host.SetSettingCount);
+        Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+        Assert.True(sut.ModelCatalogFetchedAt >= firstFetchedAt);
     }
 
     [Fact]
@@ -223,7 +347,7 @@ public sealed class GeminiPluginTests
             ["gemini-flash-lite-latest", "gemini-flash-latest", "gemini-pro-latest"],
             sut.SupportedModels.Select(model => model.Id).ToArray());
         Assert.Empty(host.GetSetting<List<GeminiFetchedModel>>("fetchedLlmModels.v2")!);
-        Assert.Equal(1, host.SetSettingCount);
+        Assert.Equal(3, host.SetSettingCount);
         Assert.Equal(1, host.NotifyCapabilitiesChangedCount);
     }
 
@@ -289,6 +413,185 @@ public sealed class GeminiPluginTests
         Assert.Empty(sut.FetchedLlmModels);
         Assert.Equal(GeminiPlugin.DefaultModel, sut.SupportedModels[0].Id);
         Assert.Equal(0, host.NotifyCapabilitiesChangedCount);
+    }
+
+    [Fact]
+    public async Task TranscribeWithLanguageHintsAsync_UploadsInteractionAndDeletesTemporaryAudio()
+    {
+        string? interactionBody = null;
+        var requests = new List<(HttpMethod Method, string Uri)>();
+        var handler = new CapturingHandler((request, body) =>
+        {
+            var uri = request.RequestUri!.ToString();
+            requests.Add((request.Method, uri));
+            if (uri.EndsWith("/upload/v1beta/files", StringComparison.Ordinal))
+            {
+                Assert.Equal("gemini-key", Assert.Single(request.Headers.GetValues("x-goog-api-key")));
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+                response.Headers.TryAddWithoutValidation(
+                    "X-Goog-Upload-URL",
+                    "https://upload.example/session-1");
+                return response;
+            }
+
+            if (uri == "https://upload.example/session-1")
+            {
+                Assert.Equal("upload, finalize", Assert.Single(request.Headers.GetValues("X-Goog-Upload-Command")));
+                return JsonResponse("""
+                    {
+                      "file": {
+                        "name": "files/audio-123",
+                        "uri": "https://generativelanguage.googleapis.com/v1beta/files/audio-123"
+                      }
+                    }
+                    """);
+            }
+
+            if (uri.EndsWith("/v1beta/interactions", StringComparison.Ordinal))
+            {
+                interactionBody = body;
+                return JsonResponse("""
+                    {
+                      "status": "completed",
+                      "steps": [{
+                        "type": "model_output",
+                        "content": [
+                          {"type":"text","text":"Hallo "},
+                          {"type":"text","text":"Welt"}
+                        ]
+                      }]
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Delete
+                && uri.EndsWith("/v1beta/files/audio-123", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {uri}");
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "gemini-key";
+        using var httpClient = new HttpClient(handler);
+        using var sut = new GeminiPlugin(httpClient);
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeWithLanguageHintsAsync(
+            CreatePcm16Wav(),
+            [" de ", "auto", "en", "DE"],
+            translate: false,
+            prompt: "TypeWhisper, Gemini",
+            CancellationToken.None);
+
+        Assert.Equal("Hallo Welt", result.Text);
+        Assert.Equal("de", result.DetectedLanguage);
+        Assert.Equal(1, result.DurationSeconds, precision: 3);
+        Assert.Equal(4, requests.Count);
+        Assert.Equal(HttpMethod.Delete, requests[^1].Method);
+
+        using var payload = JsonDocument.Parse(Assert.IsType<string>(interactionBody));
+        var root = payload.RootElement;
+        Assert.Equal("gemini-3.5-transcribe", root.GetProperty("model").GetString());
+        Assert.False(root.GetProperty("store").GetBoolean());
+        Assert.Equal(
+            "https://generativelanguage.googleapis.com/v1beta/files/audio-123",
+            root.GetProperty("input")[0].GetProperty("uri").GetString());
+        var transcriptionConfig = root
+            .GetProperty("generation_config")
+            .GetProperty("transcription_config");
+        Assert.Equal("smart", transcriptionConfig.GetProperty("mode").GetString());
+        Assert.Equal(
+            ["de", "en"],
+            transcriptionConfig.GetProperty("language_codes")
+                .EnumerateArray()
+                .Select(value => value.GetString()!)
+                .ToArray());
+        Assert.Equal(
+            ["TypeWhisper", "Gemini"],
+            transcriptionConfig.GetProperty("custom_vocabulary")
+                .EnumerateArray()
+                .Select(value => value.GetString()!)
+                .ToArray());
+    }
+
+    [Fact]
+    public void StreamingPayloadAndCollector_UseLiveTranscriptionProtocol()
+    {
+        var setupJson = GeminiStreamingSession.CreateSetupPayload(
+            "gemini-3.5-transcribe-live",
+            ["de", "en"],
+            ["TypeWhisper"],
+            GeminiTranscriptionMode.Verbatim);
+        using var setup = JsonDocument.Parse(setupJson);
+        var setupRoot = setup.RootElement.GetProperty("setup");
+        Assert.Equal("models/gemini-3.5-transcribe-live", setupRoot.GetProperty("model").GetString());
+        var transcription = setupRoot.GetProperty("inputAudioTranscription");
+        Assert.Equal("VERBATIM", transcription.GetProperty("mode").GetString());
+        Assert.Equal("TypeWhisper", transcription.GetProperty("customVocabulary")[0].GetString());
+
+        using var audio = JsonDocument.Parse(GeminiStreamingSession.CreateAudioPayload([1, 2, 3, 4]));
+        var audioPart = audio.RootElement.GetProperty("realtimeInput").GetProperty("audio");
+        Assert.Equal("AQIDBA==", audioPart.GetProperty("data").GetString());
+        Assert.Equal("audio/pcm;rate=16000", audioPart.GetProperty("mimeType").GetString());
+
+        var collector = new GeminiStreamingTranscriptCollector();
+        Assert.True(collector.ApplyEvent("""{"setup_complete":{}}""").SetupCompleted);
+        Assert.Equal(
+            new StreamingTranscriptEvent("Hallo", false),
+            collector.ApplyEvent("""
+                {"server_content":{"interim_input_transcription":{"text":" Hallo "}}}
+                """).Transcript);
+        Assert.Equal(
+            new StreamingTranscriptEvent("Hallo Welt", true),
+            collector.ApplyEvent("""
+                {"serverContent":{"inputTranscription":{"text":" Hallo Welt "}}}
+                """).Transcript);
+    }
+
+    [Theory]
+    [InlineData(WebSocketMessageType.Text, true)]
+    [InlineData(WebSocketMessageType.Binary, true)]
+    [InlineData(WebSocketMessageType.Close, false)]
+    public void StreamingSession_AcceptsJsonFromTextAndBinaryFrames(
+        WebSocketMessageType messageType,
+        bool expected)
+    {
+        Assert.Equal(expected, GeminiStreamingSession.IsJsonMessageType(messageType));
+    }
+
+    [Fact]
+    public void InteractionPayload_UsesDocumentedSmartAndVerbatimModeShapes()
+    {
+        using var smart = JsonDocument.Parse(GeminiTranscriptionClient.CreateInteractionPayload(
+            "gemini-3.5-transcribe",
+            "https://example.test/audio",
+            [],
+            [],
+            GeminiTranscriptionMode.Smart));
+        using var verbatim = JsonDocument.Parse(GeminiTranscriptionClient.CreateInteractionPayload(
+            "gemini-3.5-transcribe",
+            "https://example.test/audio",
+            [],
+            [],
+            GeminiTranscriptionMode.Verbatim));
+
+        Assert.Equal(
+            "smart",
+            smart.RootElement
+                .GetProperty("generation_config")
+                .GetProperty("transcription_config")
+                .GetProperty("mode")
+                .GetString());
+        Assert.Equal(
+            "verbatim",
+            verbatim.RootElement
+                .GetProperty("generation_config")
+                .GetProperty("transcription_config")
+                .GetProperty("mode")
+                .GetProperty("type")
+                .GetString());
     }
 
     [Fact]
@@ -537,7 +840,7 @@ public sealed class GeminiPluginTests
     [Fact]
     public async Task FetchLlmModelsAsync_RethrowsCallerCancellation()
     {
-        using var response = JsonResponse("""{"data":[]}""");
+        using var response = JsonResponse("""{"models":[]}""");
         var handler = new BlockingHandler(response);
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "gemini-key";
@@ -561,7 +864,7 @@ public sealed class GeminiPluginTests
     public async Task FetchLlmModelsAsync_DiscardsCatalogWhenApiKeyChangesInFlight()
     {
         var handler = new BlockingHandler(JsonResponse("""
-            {"data":[{"id":"gemini-3.7-flash","display_name":"Gemini 3.7 Flash"}]}
+            {"models":[{"name":"models/gemini-3.7-flash","displayName":"Gemini 3.7 Flash"}]}
             """));
         var host = new TestPluginHostServices();
         host.Secrets["api-key"] = "first-key";
@@ -621,6 +924,31 @@ public sealed class GeminiPluginTests
 
         Assert.Equal(2, host.NotifyCapabilitiesChangedCount);
         Assert.DoesNotContain("api-key", host.Secrets.Keys);
+    }
+
+    private static byte[] CreatePcm16Wav(int sampleRate = 16_000, int sampleCount = 16_000)
+    {
+        const short channelCount = 1;
+        const short bitsPerSample = 16;
+        var dataSize = sampleCount * sizeof(short);
+        using var stream = new MemoryStream(44 + dataSize);
+        using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
+        writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+        writer.Write(36 + dataSize);
+        writer.Write(Encoding.ASCII.GetBytes("WAVE"));
+        writer.Write(Encoding.ASCII.GetBytes("fmt "));
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write(channelCount);
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * channelCount * bitsPerSample / 8);
+        writer.Write((short)(channelCount * bitsPerSample / 8));
+        writer.Write(bitsPerSample);
+        writer.Write(Encoding.ASCII.GetBytes("data"));
+        writer.Write(dataSize);
+        writer.Write(new byte[dataSize]);
+        writer.Flush();
+        return stream.ToArray();
     }
 
     private static HttpResponseMessage JsonResponse(string json) =>

--- a/plugins/TypeWhisper.Plugin.Gemini/manifest.json
+++ b/plugins/TypeWhisper.Plugin.Gemini/manifest.json
@@ -1,15 +1,15 @@
 {
   "id": "com.typewhisper.gemini",
   "name": "Google Gemini",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
-  "description": "Google Gemini and Gemma LLM provider with dynamic model discovery for prompt actions and translation",
+  "description": "Google Gemini transcription and Gemini/Gemma prompt processing with automatic model discovery, smart dictation, and live preview",
   "descriptions": {
-    "de": "Google-Gemini- und Gemma-LLM-Anbieter mit dynamischer Modellerkennung für Prompt-Aktionen und Übersetzungen"
+    "de": "Google-Gemini-Transkription und Gemini-/Gemma-Promptverarbeitung mit automatischer Modellerkennung, Smart-Diktat und Live-Vorschau"
   },
   "category": "llm",
-  "categories": ["llm"],
+  "categories": ["llm", "transcription"],
   "requiresApiKey": true,
   "assemblyName": "TypeWhisper.Plugin.Gemini.dll",
   "pluginClass": "TypeWhisper.Plugin.Gemini.GeminiPlugin"

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
@@ -18,7 +18,7 @@ public sealed class WorkflowProviderReleaseMetadataTests
     public static TheoryData<string, string> Providers => new()
     {
         { "TypeWhisper.Plugin.Claude", "1.0.1" },
-        { "TypeWhisper.Plugin.Gemini", "1.2.1" },
+        { "TypeWhisper.Plugin.Gemini", "1.3.0" },
         { "TypeWhisper.Plugin.GemmaLocal", "1.0.1" },
         { "TypeWhisper.Plugin.Groq", "1.0.6" },
         { "TypeWhisper.Plugin.OpenAi", "1.1.2" },


### PR DESCRIPTION
## Summary

- add Gemini 3.5 Transcribe batch transcription through the Files and Interactions APIs
- add Gemini 3.5 Transcribe Live streaming with interim and final transcript events
- discover Gemini chat and transcription models from the native paginated model catalog and refresh the cached catalog automatically
- add Smart and Verbatim transcription settings, localization, manifest metadata, and release metadata for plugin version 1.3.0

## Validation

- `dotnet build plugins/TypeWhisper.Plugin.Gemini/TypeWhisper.Plugin.Gemini.csproj -c Release -p:PluginVersion=1.3.0 --no-restore`
- Gemini and release metadata tests: 63 passed
- broader plugin-system suite: 2,145 passed; 3 packaging tests could not start locally because `pwsh` is unavailable in the environment
- required Windows dev build and UI smoke test passed
- real Gemini API key validation passed; catalog returned 17 chat models and one transcription model
- real Gemini batch test passed with 6.47 seconds of synthetic WAV audio and the correct final transcript
- real Gemini Live test passed with 5.68 seconds of synthetic PCM16 mono 16 kHz speech, 11 interim events, and one correct final transcript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Gemini transcription with Smart and Verbatim modes, language hints, custom vocabulary, and model selection.
  * Added live streaming transcription with real-time preview support.
  * Added automatic discovery of chat and transcription models with periodic refresh.
  * Added improved API-key validation and transcription settings persistence.
  * Updated Gemini plugin to version 1.3.0.
* **Accessibility & Localization**
  * Improved settings labels, hints, and accessibility metadata.
  * Updated English and German translations for model discovery and transcription modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->