### PR TITLE
Fix Parakeet transcription for long audio

### DIFF
--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Windows.Controls;
 using SherpaOnnx;
 using TypeWhisper.PluginSDK;
@@ -15,10 +16,19 @@ namespace TypeWhisper.Plugin.SherpaOnnx;
 /// </summary>
 public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEnginePlugin
 {
+    internal const int SampleRate = 16000;
+    // The exported encoder fails near 400 seconds; use a lower bound to leave room for feature padding.
+    internal const int ParakeetMaximumChunkSeconds = 300;
+    internal const int ParakeetChunkOverlapSeconds = 5;
+    private const int MinimumTranscriptOverlapWords = 2;
+    private const int MaximumTranscriptOverlapWords = 40;
     private const string ParakeetRepo = "https://huggingface.co/csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main";
     private const string CanaryRepo = "https://huggingface.co/csukuangfj/sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8/resolve/main";
 
     private static readonly IReadOnlyList<string> CanarySupportedLanguages = ["en", "de", "fr", "es"];
+    private static readonly Regex TranscriptWordRegex = new(
+        @"[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly IReadOnlyList<ModelDefinition> Models =
     [
@@ -98,7 +108,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
     /// <summary>
     /// Gets the plugin version reported to the host.
     /// </summary>
-    public string PluginVersion => "1.0.5";
+    public string PluginVersion => "1.0.6";
 
     // ITranscriptionEnginePlugin
     /// <summary>
@@ -425,7 +435,7 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         return Task.Run(() =>
         {
             var audioSamples = DecodeWav(wavAudio);
-            var audioDuration = audioSamples.Length / 16000.0;
+            var audioDuration = audioSamples.Length / (double)SampleRate;
 
             lock (_sync)
             {
@@ -437,11 +447,9 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
                 if (model.SupportsTranslation)
                     EnsureCanaryLanguage(language, translate);
 
-                using var stream = _recognizer.CreateStream();
-                stream.AcceptWaveform(16000, audioSamples);
-                _recognizer.Decode(stream);
-
-                var rawText = stream.Result.Text.Trim();
+                var rawText = model.Id == "parakeet-tdt-0.6b"
+                    ? TranscribeParakeetSamples(_recognizer, audioSamples, ct)
+                    : RecognizeSamples(_recognizer, audioSamples);
 
                 var (text, detectedLanguage) = model.SupportsTranslation
                     ? ParseCanaryResult(rawText)
@@ -451,6 +459,132 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
             }
         }, ct);
     }
+
+    private string TranscribeParakeetSamples(
+        OfflineRecognizer recognizer,
+        float[] audioSamples,
+        CancellationToken ct)
+    {
+        var chunks = CreateParakeetChunks(audioSamples.Length);
+        if (chunks.Count == 1)
+            return RecognizeSamples(recognizer, audioSamples);
+
+        _host?.Log(
+            PluginLogLevel.Info,
+            $"Splitting {audioSamples.Length / (double)SampleRate:F1}s of Parakeet audio into {chunks.Count} chunks.");
+
+        var transcript = string.Empty;
+        foreach (var chunk in chunks)
+        {
+            ct.ThrowIfCancellationRequested();
+            var samples = new float[chunk.Count];
+            Array.Copy(audioSamples, chunk.Offset, samples, 0, chunk.Count);
+            transcript = MergeChunkTranscripts(transcript, RecognizeSamples(recognizer, samples));
+        }
+
+        return transcript;
+    }
+
+    private static string RecognizeSamples(OfflineRecognizer recognizer, float[] samples)
+    {
+        using var stream = recognizer.CreateStream();
+        stream.AcceptWaveform(SampleRate, samples);
+        recognizer.Decode(stream);
+        return stream.Result.Text.Trim();
+    }
+
+    internal static IReadOnlyList<(int Offset, int Count)> CreateParakeetChunks(int sampleCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(sampleCount);
+
+        var maximumChunkSamples = ParakeetMaximumChunkSeconds * SampleRate;
+        if (sampleCount <= maximumChunkSamples)
+            return [(0, sampleCount)];
+
+        var overlapSamples = ParakeetChunkOverlapSeconds * SampleRate;
+        var strideSamples = maximumChunkSamples - overlapSamples;
+        var chunkCount = (int)Math.Ceiling(
+            (sampleCount - overlapSamples) / (double)strideSamples);
+        var processedSampleCount = sampleCount + ((chunkCount - 1) * overlapSamples);
+        var baseChunkSize = processedSampleCount / chunkCount;
+        var longerChunkCount = processedSampleCount % chunkCount;
+        var chunks = new List<(int Offset, int Count)>(chunkCount);
+        var offset = 0;
+
+        for (var index = 0; index < chunkCount; index++)
+        {
+            var count = baseChunkSize + (index < longerChunkCount ? 1 : 0);
+            chunks.Add((offset, count));
+            offset += count - overlapSamples;
+        }
+
+        return chunks;
+    }
+
+    internal static string MergeChunkTranscripts(string transcript, string nextChunk)
+    {
+        transcript = transcript.Trim();
+        nextChunk = nextChunk.Trim();
+        if (string.IsNullOrEmpty(transcript))
+            return nextChunk;
+        if (string.IsNullOrEmpty(nextChunk))
+            return transcript;
+
+        var transcriptWords = TokenizeTranscriptWords(transcript);
+        var nextWords = TokenizeTranscriptWords(nextChunk);
+        var maximumOverlap = Math.Min(
+            MaximumTranscriptOverlapWords,
+            Math.Min(transcriptWords.Count, nextWords.Count));
+
+        for (var overlap = maximumOverlap; overlap >= MinimumTranscriptOverlapWords; overlap--)
+        {
+            var transcriptStart = transcriptWords.Count - overlap;
+            var matches = true;
+            for (var index = 0; index < overlap; index++)
+            {
+                if (!string.Equals(
+                        transcriptWords[transcriptStart + index].Normalized,
+                        nextWords[index].Normalized,
+                        StringComparison.Ordinal))
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+                return AppendTranscript(transcript, nextChunk[nextWords[overlap - 1].End..]);
+        }
+
+        return AppendTranscript(transcript, nextChunk);
+    }
+
+    private static List<TranscriptWord> TokenizeTranscriptWords(string text) =>
+        TranscriptWordRegex.Matches(text)
+            .Select(match => new TranscriptWord(
+                match.Value.Replace('’', '\'').ToUpperInvariant(),
+                match.Index + match.Length))
+            .ToList();
+
+    private static string AppendTranscript(string transcript, string tail)
+    {
+        tail = tail.TrimStart();
+        if (string.IsNullOrEmpty(tail))
+            return transcript;
+
+        if (char.IsPunctuation(tail[0]))
+        {
+            var transcriptEnd = transcript.Length;
+            while (transcriptEnd > 0 && char.IsPunctuation(transcript[transcriptEnd - 1]))
+                transcriptEnd--;
+
+            return transcript[..transcriptEnd] + tail;
+        }
+
+        return transcript + " " + tail;
+    }
+
+    private sealed record TranscriptWord(string Normalized, int End);
 
     /// <summary>
     /// Releases resources held by the instance.

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/SherpaOnnxPlugin.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -572,7 +573,15 @@ public sealed class SherpaOnnxPlugin : ITypeWhisperPlugin, ITranscriptionEngineP
         if (string.IsNullOrEmpty(tail))
             return transcript;
 
-        if (char.IsPunctuation(tail[0]))
+        var firstCharacter = tail[0];
+        var punctuationCategory = char.GetUnicodeCategory(firstCharacter);
+        var isOpeningPunctuation = punctuationCategory is UnicodeCategory.OpenPunctuation
+            or UnicodeCategory.InitialQuotePunctuation
+            || ((firstCharacter is '"' or '\'')
+                && tail.Length > 1
+                && !char.IsWhiteSpace(tail[1]));
+
+        if (char.IsPunctuation(firstCharacter) && !isOpeningPunctuation)
         {
             var transcriptEnd = transcript.Length;
             while (transcriptEnd > 0 && char.IsPunctuation(transcript[transcriptEnd - 1]))

--- a/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
+++ b/plugins/TypeWhisper.Plugin.SherpaOnnx/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.sherpa-onnx",
   "name": "Lokale Modelle (sherpa-onnx)",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "TypeWhisper",
   "description": "Offline transcription via sherpa-onnx (NVIDIA NeMo Parakeet + Canary)",
   "assemblyName": "TypeWhisper.Plugin.SherpaOnnx.dll",

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -29,8 +29,59 @@ public class SherpaOnnxPluginTests
         var sut = new SherpaOnnxPlugin();
 
         Assert.NotNull(manifest);
-        Assert.Equal("1.0.5", manifest.Version);
+        Assert.Equal("1.0.6", manifest.Version);
         Assert.Equal(manifest.Version, sut.PluginVersion);
+    }
+
+    [Fact]
+    public void CreateParakeetChunks_ShortAudioUsesOneUnchangedChunk()
+    {
+        var sampleCount = (SherpaOnnxPlugin.ParakeetMaximumChunkSeconds - 1)
+            * SherpaOnnxPlugin.SampleRate;
+
+        var chunks = SherpaOnnxPlugin.CreateParakeetChunks(sampleCount);
+
+        Assert.Equal([(0, sampleCount)], chunks);
+    }
+
+    [Fact]
+    public void CreateParakeetChunks_LongAudioStaysWithinEncoderLimitAndCoversInput()
+    {
+        var sampleCount = 8 * 60 * SherpaOnnxPlugin.SampleRate;
+        var maximumChunkSamples = SherpaOnnxPlugin.ParakeetMaximumChunkSeconds
+            * SherpaOnnxPlugin.SampleRate;
+        var overlapSamples = SherpaOnnxPlugin.ParakeetChunkOverlapSeconds
+            * SherpaOnnxPlugin.SampleRate;
+
+        var chunks = SherpaOnnxPlugin.CreateParakeetChunks(sampleCount);
+
+        Assert.Equal(2, chunks.Count);
+        Assert.All(chunks, chunk => Assert.InRange(chunk.Count, 1, maximumChunkSamples));
+        Assert.Equal(0, chunks[0].Offset);
+        Assert.Equal(sampleCount, chunks[^1].Offset + chunks[^1].Count);
+        Assert.Equal(
+            overlapSamples,
+            chunks[0].Offset + chunks[0].Count - chunks[1].Offset);
+    }
+
+    [Fact]
+    public void MergeChunkTranscripts_RemovesNormalizedWordOverlap()
+    {
+        var merged = SherpaOnnxPlugin.MergeChunkTranscripts(
+            "The quick brown fox jumps over the lazy dog.",
+            "OVER the lazy dog, then rests.");
+
+        Assert.Equal("The quick brown fox jumps over the lazy dog, then rests.", merged);
+    }
+
+    [Fact]
+    public void MergeChunkTranscripts_AppendsChunkWhenNoOverlapIsRecognized()
+    {
+        var merged = SherpaOnnxPlugin.MergeChunkTranscripts(
+            "First section.",
+            "Second section.");
+
+        Assert.Equal("First section. Second section.", merged);
     }
 
     [Fact]

--- a/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/SherpaOnnxPluginTests.cs
@@ -74,6 +74,24 @@ public class SherpaOnnxPluginTests
         Assert.Equal("The quick brown fox jumps over the lazy dog, then rests.", merged);
     }
 
+    [Theory]
+    [InlineData(
+        "world again (continued).",
+        "Hello there world again. (continued).")]
+    [InlineData(
+        "world again \"continued.\"",
+        "Hello there world again. \"continued.\"")]
+    public void MergeChunkTranscripts_SeparatesOpeningPunctuation(
+        string nextChunk,
+        string expected)
+    {
+        var merged = SherpaOnnxPlugin.MergeChunkTranscripts(
+            "Hello there world again.",
+            nextChunk);
+
+        Assert.Equal(expected, merged);
+    }
+
     [Fact]
     public void MergeChunkTranscripts_AppendsChunkWhenNoOverlapIsRecognized()
     {


### PR DESCRIPTION
## Summary

- split Parakeet audio longer than five minutes into balanced overlapping chunks
- merge repeated boundary words while preserving punctuation
- keep short Parakeet and Canary transcription paths unchanged
- bump the sherpa-onnx plugin version to 1.0.6

## Reproduction

Using the real Parakeet model on CPU:

- 300 seconds: succeeds
- 360 seconds: succeeds
- 420 seconds: fails before this change with an ONNX broadcast error followed by SEHException

The failing encoder dimensions were 250 by 5250, matching the exported model's single-pass sequence limit.

## Validation

- 420-second real-model transcription succeeds after the fix
- 480-second real-model transcription succeeds after the fix
- SherpaOnnxPluginTests: 29 passed
- TypeWhisper.Core.Tests: 472 passed
- TypeWhisper.PluginSystem.Tests: 2289 passed, 1 skipped external live test
- Windows development build and launch succeeded

Fixes #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Parakeet transcription for long audio by processing overlapping sections and combining results more accurately.
  * Preserved word boundaries and punctuation when merging transcript segments, including opening parentheses and quotation marks.
  * Added cancellation support between long-audio processing steps.

* **Bug Fixes**
  * Improved handling of repeated words and transcript overlaps in chunked audio.

* **Chores**
  * Updated the Sherpa-ONNX plugin version to 1.0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->