### PR TITLE
Compress OpenAI transcription uploads to reduce latency

### DIFF
--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiPlugin.cs
@@ -2,8 +2,11 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Windows.Controls;
+using NAudio.MediaFoundation;
+using NAudio.Wave;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
 using TypeWhisper.PluginSDK.Models;
@@ -17,7 +20,8 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
 {
     private const string BaseUrl = "https://api.openai.com";
     private const string ChatGptModelsEndpoint = "https://chatgpt.com/backend-api/codex/models";
-    private const string PluginVersionValue = "1.1.2";
+    private const string PluginVersionValue = "1.1.3";
+    private const int TranscriptionUploadBitRate = 48_000;
     private const string ApiKeySecretName = "api-key";
     private const string SelectedModelSettingName = "selectedModel";
     private const string SelectedVoiceSettingName = "selectedVoice";
@@ -46,6 +50,7 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
     private readonly HttpClient _httpClient;
     private readonly SemaphoreSlim _oauthRefreshLock = new(1, 1);
     private readonly Func<byte[], ITtsPlaybackSession> _ttsPlaybackFactory;
+    private readonly Func<byte[], OpenAiTranscriptionUpload> _compressedUploadFactory;
     private IPluginHostServices? _host;
     private string? _apiKey;
     private string? _selectedModelId;
@@ -132,10 +137,14 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
     {
     }
 
-    internal OpenAiPlugin(HttpClient httpClient, Func<byte[], ITtsPlaybackSession>? ttsPlaybackFactory = null)
+    internal OpenAiPlugin(
+        HttpClient httpClient,
+        Func<byte[], ITtsPlaybackSession>? ttsPlaybackFactory = null,
+        Func<byte[], OpenAiTranscriptionUpload>? compressedUploadFactory = null)
     {
         _httpClient = httpClient;
         _ttsPlaybackFactory = ttsPlaybackFactory ?? (pcm => new OpenAiPcmTtsPlaybackSession(pcm, OpenAiTtsConfiguration.SampleRate));
+        _compressedUploadFactory = compressedUploadFactory ?? CreateCompressedUpload;
     }
 
     // ITypeWhisperPlugin
@@ -308,31 +317,141 @@ public sealed class OpenAiPlugin : ITranscriptionEnginePlugin, ILlmProviderPlugi
                 ct);
         }
 
-        if (entry.LanguageFormat == TranscriptionLanguageFormat.Plural)
+        var preferredUpload = await Task.Run(() => CreatePreferredUpload(wavAudio, ct), ct);
+
+        async Task<PluginTranscriptionResult> TranscribeUploadAsync(OpenAiTranscriptionUpload upload)
         {
-            return await OpenAiTranscriptionClient.TranscribeAsync(
+            if (entry.LanguageFormat == TranscriptionLanguageFormat.Plural)
+            {
+                return await OpenAiTranscriptionClient.TranscribeAsync(
+                    _httpClient,
+                    BaseUrl,
+                    _apiKey!,
+                    entry.ApiModelName,
+                    upload,
+                    normalizedLanguageHints,
+                    entry.ResponseFormat,
+                    prompt,
+                    ct);
+            }
+
+            return await OpenAiTranscriptionHelper.TranscribeAsync(
                 _httpClient,
                 BaseUrl,
                 _apiKey!,
                 entry.ApiModelName,
-                wavAudio,
-                normalizedLanguageHints,
-                entry.ResponseFormat,
-                prompt,
-                ct);
+                upload,
+                normalizedLanguageHints.FirstOrDefault(),
+                translate,
+                entry.ResponseFormat ?? "json",
+                ct,
+                prompt);
         }
 
-        return await OpenAiTranscriptionHelper.TranscribeAsync(
-            _httpClient,
-            BaseUrl,
-            _apiKey!,
-            entry.ApiModelName,
-            wavAudio,
-            normalizedLanguageHints.FirstOrDefault(),
-            translate,
-            entry.ResponseFormat ?? "json",
-            ct,
-            prompt);
+        try
+        {
+            return await TranscribeUploadAsync(preferredUpload);
+        }
+        catch (PluginRequestException ex) when (
+            IsM4aUpload(preferredUpload)
+            && ShouldRetryWithWav(ex))
+        {
+            ct.ThrowIfCancellationRequested();
+            _host?.Log(
+                PluginLogLevel.Warning,
+                $"OpenAI rejected the M4A upload; retrying with WAV: {ex.Message}");
+            return await TranscribeUploadAsync(CreateWavUpload(wavAudio));
+        }
+    }
+
+    private OpenAiTranscriptionUpload CreatePreferredUpload(byte[] wavAudio, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        try
+        {
+            return _compressedUploadFactory(wavAudio);
+        }
+        catch (Exception ex) when (IsExpectedCompressionFailure(ex))
+        {
+            _host?.Log(
+                PluginLogLevel.Warning,
+                $"OpenAI M4A encoding failed; falling back to WAV: {ex.Message}");
+            return CreateWavUpload(wavAudio);
+        }
+    }
+
+    private static bool IsExpectedCompressionFailure(Exception ex) =>
+        ex is InvalidDataException
+        or FormatException
+        or IOException
+        or InvalidOperationException
+        or COMException
+        or NotSupportedException;
+
+    internal static OpenAiTranscriptionUpload CreateCompressedUpload(byte[] wavAudio)
+    {
+        ArgumentNullException.ThrowIfNull(wavAudio);
+        if (wavAudio.Length == 0)
+            throw new InvalidOperationException("No WAV audio bytes were provided.");
+
+        using var input = new MemoryStream(wavAudio, writable: false);
+        using var reader = new WaveFileReader(input);
+        using var output = new MemoryStream();
+        MediaFoundationEncoder.EncodeToAac(reader, output, TranscriptionUploadBitRate);
+
+        var bytes = output.ToArray();
+        if (bytes.Length == 0)
+            throw new InvalidOperationException("Media Foundation produced an empty AAC upload.");
+
+        return new OpenAiTranscriptionUpload(bytes, "audio.m4a", "audio/mp4");
+    }
+
+    private static OpenAiTranscriptionUpload CreateWavUpload(byte[] wavAudio) =>
+        new(wavAudio, "audio.wav", "audio/wav");
+
+    private static bool IsM4aUpload(OpenAiTranscriptionUpload upload) =>
+        upload.FileName.EndsWith(".m4a", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool ShouldRetryWithWav(PluginRequestException exception)
+    {
+        if (exception.HttpStatusCode == 415)
+            return true;
+
+        var message = exception.Message;
+        if (exception.HttpStatusCode is 400 or 422)
+            return IndicatesUnsupportedAudioUpload(message);
+
+        return exception.HttpStatusCode == 500 && IndicatesMediaProbeFailure(message);
+    }
+
+    private static bool IndicatesUnsupportedAudioUpload(string message)
+    {
+        string[] rejectionTerms =
+        [
+            "unsupported", "not supported", "does not support", "invalid", "unrecognized",
+            "unknown", "could not process", "failed to process", "corrupt"
+        ];
+        string[] mediaTerms =
+        [
+            "format", "media", "mime", "content-type", "content type", "codec", "container",
+            "file type", "audio", "m4a", "mp4", "aac", "wav"
+        ];
+
+        return rejectionTerms.Any(term => message.Contains(term, StringComparison.OrdinalIgnoreCase))
+            && mediaTerms.Any(term => message.Contains(term, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IndicatesMediaProbeFailure(string message)
+    {
+        string[] probeFailures =
+        [
+            "ffprobe failed", "ffprobe error", "ffprobe returned", "ffprobe exited",
+            "ffmpeg failed", "ffmpeg error", "ffmpeg returned", "ffmpeg exited",
+            "moov atom not found", "invalid data found when processing input"
+        ];
+
+        return probeFailures.Any(term => message.Contains(term, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/plugins/TypeWhisper.Plugin.OpenAi/OpenAiTranscriptionClient.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/OpenAiTranscriptionClient.cs
@@ -13,16 +13,16 @@ internal static class OpenAiTranscriptionClient
         string baseUrl,
         string apiKey,
         string model,
-        byte[] wavAudio,
+        OpenAiTranscriptionUpload upload,
         IReadOnlyList<string> languageHints,
         string? responseFormat,
         string? prompt,
         CancellationToken ct)
     {
         using var content = new MultipartFormDataContent();
-        var fileContent = new ByteArrayContent(wavAudio);
-        fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
-        content.Add(fileContent, "file", "audio.wav");
+        var fileContent = new ByteArrayContent(upload.Data);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(upload.ContentType);
+        content.Add(fileContent, "file", upload.FileName);
         content.Add(new StringContent(model), "model");
         if (!string.IsNullOrWhiteSpace(responseFormat))
             content.Add(new StringContent(responseFormat), "response_format");

--- a/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
+++ b/plugins/TypeWhisper.Plugin.OpenAi/Tests/OpenAiPluginTests.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using TypeWhisper.Core.Audio;
 using TypeWhisper.Plugin.OpenAi;
 using TypeWhisper.PluginSDK;
 using TypeWhisper.PluginSDK.Helpers;
@@ -453,6 +455,177 @@ public class OpenAiPluginTests
     }
 
     [Fact]
+    public void CreateCompressedUpload_ProducesSmallerM4aContainer()
+    {
+        var samples = Enumerable.Range(0, 32_000)
+            .Select(index => (float)(Math.Sin(index * 2 * Math.PI * 440 / 16_000) * 0.25))
+            .ToArray();
+        var wavAudio = WavEncoder.Encode(samples);
+
+        var upload = OpenAiPlugin.CreateCompressedUpload(wavAudio);
+
+        Assert.Equal("audio.m4a", upload.FileName);
+        Assert.Equal("audio/mp4", upload.ContentType);
+        Assert.True(upload.Data.AsSpan().IndexOf("ftyp"u8) >= 0);
+        Assert.True(upload.Data.Length < wavAudio.Length);
+    }
+
+    [Fact]
+    public async Task GPTTranscribe_UsesCompressedUploadAndPreservesContextFields()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((request, body) =>
+        {
+            Assert.Equal("https://api.openai.com/v1/audio/transcriptions", request.RequestUri?.ToString());
+            capturedBody = body;
+            Assert.NotNull(body);
+            AssertMultipartToken(body, "filename", "audio.m4a");
+            Assert.Contains("Content-Type: audio/mp4", body);
+            AssertMultipartToken(body, "name", "model");
+            Assert.Contains("gpt-transcribe", body);
+            AssertMultipartToken(body, "name", "languages[]");
+            Assert.Contains("de", body);
+            AssertMultipartToken(body, "name", "prompt");
+            Assert.Contains("TypeWhisper", body);
+            return Task.FromResult(JsonResponse("""{"text":"compressed ok"}"""));
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "sk-test";
+        using var httpClient = new HttpClient(handler);
+        var sut = new OpenAiPlugin(
+            httpClient,
+            _ => new FakeTtsPlaybackSession(),
+            _ => new OpenAiTranscriptionUpload([1, 2, 3], "audio.m4a", "audio/mp4"));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeWithLanguageHintsAsync(
+            [4, 5, 6],
+            ["de"],
+            translate: false,
+            prompt: "TypeWhisper",
+            CancellationToken.None);
+
+        Assert.NotNull(capturedBody);
+        Assert.Equal("compressed ok", result.Text);
+    }
+
+    [Fact]
+    public async Task GPTTranscribe_EncoderFailureFallsBackToWavUpload()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return Task.FromResult(JsonResponse("""{"text":"wav ok"}"""));
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "sk-test";
+        using var httpClient = new HttpClient(handler);
+        var sut = new OpenAiPlugin(
+            httpClient,
+            _ => new FakeTtsPlaybackSession(),
+            _ => throw new COMException("AAC encoder unavailable"));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(
+            [4, 5, 6],
+            "de",
+            translate: false,
+            prompt: null,
+            CancellationToken.None);
+
+        Assert.NotNull(capturedBody);
+        AssertMultipartToken(capturedBody, "filename", "audio.wav");
+        Assert.Contains("Content-Type: audio/wav", capturedBody);
+        Assert.Equal("wav ok", result.Text);
+    }
+
+    [Fact]
+    public async Task GPTTranscribe_FormatRejectionRetriesWithWavAndPreservesFields()
+    {
+        var bodies = new List<string>();
+        var handler = new CapturingHandler((_, body) =>
+        {
+            bodies.Add(body ?? "");
+            if (bodies.Count == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.UnsupportedMediaType)
+                {
+                    Content = new StringContent(
+                        """{"error":{"message":"Unsupported audio format"}}""",
+                        Encoding.UTF8,
+                        "application/json")
+                });
+            }
+
+            return Task.FromResult(JsonResponse("""{"text":"fallback ok","language":"de"}"""));
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "sk-test";
+        using var httpClient = new HttpClient(handler);
+        var sut = new OpenAiPlugin(
+            httpClient,
+            _ => new FakeTtsPlaybackSession(),
+            _ => new OpenAiTranscriptionUpload([1, 2, 3], "audio.m4a", "audio/mp4"));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeWithLanguageHintsAsync(
+            [4, 5, 6],
+            ["de", "en"],
+            translate: false,
+            prompt: "TypeWhisper",
+            CancellationToken.None);
+
+        Assert.Equal("fallback ok", result.Text);
+        Assert.Equal(2, bodies.Count);
+        AssertMultipartToken(bodies[0], "filename", "audio.m4a");
+        Assert.Contains("Content-Type: audio/mp4", bodies[0]);
+        AssertMultipartToken(bodies[1], "filename", "audio.wav");
+        Assert.Contains("Content-Type: audio/wav", bodies[1]);
+        foreach (var body in bodies)
+        {
+            Assert.Contains("gpt-transcribe", body);
+            Assert.Contains("languages[]", body);
+            Assert.Contains("de", body);
+            Assert.Contains("en", body);
+            Assert.Contains("TypeWhisper", body);
+        }
+    }
+
+    [Fact]
+    public async Task WhisperTranscribe_UsesCompressedUpload()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler((_, body) =>
+        {
+            capturedBody = body;
+            return Task.FromResult(JsonResponse("""{"text":"legacy ok"}"""));
+        });
+        var host = new TestPluginHostServices();
+        host.Secrets["api-key"] = "sk-test";
+        host.SetSetting("selectedModel", "whisper-1");
+        using var httpClient = new HttpClient(handler);
+        var sut = new OpenAiPlugin(
+            httpClient,
+            _ => new FakeTtsPlaybackSession(),
+            _ => new OpenAiTranscriptionUpload([1, 2, 3], "audio.m4a", "audio/mp4"));
+        await sut.ActivateAsync(host);
+
+        var result = await sut.TranscribeAsync(
+            [4, 5, 6],
+            "de",
+            translate: false,
+            prompt: "TypeWhisper",
+            CancellationToken.None);
+
+        Assert.NotNull(capturedBody);
+        AssertMultipartToken(capturedBody, "filename", "audio.m4a");
+        Assert.Contains("Content-Type: audio/mp4", capturedBody);
+        Assert.Contains("verbose_json", capturedBody);
+        Assert.Equal("legacy ok", result.Text);
+    }
+
+    [Fact]
     public async Task GPTTranscribe_RejectsTranslationBeforeSendingRequest()
     {
         var requests = 0;
@@ -728,7 +901,7 @@ public class OpenAiPluginTests
         Assert.Equal("gpt-5.6-sol", sut.SelectedLlmModelId);
         Assert.Equal("gpt-5.6-sol", host.GetSetting<string>("selectedLLMModel"));
         Assert.Equal(
-            "https://chatgpt.com/backend-api/codex/models?client_version=1.1.2",
+            "https://chatgpt.com/backend-api/codex/models?client_version=1.1.3",
             capturedRequest?.RequestUri?.ToString());
         Assert.Equal("Bearer access-token", capturedRequest?.Headers.Authorization?.ToString());
         Assert.Equal(
@@ -793,7 +966,7 @@ public class OpenAiPluginTests
         Assert.Equal(
             [
                 "https://auth.openai.com/oauth/token",
-                "https://chatgpt.com/backend-api/codex/models?client_version=1.1.2",
+                "https://chatgpt.com/backend-api/codex/models?client_version=1.1.3",
             ],
             requestedUris);
         Assert.Equal(["gpt-5.6-sol"], models.Select(model => model.Id).ToArray());
@@ -1063,6 +1236,14 @@ public class OpenAiPluginTests
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
+
+    private static void AssertMultipartToken(string body, string name, string value)
+    {
+        Assert.True(
+            body.Contains($"{name}=\"{value}\"", StringComparison.Ordinal)
+            || body.Contains($"{name}={value}", StringComparison.Ordinal),
+            $"Multipart body did not contain {name}={value}:{Environment.NewLine}{body}");
+    }
 
     private sealed class CapturingHandler(
         Func<HttpRequestMessage, string?, Task<HttpResponseMessage>> responder) : HttpMessageHandler

--- a/plugins/TypeWhisper.Plugin.OpenAi/TypeWhisper.Plugin.OpenAi.csproj
+++ b/plugins/TypeWhisper.Plugin.OpenAi/TypeWhisper.Plugin.OpenAi.csproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <RootNamespace>TypeWhisper.Plugin.OpenAi</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="TypeWhisper.PluginSystem.Tests" />
@@ -14,6 +15,7 @@
     <Compile Remove="Tests\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.2.1" />
     <ProjectReference Include="..\..\src\TypeWhisper.PluginSDK\TypeWhisper.PluginSDK.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -35,8 +37,11 @@
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(PluginOutputDir)" />
     <ItemGroup>
       <_LocalizationFiles Include="$(ProjectDir)Localization\*.json" />
+      <_DependencyFiles Include="$(TargetDir)*.dll"
+                        Exclude="$(TargetPath);$(TargetDir)TypeWhisper.PluginSDK.dll" />
     </ItemGroup>
     <MakeDir Directories="$(PluginOutputDir)Localization\" />
     <Copy SourceFiles="@(_LocalizationFiles)" DestinationFolder="$(PluginOutputDir)Localization\" />
+    <Copy SourceFiles="@(_DependencyFiles)" DestinationFolder="$(PluginOutputDir)" />
   </Target>
 </Project>

--- a/plugins/TypeWhisper.Plugin.OpenAi/manifest.json
+++ b/plugins/TypeWhisper.Plugin.OpenAi/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.typewhisper.openai",
   "name": "OpenAI / ChatGPT",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "minHostVersion": "1.0.9",
   "author": "TypeWhisper",
   "description": "OpenAI transcription, prompt processing, and text-to-speech with dynamic API and ChatGPT model catalogs. STT/TTS require an API key; prompts can use ChatGPT login.",

--- a/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
+++ b/tests/TypeWhisper.PluginSystem.Tests/WorkflowProviderReleaseMetadataTests.cs
@@ -21,7 +21,7 @@ public sealed class WorkflowProviderReleaseMetadataTests
         { "TypeWhisper.Plugin.Gemini", "1.3.0" },
         { "TypeWhisper.Plugin.GemmaLocal", "1.0.1" },
         { "TypeWhisper.Plugin.Groq", "1.0.6" },
-        { "TypeWhisper.Plugin.OpenAi", "1.1.2" },
+        { "TypeWhisper.Plugin.OpenAi", "1.1.3" },
         { "TypeWhisper.Plugin.OpenAiCompatible", "1.0.6" },
         { "TypeWhisper.Plugin.OpenRouter", "1.1.1" },
         { "TypeWhisper.Plugin.Xai", "1.0.1" },


### PR DESCRIPTION
## Summary

- encode OpenAI file-transcription uploads as 48 kbps AAC in an M4A container before sending them
- preserve model, language, prompt, translation, and response-format fields for both `gpt-transcribe` and legacy Whisper requests
- fall back to WAV when Windows Media Foundation cannot encode or the provider explicitly rejects the compressed format
- ship the required NAudio assemblies with OpenAI plugin version 1.1.3

## Related Issue

Fixes #443

## Test Plan

- [x] `dotnet test tests/TypeWhisper.PluginSystem.Tests/TypeWhisper.PluginSystem.Tests.csproj --no-build --no-restore` (2,290 passed, 1 skipped)
- [x] Built and ran locally with `build-typewhisper-windows-dev.ps1 --run`
- [x] Verified that a real generated upload is an M4A container and smaller than its source WAV
- [x] Covered compressed multipart requests, encoder fallback, server rejection fallback, and legacy Whisper requests
- [ ] Re-run the cross-platform API benchmark with controlled account/project routing

## Notes

The solution-wide formatting check still reports pre-existing whitespace findings in unrelated files. Formatting verification passes for the changed OpenAI C# files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI transcription uploads now use compressed M4A audio by default, reducing upload size.
  * Automatically retries with WAV audio when compression fails or the service rejects the audio format.
  * Preserves transcription upload metadata, including filename and content type.
  * Whisper uploads now support compressed audio.

* **Chores**
  * Updated the OpenAI plugin release to version 1.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->