### PR TITLE
Fix Windows microphone recovery after display wake

### DIFF
--- a/src/TypeWhisper.Windows/App.xaml.cs
+++ b/src/TypeWhisper.Windows/App.xaml.cs
@@ -56,6 +56,17 @@ public partial class App : Application
         {
             System.Diagnostics.Debug.WriteLine($"Unhandled UI exception: {args.Exception}");
             LogCrash(args.Exception);
+            if (WpfRenderingSafety.IsRenderThreadFailure(args.Exception))
+            {
+                // Once WPF's render thread has failed, showing another WPF dialog can
+                // recurse into the same failure. Exit cleanly instead of hanging.
+                args.Handled = true;
+                _ = Dispatcher.BeginInvoke(
+                    DispatcherPriority.Send,
+                    new Action(() => Shutdown(-1)));
+                return;
+            }
+
             MessageBox.Show(Loc.Instance.GetString("App.ErrorFormat", args.Exception.Message),
                 Loc.Instance["App.ErrorTitle"], MessageBoxButton.OK, MessageBoxImage.Error);
             args.Handled = true;

--- a/src/TypeWhisper.Windows/Program.cs
+++ b/src/TypeWhisper.Windows/Program.cs
@@ -48,6 +48,11 @@ public static class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // UCEERR_RENDERTHREADFAILURE cannot be recovered after WPF's shared render
+        // thread has failed. This app's lightweight windows favor reliability across
+        // monitor sleep/DPI topology changes over GPU-accelerated composition.
+        WpfRenderingSafety.EnableBeforeAnyWindow();
+
         if (NativeModelProbe.TryRun(args, out var probeExitCode))
         {
             Environment.ExitCode = probeExitCode;

--- a/src/TypeWhisper.Windows/Services/AudioCaptureDiagnostics.cs
+++ b/src/TypeWhisper.Windows/Services/AudioCaptureDiagnostics.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using TypeWhisper.Core;
 
 namespace TypeWhisper.Windows.Services;
 
@@ -14,9 +15,7 @@ internal static class AudioCaptureDiagnostics
             StringComparison.Ordinal);
 
     private static readonly string LogPath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        SafePathSegment("TypeWhisper"),
-        SafePathSegment("Logs"),
+        TypeWhisperEnvironment.LogsPath,
         SafePathSegment("audio-capture-diagnostics.log"));
 
     internal static event Action<string>? MessageLogged;

--- a/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
+++ b/src/TypeWhisper.Windows/Services/AudioRecordingService.cs
@@ -2,6 +2,7 @@ using NAudio;
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
 using NAudio.Wave;
+using System.Text.RegularExpressions;
 using TypeWhisper.Core.Models;
 using TypeWhisper.Core.Services;
 
@@ -260,27 +261,29 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
                 return false;
             }
 
-            _activeDeviceNumber = ResolvePreferredDeviceNumber(allowFallback: true);
-            if (_activeDeviceNumber < 0)
+            var captureSelection = ResolvePreferredDeviceSelection();
+            if (captureSelection is null)
             {
                 AudioCaptureDiagnostics.Log("WarmUp no active device after resolve");
                 StartDevicePolling();
                 return false;
             }
 
+            _activeDeviceNumber = captureSelection.LastKnownDeviceNumber;
+
             try
             {
                 AudioCaptureDiagnostics.Log(
-                    $"WarmUp creating capture active={_activeDeviceNumber}:{TryGetDeviceName(_activeDeviceNumber) ?? "<unknown>"}");
+                    $"WarmUp creating capture active={captureSelection.LastKnownDeviceNumber}:{captureSelection.Name} id={captureSelection.Id}");
                 _waveIn = _captureFactory.Create(
-                    _activeDeviceNumber,
+                    captureSelection,
                     new WaveFormat(SampleRate, BitsPerSample, Channels),
                     bufferMilliseconds: 30);
                 _waveIn.Prepare();
                 _waveIn.DataAvailable += OnDataAvailable;
                 _waveIn.RecordingStopped += OnRecordingStopped;
 
-                SetActiveDeviceIdentity(_activeDeviceNumber);
+                SetActiveDeviceIdentity(captureSelection);
                 _isWarmedUp = true;
                 _activeCaptureGeneration = ++_captureGeneration;
                 AudioCaptureDiagnostics.Log(
@@ -359,6 +362,8 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             // Always stop preview before entering recording mode.
             if (_isPreviewing)
                 StopPreview();
+
+            RefreshPreparedCaptureSelection();
 
             if ((!_isWarmedUp || _waveIn is null) && !WarmUp())
             {
@@ -724,10 +729,10 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         return deviceCount > 0 ? 0 : -1;
     }
 
-    private int ResolvePreferredDeviceNumber(bool allowFallback)
+    private int ResolvePreferredDeviceNumber()
     {
         var priorityDeviceNumber = FindPriorityDeviceNumber();
-        if (priorityDeviceNumber >= 0)
+        if (_microphonePriorityList.Count > 0)
             return priorityDeviceNumber;
 
         if (_configuredDeviceNumber is int configuredDeviceNumber)
@@ -746,10 +751,32 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             if (rememberedDeviceNumber >= 0)
                 return rememberedDeviceNumber;
 
-            return allowFallback ? FindBestMicrophoneDevice() : -1;
+            // A numeric WaveIn index is only a legacy hint, never durable device
+            // identity. If its remembered name is gone, do not open whatever
+            // endpoint now happens to occupy the old index.
+            return -1;
         }
 
         return FindBestMicrophoneDevice();
+    }
+
+    private AudioInputDeviceSelection? ResolvePreferredDeviceSelection()
+    {
+        var deviceNumber = ResolvePreferredDeviceNumber();
+        if (deviceNumber < 0)
+            return null;
+
+        var info = TryGetDeviceInfo(deviceNumber);
+        if (info is not null)
+            return new AudioInputDeviceSelection(info.Id, info.Name, info.DeviceNumber);
+
+        var name = TryGetDeviceName(deviceNumber);
+        return name is null
+            ? null
+            : new AudioInputDeviceSelection(
+                StableDeviceIdFromName(name),
+                name,
+                deviceNumber);
     }
 
     private void ApplyPreferredDeviceChange()
@@ -759,7 +786,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             if (!_isWarmedUp)
                 return;
 
-            var newDevice = ResolvePreferredDeviceNumber(allowFallback: true);
+            var newDevice = ResolvePreferredDeviceNumber();
             if (!ActiveDeviceMatches(newDevice))
             {
                 DisposeWaveIn(reason: "device change");
@@ -898,6 +925,27 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         _activeDeviceNumber = deviceNumber;
         _activeDeviceId = info?.Id;
         _activeDeviceName = info?.Name ?? TryGetDeviceName(deviceNumber);
+    }
+
+    private void SetActiveDeviceIdentity(AudioInputDeviceSelection selection)
+    {
+        _activeDeviceNumber = selection.LastKnownDeviceNumber;
+        _activeDeviceId = selection.Id;
+        _activeDeviceName = selection.Name;
+    }
+
+    private void RefreshPreparedCaptureSelection()
+    {
+        if (!_isWarmedUp || _waveIn is null)
+            return;
+
+        var snapshot = GetDeviceSnapshot(refresh: true);
+        if (IsActiveDeviceAvailable(snapshot) && IsActiveDevicePreferred())
+            return;
+
+        AudioCaptureDiagnostics.Log(
+            $"Prepared capture identity is stale active={_activeDeviceNumber}:{_activeDeviceName ?? "<unknown>"} id={_activeDeviceId ?? "<unknown>"}");
+        DisposeWaveIn(reason: "stale prepared capture identity");
     }
 
     private bool ActiveDeviceMatches(int deviceNumber)
@@ -1168,6 +1216,27 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         DeviceAvailable?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// Recreates an idle prepared capture after display, power, or session topology changes.
+    /// </summary>
+    internal void RefreshAfterDisplayOrPowerChange()
+    {
+        var recreatePreparedCapture = false;
+        lock (_captureLifecycleLock)
+        {
+            if (_disposed)
+                return;
+
+            recreatePreparedCapture = !_isRecording;
+            if (recreatePreparedCapture)
+                DisposeWaveIn(reason: "display or power change");
+        }
+
+        CheckForDeviceChanges();
+        if (recreatePreparedCapture)
+            WarmUp();
+    }
+
     private void ClearRecordingState()
     {
         _isRecording = false;
@@ -1223,7 +1292,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
                 return true;
             }
 
-            return devices.Count > 0;
+            return false;
         }
 
         if (_configuredDeviceNumber is not int configuredDeviceNumber)
@@ -1259,7 +1328,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         if (_activeDeviceNumber < 0)
             return false;
 
-        var preferredDeviceNumber = ResolvePreferredDeviceNumber(allowFallback: true);
+        var preferredDeviceNumber = ResolvePreferredDeviceNumber();
         if (preferredDeviceNumber < 0)
             return true;
 
@@ -1289,14 +1358,21 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
             var deviceIndex = deviceNumber.HasValue
                 ? TryGetDeviceName(deviceNumber.Value) is not null
                     ? deviceNumber.Value
-                    : ResolvePreferredDeviceNumber(allowFallback: true)
+                    : ResolvePreferredDeviceNumber()
                 : FindBestMicrophoneDevice();
             if (deviceIndex < 0) return;
+
+            var captureSelection = TryGetDeviceInfo(deviceIndex) is { } info
+                ? new AudioInputDeviceSelection(info.Id, info.Name, info.DeviceNumber)
+                : TryGetDeviceName(deviceIndex) is { } name
+                    ? new AudioInputDeviceSelection(StableDeviceIdFromName(name), name, deviceIndex)
+                    : null;
+            if (captureSelection is null) return;
 
             try
             {
                 _previewWaveIn = _captureFactory.Create(
-                    deviceIndex,
+                    captureSelection,
                     new WaveFormat(SampleRate, BitsPerSample, Channels),
                     bufferMilliseconds: 50);
                 _previewWaveIn.DataAvailable += OnPreviewDataAvailable;
@@ -1576,7 +1652,7 @@ public sealed class AudioRecordingService : IStreamingAudioSource, IDisposable
         WasapiAudioInputDeviceOrdering.DeviceNamesMatch(first, second);
 
     private static string StableDeviceIdFromName(string name) =>
-        $"name:{name.Trim().ToUpperInvariant()}";
+        $"name:{WasapiAudioInputDeviceOrdering.NormalizeDeviceName(name).ToUpperInvariant()}";
 }
 
 /// <summary>
@@ -1625,6 +1701,8 @@ internal sealed record AudioInputDeviceInfo(int DeviceNumber, string Id, string 
 
 internal sealed record AudioInputDeviceSnapshot(int DeviceNumber, string Id, string Name, bool IsDefault);
 
+internal sealed record AudioInputDeviceSelection(string Id, string Name, int LastKnownDeviceNumber);
+
 internal interface IAudioInputDeviceProvider
 {
     int DeviceCount { get; }
@@ -1647,7 +1725,10 @@ internal interface IAudioInputDeviceChangeNotifier : IDisposable
 
 internal interface IAudioInputCaptureFactory
 {
-    IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds);
+    IAudioInputCapture Create(
+        AudioInputDeviceSelection selection,
+        WaveFormat waveFormat,
+        int bufferMilliseconds);
 }
 
 internal interface IAudioInputCapture : IDisposable
@@ -1757,7 +1838,7 @@ internal sealed class WaveInAudioInputDeviceProvider : IAudioInputDeviceProvider
         string.IsNullOrWhiteSpace(id) ? StableFallbackDeviceId(name) : id;
 
     private static string StableFallbackDeviceId(string name) =>
-        $"name:{name.Trim().ToUpperInvariant()}";
+        $"name:{WasapiAudioInputDeviceOrdering.NormalizeDeviceName(name).ToUpperInvariant()}";
 
     private static IReadOnlyList<string> GetWaveInDeviceNames()
     {
@@ -1948,11 +2029,19 @@ internal sealed class WasapiAudioInputDeviceChangeNotifier : IAudioInputDeviceCh
 
 internal sealed class WaveInAudioInputCaptureFactory : IAudioInputCaptureFactory
 {
-    /// <summary>
-    /// Creates.
-    /// </summary>
-    public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds) =>
-        new WaveInAudioInputCapture(deviceNumber, waveFormat, bufferMilliseconds);
+    public IAudioInputCapture Create(
+        AudioInputDeviceSelection selection,
+        WaveFormat waveFormat,
+        int bufferMilliseconds)
+    {
+        var devices = new WaveInAudioInputDeviceProvider().GetDeviceInfos();
+        var resolved = AudioInputDeviceSelectionResolver.Resolve(selection, devices)
+            ?? throw new InvalidOperationException(
+                $"Microphone '{selection.Name}' is no longer available for WaveIn capture.");
+        AudioCaptureDiagnostics.Log(
+            $"WaveIn capture resolved id={selection.Id} oldIndex={selection.LastKnownDeviceNumber} currentIndex={resolved.DeviceNumber} name={resolved.Name}");
+        return new WaveInAudioInputCapture(resolved.DeviceNumber, waveFormat, bufferMilliseconds);
+    }
 }
 
 internal sealed class WaveInAudioInputCapture : IAudioInputCapture
@@ -2065,7 +2154,7 @@ internal sealed class WasapiAudioInputDeviceProvider : IAudioInputDeviceProvider
                 .Select((device, index) => new AudioInputDeviceInfo(
                     index,
                     string.IsNullOrWhiteSpace(device.ID)
-                        ? $"name:{device.FriendlyName.Trim().ToUpperInvariant()}"
+                        ? $"name:{WasapiAudioInputDeviceOrdering.NormalizeDeviceName(device.FriendlyName).ToUpperInvariant()}"
                         : device.ID,
                     device.FriendlyName,
                     string.Equals(device.ID, defaultDeviceId, StringComparison.OrdinalIgnoreCase)))
@@ -2083,17 +2172,31 @@ internal sealed class WasapiAudioInputDeviceProvider : IAudioInputDeviceProvider
 
 internal sealed class WasapiAudioInputCaptureFactory : IAudioInputCaptureFactory
 {
-    public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
+    public IAudioInputCapture Create(
+        AudioInputDeviceSelection selection,
+        WaveFormat waveFormat,
+        int bufferMilliseconds)
     {
         var devices = WasapiAudioInputDeviceResolver.GetCaptureDevicesInWaveInOrder();
         try
         {
-            if (deviceNumber < 0 || deviceNumber >= devices.Count)
-                throw new ArgumentOutOfRangeException(nameof(deviceNumber));
+            var currentDevices = devices
+                .Select((device, index) => new AudioInputDeviceInfo(
+                    index,
+                    string.IsNullOrWhiteSpace(device.ID)
+                        ? $"name:{WasapiAudioInputDeviceOrdering.NormalizeDeviceName(device.FriendlyName).ToUpperInvariant()}"
+                        : device.ID,
+                    device.FriendlyName,
+                    false))
+                .ToList();
+            var resolved = AudioInputDeviceSelectionResolver.Resolve(selection, currentDevices)
+                ?? throw new InvalidOperationException(
+                    $"Microphone '{selection.Name}' is no longer available for WASAPI capture.");
 
-            var selectedDevice = devices[deviceNumber];
-            devices.RemoveAt(deviceNumber);
-
+            var selectedDevice = devices[resolved.DeviceNumber];
+            devices.RemoveAt(resolved.DeviceNumber);
+            AudioCaptureDiagnostics.Log(
+                $"WASAPI capture resolved id={selection.Id} oldIndex={selection.LastKnownDeviceNumber} currentIndex={resolved.DeviceNumber} name={resolved.Name}");
             return new WasapiAudioInputCapture(selectedDevice, bufferMilliseconds);
         }
         finally
@@ -2108,13 +2211,13 @@ internal sealed class FallbackAudioInputCaptureFactory(
     IAudioInputCaptureFactory fallbackFactory) : IAudioInputCaptureFactory
 {
     public IAudioInputCapture Create(
-        int deviceNumber,
+        AudioInputDeviceSelection selection,
         WaveFormat waveFormat,
         int bufferMilliseconds) =>
         new FallbackAudioInputCapture(
             primaryFactory,
             fallbackFactory,
-            deviceNumber,
+            selection,
             waveFormat,
             bufferMilliseconds);
 }
@@ -2122,7 +2225,7 @@ internal sealed class FallbackAudioInputCaptureFactory(
 internal sealed class FallbackAudioInputCapture : IAudioInputCapture
 {
     private readonly IAudioInputCaptureFactory _fallbackFactory;
-    private readonly int _deviceNumber;
+    private readonly AudioInputDeviceSelection _selection;
     private readonly WaveFormat _requestedWaveFormat;
     private readonly int _bufferMilliseconds;
     private IAudioInputCapture? _capture;
@@ -2132,25 +2235,25 @@ internal sealed class FallbackAudioInputCapture : IAudioInputCapture
     public FallbackAudioInputCapture(
         IAudioInputCaptureFactory primaryFactory,
         IAudioInputCaptureFactory fallbackFactory,
-        int deviceNumber,
+        AudioInputDeviceSelection selection,
         WaveFormat waveFormat,
         int bufferMilliseconds)
     {
         _fallbackFactory = fallbackFactory;
-        _deviceNumber = deviceNumber;
+        _selection = selection;
         _requestedWaveFormat = waveFormat;
         _bufferMilliseconds = bufferMilliseconds;
 
         try
         {
-            _capture = primaryFactory.Create(deviceNumber, waveFormat, bufferMilliseconds);
+            _capture = primaryFactory.Create(selection, waveFormat, bufferMilliseconds);
         }
         catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             AudioCaptureDiagnostics.Log(
                 $"Primary microphone capture creation failed; using fallback {ex.GetType().Name}: {ex.Message}");
             _usingFallback = true;
-            _capture = fallbackFactory.Create(deviceNumber, waveFormat, bufferMilliseconds);
+            _capture = fallbackFactory.Create(selection, waveFormat, bufferMilliseconds);
         }
 
         AttachCapture();
@@ -2238,12 +2341,12 @@ internal sealed class FallbackAudioInputCapture : IAudioInputCapture
         try
         {
             _capture = _fallbackFactory.Create(
-                _deviceNumber,
+                _selection,
                 _requestedWaveFormat,
                 _bufferMilliseconds);
             AttachCapture();
             AudioCaptureDiagnostics.Log(
-                $"WaveIn fallback recreated deviceNumber={_deviceNumber} bufferMs={_bufferMilliseconds}");
+                $"WaveIn fallback recreated id={_selection.Id} oldIndex={_selection.LastKnownDeviceNumber} bufferMs={_bufferMilliseconds}");
         }
         catch
         {
@@ -2365,6 +2468,10 @@ internal static class WasapiAudioInputDeviceResolver
 
 internal static class WasapiAudioInputDeviceOrdering
 {
+    private static readonly Regex WindowsOrdinalPrefix = new(
+        @"(?<=\()\s*\d+\s*-\s*",
+        RegexOptions.CultureInvariant);
+
     public static IReadOnlyList<int> BuildWaveInCompatibleOrder(
         IReadOnlyList<string> wasapiDeviceNames,
         IReadOnlyList<string> waveInDeviceNames)
@@ -2387,11 +2494,36 @@ internal static class WasapiAudioInputDeviceOrdering
 
     internal static bool DeviceNamesMatch(string wasapiDeviceName, string waveInDeviceName)
     {
-        if (string.Equals(wasapiDeviceName, waveInDeviceName, StringComparison.OrdinalIgnoreCase))
+        var normalizedWasapiName = NormalizeDeviceName(wasapiDeviceName);
+        var normalizedWaveInName = NormalizeDeviceName(waveInDeviceName);
+        if (string.Equals(normalizedWasapiName, normalizedWaveInName, StringComparison.OrdinalIgnoreCase))
             return true;
 
-        var trimmedWaveInName = waveInDeviceName.Trim();
-        return wasapiDeviceName.StartsWith(trimmedWaveInName, StringComparison.OrdinalIgnoreCase)
-            || trimmedWaveInName.StartsWith(wasapiDeviceName, StringComparison.OrdinalIgnoreCase);
+        return normalizedWasapiName.StartsWith(normalizedWaveInName, StringComparison.OrdinalIgnoreCase)
+            || normalizedWaveInName.StartsWith(normalizedWasapiName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string NormalizeDeviceName(string name)
+    {
+        var withoutOrdinal = WindowsOrdinalPrefix.Replace(name.Trim(), "");
+        return string.Join(
+            ' ',
+            withoutOrdinal.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+}
+
+internal static class AudioInputDeviceSelectionResolver
+{
+    public static AudioInputDeviceInfo? Resolve(
+        AudioInputDeviceSelection selection,
+        IReadOnlyList<AudioInputDeviceInfo> currentDevices)
+    {
+        var byId = currentDevices.FirstOrDefault(device =>
+            string.Equals(device.Id, selection.Id, StringComparison.OrdinalIgnoreCase));
+        if (byId is not null)
+            return byId;
+
+        return currentDevices.FirstOrDefault(device =>
+            WasapiAudioInputDeviceOrdering.DeviceNamesMatch(device.Name, selection.Name));
     }
 }

--- a/src/TypeWhisper.Windows/Services/CoalescedRefreshDispatcher.cs
+++ b/src/TypeWhisper.Windows/Services/CoalescedRefreshDispatcher.cs
@@ -1,0 +1,52 @@
+namespace TypeWhisper.Windows.Services;
+
+internal sealed class CoalescedRefreshDispatcher
+{
+    private readonly Action _refresh;
+    private readonly Action<Action> _queue;
+    private int _requestedGeneration;
+    private int _workerRunning;
+
+    internal CoalescedRefreshDispatcher(Action refresh, Action<Action>? queue = null)
+    {
+        _refresh = refresh ?? throw new ArgumentNullException(nameof(refresh));
+        _queue = queue ?? QueueOnThreadPool;
+    }
+
+    internal void Request()
+    {
+        Interlocked.Increment(ref _requestedGeneration);
+        if (Interlocked.CompareExchange(ref _workerRunning, 1, 0) == 0)
+            _queue(Run);
+    }
+
+    private void Run()
+    {
+        var handledGeneration = 0;
+        try
+        {
+            do
+            {
+                handledGeneration = Volatile.Read(ref _requestedGeneration);
+                _refresh();
+            }
+            while (handledGeneration != Volatile.Read(ref _requestedGeneration));
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _workerRunning, 0);
+
+            // A request can arrive after the last generation check but before the
+            // worker flag is cleared. Claim another run unless that request already
+            // queued a replacement worker.
+            if (handledGeneration != Volatile.Read(ref _requestedGeneration) &&
+                Interlocked.CompareExchange(ref _workerRunning, 1, 0) == 0)
+            {
+                _queue(Run);
+            }
+        }
+    }
+
+    private static void QueueOnThreadPool(Action action) =>
+        ThreadPool.QueueUserWorkItem(static state => ((Action)state!).Invoke(), action);
+}

--- a/src/TypeWhisper.Windows/Services/CoalescedRefreshDispatcher.cs
+++ b/src/TypeWhisper.Windows/Services/CoalescedRefreshDispatcher.cs
@@ -4,13 +4,18 @@ internal sealed class CoalescedRefreshDispatcher
 {
     private readonly Action _refresh;
     private readonly Action<Action> _queue;
+    private readonly Action<Exception> _reportFailure;
     private int _requestedGeneration;
     private int _workerRunning;
 
-    internal CoalescedRefreshDispatcher(Action refresh, Action<Action>? queue = null)
+    internal CoalescedRefreshDispatcher(
+        Action refresh,
+        Action<Action>? queue = null,
+        Action<Exception>? reportFailure = null)
     {
         _refresh = refresh ?? throw new ArgumentNullException(nameof(refresh));
         _queue = queue ?? QueueOnThreadPool;
+        _reportFailure = reportFailure ?? ReportFailure;
     }
 
     internal void Request()
@@ -28,7 +33,14 @@ internal sealed class CoalescedRefreshDispatcher
             do
             {
                 handledGeneration = Volatile.Read(ref _requestedGeneration);
-                _refresh();
+                try
+                {
+                    _refresh();
+                }
+                catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+                {
+                    _reportFailure(ex);
+                }
             }
             while (handledGeneration != Volatile.Read(ref _requestedGeneration));
         }
@@ -49,4 +61,8 @@ internal sealed class CoalescedRefreshDispatcher
 
     private static void QueueOnThreadPool(Action action) =>
         ThreadPool.QueueUserWorkItem(static state => ((Action)state!).Invoke(), action);
+
+    private static void ReportFailure(Exception exception) =>
+        System.Diagnostics.Debug.WriteLine(
+            $"[Audio] Display/power refresh failed: {exception.Message}");
 }

--- a/src/TypeWhisper.Windows/Services/HttpApiResponseSender.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiResponseSender.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace TypeWhisper.Windows.Services;
+
+internal interface IHttpApiResponseTransport
+{
+    Task SubmitAsync(HttpApiResponse response, CancellationToken cancellationToken);
+    void Close();
+}
+
+internal sealed class HttpListenerResponseTransport(HttpListenerResponse response)
+    : IHttpApiResponseTransport
+{
+    public async Task SubmitAsync(HttpApiResponse apiResponse, CancellationToken cancellationToken)
+    {
+        response.StatusCode = apiResponse.StatusCode;
+        response.ContentType = apiResponse.ContentType;
+        foreach (var (name, value) in apiResponse.Headers)
+            response.Headers[name] = value;
+
+        var bytes = Encoding.UTF8.GetBytes(apiResponse.Body);
+        response.ContentLength64 = bytes.Length;
+        if (bytes.Length > 0)
+            await response.OutputStream.WriteAsync(bytes, cancellationToken);
+    }
+
+    public void Close() => response.Close();
+}
+
+internal sealed class HttpApiResponseSender(IHttpApiResponseTransport transport)
+{
+    private int _submissionAttempted;
+
+    public bool SubmissionAttempted => Volatile.Read(ref _submissionAttempted) != 0;
+
+    public async Task<bool> TrySendAsync(
+        HttpApiResponse response,
+        CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _submissionAttempted, 1) != 0)
+            return false;
+
+        try
+        {
+            await transport.SubmitAsync(response, cancellationToken);
+            return true;
+        }
+        catch (Exception ex) when (IsExpectedResponseTermination(ex))
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[HttpApi] Response ended before submission completed: {ex.Message}");
+            return false;
+        }
+    }
+
+    public void Close()
+    {
+        try
+        {
+            transport.Close();
+        }
+        catch (Exception ex) when (IsExpectedResponseTermination(ex))
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[HttpApi] Response close was interrupted: {ex.Message}");
+        }
+    }
+
+    internal static bool IsExpectedResponseTermination(Exception exception) =>
+        exception is OperationCanceledException
+            or IOException
+            or HttpListenerException
+            or ObjectDisposedException
+            or InvalidOperationException;
+}

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -188,7 +188,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             try
             {
                 var context = await _listener.GetContextAsync();
-                ObserveRequestTask(DispatchRequestAsync(() => RunRequestAsync(context, ct)));
+                ObserveRequestTask(DispatchRequestAsync(() => RunRequestAsync(context, ct), ct));
             }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
             catch (ObjectDisposedException) { break; }
@@ -196,8 +196,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         }
     }
 
-    internal static Task DispatchRequestAsync(Func<Task> request) =>
-        Task.Run(request, CancellationToken.None);
+    internal static Task DispatchRequestAsync(Func<Task> request, CancellationToken ct) =>
+        Task.Run(request, ct);
 
     private static void ObserveRequestTask(Task requestTask)
     {
@@ -213,6 +213,10 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         try
         {
             await HandleRequest(context, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Listener shutdown cancels accepted work that has not completed.
         }
         catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
@@ -248,6 +252,10 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
 
             await sender.TrySendAsync(apiResponse, ct);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Closing the listener cancels request conversion and response delivery.
+        }
         catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
             // TrySendAsync is intentionally idempotent. If headers or body submission
@@ -262,6 +270,8 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
 
     internal async Task<HttpApiResponse> HandleRequestAsync(HttpApiRequest request, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+
         if (request.Method == "OPTIONS")
             return new HttpApiResponse(204, "", "text/plain");
 
@@ -284,7 +294,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                 ("/v1/transcribe/local-file", "POST") => await HandleTranscribeLocalFile(request, ct),
                 ("/v1/history", "GET") => HandleHistorySearch(request),
                 ("/v1/history", "DELETE") => HandleHistoryDelete(request),
-                ("/v1/dictation/start", "POST") => await HandleDictationStart(request),
+                ("/v1/dictation/start", "POST") => await HandleDictationStart(request, ct),
                 ("/v1/dictation/stop", "POST") => await HandleDictationStop(),
                 ("/v1/dictation/status", "GET") => HandleDictationStatus(),
                 ("/v1/dictation/transcription", "GET") => HandleDictationTranscription(request),
@@ -323,6 +333,10 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         catch (DispatcherUnavailableException ex)
         {
             return Error(503, ex.Message);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -627,7 +641,9 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         return Json(new { deleted = true, id });
     }
 
-    private async Task<HttpApiResponse> HandleDictationStart(HttpApiRequest request)
+    private async Task<HttpApiResponse> HandleDictationStart(
+        HttpApiRequest request,
+        CancellationToken ct)
     {
         if (_dictation.IsRecording)
             return Error(409, "Already recording");
@@ -663,7 +679,10 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                 return Error(409, "Workflow is disabled");
         }
 
-        var id = await InvokeOnDispatcherAsync(() => _dictation.StartRecordingForApiAsync(workflow?.Id));
+        ct.ThrowIfCancellationRequested();
+        var id = await InvokeOnDispatcherAsync(
+            () => _dictation.StartRecordingForApiAsync(workflow?.Id),
+            ct);
         var session = _dictation.GetApiDictationSession(id);
         if (session?.Status == ApiDictationSessionStatus.Failed)
             return Error(409, session.Error ?? "Failed to start dictation");
@@ -1570,8 +1589,11 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             : dispatcher;
     }
 
-    private async Task<T> InvokeOnDispatcherAsync<T>(Func<Task<T>> action)
+    private async Task<T> InvokeOnDispatcherAsync<T>(
+        Func<Task<T>> action,
+        CancellationToken ct = default)
     {
+        ct.ThrowIfCancellationRequested();
         var dispatcher = _dispatcher;
         if (dispatcher is null)
             return await action();
@@ -1580,11 +1602,14 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             throw new DispatcherUnavailableException("Application is shutting down.");
 
         if (dispatcher.CheckAccess())
+        {
+            ct.ThrowIfCancellationRequested();
             return await action();
+        }
 
         try
         {
-            var operation = dispatcher.InvokeAsync(action);
+            var operation = dispatcher.InvokeAsync(action, DispatcherPriority.Normal, ct);
             return await await operation.Task;
         }
         catch (TaskCanceledException) when (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -188,12 +188,24 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             try
             {
                 var context = await _listener.GetContextAsync();
-                _ = RunRequestAsync(context, ct);
+                ObserveRequestTask(DispatchRequestAsync(() => RunRequestAsync(context, ct)));
             }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
             catch (ObjectDisposedException) { break; }
             catch { /* continue listening */ }
         }
+    }
+
+    internal static Task DispatchRequestAsync(Func<Task> request) =>
+        Task.Run(request, CancellationToken.None);
+
+    private static void ObserveRequestTask(Task requestTask)
+    {
+        _ = requestTask.ContinueWith(
+            static completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task RunRequestAsync(HttpListenerContext context, CancellationToken ct)

--- a/src/TypeWhisper.Windows/Services/HttpApiService.cs
+++ b/src/TypeWhisper.Windows/Services/HttpApiService.cs
@@ -188,7 +188,7 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
             try
             {
                 var context = await _listener.GetContextAsync();
-                _ = Task.Run(() => HandleRequest(context, ct), ct);
+                _ = RunRequestAsync(context, ct);
             }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
             catch (ObjectDisposedException) { break; }
@@ -196,9 +196,23 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
         }
     }
 
+    private async Task RunRequestAsync(HttpListenerContext context, CancellationToken ct)
+    {
+        try
+        {
+            await HandleRequest(context, ct);
+        }
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[HttpApi] Request processing failed: {ex.Message}");
+        }
+    }
+
     private async Task HandleRequest(HttpListenerContext context, CancellationToken ct)
     {
-        var response = context.Response;
+        var sender = new HttpApiResponseSender(
+            new HttpListenerResponseTransport(context.Response));
 
         try
         {
@@ -220,28 +234,17 @@ public sealed class HttpApiService : ILocalApiServer, IDisposable
                 apiResponse = await HandleRequestAsync(request, ct);
             }
 
-            response.StatusCode = apiResponse.StatusCode;
-            response.ContentType = apiResponse.ContentType;
-            foreach (var (name, value) in apiResponse.Headers)
-                response.Headers[name] = value;
-
-            var bytes = Encoding.UTF8.GetBytes(apiResponse.Body);
-            response.ContentLength64 = bytes.Length;
-            if (bytes.Length > 0)
-                await response.OutputStream.WriteAsync(bytes, ct);
+            await sender.TrySendAsync(apiResponse, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (NonFatalExceptionFilter.IsNonFatal(ex))
         {
-            var apiResponse = Error(500, ex.Message);
-            response.StatusCode = apiResponse.StatusCode;
-            response.ContentType = apiResponse.ContentType;
-            var errorBytes = Encoding.UTF8.GetBytes(apiResponse.Body);
-            response.ContentLength64 = errorBytes.Length;
-            await response.OutputStream.WriteAsync(errorBytes, ct);
+            // TrySendAsync is intentionally idempotent. If headers or body submission
+            // already began, this call is a no-op rather than a second response.
+            await sender.TrySendAsync(Error(500, ex.Message), ct);
         }
         finally
         {
-            response.Close();
+            sender.Close();
         }
     }
 

--- a/src/TypeWhisper.Windows/Services/WpfRenderingSafety.cs
+++ b/src/TypeWhisper.Windows/Services/WpfRenderingSafety.cs
@@ -1,0 +1,23 @@
+using System.Windows.Interop;
+using System.Windows.Media;
+
+namespace TypeWhisper.Windows.Services;
+
+internal static class WpfRenderingSafety
+{
+    internal const int RenderThreadFailureHResult = unchecked((int)0x88980406);
+
+    public static void EnableBeforeAnyWindow() =>
+        RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
+
+    public static bool IsRenderThreadFailure(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current.HResult == RenderThreadFailureHResult)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/TypeWhisper.Windows/Views/MainWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/MainWindow.xaml.cs
@@ -33,11 +33,10 @@ public partial class MainWindow : Window
     private static partial int SetWindowLongW(IntPtr hWnd, int nIndex, int dwNewLong);
 
     private readonly ISettingsService _settings;
-    private readonly AudioRecordingService _audio;
+    private readonly CoalescedRefreshDispatcher _audioRefreshDispatcher;
     private readonly RecordingOverlayViewModel _viewModel;
     private readonly DispatcherTimer _overlayRecoveryTimer;
     private OverlayPlacementTarget _currentPlacementTarget = OverlayPlacementTarget.CursorMonitor;
-    private int _audioRefreshQueued;
 
     /// <summary>
     /// Initializes a new instance of the MainWindow class.
@@ -51,7 +50,8 @@ public partial class MainWindow : Window
         DataContext = viewModel;
         _viewModel = viewModel;
         _settings = settings;
-        _audio = audio;
+        _audioRefreshDispatcher = new CoalescedRefreshDispatcher(
+            audio.RefreshAfterDisplayOrPowerChange);
         _overlayRecoveryTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
         {
             Interval = OverlayRecoveryDelay
@@ -144,24 +144,7 @@ public partial class MainWindow : Window
         }
     }
 
-    private void DispatchAudioCaptureRefresh()
-    {
-        if (Interlocked.Exchange(ref _audioRefreshQueued, 1) != 0)
-            return;
-
-        ThreadPool.QueueUserWorkItem(static state =>
-        {
-            var window = (MainWindow)state!;
-            try
-            {
-                window._audio.RefreshAfterDisplayOrPowerChange();
-            }
-            finally
-            {
-                Interlocked.Exchange(ref window._audioRefreshQueued, 0);
-            }
-        }, this);
-    }
+    private void DispatchAudioCaptureRefresh() => _audioRefreshDispatcher.Request();
 
     private void DispatchPrimaryOverlayRecovery()
     {

--- a/src/TypeWhisper.Windows/Views/MainWindow.xaml.cs
+++ b/src/TypeWhisper.Windows/Views/MainWindow.xaml.cs
@@ -33,19 +33,25 @@ public partial class MainWindow : Window
     private static partial int SetWindowLongW(IntPtr hWnd, int nIndex, int dwNewLong);
 
     private readonly ISettingsService _settings;
+    private readonly AudioRecordingService _audio;
     private readonly RecordingOverlayViewModel _viewModel;
     private readonly DispatcherTimer _overlayRecoveryTimer;
     private OverlayPlacementTarget _currentPlacementTarget = OverlayPlacementTarget.CursorMonitor;
+    private int _audioRefreshQueued;
 
     /// <summary>
     /// Initializes a new instance of the MainWindow class.
     /// </summary>
-    public MainWindow(RecordingOverlayViewModel viewModel, ISettingsService settings)
+    public MainWindow(
+        RecordingOverlayViewModel viewModel,
+        ISettingsService settings,
+        AudioRecordingService audio)
     {
         InitializeComponent();
         DataContext = viewModel;
         _viewModel = viewModel;
         _settings = settings;
+        _audio = audio;
         _overlayRecoveryTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
         {
             Interval = OverlayRecoveryDelay
@@ -114,19 +120,47 @@ public partial class MainWindow : Window
         ReassertTopmost();
     }
 
-    private void OnDisplaySettingsChanged(object? sender, EventArgs e) =>
+    private void OnDisplaySettingsChanged(object? sender, EventArgs e)
+    {
         DispatchPrimaryOverlayRecovery();
+        DispatchAudioCaptureRefresh();
+    }
 
     private void OnPowerModeChanged(object? sender, PowerModeChangedEventArgs e)
     {
         if (e.Mode == PowerModes.Resume)
+        {
             DispatchPrimaryOverlayRecovery();
+            DispatchAudioCaptureRefresh();
+        }
     }
 
     private void OnSessionSwitch(object? sender, SessionSwitchEventArgs e)
     {
         if (e.Reason == SessionSwitchReason.SessionUnlock)
+        {
             DispatchPrimaryOverlayRecovery();
+            DispatchAudioCaptureRefresh();
+        }
+    }
+
+    private void DispatchAudioCaptureRefresh()
+    {
+        if (Interlocked.Exchange(ref _audioRefreshQueued, 1) != 0)
+            return;
+
+        ThreadPool.QueueUserWorkItem(static state =>
+        {
+            var window = (MainWindow)state!;
+            try
+            {
+                window._audio.RefreshAfterDisplayOrPowerChange();
+            }
+            finally
+            {
+                Interlocked.Exchange(ref window._audioRefreshQueued, 0);
+            }
+        }, this);
     }
 
     private void DispatchPrimaryOverlayRecovery()

--- a/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/AudioRecordingServiceTests.cs
@@ -66,7 +66,7 @@ public sealed class AudioRecordingServiceDeviceChangeTests
         var waveIn = new FakeAudioInputCaptureFactory();
         var factory = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
         using var capture = factory.Create(
-            deviceNumber: 0,
+            new AudioInputDeviceSelection("usb", "USB Microphone", 0),
             new WaveFormat(16000, 16, 1),
             bufferMilliseconds: 30);
 
@@ -87,7 +87,7 @@ public sealed class AudioRecordingServiceDeviceChangeTests
         var waveIn = new FakeAudioInputCaptureFactory();
         var factory = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
         using var capture = factory.Create(
-            deviceNumber: 0,
+            new AudioInputDeviceSelection("usb", "USB Microphone", 0),
             new WaveFormat(16000, 16, 1),
             bufferMilliseconds: 30);
 
@@ -229,7 +229,7 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
-    public void CheckForDeviceChanges_FallsBackWithoutClearingConfiguredSelection_WhenSelectedDeviceDisappears()
+    public void CheckForDeviceChanges_DoesNotReuseLegacyIndex_WhenSelectedDeviceDisappears()
     {
         var devices = new FakeAudioInputDeviceProvider("Built-in Microphone", "USB Microphone");
         var captures = new FakeAudioInputCaptureFactory();
@@ -240,7 +240,8 @@ public sealed class AudioRecordingServiceDeviceChangeTests
         devices.SetDevices("Built-in Microphone");
         sut.CheckForDeviceChanges();
 
-        Assert.Equal([1, 0], captures.Created.Select(c => c.DeviceNumber));
+        Assert.Equal([1], captures.Created.Select(c => c.DeviceNumber));
+        Assert.True(captures.Created[0].Disposed);
     }
 
     [Fact]
@@ -283,7 +284,113 @@ public sealed class AudioRecordingServiceDeviceChangeTests
     }
 
     [Fact]
-    public void WarmUp_UsesNextAvailablePriorityDevice_ThenFallsBackToSystemDefault()
+    public void EndpointIdSelection_ResolvesSameMicrophoneAfterIndexesChange()
+    {
+        var selection = new AudioInputDeviceSelection(
+            "usb-endpoint",
+            "Microphone (4- Shure MV7)",
+            LastKnownDeviceNumber: 1);
+        var reordered = new[]
+        {
+            new AudioInputDeviceInfo(0, "usb-endpoint", "Microphone (5- Shure MV7)", false),
+            new AudioInputDeviceInfo(1, "built-in", "Microphone Array", true)
+        };
+
+        var resolved = AudioInputDeviceSelectionResolver.Resolve(selection, reordered);
+
+        Assert.NotNull(resolved);
+        Assert.Equal("usb-endpoint", resolved.Id);
+        Assert.Equal(0, resolved.DeviceNumber);
+    }
+
+    [Fact]
+    public void DeviceNameFallback_IgnoresChangedWindowsOrdinalNumber()
+    {
+        var selection = new AudioInputDeviceSelection(
+            "removed-endpoint",
+            "Microphone (4- Shure MV7)",
+            LastKnownDeviceNumber: 1);
+        var current = new[]
+        {
+            new AudioInputDeviceInfo(0, "replacement-endpoint", "Microphone (5- Shure MV7)", false)
+        };
+
+        var resolved = AudioInputDeviceSelectionResolver.Resolve(selection, current);
+
+        Assert.NotNull(resolved);
+        Assert.Equal("replacement-endpoint", resolved.Id);
+        Assert.Equal(0, resolved.DeviceNumber);
+    }
+
+    [Fact]
+    public void PreparedWasapiToWaveInFallback_PreservesStableDeviceIdentity()
+    {
+        var wasapi = new FakeAudioInputCaptureFactory
+        {
+            StartException = new InvalidOperationException("WASAPI endpoint became stale.")
+        };
+        var waveIn = new FakeAudioInputCaptureFactory();
+        var factory = new FallbackAudioInputCaptureFactory(wasapi, waveIn);
+        var selection = new AudioInputDeviceSelection(
+            "usb-endpoint",
+            "Microphone (4- Shure MV7)",
+            LastKnownDeviceNumber: 1);
+        using var capture = factory.Create(
+            selection,
+            new WaveFormat(16000, 16, 1),
+            bufferMilliseconds: 30);
+
+        capture.StartRecording();
+
+        Assert.Equal("usb-endpoint", Assert.Single(wasapi.Created).Selection.Id);
+        Assert.Equal("usb-endpoint", Assert.Single(waveIn.Created).Selection.Id);
+        Assert.Equal("Microphone (4- Shure MV7)", waveIn.Created.Single().Selection.Name);
+    }
+
+    [Fact]
+    public void MissingPriorityMicrophone_DoesNotOpenAnUnrelatedDevice()
+    {
+        var devices = new FakeAudioInputDeviceProvider(
+            new FakeAudioInputDevice("usb", "USB Microphone"),
+            new FakeAudioInputDevice("built-in", "Built-in Microphone"));
+        var captures = new FakeAudioInputCaptureFactory();
+        using var sut = CreateService(devices, captures);
+        sut.SetMicrophonePriorityList([new MicrophonePriorityItem("usb", "USB Microphone")]);
+        Assert.True(sut.WarmUp());
+
+        devices.SetDevices(new FakeAudioInputDevice("built-in", "Built-in Microphone"));
+        sut.CheckForDeviceChanges();
+
+        Assert.Single(captures.Created);
+        Assert.True(captures.Created[0].Disposed);
+        Assert.False(sut.IsRecording);
+        Assert.False(sut.WarmUp());
+    }
+
+    [Fact]
+    public void DisplayWakeRefresh_RecreatesPreparedCaptureWithStableIdentity()
+    {
+        var devices = new FakeAudioInputDeviceProvider(
+            new FakeAudioInputDevice("built-in", "Built-in Microphone"),
+            new FakeAudioInputDevice("usb", "USB Microphone"));
+        var captures = new FakeAudioInputCaptureFactory { CanRestartAfterStop = true };
+        using var sut = CreateService(devices, captures);
+        sut.SetMicrophonePriorityList([new MicrophonePriorityItem("usb", "USB Microphone")]);
+        Assert.True(sut.WarmUp());
+
+        devices.SetDevices(
+            new FakeAudioInputDevice("usb", "USB Microphone"),
+            new FakeAudioInputDevice("built-in", "Built-in Microphone"));
+        sut.RefreshAfterDisplayOrPowerChange();
+
+        Assert.Equal(2, captures.Created.Count);
+        Assert.True(captures.Created[0].Disposed);
+        Assert.Equal("usb", captures.Created[1].Selection.Id);
+        Assert.Equal(0, captures.Created[1].DeviceNumber);
+    }
+
+    [Fact]
+    public void WarmUp_UsesNextAvailablePriorityDevice_WithoutUnrelatedDefaultFallback()
     {
         var devices = new FakeAudioInputDeviceProvider(
             new FakeAudioInputDevice("built-in", "Built-in Microphone"),
@@ -305,7 +412,8 @@ public sealed class AudioRecordingServiceDeviceChangeTests
         devices.SetDevices(new FakeAudioInputDevice("built-in", "Built-in Microphone"));
         sut.CheckForDeviceChanges();
 
-        Assert.Equal(0, captures.Created.Last().DeviceNumber);
+        Assert.Single(captures.Created);
+        Assert.True(captures.Created[0].Disposed);
     }
 
     [Fact]
@@ -1867,12 +1975,15 @@ internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
     public Exception? StopException { get; set; }
     public bool CanRestartAfterStop { get; set; }
 
-    public IAudioInputCapture Create(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
+    public IAudioInputCapture Create(
+        AudioInputDeviceSelection selection,
+        WaveFormat waveFormat,
+        int bufferMilliseconds)
     {
         if (CreateException is not null)
             throw CreateException;
 
-        var capture = new FakeAudioInputCapture(deviceNumber, ActualWaveFormat ?? waveFormat)
+        var capture = new FakeAudioInputCapture(selection, ActualWaveFormat ?? waveFormat)
         {
             CanRestartAfterStop = CanRestartAfterStop,
             PrepareException = PrepareException,
@@ -1884,9 +1995,10 @@ internal sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
     }
 }
 
-internal sealed class FakeAudioInputCapture(int deviceNumber, WaveFormat waveFormat) : IAudioInputCapture
+internal sealed class FakeAudioInputCapture(AudioInputDeviceSelection selection, WaveFormat waveFormat) : IAudioInputCapture
 {
-    public int DeviceNumber { get; } = deviceNumber;
+    public AudioInputDeviceSelection Selection { get; } = selection;
+    public int DeviceNumber => Selection.LastKnownDeviceNumber;
     public WaveFormat WaveFormat { get; } = waveFormat;
     public bool CanRestartAfterStop { get; init; }
     public bool Prepared => PrepareCount > 0;

--- a/tests/TypeWhisper.PluginSystem.Tests/CoalescedRefreshDispatcherTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CoalescedRefreshDispatcherTests.cs
@@ -1,0 +1,32 @@
+using TypeWhisper.Windows.Services;
+
+namespace TypeWhisper.PluginSystem.Tests;
+
+public sealed class CoalescedRefreshDispatcherTests
+{
+    [Fact]
+    public void Request_DuringRefreshRunsTheNewestGeneration()
+    {
+        Action? queuedWorker = null;
+        CoalescedRefreshDispatcher? dispatcher = null;
+        var refreshCount = 0;
+        dispatcher = new CoalescedRefreshDispatcher(
+            () =>
+            {
+                if (Interlocked.Increment(ref refreshCount) == 1)
+                    dispatcher!.Request();
+            },
+            worker =>
+            {
+                Assert.Null(queuedWorker);
+                queuedWorker = worker;
+            });
+
+        dispatcher.Request();
+        Assert.NotNull(queuedWorker);
+
+        queuedWorker();
+
+        Assert.Equal(2, refreshCount);
+    }
+}

--- a/tests/TypeWhisper.PluginSystem.Tests/CoalescedRefreshDispatcherTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/CoalescedRefreshDispatcherTests.cs
@@ -29,4 +29,31 @@ public sealed class CoalescedRefreshDispatcherTests
 
         Assert.Equal(2, refreshCount);
     }
+
+    [Fact]
+    public void RefreshFailure_IsReportedAndDoesNotBlockLaterRequests()
+    {
+        var queuedWorkers = new Queue<Action>();
+        var refreshCount = 0;
+        Exception? reportedFailure = null;
+        var dispatcher = new CoalescedRefreshDispatcher(
+            () =>
+            {
+                if (Interlocked.Increment(ref refreshCount) == 1)
+                    throw new InvalidOperationException("capture disposal failed");
+            },
+            queuedWorkers.Enqueue,
+            exception => reportedFailure = exception);
+
+        dispatcher.Request();
+        Assert.Single(queuedWorkers);
+        queuedWorkers.Dequeue()();
+
+        dispatcher.Request();
+        Assert.Single(queuedWorkers);
+        queuedWorkers.Dequeue()();
+
+        Assert.Equal(2, refreshCount);
+        Assert.IsType<InvalidOperationException>(reportedFailure);
+    }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -36,6 +36,70 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ResponseSender_SubmitsHeadersAndBodyOnlyOnce()
+    {
+        var transport = new FakeHttpApiResponseTransport();
+        var sender = new HttpApiResponseSender(transport);
+
+        var first = await sender.TrySendAsync(
+            new HttpApiResponse(200, "ok", "text/plain"),
+            CancellationToken.None);
+        var second = await sender.TrySendAsync(
+            new HttpApiResponse(500, "error"),
+            CancellationToken.None);
+        sender.Close();
+
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Equal(1, transport.SubmitCount);
+        Assert.Equal(200, Assert.Single(transport.Responses).StatusCode);
+        Assert.Equal(1, transport.CloseCount);
+    }
+
+    [Fact]
+    public async Task ResponseSender_DoesNotRetryAfterHeadersWereAlreadySubmitted()
+    {
+        var transport = new FakeHttpApiResponseTransport
+        {
+            SubmitException = new InvalidOperationException(
+                "This operation cannot be performed after the response has been submitted.")
+        };
+        var sender = new HttpApiResponseSender(transport);
+
+        var first = await sender.TrySendAsync(
+            new HttpApiResponse(200, "ok"),
+            CancellationToken.None);
+        var retry = await sender.TrySendAsync(
+            new HttpApiResponse(500, "error"),
+            CancellationToken.None);
+
+        Assert.False(first);
+        Assert.False(retry);
+        Assert.Equal(1, transport.SubmitCount);
+    }
+
+    [Fact]
+    public async Task ResponseSender_ObservesClientAbortAndCloseFailures()
+    {
+        var transport = new FakeHttpApiResponseTransport
+        {
+            SubmitException = new IOException("The client disconnected."),
+            CloseException = new ObjectDisposedException("response")
+        };
+        var sender = new HttpApiResponseSender(transport);
+
+        var exception = await Record.ExceptionAsync(() => sender.TrySendAsync(
+            new HttpApiResponse(200, "ok"),
+            new CancellationToken(canceled: true)));
+        var closeException = Record.Exception(sender.Close);
+
+        Assert.Null(exception);
+        Assert.Null(closeException);
+        Assert.Equal(1, transport.SubmitCount);
+        Assert.Equal(1, transport.CloseCount);
+    }
+
+    [Fact]
     public async Task Options_ReturnsNoContentWithoutJsonBody()
     {
         var service = CreateService();
@@ -1686,5 +1750,31 @@ public class HttpApiServiceTests : IDisposable
         }
 
         public void Dispose() { }
+    }
+}
+
+internal sealed class FakeHttpApiResponseTransport : IHttpApiResponseTransport
+{
+    public List<HttpApiResponse> Responses { get; } = [];
+    public Exception? SubmitException { get; init; }
+    public Exception? CloseException { get; init; }
+    public int SubmitCount { get; private set; }
+    public int CloseCount { get; private set; }
+
+    public Task SubmitAsync(HttpApiResponse response, CancellationToken cancellationToken)
+    {
+        SubmitCount++;
+        Responses.Add(response);
+        if (SubmitException is not null)
+            throw SubmitException;
+
+        return Task.CompletedTask;
+    }
+
+    public void Close()
+    {
+        CloseCount++;
+        if (CloseException is not null)
+            throw CloseException;
     }
 }

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -100,6 +100,37 @@ public class HttpApiServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RequestDispatch_DoesNotBlockListenerForSynchronousRouteWork()
+    {
+        using var handlerStarted = new ManualResetEventSlim();
+        using var releaseHandler = new ManualResetEventSlim();
+        var dispatchCall = Task.Factory.StartNew(
+            () => HttpApiService.DispatchRequestAsync(() =>
+            {
+                handlerStarted.Set();
+                releaseHandler.Wait(TimeSpan.FromSeconds(5));
+                return Task.CompletedTask;
+            }),
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default);
+
+        try
+        {
+            Assert.True(handlerStarted.Wait(TimeSpan.FromSeconds(2)));
+            var requestTask = await dispatchCall.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.False(requestTask.IsCompleted);
+
+            releaseHandler.Set();
+            await requestTask.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            releaseHandler.Set();
+        }
+    }
+
+    [Fact]
     public async Task Options_ReturnsNoContentWithoutJsonBody()
     {
         var service = CreateService();

--- a/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/HttpApiServiceTests.cs
@@ -110,7 +110,7 @@ public class HttpApiServiceTests : IDisposable
                 handlerStarted.Set();
                 releaseHandler.Wait(TimeSpan.FromSeconds(5));
                 return Task.CompletedTask;
-            }),
+            }, CancellationToken.None),
             CancellationToken.None,
             TaskCreationOptions.DenyChildAttach,
             TaskScheduler.Default);
@@ -128,6 +128,42 @@ public class HttpApiServiceTests : IDisposable
         {
             releaseHandler.Set();
         }
+    }
+
+    [Fact]
+    public async Task RequestDispatch_DoesNotStartQueuedWorkAfterShutdown()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var requestStarted = false;
+
+        var requestTask = HttpApiService.DispatchRequestAsync(() =>
+        {
+            requestStarted = true;
+            return Task.CompletedTask;
+        }, cts.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.False(requestStarted);
+    }
+
+    [Fact]
+    public async Task DictationStart_DoesNotMutateStateAfterRequestCancellation()
+    {
+        var service = CreateService();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.HandleRequestAsync(new HttpApiRequest(
+                "POST",
+                "/v1/dictation/start",
+                new NameValueCollection(),
+                new Dictionary<string, string>(),
+                []), cts.Token));
+
+        Assert.Empty(_dictation.StartWorkflowIds);
+        Assert.False(_dictation.IsRecording);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/MainWindowLayoutTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/MainWindowLayoutTests.cs
@@ -67,6 +67,44 @@ public sealed class MainWindowLayoutTests
         Assert.Contains("PowerModes.Resume", code);
         Assert.Contains("SessionSwitchReason.SessionUnlock", code);
         Assert.Contains("SchedulePrimaryOverlayRecovery", code);
+        Assert.Contains("DispatchAudioCaptureRefresh", code);
+        Assert.Contains("RefreshAfterDisplayOrPowerChange", code);
+    }
+
+    [Fact]
+    public void SoftwareRenderingSafety_IsEnabledBeforeFirstWpfWindow()
+    {
+        var program = TestFile.ReadProjectFile(
+            "src",
+            "TypeWhisper.Windows",
+            "Program.cs");
+        var safetyCall = program.IndexOf(
+            "WpfRenderingSafety.EnableBeforeAnyWindow();",
+            StringComparison.Ordinal);
+        var firstAppWindow = program.IndexOf("new App()", StringComparison.Ordinal);
+        var firstMessageBox = program.IndexOf("MessageBox.Show", StringComparison.Ordinal);
+        var firstWindow = Math.Min(firstAppWindow, firstMessageBox);
+
+        Assert.True(safetyCall >= 0);
+        Assert.True(firstAppWindow >= 0);
+        Assert.True(firstMessageBox >= 0);
+        Assert.True(firstWindow > safetyCall);
+
+        TypeWhisper.Windows.Services.WpfRenderingSafety.EnableBeforeAnyWindow();
+        Assert.Equal(
+            System.Windows.Interop.RenderMode.SoftwareOnly,
+            System.Windows.Media.RenderOptions.ProcessRenderMode);
+    }
+
+    [Fact]
+    public void RenderingSafety_RecognizesWrappedUceRenderThreadFailure()
+    {
+        var renderFailure = new System.Runtime.InteropServices.COMException(
+            "render thread failed",
+            TypeWhisper.Windows.Services.WpfRenderingSafety.RenderThreadFailureHResult);
+
+        Assert.True(TypeWhisper.Windows.Services.WpfRenderingSafety.IsRenderThreadFailure(
+            new InvalidOperationException("wrapper", renderFailure)));
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/WelcomeViewModelTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WelcomeViewModelTests.cs
@@ -776,7 +776,10 @@ public sealed class WelcomeViewModelTests
 
     private sealed class FakeAudioInputCaptureFactory : IAudioInputCaptureFactory
     {
-        public IAudioInputCapture Create(int deviceNumber, NAudio.Wave.WaveFormat waveFormat, int bufferMilliseconds) =>
+        public IAudioInputCapture Create(
+            AudioInputDeviceSelection selection,
+            NAudio.Wave.WaveFormat waveFormat,
+            int bufferMilliseconds) =>
             throw new InvalidOperationException("No capture should be created when no input device exists.");
     }
 


### PR DESCRIPTION
## Summary

- preserve stable microphone endpoint identity through WASAPI capture creation and WaveIn fallback
- re-resolve the selected endpoint immediately before opening capture and refresh prepared capture state after display, power, and session topology changes
- normalize Windows microphone ordinal prefixes for name fallback without opening an unrelated device when the selected microphone is missing
- harden single-submission HTTP responses and observe expected client-disconnect failures
- enable WPF software rendering before the first window and shut down cleanly after render-thread failure HRESULT 0x88980406

## WPF trade-off

WPF composition is deliberately forced to software rendering process-wide because the reported render-thread failure is process-wide and can make later WPF UI operations unsafe. This improves reliability across display-topology and DPI changes at the cost of additional CPU rendering work and reduced GPU acceleration.

## Validation

- `dotnet restore TypeWhisper.slnx --nologo`
- `dotnet build TypeWhisper.slnx -c Debug --no-restore --nologo` — 0 warnings, 0 errors
- initial full test suite — 2,725 passed, 1 skipped
- directly affected tests — 106 passed
- final suite after manual testing — 2,716 passed, 1 skipped, excluding the nine-test real Windows clipboard integration class because its delayed-DIB test hangs while the Windows session is locked
- five Windows monitor-off/wake cycles — Dictation and Recorder capture opened and stopped successfully, and the app remained responsive
- whisper.cpp Large V3 Turbo Q5_0 remained active with NVIDIA CUDA
- 40 aborted HTTP clients followed by successful status and model requests

## Test environment and limitations

Testing used Windows 11 build 26200, two monitors, and a USB HyperX QuadCast 2. The exact customer hardware (Shure MV7 and four monitors) was not available. Endpoint reordering, ordinal-name changes, prepared WASAPI fallback, and missing-device behavior are covered by deterministic tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from WPF rendering failures with safer software rendering and fewer duplicate error dialogs.
  * Improved audio device reliability by preserving device identity, detecting unavailable devices, and refreshing captures after display or power changes.
  * Improved HTTP API handling for client disconnects, duplicate submissions, cancellation, and request-processing failures.
  * Improved refresh behavior by coalescing overlapping audio updates and applying the latest changes.
* **Tests**
  * Added coverage for rendering recovery, audio-device changes, refresh coordination, cancellation, and HTTP response delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->