### PR TITLE
Increase PowerShell runner test timeout

### DIFF
--- a/tests/TypeWhisper.PluginSystem.Tests/ScriptPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/ScriptPluginTests.cs
@@ -490,7 +490,7 @@ public sealed class ScriptPluginTests
                 Name = shell,
                 Shell = shell,
                 Command = "$text = [Console]::In.ReadToEnd(); [Console]::Out.Write($env:TYPEWHISPER_LANGUAGE + '|' + $text)",
-                TimeoutSeconds = 15
+                TimeoutSeconds = 30
             },
             "hello",
             new PostProcessingContext { SourceLanguage = "de" },


### PR DESCRIPTION
## Summary
- increase the PowerShell script runner integration test timeout from 15 to 30 seconds
- reduce recurring flakes on slow GitHub-hosted Windows runners

## Context
The scheduled release run https://github.com/TypeWhisper/typewhisper-win/actions/runs/33490619394 timed out while exercising Windows PowerShell, despite the same commit passing in the previous scheduled run.

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for PowerShell variant execution tests to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->