### PR TITLE
Clear unrestorable clipboard before dictation

### DIFF
--- a/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
+++ b/src/TypeWhisper.Windows/Services/WindowsClipboardTransaction.cs
@@ -182,7 +182,7 @@ internal sealed class WindowsClipboardTransaction : IDisposable
         if (enterpriseFormat == 0)
             throw LastClipboardError("Could not register the enterprise clipboard metadata format.");
 
-        var snapshot = CaptureSnapshotCore(enterpriseFormat);
+        var snapshot = CaptureSnapshotOrEmptyCore(enterpriseFormat);
         var clipboardCleared = false;
         try
         {
@@ -214,6 +214,20 @@ internal sealed class WindowsClipboardTransaction : IDisposable
 
             snapshot.Dispose();
             throw;
+        }
+    }
+
+    private WindowsClipboardSnapshot CaptureSnapshotOrEmptyCore(uint enterpriseFormat)
+    {
+        try
+        {
+            return CaptureSnapshotCore(enterpriseFormat);
+        }
+        catch (Exception exception) when (exception is ExternalException or InvalidOperationException)
+        {
+            // If the current clipboard cannot be preserved, prefer clearing it over
+            // blocking dictated text insertion.
+            return new WindowsClipboardSnapshot([]);
         }
     }
 

--- a/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WindowsClipboardTransactionTests.cs
@@ -393,7 +393,7 @@ public sealed class WindowsClipboardTransactionTests
     }
 
     [Fact]
-    public void UnavailableUniqueFormat_AbortsBeforeClearingAndReleasesCapturedHandles()
+    public void UnavailableUniqueFormat_ClearsClipboardAndAllowsTemporaryText()
     {
         lock (ClipboardTestLock)
         {
@@ -409,13 +409,21 @@ public sealed class WindowsClipboardTransactionTests
                     using var owner = SeedUnavailableUniqueFormat();
                     releasedFormats.Clear();
 
-                    Assert.Throws<COMException>(() =>
-                        transaction.BeginTemporaryTextAsync("dictated", CancellationToken.None)
-                            .GetAwaiter()
-                            .GetResult());
+                    using var lease = transaction.BeginTemporaryTextAsync(
+                            "dictated",
+                            CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
 
-                    Assert.Equal("previous", Clipboard.GetText());
+                    Assert.Equal("dictated", Clipboard.GetText());
                     Assert.NotEmpty(releasedFormats);
+
+                    var result = transaction.RestoreAsync(lease, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Assert.Equal(ClipboardRestoreResult.Restored, result);
+                    Assert.Empty(EnumerateClipboardFormats());
                 }
                 finally
                 {


### PR DESCRIPTION
## Summary
- fall back to an empty clipboard snapshot when existing clipboard formats cannot be materialized
- continue dictated text insertion instead of surfacing a clipboard preservation error
- cover the fallback and clipboard clearing behavior with a regression test

## Testing
- `dotnet test tests\TypeWhisper.PluginSystem.Tests\TypeWhisper.PluginSystem.Tests.csproj --filter "FullyQualifiedName~WindowsClipboardTransactionTests"`

Fixes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary text insertion now proceeds even when existing clipboard contents cannot be captured.
  * Clipboard operations complete successfully when clipboard formats are unavailable.
  * Clipboard resources are released correctly, and the clipboard is restored after temporary text use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->