### PR TITLE
Prepare whisper.cpp plugin v1.0.3 release

### DIFF
--- a/plugins/TypeWhisper.Plugin.WhisperCpp/manifest.json
+++ b/plugins/TypeWhisper.Plugin.WhisperCpp/manifest.json
@@ -2,6 +2,7 @@
   "id": "com.typewhisper.whisper-cpp",
   "name": "whisper.cpp (Local)",
   "version": "1.0.3",
+  "minHostVersion": "1.0.7",
   "author": "TypeWhisper",
   "description": "Offline transcription via whisper.cpp using Whisper.net",
   "category": "transcription",

--- a/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WhisperCppPluginTests.cs
@@ -37,6 +37,7 @@ public class WhisperCppPluginTests
 
         Assert.NotNull(manifest);
         Assert.Equal("1.0.3", manifest.Version);
+        Assert.Equal("1.0.7", manifest.MinHostVersion);
         Assert.Equal(manifest.Version, sut.PluginVersion);
     }
 


### PR DESCRIPTION
## Summary

- require TypeWhisper 1.0.7 or newer for whisper.cpp plugin v1.0.3
- lock the minimum host version in the plugin manifest regression test
- prevent the registry from offering the diagnostics-enabled plugin to hosts that predate the required Plugin SDK APIs

Refs #234.

## Validation

- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Debug --filter "FullyQualifiedName=TypeWhisper.PluginSystem.Tests.WhisperCppPluginTests.PluginVersion_MatchesManifestVersion"`
- Release configuration reached the existing local ARM64 MSVC redistributable check and could not complete because this machine lacks the ARM64 redistributable files; GitHub's Windows release runner performs the authoritative release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * The WhisperCpp plugin now requires host version 1.0.7 or later.
* **Tests**
  * Added verification that the plugin declares the correct minimum host version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->