### PR TITLE
Add Explorer and Share Sheet transcription entry points

### DIFF
--- a/src/TypeWhisper.Windows.StorePackage/Package.appxmanifest.template
+++ b/src/TypeWhisper.Windows.StorePackage/Package.appxmanifest.template
@@ -2,9 +2,11 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
   xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap uap5 rescap">
+  IgnorableNamespaces="uap uap2 uap3 uap5 rescap">
 
   <Identity
     Name="TypeWhisper.TypeWhisper"
@@ -60,6 +62,52 @@
         </uap5:Extension>
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="typewhisper" />
+        </uap:Extension>
+        <uap3:Extension Category="windows.fileTypeAssociation">
+          <uap3:FileTypeAssociation
+            Name="typewhisper-media"
+            Parameters="--transcribe-file &quot;%1&quot;"
+            MultiSelectModel="Player">
+            <uap:SupportedFileTypes>
+              <uap:FileType>.wav</uap:FileType>
+              <uap:FileType>.mp3</uap:FileType>
+              <uap:FileType>.m4a</uap:FileType>
+              <uap:FileType>.aac</uap:FileType>
+              <uap:FileType>.ogg</uap:FileType>
+              <uap:FileType>.flac</uap:FileType>
+              <uap:FileType>.wma</uap:FileType>
+              <uap:FileType>.mp4</uap:FileType>
+              <uap:FileType>.mkv</uap:FileType>
+              <uap:FileType>.avi</uap:FileType>
+              <uap:FileType>.mov</uap:FileType>
+              <uap:FileType>.webm</uap:FileType>
+            </uap:SupportedFileTypes>
+            <uap2:SupportedVerbs>
+              <uap3:Verb
+                Id="transcribe"
+                Parameters="--transcribe-file &quot;%1&quot;"
+                MultiSelectModel="Player">Transcribe with TypeWhisper</uap3:Verb>
+            </uap2:SupportedVerbs>
+          </uap3:FileTypeAssociation>
+        </uap3:Extension>
+        <uap:Extension Category="windows.shareTarget">
+          <uap:ShareTarget Description="Transcribe audio and video with TypeWhisper">
+            <uap:SupportedFileTypes>
+              <uap:FileType>.wav</uap:FileType>
+              <uap:FileType>.mp3</uap:FileType>
+              <uap:FileType>.m4a</uap:FileType>
+              <uap:FileType>.aac</uap:FileType>
+              <uap:FileType>.ogg</uap:FileType>
+              <uap:FileType>.flac</uap:FileType>
+              <uap:FileType>.wma</uap:FileType>
+              <uap:FileType>.mp4</uap:FileType>
+              <uap:FileType>.mkv</uap:FileType>
+              <uap:FileType>.avi</uap:FileType>
+              <uap:FileType>.mov</uap:FileType>
+              <uap:FileType>.webm</uap:FileType>
+            </uap:SupportedFileTypes>
+            <uap:DataFormat>StorageItems</uap:DataFormat>
+          </uap:ShareTarget>
         </uap:Extension>
       </Extensions>
     </Application>

--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -133,6 +133,10 @@ public partial class App : Application
         // Initialize localization
         Loc.Instance.CurrentLanguage = settings.Current.UiLanguage
             ?? Loc.Instance.DetectSystemLanguage();
+#if !TYPEWHISPER_STORE
+        ShellTranscriptionService.EnsureContextMenuRegistration(
+            Loc.Instance["Shell.TranscribeWithTypeWhisper"]);
+#endif
 
         // Configure feedback before the overlay graph is created.
         var soundService = _serviceProvider.GetRequiredService<SoundService>();
@@ -280,14 +284,16 @@ public partial class App : Application
                     : WelcomeCompletionRequest.None;
                 settings.Save(settings.Current with { HasCompletedOnboarding = true });
                 _welcomeWindow = null;
-                if (completionRequest.SettingsRoute is { } route)
+                if (ShellTranscriptionService.HasPendingRequests())
+                    ActivatePrimaryInstance();
+                else if (completionRequest.SettingsRoute is { } route)
                     ShowSettingsWindow(route, focusPluginId: completionRequest.PluginIdToConfigure);
             };
             _welcomeWindow.Show();
         }
 
         _startupPresentationReady = true;
-        if (_pendingSingleInstanceActivation)
+        if (_pendingSingleInstanceActivation || ShellTranscriptionService.HasPendingRequests())
         {
             _pendingSingleInstanceActivation = false;
             ActivatePrimaryInstance();
@@ -500,6 +506,15 @@ public partial class App : Application
         if (_welcomeWindow is { IsLoaded: true })
         {
             RestoreAndActivateWindow(_welcomeWindow);
+            return;
+        }
+
+        var shellTranscriptionPaths = ShellTranscriptionService.Drain();
+        if (shellTranscriptionPaths.Count > 0)
+        {
+            ShowSettingsWindow(SettingsRoute.FileTranscription);
+            _serviceProvider!.GetRequiredService<FileTranscriptionViewModel>()
+                .AddFilesCommand.Execute(shellTranscriptionPaths);
             return;
         }
 

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -73,9 +73,11 @@ public static class Program
 #if TYPEWHISPER_STORE
         try
         {
-            isStartupActivation = AppInstance.GetActivatedEventArgs()?.Kind == ActivationKind.StartupTask;
+            var activationArgs = AppInstance.GetActivatedEventArgs();
+            isStartupActivation = activationArgs?.Kind == ActivationKind.StartupTask;
+            StoreShareTargetService.TryQueueSharedFiles(activationArgs);
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is InvalidOperationException or System.Runtime.InteropServices.COMException)
         {
             Debug.WriteLine($"Store activation detection failed: {ex.Message}");
         }
@@ -88,6 +90,7 @@ public static class Program
                 .OnBeforeUninstallFastCallback((v) =>
                 {
                     UninstallUserDataProtector.ProtectLegacyAudioDirectory();
+                    ShellTranscriptionService.RemoveContextMenuRegistration();
                 })
                 .OnAfterUpdateFastCallback((v) =>
                 {
@@ -101,6 +104,7 @@ public static class Program
         StartMinimized = isStartupActivation
             || args.Contains("--minimized", StringComparer.OrdinalIgnoreCase);
         var callbackArg = args.FirstOrDefault(SupporterDiscordService.CanHandleCallbackUri);
+        var shellTranscriptionPaths = ShellTranscriptionService.ParseFilePaths(args);
 
         // Single instance check
         var synchronizationSuffix = UiAutomation.IsEnabled ? $"-UiAutomation-{UiAutomation.InstanceId}" : string.Empty;
@@ -114,6 +118,9 @@ public static class Program
         {
             try
             {
+                if (shellTranscriptionPaths.Count > 0)
+                    ShellTranscriptionService.Enqueue(shellTranscriptionPaths);
+
                 if (!string.IsNullOrWhiteSpace(callbackArg))
                 {
                     Directory.CreateDirectory(TypeWhisperEnvironment.DataPath);
@@ -137,6 +144,8 @@ public static class Program
         }
 
         _singleInstanceActivationSignal = activationSignal;
+        if (shellTranscriptionPaths.Count > 0)
+            ShellTranscriptionService.Enqueue(shellTranscriptionPaths);
 
         try
         {

--- a/src/TypeWhisper.Windows/Resources/Localization/de.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/de.json
@@ -7,6 +7,7 @@
   "Nav.Recording": "Aufnahme",
   "Nav.Shortcuts": "Tastenkürzel",
   "Nav.FileTranscription": "Datei-Transkription",
+  "Shell.TranscribeWithTypeWhisper": "Mit TypeWhisper transkribieren",
   "Nav.Recovery": "Wiederherstellung",
   "Page.RecoverySubtitle": "Fehlgeschlagene Diktate wiederherstellen und robuste Transkriptions- und Workflow-Anfragen konfigurieren.",
   "Tray.RecoverLastRecording": "Letzte Aufnahme wiederherstellen",

--- a/src/TypeWhisper.Windows/Resources/Localization/en.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/en.json
@@ -7,6 +7,7 @@
   "Nav.Recording": "Recording",
   "Nav.Shortcuts": "Shortcuts",
   "Nav.FileTranscription": "File transcription",
+  "Shell.TranscribeWithTypeWhisper": "Transcribe with TypeWhisper",
   "Nav.Recovery": "Recovery",
   "Page.RecoverySubtitle": "Recover failed dictations and configure resilient transcription and workflow requests.",
   "Tray.RecoverLastRecording": "Recover last recording",

--- a/src/TypeWhisper.Windows/Resources/Localization/ja.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ja.json
@@ -7,6 +7,7 @@
   "Nav.Recording": "録音",
   "Nav.Shortcuts": "ショートカット",
   "Nav.FileTranscription": "ファイル文字起こし",
+  "Shell.TranscribeWithTypeWhisper": "TypeWhisper で文字起こし",
   "Nav.Recovery": "復旧",
   "Page.RecoverySubtitle": "失敗した音声入力を復旧し、文字起こしとワークフロー要求の回復性を設定します。",
   "Tray.RecoverLastRecording": "直前の録音を復旧",

--- a/src/TypeWhisper.Windows/Resources/Localization/ru.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/ru.json
@@ -7,6 +7,7 @@
   "Nav.Recording": "Запись",
   "Nav.Shortcuts": "Горячие клавиши",
   "Nav.FileTranscription": "Транскрипция файлов",
+  "Shell.TranscribeWithTypeWhisper": "Транскрибировать с помощью TypeWhisper",
   "Nav.Recovery": "Восстановление",
   "Page.RecoverySubtitle": "Восстановление неудачных диктовок и настройка устойчивых запросов транскрипции и рабочих процессов.",
   "Tray.RecoverLastRecording": "Восстановить последнюю запись",

--- a/src/TypeWhisper.Windows/Resources/Localization/zh-Hans.json
+++ b/src/TypeWhisper.Windows/Resources/Localization/zh-Hans.json
@@ -7,6 +7,7 @@
   "Nav.Recording": "录音",
   "Nav.Shortcuts": "快捷键",
   "Nav.FileTranscription": "文件转写",
+  "Shell.TranscribeWithTypeWhisper": "使用 TypeWhisper 转录",
   "Nav.Recovery": "恢复",
   "Page.RecoverySubtitle": "恢复失败的听写，并配置更可靠的转写和工作流请求。",
   "Tray.RecoverLastRecording": "恢复上次录音",

--- a/src/TypeWhisper.Windows/Services/AudioFileService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioFileService.cs
@@ -18,6 +18,8 @@ public sealed class AudioFileService
         ".mp4", ".mkv", ".avi", ".mov", ".webm"
     };
 
+    internal static IReadOnlyCollection<string> SupportedFileExtensions => SupportedExtensions;
+
     /// <summary>
     /// Returns whether supported.
     /// </summary>

--- a/src/TypeWhisper.Windows/Services/ShellTranscriptionService.cs
+++ b/src/TypeWhisper.Windows/Services/ShellTranscriptionService.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Win32;
+using TypeWhisper.Core;
+
+namespace TypeWhisper.Windows.Services;
+
+/// <summary>
+/// Registers the Explorer transcription verb and transfers shell activations
+/// to the primary TypeWhisper instance.
+/// </summary>
+internal static class ShellTranscriptionService
+{
+    internal const string CommandLineSwitch = "--transcribe-file";
+    private const string VerbName = "TypeWhisper.Transcribe";
+    private const string RequestDirectoryName = "shell-transcription-requests";
+
+    internal static IReadOnlyList<string> ParseFilePaths(IReadOnlyList<string> args)
+    {
+        var paths = new List<string>();
+        for (var index = 0; index < args.Count; index++)
+        {
+            if (!string.Equals(args[index], CommandLineSwitch, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            for (index++; index < args.Count && !args[index].StartsWith("--", StringComparison.Ordinal); index++)
+            {
+                var path = args[index];
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                try
+                {
+                    paths.Add(Path.GetFullPath(path));
+                }
+                catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+                {
+                    Debug.WriteLine($"Ignored invalid shell transcription path: {ex.Message}");
+                }
+            }
+
+            index--;
+        }
+
+        return paths.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    internal static bool Enqueue(IReadOnlyCollection<string> paths, string? requestDirectory = null)
+    {
+        var normalizedPaths = paths
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (normalizedPaths.Length == 0)
+            return false;
+
+        try
+        {
+            var directory = requestDirectory ?? GetRequestDirectory();
+            Directory.CreateDirectory(directory);
+            var requestName = $"{DateTime.UtcNow:yyyyMMddHHmmssfffffff}-{Guid.NewGuid():N}";
+            var temporaryPath = Path.Combine(directory, $"{requestName}.tmp");
+            var requestPath = Path.Combine(directory, $"{requestName}.json");
+            File.WriteAllText(temporaryPath, JsonSerializer.Serialize(normalizedPaths));
+            File.Move(temporaryPath, requestPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            Debug.WriteLine($"Could not queue shell transcription request: {ex.Message}");
+            return false;
+        }
+    }
+
+    internal static IReadOnlyList<string> Drain(string? requestDirectory = null)
+    {
+        var directory = requestDirectory ?? GetRequestDirectory();
+        if (!Directory.Exists(directory))
+            return [];
+
+        string[] requestFiles;
+        try
+        {
+            requestFiles = Directory.EnumerateFiles(directory, "*.json")
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Debug.WriteLine($"Could not enumerate shell transcription requests: {ex.Message}");
+            return [];
+        }
+
+        var paths = new List<string>();
+        foreach (var requestFile in requestFiles)
+        {
+            try
+            {
+                var requestPaths = JsonSerializer.Deserialize<string[]>(File.ReadAllText(requestFile));
+                if (requestPaths is not null)
+                    paths.AddRange(requestPaths.Where(path => !string.IsNullOrWhiteSpace(path)));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+            {
+                Debug.WriteLine($"Could not read shell transcription request: {ex.Message}");
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(requestFile);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    Debug.WriteLine($"Could not remove shell transcription request: {ex.Message}");
+                }
+            }
+        }
+
+        return paths.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    internal static bool HasPendingRequests(string? requestDirectory = null)
+    {
+        try
+        {
+            var directory = requestDirectory ?? GetRequestDirectory();
+            return Directory.Exists(directory) && Directory.EnumerateFiles(directory, "*.json").Any();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Debug.WriteLine($"Could not inspect shell transcription requests: {ex.Message}");
+            return false;
+        }
+    }
+
+    internal static void EnsureContextMenuRegistration(string displayName)
+    {
+        var executablePath = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(executablePath) || string.IsNullOrWhiteSpace(displayName))
+            return;
+
+        try
+        {
+            foreach (var extension in AudioFileService.SupportedFileExtensions)
+            {
+                using var verbKey = Registry.CurrentUser.CreateSubKey(GetVerbRegistryPath(extension), writable: true);
+                if (verbKey is null)
+                    continue;
+
+                verbKey.SetValue(string.Empty, displayName);
+                verbKey.SetValue("Icon", $"\"{executablePath}\",0");
+                verbKey.SetValue("MultiSelectModel", "Player");
+
+                using var commandKey = verbKey.CreateSubKey("command", writable: true);
+                commandKey?.SetValue(string.Empty, BuildCommand(executablePath));
+            }
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException or IOException)
+        {
+            Debug.WriteLine($"Explorer context menu registration failed: {ex.Message}");
+        }
+    }
+
+    internal static void RemoveContextMenuRegistration()
+    {
+        try
+        {
+            foreach (var extension in AudioFileService.SupportedFileExtensions)
+                Registry.CurrentUser.DeleteSubKeyTree(GetVerbRegistryPath(extension), throwOnMissingSubKey: false);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException or IOException)
+        {
+            Debug.WriteLine($"Explorer context menu cleanup failed: {ex.Message}");
+        }
+    }
+
+    internal static string BuildCommand(string executablePath) =>
+        $"\"{executablePath}\" {CommandLineSwitch} \"%1\"";
+
+    private static string GetRequestDirectory() =>
+        Path.Combine(TypeWhisperEnvironment.DataPath, RequestDirectoryName);
+
+    private static string GetVerbRegistryPath(string extension) =>
+        $@"Software\Classes\SystemFileAssociations\{extension}\shell\{VerbName}";
+}

--- a/src/TypeWhisper.Windows/Services/ShellTranscriptionService.cs
+++ b/src/TypeWhisper.Windows/Services/ShellTranscriptionService.cs
@@ -24,9 +24,10 @@ internal static class ShellTranscriptionService
             if (!string.Equals(args[index], CommandLineSwitch, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            for (index++; index < args.Count && !args[index].StartsWith("--", StringComparison.Ordinal); index++)
+            var pathIndex = index + 1;
+            for (; pathIndex < args.Count && !args[pathIndex].StartsWith("--", StringComparison.Ordinal); pathIndex++)
             {
-                var path = args[index];
+                var path = args[pathIndex];
                 if (string.IsNullOrWhiteSpace(path))
                     continue;
 
@@ -40,7 +41,7 @@ internal static class ShellTranscriptionService
                 }
             }
 
-            index--;
+            index = pathIndex - 1;
         }
 
         return paths.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
@@ -60,8 +61,8 @@ internal static class ShellTranscriptionService
             var directory = requestDirectory ?? GetRequestDirectory();
             Directory.CreateDirectory(directory);
             var requestName = $"{DateTime.UtcNow:yyyyMMddHHmmssfffffff}-{Guid.NewGuid():N}";
-            var temporaryPath = Path.Combine(directory, $"{requestName}.tmp");
-            var requestPath = Path.Combine(directory, $"{requestName}.json");
+            var temporaryPath = Path.Join(directory, $"{requestName}.tmp");
+            var requestPath = Path.Join(directory, $"{requestName}.json");
             File.WriteAllText(temporaryPath, JsonSerializer.Serialize(normalizedPaths));
             File.Move(temporaryPath, requestPath);
             return true;
@@ -180,7 +181,7 @@ internal static class ShellTranscriptionService
         $"\"{executablePath}\" {CommandLineSwitch} \"%1\"";
 
     private static string GetRequestDirectory() =>
-        Path.Combine(TypeWhisperEnvironment.DataPath, RequestDirectoryName);
+        Path.Join(TypeWhisperEnvironment.DataPath, RequestDirectoryName);
 
     private static string GetVerbRegistryPath(string extension) =>
         $@"Software\Classes\SystemFileAssociations\{extension}\shell\{VerbName}";

--- a/src/TypeWhisper.Windows/Services/StoreShareTargetService.cs
+++ b/src/TypeWhisper.Windows/Services/StoreShareTargetService.cs
@@ -1,0 +1,75 @@
+#if TYPEWHISPER_STORE
+using System.Diagnostics;
+using Windows.ApplicationModel.Activation;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+
+namespace TypeWhisper.Windows.Services;
+
+/// <summary>
+/// Receives Store package share-target activations and forwards shared media
+/// files to the normal shell transcription inbox.
+/// </summary>
+internal static class StoreShareTargetService
+{
+    internal static bool TryQueueSharedFiles(IActivatedEventArgs? activationArgs)
+    {
+        if (activationArgs is not ShareTargetActivatedEventArgs shareTargetArgs)
+            return false;
+
+        var shareOperation = shareTargetArgs.ShareOperation;
+        shareOperation.ReportStarted();
+
+        try
+        {
+            if (!shareOperation.Data.Contains(StandardDataFormats.StorageItems))
+            {
+                shareOperation.ReportError("TypeWhisper did not receive any files to transcribe.");
+                return true;
+            }
+
+            var sharedItems = shareOperation.Data.GetStorageItemsAsync()
+                .AsTask()
+                .GetAwaiter()
+                .GetResult();
+            shareOperation.ReportDataRetrieved();
+
+            var paths = sharedItems
+                .Where(item => item.IsOfType(StorageItemTypes.File))
+                .Select(item => item.Path)
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (paths.Length == 0)
+            {
+                shareOperation.ReportError(
+                    "TypeWhisper can only transcribe files that are available on this device.");
+                return true;
+            }
+
+            if (!ShellTranscriptionService.Enqueue(paths))
+            {
+                shareOperation.ReportError("TypeWhisper could not queue the shared files.");
+                return true;
+            }
+
+            shareOperation.ReportCompleted();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Share target activation failed: {ex}");
+            try
+            {
+                shareOperation.ReportError("TypeWhisper could not receive the shared files.");
+            }
+            catch (Exception reportException)
+            {
+                Debug.WriteLine($"Share target error reporting failed: {reportException.Message}");
+            }
+        }
+
+        return true;
+    }
+}
+#endif

--- a/tests/TypeWhisper.PluginSystem.Tests/ShellTranscriptionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ShellTranscriptionServiceTests.cs
@@ -9,8 +9,8 @@ public sealed class ShellTranscriptionServiceTests
     [Fact]
     public void ParseFilePaths_ReadsAndDeduplicatesPathsFollowingTheShellSwitch()
     {
-        var first = Path.Combine(Path.GetTempPath(), "TypeWhisper shell test", "first clip.webm");
-        var second = Path.Combine(Path.GetTempPath(), "TypeWhisper shell test", "second.mp3");
+        var first = Path.Join(Path.GetTempPath(), "TypeWhisper shell test", "first clip.webm");
+        var second = Path.Join(Path.GetTempPath(), "TypeWhisper shell test", "second.mp3");
 
         var paths = ShellTranscriptionService.ParseFilePaths([
             "--minimized",
@@ -25,20 +25,26 @@ public sealed class ShellTranscriptionServiceTests
     }
 
     [Fact]
-    public void RequestInbox_PreservesConcurrentRequestsUntilTheyAreDrained()
+    public async Task RequestInbox_PreservesConcurrentRequestsUntilTheyAreDrained()
     {
         var requestDirectory = CreateTemporaryDirectory();
         try
         {
-            Assert.True(ShellTranscriptionService.Enqueue([@"C:\media\first.webm"], requestDirectory));
-            Assert.True(ShellTranscriptionService.Enqueue(
-                [@"C:\media\second.mp3", @"C:\media\first.webm"],
-                requestDirectory));
+            var results = await Task.WhenAll(
+                Task.Run(() => ShellTranscriptionService.Enqueue([@"C:\media\first.webm"], requestDirectory)),
+                Task.Run(() => ShellTranscriptionService.Enqueue(
+                    [@"C:\media\second.mp3", @"C:\media\first.webm"],
+                    requestDirectory)));
+
+            Assert.All(results, result => Assert.True(result));
             Assert.True(ShellTranscriptionService.HasPendingRequests(requestDirectory));
 
             var paths = ShellTranscriptionService.Drain(requestDirectory);
+            string[] expectedPaths = [@"C:\media\first.webm", @"C:\media\second.mp3"];
 
-            Assert.Equal([@"C:\media\first.webm", @"C:\media\second.mp3"], paths);
+            Assert.Equal(
+                expectedPaths.Order(StringComparer.OrdinalIgnoreCase),
+                paths.Order(StringComparer.OrdinalIgnoreCase));
             Assert.False(ShellTranscriptionService.HasPendingRequests(requestDirectory));
         }
         finally
@@ -53,7 +59,7 @@ public sealed class ShellTranscriptionServiceTests
         var requestDirectory = CreateTemporaryDirectory();
         try
         {
-            File.WriteAllText(Path.Combine(requestDirectory, "000-invalid.json"), "not json");
+            File.WriteAllText(Path.Join(requestDirectory, "000-invalid.json"), "not json");
             Assert.True(ShellTranscriptionService.Enqueue([@"C:\media\clip.wav"], requestDirectory));
 
             Assert.Equal([@"C:\media\clip.wav"], ShellTranscriptionService.Drain(requestDirectory));
@@ -127,7 +133,7 @@ public sealed class ShellTranscriptionServiceTests
 
     private static string CreateTemporaryDirectory()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"TypeWhisper-shell-{Guid.NewGuid():N}");
+        var path = Path.Join(Path.GetTempPath(), $"TypeWhisper-shell-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
     }

--- a/tests/TypeWhisper.PluginSystem.Tests/ShellTranscriptionServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ShellTranscriptionServiceTests.cs
@@ -1,0 +1,134 @@
+using System.IO;
+using System.Xml.Linq;
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class ShellTranscriptionServiceTests
+{
+    [Fact]
+    public void ParseFilePaths_ReadsAndDeduplicatesPathsFollowingTheShellSwitch()
+    {
+        var first = Path.Combine(Path.GetTempPath(), "TypeWhisper shell test", "first clip.webm");
+        var second = Path.Combine(Path.GetTempPath(), "TypeWhisper shell test", "second.mp3");
+
+        var paths = ShellTranscriptionService.ParseFilePaths([
+            "--minimized",
+            ShellTranscriptionService.CommandLineSwitch,
+            first,
+            second,
+            first,
+            "--another-option"
+        ]);
+
+        Assert.Equal([Path.GetFullPath(first), Path.GetFullPath(second)], paths);
+    }
+
+    [Fact]
+    public void RequestInbox_PreservesConcurrentRequestsUntilTheyAreDrained()
+    {
+        var requestDirectory = CreateTemporaryDirectory();
+        try
+        {
+            Assert.True(ShellTranscriptionService.Enqueue([@"C:\media\first.webm"], requestDirectory));
+            Assert.True(ShellTranscriptionService.Enqueue(
+                [@"C:\media\second.mp3", @"C:\media\first.webm"],
+                requestDirectory));
+            Assert.True(ShellTranscriptionService.HasPendingRequests(requestDirectory));
+
+            var paths = ShellTranscriptionService.Drain(requestDirectory);
+
+            Assert.Equal([@"C:\media\first.webm", @"C:\media\second.mp3"], paths);
+            Assert.False(ShellTranscriptionService.HasPendingRequests(requestDirectory));
+        }
+        finally
+        {
+            Directory.Delete(requestDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RequestInbox_DiscardsMalformedRequestsWithoutBlockingValidOnes()
+    {
+        var requestDirectory = CreateTemporaryDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(requestDirectory, "000-invalid.json"), "not json");
+            Assert.True(ShellTranscriptionService.Enqueue([@"C:\media\clip.wav"], requestDirectory));
+
+            Assert.Equal([@"C:\media\clip.wav"], ShellTranscriptionService.Drain(requestDirectory));
+            Assert.Empty(Directory.EnumerateFiles(requestDirectory, "*.json"));
+        }
+        finally
+        {
+            Directory.Delete(requestDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExplorerCommand_QuotesTheExecutableAndSelectedFile()
+    {
+        Assert.Equal(
+            "\"C:\\Program Files\\TypeWhisper\\TypeWhisper.exe\" --transcribe-file \"%1\"",
+            ShellTranscriptionService.BuildCommand(@"C:\Program Files\TypeWhisper\TypeWhisper.exe"));
+    }
+
+    [Fact]
+    public void StoreManifest_RegistersTheTranscriptionVerbForEverySupportedMediaType()
+    {
+        var manifestPath = TestFile.ProjectFile(
+            "src",
+            "TypeWhisper.Windows.StorePackage",
+            "Package.appxmanifest.template");
+        var document = XDocument.Load(manifestPath);
+        XNamespace uap = "http://schemas.microsoft.com/appx/manifest/uap/windows10";
+        XNamespace uap2 = "http://schemas.microsoft.com/appx/manifest/uap/windows10/2";
+        XNamespace uap3 = "http://schemas.microsoft.com/appx/manifest/uap/windows10/3";
+
+        var association = Assert.Single(document.Descendants(uap3 + "FileTypeAssociation"));
+        Assert.Equal("--transcribe-file \"%1\"", (string?)association.Attribute("Parameters"));
+        Assert.Equal("Player", (string?)association.Attribute("MultiSelectModel"));
+        Assert.Equal(
+            AudioFileService.SupportedFileExtensions.Order(StringComparer.OrdinalIgnoreCase),
+            association.Descendants(uap + "FileType")
+                .Select(element => element.Value)
+                .Order(StringComparer.OrdinalIgnoreCase));
+
+        var verb = Assert.Single(association.Descendants(uap2 + "SupportedVerbs").Elements(uap3 + "Verb"));
+        Assert.Equal("transcribe", (string?)verb.Attribute("Id"));
+        Assert.Equal("--transcribe-file \"%1\"", (string?)verb.Attribute("Parameters"));
+        Assert.Equal("Player", (string?)verb.Attribute("MultiSelectModel"));
+        Assert.Equal("Transcribe with TypeWhisper", verb.Value);
+    }
+
+    [Fact]
+    public void StoreManifest_RegistersShareTargetForEverySupportedMediaType()
+    {
+        var manifestPath = TestFile.ProjectFile(
+            "src",
+            "TypeWhisper.Windows.StorePackage",
+            "Package.appxmanifest.template");
+        var document = XDocument.Load(manifestPath);
+        XNamespace uap = "http://schemas.microsoft.com/appx/manifest/uap/windows10";
+
+        var extension = Assert.Single(
+            document.Descendants(uap + "Extension"),
+            element => (string?)element.Attribute("Category") == "windows.shareTarget");
+        var shareTarget = Assert.Single(extension.Elements(uap + "ShareTarget"));
+
+        Assert.Equal("Transcribe audio and video with TypeWhisper", (string?)shareTarget.Attribute("Description"));
+        Assert.Equal(
+            AudioFileService.SupportedFileExtensions.Order(StringComparer.OrdinalIgnoreCase),
+            shareTarget.Descendants(uap + "FileType")
+                .Select(element => element.Value)
+                .Order(StringComparer.OrdinalIgnoreCase));
+        Assert.Equal(["StorageItems"], shareTarget.Elements(uap + "DataFormat").Select(element => element.Value));
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"TypeWhisper-shell-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary
- add a localized Explorer context-menu action for transcribing supported audio and video files
- forward shell activations to the primary TypeWhisper instance and open the file transcription queue
- register the Store package as a file-type verb and Windows Share target
- clean up the classic shell registration during uninstall and cover the manifest and request inbox with tests

## Validation
- `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj -c Debug --filter "FullyQualifiedName~ShellTranscriptionServiceTests"`
- `eng/Build-StorePackage.ps1 -Version 0.0.1-sharetarget -RuntimeIdentifier win-x64 -OutputRoot artifacts/store-share-target-check`
- built and launched the Windows development app with the required development build script
- verified a second-instance shell activation opens File Transcription and successfully transcribes the queued bundled WAV fixture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows Explorer integration to transcribe supported audio and video files from the context menu.
  * Added Windows share support for sending supported media directly to TypeWhisper for transcription.
  * Files selected through shell actions or sharing are queued and processed automatically.
* **Localization**
  * Added translations for the transcription context-menu action in English, German, Japanese, Russian, and Simplified Chinese.
* **Bug Fixes**
  * Improved handling of startup activation, duplicate files, malformed requests, and cleanup during uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->